### PR TITLE
Add optional RIR and note per set

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -130,6 +130,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                               const SizedBox(height: 8),
                               for (var set in prov.lastSessionSets)
                                 Row(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
                                   children: [
                                     SizedBox(
                                       width: 24,
@@ -141,6 +142,16 @@ class _DeviceScreenState extends State<DeviceScreen> {
                                     ),
                                     const SizedBox(width: 16),
                                     Text('${set['reps']} x'),
+                                    if (set['rir'] != null && set['rir']!.isNotEmpty) ...[
+                                      const SizedBox(width: 16),
+                                      Text('RIR ${set['rir']}'),
+                                    ],
+                                    if (set['note'] != null && set['note']!.isNotEmpty) ...[
+                                      const SizedBox(width: 16),
+                                      Expanded(
+                                        child: Text(set['note']!),
+                                      ),
+                                    ],
                                   ],
                                 ),
                               if (prov.lastSessionNote.isNotEmpty) ...[
@@ -198,8 +209,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                                 onChanged: (v) {
                                   prov.updateSet(
                                     entry.key,
-                                    v,
-                                    entry.value['reps']!,
+                                    weight: v,
                                   );
                                 },
                                 validator: (v) {
@@ -225,8 +235,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                                 onChanged: (v) {
                                   prov.updateSet(
                                     entry.key,
-                                    entry.value['weight']!,
-                                    v,
+                                    reps: v,
                                   );
                                 },
                                 validator: (v) {
@@ -237,6 +246,40 @@ class _DeviceScreenState extends State<DeviceScreen> {
                                     return 'Ganzzahl';
                                   }
                                   return null;
+                                },
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: TextFormField(
+                                initialValue: entry.value['rir'],
+                                decoration: const InputDecoration(
+                                  labelText: 'RIR',
+                                  isDense: true,
+                                ),
+                                keyboardType: TextInputType.number,
+                                onChanged: (v) {
+                                  prov.updateSet(
+                                    entry.key,
+                                    rir: v,
+                                  );
+                                },
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              flex: 2,
+                              child: TextFormField(
+                                initialValue: entry.value['note'],
+                                decoration: const InputDecoration(
+                                  labelText: 'Notiz',
+                                  isDense: true,
+                                ),
+                                onChanged: (v) {
+                                  prov.updateSet(
+                                    entry.key,
+                                    note: v,
+                                  );
                                 },
                               ),
                             ),

--- a/lib/features/history/data/dtos/workout_log_dto.dart
+++ b/lib/features/history/data/dtos/workout_log_dto.dart
@@ -22,6 +22,8 @@ class WorkoutLogDto {
 
   final int weight;
   final int reps;
+  final int? rir;
+  final String? note;
 
   WorkoutLogDto({
     required this.userId,
@@ -29,6 +31,8 @@ class WorkoutLogDto {
     required this.timestamp,
     required this.weight,
     required this.reps,
+    this.rir,
+    this.note,
   });
 
   factory WorkoutLogDto.fromJson(Map<String, dynamic> json) =>
@@ -52,6 +56,8 @@ class WorkoutLogDto {
         timestamp: timestamp,
         weight: weight,
         reps: reps,
+        rir: rir,
+        note: note,
       );
 
   static DateTime _timestampToDate(Timestamp ts) => ts.toDate();

--- a/lib/features/history/data/dtos/workout_log_dto.g.dart
+++ b/lib/features/history/data/dtos/workout_log_dto.g.dart
@@ -13,6 +13,8 @@ WorkoutLogDto _$WorkoutLogDtoFromJson(Map<String, dynamic> json) =>
       timestamp: WorkoutLogDto._timestampToDate(json['timestamp'] as Timestamp),
       weight: (json['weight'] as num).toInt(),
       reps: (json['reps'] as num).toInt(),
+      rir: json['rir'] as int?,
+      note: json['setNote'] as String?,
     );
 
 Map<String, dynamic> _$WorkoutLogDtoToJson(WorkoutLogDto instance) =>
@@ -22,4 +24,6 @@ Map<String, dynamic> _$WorkoutLogDtoToJson(WorkoutLogDto instance) =>
       'timestamp': WorkoutLogDto._dateToTimestamp(instance.timestamp),
       'weight': instance.weight,
       'reps': instance.reps,
+      if (instance.rir != null) 'rir': instance.rir,
+      if (instance.note != null) 'setNote': instance.note,
     };

--- a/lib/features/history/domain/models/workout_log.dart
+++ b/lib/features/history/domain/models/workout_log.dart
@@ -8,6 +8,8 @@ class WorkoutLog {
   final DateTime timestamp;
   final int weight;
   final int reps;
+  final int? rir;
+  final String? note;
 
   WorkoutLog({
     required this.id,
@@ -16,5 +18,7 @@ class WorkoutLog {
     required this.timestamp,
     required this.weight,
     required this.reps,
+    this.rir,
+    this.note,
   });
 }

--- a/lib/features/history/presentation/screens/history_screen.dart
+++ b/lib/features/history/presentation/screens/history_screen.dart
@@ -182,6 +182,15 @@ class _HistoryScreenState extends State<HistoryScreen> {
                       children: logs
                           .map((log) => ListTile(
                                 title: Text('${log.weight} kg × ${log.reps} Wdh.'),
+                                subtitle: Row(
+                                  children: [
+                                    if (log.rir != null) Text('RIR ${log.rir}'),
+                                    if (log.note != null && log.note!.isNotEmpty) ...[
+                                      if (log.rir != null) const SizedBox(width: 8),
+                                      Expanded(child: Text(log.note!)),
+                                    ],
+                                  ],
+                                ),
                               ))
                           .toList(),
                     ),


### PR DESCRIPTION
## Summary
- extend workout log model & DTOs with `rir` and `note`
- allow entering RIR and set notes for new sessions
- show RIR and notes of last session and in history
- fix transaction order in leaderboard update

## Testing
- `flutter format lib/core/providers/device_provider.dart` *(fails: command not found)*
- `dart format lib/core/providers/device_provider.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb6ef0ab883209fb1312aba57d553