### PR TITLE
Implement per-user plan filtering

### DIFF
--- a/lib/core/providers/training_plan_provider.dart
+++ b/lib/core/providers/training_plan_provider.dart
@@ -22,12 +22,12 @@ class TrainingPlanProvider extends ChangeNotifier {
   TrainingPlanProvider({TrainingPlanRepository? repo})
     : _repo = repo ?? TrainingPlanRepositoryImpl(FirestoreTrainingPlanSource());
 
-  Future<void> loadPlans(String gymId) async {
+  Future<void> loadPlans(String gymId, String userId) async {
     isLoading = true;
     error = null;
     notifyListeners();
     try {
-      plans = await _repo.getPlans(gymId);
+      plans = await _repo.getPlans(gymId, userId);
     } catch (e) {
       error = e.toString();
     } finally {

--- a/lib/features/training_plan/data/repositories/training_plan_repository_impl.dart
+++ b/lib/features/training_plan/data/repositories/training_plan_repository_impl.dart
@@ -9,8 +9,8 @@ class TrainingPlanRepositoryImpl implements TrainingPlanRepository {
   TrainingPlanRepositoryImpl(this._source);
 
   @override
-  Future<List<TrainingPlan>> getPlans(String gymId) async {
-    final dtos = await _source.getPlans(gymId);
+  Future<List<TrainingPlan>> getPlans(String gymId, String userId) async {
+    final dtos = await _source.getPlans(gymId, userId);
     return dtos.map((d) => d.toModel()).toList();
   }
 

--- a/lib/features/training_plan/data/sources/firestore_training_plan_source.dart
+++ b/lib/features/training_plan/data/sources/firestore_training_plan_source.dart
@@ -14,8 +14,11 @@ class FirestoreTrainingPlanSource {
   CollectionReference<Map<String, dynamic>> _plansCol(String gymId) =>
       _firestore.collection('gyms').doc(gymId).collection('trainingPlans');
 
-  Future<List<TrainingPlanDto>> getPlans(String gymId) async {
-    final snap = await _plansCol(gymId).orderBy('name').get();
+  Future<List<TrainingPlanDto>> getPlans(String gymId, String userId) async {
+    final snap = await _plansCol(gymId)
+        .where('createdBy', isEqualTo: userId)
+        .orderBy('name')
+        .get();
     final List<TrainingPlanDto> plans = [];
     for (final doc in snap.docs) {
       final weeks = await _loadWeeks(doc.reference);

--- a/lib/features/training_plan/domain/repositories/training_plan_repository.dart
+++ b/lib/features/training_plan/domain/repositories/training_plan_repository.dart
@@ -1,6 +1,6 @@
 import '../models/training_plan.dart';
 
 abstract class TrainingPlanRepository {
-  Future<List<TrainingPlan>> getPlans(String gymId);
+  Future<List<TrainingPlan>> getPlans(String gymId, String userId);
   Future<void> savePlan(String gymId, TrainingPlan plan);
 }

--- a/lib/features/training_plan/presentation/screens/plan_overview_screen.dart
+++ b/lib/features/training_plan/presentation/screens/plan_overview_screen.dart
@@ -18,9 +18,10 @@ class _PlanOverviewScreenState extends State<PlanOverviewScreen> {
   void initState() {
     super.initState();
     final gymId = context.read<AuthProvider>().gymCode;
-    if (gymId != null) {
+    final userId = context.read<AuthProvider>().userId;
+    if (gymId != null && userId != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        context.read<TrainingPlanProvider>().loadPlans(gymId);
+        context.read<TrainingPlanProvider>().loadPlans(gymId, userId);
       });
     }
   }


### PR DESCRIPTION
## Summary
- add userId filtering when listing training plans
- propagate userId through repository and provider
- load plans with userId in overview screen

## Testing
- `npm test` *(fails: Error no test specified)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f5a06bb308320bfb08d65e417c35e