### PR TITLE
Fix provider class bracket and import path

### DIFF
--- a/lib/core/providers/training_plan_provider.dart
+++ b/lib/core/providers/training_plan_provider.dart
@@ -81,7 +81,6 @@ class TrainingPlanProvider extends ChangeNotifier {
     );
     notifyListeners();
   }
-  }
 
   void addExercise(int week, DateTime day, ExerciseEntry entry) {
     final w = currentPlan?.weeks.firstWhere((e) => e.weekNumber == week);

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -9,7 +9,7 @@ import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/core/providers/device_provider.dart';
 import 'package:tapem/core/providers/training_plan_provider.dart';
-import '../../training_plan/domain/models/exercise_entry.dart';
+import '../../../training_plan/domain/models/exercise_entry.dart';
 import '../widgets/rest_timer_widget.dart';
 import '../widgets/note_button_widget.dart';
 


### PR DESCRIPTION
## Summary
- fix stray bracket in `TrainingPlanProvider`
- correct import path for `ExerciseEntry`

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_685f63ce6fc88320bfe52af441d7853b