### PR TITLE
Implement start date for training plans

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -8,6 +8,8 @@ import 'package:intl/intl.dart';
 import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/core/providers/device_provider.dart';
+import 'package:tapem/core/providers/training_plan_provider.dart';
+import '../../training_plan/domain/models/exercise_entry.dart';
 import '../widgets/rest_timer_widget.dart';
 import '../widgets/note_button_widget.dart';
 
@@ -151,6 +153,31 @@ class _DeviceScreenState extends State<DeviceScreen> {
                       ),
                     ],
                     const Divider(),
+                    if (context.read<TrainingPlanProvider>().entryForDate(
+                            widget.deviceId,
+                            widget.exerciseId,
+                            DateTime.now(),
+                          ) !=
+                        null) ...[
+                      const Text(
+                        'Heute dran',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      _PlannedTable(
+                        entry: context
+                            .read<TrainingPlanProvider>()
+                            .entryForDate(
+                              widget.deviceId,
+                              widget.exerciseId,
+                              DateTime.now(),
+                            )!,
+                      ),
+                      const Divider(),
+                    ],
                     const Text(
                       'Neue Session',
                       style: TextStyle(
@@ -292,6 +319,35 @@ class _DeviceScreenState extends State<DeviceScreen> {
           ),
         ],
       ),
+    );
+  }
+}
+
+class _PlannedTable extends StatelessWidget {
+  final ExerciseEntry entry;
+
+  const _PlannedTable({required this.entry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Table(
+      columnWidths: const {
+        0: IntrinsicColumnWidth(),
+        1: FlexColumnWidth(),
+      },
+      children: [
+        for (var i = 0; i < entry.totalSets; i++)
+          TableRow(children: [
+            Padding(
+              padding: const EdgeInsets.all(4),
+              child: Text(entry.setType),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(4),
+              child: Text('Pause ${entry.restInSeconds}s RIR ${entry.rir}'),
+            ),
+          ])
+      ],
     );
   }
 }

--- a/lib/features/training_plan/data/dtos/training_plan_dto.dart
+++ b/lib/features/training_plan/data/dtos/training_plan_dto.dart
@@ -10,6 +10,7 @@ class TrainingPlanDto {
   final String name;
   final DateTime createdAt;
   final String createdBy;
+  final DateTime startDate;
   final List<WeekBlock> weeks;
 
   TrainingPlanDto({
@@ -18,6 +19,7 @@ class TrainingPlanDto {
     required this.createdAt,
     required this.createdBy,
     required this.weeks,
+    required this.startDate,
   });
 
   factory TrainingPlanDto.fromDoc(
@@ -30,6 +32,7 @@ class TrainingPlanDto {
       name: data['name'] as String? ?? '',
       createdAt: (data['createdAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
       createdBy: data['createdBy'] as String? ?? '',
+      startDate: (data['startDate'] as Timestamp?)?.toDate() ?? DateTime.now(),
       weeks:
           weeks ??
           (data['weeks'] as List<dynamic>? ?? [])
@@ -42,6 +45,7 @@ class TrainingPlanDto {
     'name': name,
     'createdAt': Timestamp.fromDate(createdAt),
     'createdBy': createdBy,
+    'startDate': Timestamp.fromDate(startDate),
   };
 
   TrainingPlan toModel() => TrainingPlan(
@@ -49,6 +53,7 @@ class TrainingPlanDto {
     name: name,
     createdAt: createdAt,
     createdBy: createdBy,
+    startDate: startDate,
     weeks: weeks,
   );
 
@@ -57,6 +62,7 @@ class TrainingPlanDto {
     name: plan.name,
     createdAt: plan.createdAt,
     createdBy: plan.createdBy,
+    startDate: plan.startDate,
     weeks: plan.weeks,
   );
 }

--- a/lib/features/training_plan/domain/models/day_entry.dart
+++ b/lib/features/training_plan/domain/models/day_entry.dart
@@ -1,21 +1,23 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 import 'exercise_entry.dart';
 
 class DayEntry {
-  final String day; // z.B. 'Mo', 'Do'
+  final DateTime date;
   final List<ExerciseEntry> exercises;
 
-  DayEntry({required this.day, required List<ExerciseEntry> exercises})
+  DayEntry({required this.date, required List<ExerciseEntry> exercises})
       : exercises = List.from(exercises);
 
   factory DayEntry.fromMap(Map<String, dynamic> map) => DayEntry(
-        day: map['day'] as String? ?? '',
+        date: (map['date'] as Timestamp).toDate(),
         exercises: (map['exercises'] as List<dynamic>? ?? [])
             .map((e) => ExerciseEntry.fromMap(e as Map<String, dynamic>))
             .toList(),
       );
 
   Map<String, dynamic> toMap() => {
-        'day': day,
+        'date': Timestamp.fromDate(date),
         'exercises': exercises.map((e) => e.toMap()).toList(),
       };
 }

--- a/lib/features/training_plan/domain/models/training_plan.dart
+++ b/lib/features/training_plan/domain/models/training_plan.dart
@@ -7,6 +7,7 @@ class TrainingPlan {
   final String name;
   final DateTime createdAt;
   final String createdBy;
+  final DateTime startDate;
   final List<WeekBlock> weeks;
 
   TrainingPlan({
@@ -15,6 +16,7 @@ class TrainingPlan {
     required this.createdAt,
     required this.createdBy,
     required List<WeekBlock> weeks,
+    required this.startDate,
   }) : weeks = List.from(weeks);
 
   TrainingPlan copyWith({
@@ -23,12 +25,14 @@ class TrainingPlan {
     DateTime? createdAt,
     String? createdBy,
     List<WeekBlock>? weeks,
+    DateTime? startDate,
   }) {
     return TrainingPlan(
       id: id ?? this.id,
       name: name ?? this.name,
       createdAt: createdAt ?? this.createdAt,
       createdBy: createdBy ?? this.createdBy,
+      startDate: startDate ?? this.startDate,
       weeks: weeks ?? this.weeks,
     );
   }
@@ -39,6 +43,7 @@ class TrainingPlan {
         name: map['name'] as String? ?? '',
         createdAt: (map['createdAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
         createdBy: map['createdBy'] as String? ?? '',
+        startDate: (map['startDate'] as Timestamp?)?.toDate() ?? DateTime.now(),
         weeks:
             (map['weeks'] as List<dynamic>? ?? [])
                 .map((e) => WeekBlock.fromMap(e as Map<String, dynamic>))
@@ -49,6 +54,7 @@ class TrainingPlan {
     'name': name,
     'createdAt': Timestamp.fromDate(createdAt),
     'createdBy': createdBy,
+    'startDate': Timestamp.fromDate(startDate),
     'weeks': weeks.map((w) => w.toMap()).toList(),
   };
 }

--- a/lib/features/training_plan/presentation/screens/import_plan_screen.dart
+++ b/lib/features/training_plan/presentation/screens/import_plan_screen.dart
@@ -118,7 +118,13 @@ class _ImportPlanScreenState extends State<ImportPlanScreen> {
     final repsIdx = headerMap['reps']!;
     final prov = context.read<TrainingPlanProvider>();
     final userId = context.read<AuthProvider>().userId!;
-    prov.createNewPlan('Import', userId);
+    prov.createNewPlan(
+      'Import',
+      userId,
+      startDate: DateTime.now(),
+      weeks: 4,
+      week1Dates: [DateTime.now()],
+    );
     for (var row in data.skip(1)) {
       final week = int.tryParse(row[weekIdx].toString()) ?? 1;
       final day = row[dayIdx].toString();


### PR DESCRIPTION
## Summary
- extend data models with `startDate` and `date` fields
- persist new fields in Firestore source
- update training plan provider and editor UI for calendar based plan creation
- show planned sets on device screen when a plan entry exists for today

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f6146f31083209890819bdaa1dc76