### PR TITLE
Align training plan UI with device sets

### DIFF
--- a/lib/core/providers/training_plan_provider.dart
+++ b/lib/core/providers/training_plan_provider.dart
@@ -57,9 +57,20 @@ class TrainingPlanProvider extends ChangeNotifier {
     String createdBy, {
     required int weeks,
   }) {
+    final now = DateTime.now();
+    final monday = now.subtract(Duration(days: now.weekday - 1));
     final weekBlocks = [
       for (var i = 0; i < weeks; i++)
-        WeekBlock(weekNumber: i + 1, days: [])
+        WeekBlock(
+          weekNumber: i + 1,
+          days: [
+            for (var d = 0; d < 7; d++)
+              DayEntry(
+                date: monday.add(Duration(days: i * 7 + d)),
+                exercises: [],
+              )
+          ],
+        )
     ];
 
     currentPlan = TrainingPlan(

--- a/lib/features/training_plan/domain/models/exercise_entry.dart
+++ b/lib/features/training_plan/domain/models/exercise_entry.dart
@@ -1,3 +1,5 @@
+import 'planned_set.dart';
+
 class ExerciseEntry {
   final String deviceId;
   final String exerciseId;
@@ -9,6 +11,7 @@ class ExerciseEntry {
   final int rir;
   final int restInSeconds;
   final String? notes;
+  final List<PlannedSet> sets;
 
   ExerciseEntry({
     required this.deviceId,
@@ -21,7 +24,8 @@ class ExerciseEntry {
     required this.rir,
     required this.restInSeconds,
     this.notes,
-  });
+    List<PlannedSet>? sets,
+  }) : sets = List.from(sets ?? []);
 
   factory ExerciseEntry.fromMap(Map<String, dynamic> map) => ExerciseEntry(
     deviceId: map['deviceId'] as String,
@@ -34,6 +38,9 @@ class ExerciseEntry {
     rir: (map['rir'] as num?)?.toInt() ?? 0,
     restInSeconds: (map['restInSeconds'] as num?)?.toInt() ?? 0,
     notes: map['notes'] as String?,
+    sets: (map['sets'] as List<dynamic>? ?? [])
+        .map((e) => PlannedSet.fromMap(e as Map<String, dynamic>))
+        .toList(),
   );
 
   Map<String, dynamic> toMap() => {
@@ -47,5 +54,6 @@ class ExerciseEntry {
     'rir': rir,
     'restInSeconds': restInSeconds,
     if (notes != null) 'notes': notes,
+    'sets': sets.map((s) => s.toMap()).toList(),
   };
 }

--- a/lib/features/training_plan/domain/models/planned_set.dart
+++ b/lib/features/training_plan/domain/models/planned_set.dart
@@ -1,0 +1,27 @@
+class PlannedSet {
+  final double weight;
+  final int reps;
+  final int? rir;
+  final String? note;
+
+  PlannedSet({
+    required this.weight,
+    required this.reps,
+    this.rir,
+    this.note,
+  });
+
+  factory PlannedSet.fromMap(Map<String, dynamic> map) => PlannedSet(
+        weight: (map['weight'] as num?)?.toDouble() ?? 0,
+        reps: (map['reps'] as num?)?.toInt() ?? 0,
+        rir: (map['rir'] as num?)?.toInt(),
+        note: map['note'] as String?,
+      );
+
+  Map<String, dynamic> toMap() => {
+        'weight': weight,
+        'reps': reps,
+        if (rir != null) 'rir': rir,
+        if (note != null && note!.isNotEmpty) 'note': note,
+      };
+}

--- a/lib/features/training_plan/presentation/screens/import_plan_screen.dart
+++ b/lib/features/training_plan/presentation/screens/import_plan_screen.dart
@@ -150,6 +150,18 @@ class _ImportPlanScreenState extends State<ImportPlanScreen> {
             headerMap.containsKey('notiz')
                 ? row[headerMap['notiz']!].toString()
                 : '',
+        sets: [
+          PlannedSet(
+            weight: headerMap.containsKey('gewicht')
+                ? double.tryParse(row[headerMap['gewicht']!].toString()) ?? 0
+                : 0,
+            reps: int.tryParse(row[repsIdx].toString()) ?? 0,
+            rir: int.tryParse(row[headerMap['rir']!].toString()),
+            note: headerMap.containsKey('setnotiz')
+                ? row[headerMap['setnotiz']!].toString()
+                : null,
+          )
+        ],
       );
       prov.addExercise(week, day, entry);
     }

--- a/lib/features/training_plan/presentation/widgets/device_selection_dialog.dart
+++ b/lib/features/training_plan/presentation/widgets/device_selection_dialog.dart
@@ -112,6 +112,7 @@ Future<ExerciseEntry?> showDeviceSelectionDialog(
                   rir: entry.rir,
                   restInSeconds: entry.restInSeconds,
                   notes: entry.notes,
+                  sets: entry.sets,
                 );
                 Navigator.pop(context, result);
               },


### PR DESCRIPTION
## Summary
- add `PlannedSet` model
- extend `ExerciseEntry` to hold planned sets
- auto-create all weekdays when creating a plan
- redesign plan editor to edit per-set values like device screen
- adjust import and device dialogs for new model

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860bd37897083209f6a34e2ababeaab