### PR TITLE
Implement device XP ranking

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ Tap’em ist eine modular aufgebaute Flutter-App, die es Fitnessstudios ermögli
 - **Dynamisches Branding**: Farbschema, Logos und App-Namen pro Studio konfigurierbar  
 - **State Management**: Provider / optional Riverpod oder BLoC für skalierbare Business-Logik  
 - **Visualisierung**: Kalender-Übersicht, Charts (fl_chart), Streak-Badges, Trainingshistorie  
-- **Offline-Support**: Firestore-Persistence für unterbrechungsfreie Datenerfassung  
-- **CI/CD ready**: GitHub Actions für Analyse, Tests und Matrix-Builds von Flavors  
+- **Offline-Support**: Firestore-Persistence für unterbrechungsfreie Datenerfassung
+- **Geräte-XP**: Erfahrungspunkte pro Gerät werden in `userXp/{userId}` gespeichert
+- **CI/CD ready**: GitHub Actions für Analyse, Tests und Matrix-Builds von Flavors
 
 ---
 
@@ -45,4 +46,10 @@ Tap’em ist eine modular aufgebaute Flutter-App, die es Fitnessstudios ermögli
    ```bash
    flutter pub get
    ```
+
+## XP & Rangliste
+
+Bei jedem Abschluss einer Single-Geräte-Session erhöht die App automatisch
+das Dokument `gyms/{gymId}/devices/{deviceId}/userXp/{userId}` um einen Punkt.
+Diese Werte können in einer Rangliste pro Gerät eingesehen werden.
 

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -8,6 +8,7 @@ import 'package:tapem/features/device/presentation/screens/device_screen.dart';
 import 'package:tapem/features/device/presentation/screens/exercise_list_screen.dart';
 import 'package:tapem/features/history/presentation/screens/history_screen.dart';
 import 'package:tapem/features/home/presentation/screens/home_screen.dart';
+import 'package:tapem/features/rank/presentation/screens/rank_screen.dart';
 import 'package:tapem/features/report/presentation/screens/report_screen.dart';
 import 'package:tapem/features/splash/presentation/screens/splash_screen.dart';
 import 'package:tapem/features/training_details/presentation/screens/training_details_screen.dart';
@@ -19,6 +20,7 @@ class AppRouter {
   static const device          = '/device';
   static const exerciseList    = '/exercise_list';
   static const history         = '/history';
+  static const rank            = '/rank';
   static const report          = '/report';
   static const admin           = '/admin';
   static const affiliate       = '/affiliate';
@@ -61,6 +63,15 @@ class AppRouter {
         final deviceId = settings.arguments as String? ?? '';
         return MaterialPageRoute(
           builder: (_) => HistoryScreen(deviceId: deviceId),
+        );
+
+      case rank:
+        final args = settings.arguments as Map<String, String>;
+        return MaterialPageRoute(
+          builder: (_) => RankScreen(
+            gymId: args['gymId']!,
+            deviceId: args['deviceId']!,
+          ),
         );
 
       case report:

--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -125,6 +125,19 @@ class DeviceProvider extends ChangeNotifier {
       .collection('userNotes').doc(userId);
     batch.set(noteDoc, {'note': _note, 'updatedAt': ts});
 
+    // XP hochzählen für Single-Geräte
+    if (!_device!.isMulti) {
+      final xpDoc = _firestore
+          .collection('gyms').doc(gymId)
+          .collection('devices').doc(_device!.id)
+          .collection('userXp').doc(userId);
+      batch.set(
+        xpDoc,
+        {'xp': FieldValue.increment(1)},
+        SetOptions(merge: true),
+      );
+    }
+
     await batch.commit();
 
     // Lokal aktualisieren

--- a/lib/core/providers/rank_provider.dart
+++ b/lib/core/providers/rank_provider.dart
@@ -1,0 +1,67 @@
+// lib/core/providers/rank_provider.dart
+
+import 'package:flutter/foundation.dart';
+import 'package:tapem/features/rank/data/repositories/rank_repository_impl.dart';
+import 'package:tapem/features/rank/data/sources/firestore_rank_source.dart';
+import 'package:tapem/features/rank/data/device_xp.dart';
+
+class RankProvider extends ChangeNotifier {
+  final RankRepositoryImpl _repo;
+
+  RankProvider({RankRepositoryImpl? repo})
+      : _repo = repo ?? RankRepositoryImpl(FirestoreRankSource());
+
+  bool _isLoading = false;
+  String? _error;
+  DeviceXp? _userXp;
+  List<MapEntry<String, DeviceXp>> _leaderboard = [];
+
+  bool get isLoading => _isLoading;
+  String? get error => _error;
+  DeviceXp? get userXp => _userXp;
+  List<MapEntry<String, DeviceXp>> get leaderboard => List.unmodifiable(_leaderboard);
+
+  Future<void> loadUserXp({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+  }) async {
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      _userXp = await _repo.getUserXp(
+        gymId: gymId,
+        deviceId: deviceId,
+        userId: userId,
+      );
+    } catch (e, st) {
+      _error = e.toString();
+      debugPrintStack(label: 'RankProvider.loadUserXp', stackTrace: st);
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadLeaderboard({
+    required String gymId,
+    required String deviceId,
+  }) async {
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      _leaderboard = await _repo.getLeaderboard(
+        gymId: gymId,
+        deviceId: deviceId,
+      );
+    } catch (e, st) {
+      _error = e.toString();
+      debugPrintStack(label: 'RankProvider.loadLeaderboard', stackTrace: st);
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+}

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -7,6 +7,7 @@ import 'package:intl/intl.dart';
 import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/core/providers/device_provider.dart';
+import 'package:tapem/core/providers/rank_provider.dart';
 import '../widgets/rest_timer_widget.dart';
 import '../widgets/note_button_widget.dart';
 
@@ -40,6 +41,11 @@ class _DeviceScreenState extends State<DeviceScreen> {
         deviceId:   widget.deviceId,
         exerciseId: widget.exerciseId,
         userId:     auth.userId!,
+      );
+      context.read<RankProvider>().loadUserXp(
+        gymId: widget.gymId,
+        deviceId: widget.deviceId,
+        userId: auth.userId!,
       );
     });
   }
@@ -91,6 +97,17 @@ class _DeviceScreenState extends State<DeviceScreen> {
               arguments: widget.deviceId,
             ),
           ),
+          IconButton(
+            icon: const Icon(Icons.leaderboard),
+            tooltip: 'Rangliste',
+            onPressed: () => Navigator.of(context).pushNamed(
+              AppRouter.rank,
+              arguments: {
+                'gymId': widget.gymId,
+                'deviceId': widget.deviceId,
+              },
+            ),
+          ),
         ],
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
@@ -110,6 +127,13 @@ class _DeviceScreenState extends State<DeviceScreen> {
                         style: const TextStyle(color: Colors.black54)),
                       const SizedBox(height: 16),
                     ],
+                    Consumer<RankProvider>(
+                      builder: (_, rp, __) => Text(
+                        'XP: ${rp.userXp?.xp ?? 0}',
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
                     if (prov.lastSessionSets.isNotEmpty) ...[
                       Card(
                         margin: const EdgeInsets.symmetric(vertical: 8),

--- a/lib/features/rank/data/device_xp.dart
+++ b/lib/features/rank/data/device_xp.dart
@@ -1,0 +1,24 @@
+// lib/features/rank/data/device_xp.dart
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Modell für Erfahrungspunkte an einem Gerät
+class DeviceXp {
+  final int xp;
+  final DateTime? updatedAt;
+
+  DeviceXp({required this.xp, this.updatedAt});
+
+  factory DeviceXp.fromDocument(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data() ?? {};
+    return DeviceXp(
+      xp: data['xp'] as int? ?? 0,
+      updatedAt: (data['updatedAt'] as Timestamp?)?.toDate(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'xp': xp,
+        if (updatedAt != null) 'updatedAt': Timestamp.fromDate(updatedAt!),
+      };
+}

--- a/lib/features/rank/data/repositories/rank_repository_impl.dart
+++ b/lib/features/rank/data/repositories/rank_repository_impl.dart
@@ -1,0 +1,42 @@
+// lib/features/rank/data/repositories/rank_repository_impl.dart
+
+import '../device_xp.dart';
+import '../sources/firestore_rank_source.dart';
+
+class RankRepositoryImpl {
+  final FirestoreRankSource _source;
+  RankRepositoryImpl(this._source);
+
+  Future<DeviceXp?> getUserXp({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+  }) {
+    return _source.getUserXp(
+      gymId: gymId,
+      deviceId: deviceId,
+      userId: userId,
+    );
+  }
+
+  Future<void> updateUserXp({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    required int increment,
+  }) {
+    return _source.updateUserXp(
+      gymId: gymId,
+      deviceId: deviceId,
+      userId: userId,
+      increment: increment,
+    );
+  }
+
+  Future<List<MapEntry<String, DeviceXp>>> getLeaderboard({
+    required String gymId,
+    required String deviceId,
+  }) {
+    return _source.getLeaderboard(gymId: gymId, deviceId: deviceId);
+  }
+}

--- a/lib/features/rank/data/sources/firestore_rank_source.dart
+++ b/lib/features/rank/data/sources/firestore_rank_source.dart
@@ -1,0 +1,56 @@
+// lib/features/rank/data/sources/firestore_rank_source.dart
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../device_xp.dart';
+
+class FirestoreRankSource {
+  final FirebaseFirestore _firestore;
+
+  FirestoreRankSource([FirebaseFirestore? firestore])
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  Future<DeviceXp?> getUserXp({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+  }) async {
+    final snap = await _firestore
+        .collection('gyms').doc(gymId)
+        .collection('devices').doc(deviceId)
+        .collection('userXp').doc(userId)
+        .get();
+    if (!snap.exists) return null;
+    return DeviceXp.fromDocument(snap);
+  }
+
+  Future<void> updateUserXp({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    required int increment,
+  }) async {
+    final doc = _firestore
+        .collection('gyms').doc(gymId)
+        .collection('devices').doc(deviceId)
+        .collection('userXp').doc(userId);
+    await doc.set({
+      'xp': FieldValue.increment(increment),
+      'updatedAt': Timestamp.now(),
+    }, SetOptions(merge: true));
+  }
+
+  Future<List<MapEntry<String, DeviceXp>>> getLeaderboard({
+    required String gymId,
+    required String deviceId,
+  }) async {
+    final snap = await _firestore
+        .collection('gyms').doc(gymId)
+        .collection('devices').doc(deviceId)
+        .collection('userXp')
+        .orderBy('xp', descending: true)
+        .get();
+    return snap.docs
+        .map((d) => MapEntry(d.id, DeviceXp.fromDocument(d)))
+        .toList();
+  }
+}

--- a/lib/features/rank/presentation/screens/rank_screen.dart
+++ b/lib/features/rank/presentation/screens/rank_screen.dart
@@ -1,0 +1,50 @@
+// lib/features/rank/presentation/screens/rank_screen.dart
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../../core/providers/rank_provider.dart';
+
+class RankScreen extends StatefulWidget {
+  final String gymId;
+  final String deviceId;
+  const RankScreen({Key? key, required this.gymId, required this.deviceId}) : super(key: key);
+
+  @override
+  State<RankScreen> createState() => _RankScreenState();
+}
+
+class _RankScreenState extends State<RankScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<RankProvider>().loadLeaderboard(
+            gymId: widget.gymId,
+            deviceId: widget.deviceId,
+          );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final prov = context.watch<RankProvider>();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Rangliste')),
+      body: prov.isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView.builder(
+              itemCount: prov.leaderboard.length,
+              itemBuilder: (_, idx) {
+                final entry = prov.leaderboard[idx];
+                return ListTile(
+                  leading: Text('#${idx + 1}'),
+                  title: Text(entry.key),
+                  trailing: Text('${entry.value.xp} XP'),
+                );
+              },
+            ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- support per-device XP in README docs
- model DeviceXp for Firestore userXp docs
- source, repository and provider for XP handling
- update DeviceProvider to increment XP when saving
- show XP and link to leaderboard in DeviceScreen
- add RankScreen and routing

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6857ac36990c8320942b3309873d47aa