### PR TITLE
Fix import plan screen

### DIFF
--- a/lib/features/training_plan/presentation/screens/import_plan_screen.dart
+++ b/lib/features/training_plan/presentation/screens/import_plan_screen.dart
@@ -122,9 +122,7 @@ class _ImportPlanScreenState extends State<ImportPlanScreen> {
     prov.createNewPlan(
       'Import',
       userId,
-      startDate: DateTime.now(),
       weeks: 4,
-      week1Dates: [DateTime.now()],
     );
     for (var row in data.skip(1)) {
       final week = int.tryParse(row[weekIdx].toString()) ?? 1;


### PR DESCRIPTION
## Summary
- remove obsolete parameters from `createNewPlan` call in `ImportPlanScreen`

## Testing
- `flutter test` *(fails: command not found)*
- `npx mocha firestore-tests/security_rules.test.js` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685f74a8a2bc8320b8690cf43c8457da