### PR TITLE
Implement training plan management

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,9 +1,24 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    // Erlaubt globale Lese- und Schreibzugriffe auf alle Dokumente:
-    match /{document=**} {
-      allow read, write: if true;
+    match /gyms/{gymId} {
+      match /trainingPlans/{planId}/{document=**} {
+        allow read, write: if request.auth != null &&
+          request.auth.token.gymId == gymId &&
+          request.auth.uid == resource.data.createdBy;
+      }
+      match /trainingPlans/{planId} {
+        allow create: if request.auth != null &&
+          request.auth.token.gymId == gymId &&
+          request.resource.data.createdBy == request.auth.uid;
+        allow read, update, delete: if request.auth != null &&
+          request.auth.token.gymId == gymId &&
+          request.auth.uid == resource.data.createdBy;
+      }
+      match /{document=**} {
+        allow read, write: if request.auth != null &&
+          request.auth.token.gymId == gymId;
+      }
     }
   }
 }

--- a/lib/core/providers/training_plan_provider.dart
+++ b/lib/core/providers/training_plan_provider.dart
@@ -156,11 +156,36 @@ class TrainingPlanProvider extends ChangeNotifier {
     notifyListeners();
     try {
       await _repo.savePlan(gymId, currentPlan!);
+      plans = await _repo.getPlans(gymId, currentPlan!.createdBy);
     } catch (e) {
       error = 'Fehler beim Speichern: ' + e.toString();
     } finally {
       isSaving = false;
       notifyListeners();
     }
+  }
+
+  Future<void> renamePlan(
+    String gymId,
+    String planId,
+    String newName,
+  ) async {
+    await _repo.renamePlan(gymId, planId, newName);
+    final idx = plans.indexWhere((p) => p.id == planId);
+    if (idx >= 0) {
+      plans[idx] = plans[idx].copyWith(name: newName);
+    }
+    notifyListeners();
+  }
+
+  Future<void> deletePlan(String gymId, String planId) async {
+    await _repo.deletePlan(gymId, planId);
+    plans.removeWhere((p) => p.id == planId);
+    if (activePlanId == planId) {
+      activePlanId = null;
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove('activePlanId');
+    }
+    notifyListeners();
   }
 }

--- a/lib/features/training_plan/data/repositories/training_plan_repository_impl.dart
+++ b/lib/features/training_plan/data/repositories/training_plan_repository_impl.dart
@@ -19,4 +19,18 @@ class TrainingPlanRepositoryImpl implements TrainingPlanRepository {
     final dto = TrainingPlanDto.fromModel(plan);
     await _source.savePlan(gymId, dto);
   }
+
+  @override
+  Future<void> renamePlan(
+    String gymId,
+    String planId,
+    String newName,
+  ) async {
+    await _source.renamePlan(gymId, planId, newName);
+  }
+
+  @override
+  Future<void> deletePlan(String gymId, String planId) async {
+    await _source.deletePlan(gymId, planId);
+  }
 }

--- a/lib/features/training_plan/data/sources/firestore_training_plan_source.dart
+++ b/lib/features/training_plan/data/sources/firestore_training_plan_source.dart
@@ -88,4 +88,16 @@ class FirestoreTrainingPlanSource {
       }
     }
   }
+
+  Future<void> renamePlan(
+    String gymId,
+    String planId,
+    String newName,
+  ) async {
+    await _plansCol(gymId).doc(planId).update({'name': newName});
+  }
+
+  Future<void> deletePlan(String gymId, String planId) async {
+    await _plansCol(gymId).doc(planId).delete();
+  }
 }

--- a/lib/features/training_plan/domain/repositories/training_plan_repository.dart
+++ b/lib/features/training_plan/domain/repositories/training_plan_repository.dart
@@ -3,4 +3,11 @@ import '../models/training_plan.dart';
 abstract class TrainingPlanRepository {
   Future<List<TrainingPlan>> getPlans(String gymId, String userId);
   Future<void> savePlan(String gymId, TrainingPlan plan);
+  Future<void> renamePlan(
+    String gymId,
+    String planId,
+    String newName,
+  );
+
+  Future<void> deletePlan(String gymId, String planId);
 }


### PR DESCRIPTION
## Summary
- add rename and delete operations to training plan repository
- allow selecting active plan and managing plans in overview screen
- persist changes in training plan provider
- secure firestore rules using gymId and createdBy
- remove unused `trainingsplan_screen.dart`

## Testing
- `npm test --silent` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685f7d3a370c8320aa65e2b5ce589afa