### PR TITLE
Fix optional RIR/note inputs and transaction handling

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -210,7 +210,11 @@ class DeviceProvider extends ChangeNotifier {
 
     // Leaderboard aktualisieren, nur bei Einzelgeräten und Opt-in
     if (!_device!.isMulti && showInLeaderboard) {
-      await _updateLeaderboard(gymId, userId, showInLeaderboard);
+      try {
+        await _updateLeaderboard(gymId, userId, showInLeaderboard);
+      } catch (e, st) {
+        debugPrintStack(label: '_updateLeaderboard', stackTrace: st);
+      }
     }
 
     // Lokalen State zurücksetzen

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -417,8 +417,8 @@ class _PlannedTable extends StatelessWidget {
                     keyboardType: TextInputType.number,
                     onChanged: (v) => prov.updateSet(
                       i,
-                      v,
-                      prov.sets[i]['reps']!,
+                      weight: v,
+                      reps: prov.sets[i]['reps']!,
                     ),
                     validator: (v) {
                       if (v == null || v.isEmpty) return 'Gewicht?';
@@ -438,8 +438,8 @@ class _PlannedTable extends StatelessWidget {
                     keyboardType: TextInputType.number,
                     onChanged: (v) => prov.updateSet(
                       i,
-                      prov.sets[i]['weight']!,
-                      v,
+                      weight: prov.sets[i]['weight']!,
+                      reps: v,
                     ),
                     validator: (v) {
                       if (v == null || v.isEmpty) return 'Wdh.?';


### PR DESCRIPTION
## Summary
- fix `updateSet` calls to use named parameters
- guard leaderboard update so failed transactions don't stop session saving

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb99cbe78832087369df542cde357