### PR TITLE
Implement plan start date selection and simplify entry editing

### DIFF
--- a/lib/core/providers/training_plan_provider.dart
+++ b/lib/core/providers/training_plan_provider.dart
@@ -58,7 +58,8 @@ class TrainingPlanProvider extends ChangeNotifier {
     required int weeks,
   }) {
     final now = DateTime.now();
-    final monday = now.subtract(Duration(days: now.weekday - 1));
+    final monday = DateTime(now.year, now.month, now.day)
+        .subtract(Duration(days: now.weekday - 1));
     final weekBlocks = [
       for (var i = 0; i < weeks; i++)
         WeekBlock(
@@ -78,9 +79,25 @@ class TrainingPlanProvider extends ChangeNotifier {
       name: name,
       createdAt: DateTime.now(),
       createdBy: createdBy,
-      startDate: DateTime.now(),
+      startDate: monday,
       weeks: weekBlocks,
     );
+    notifyListeners();
+  }
+
+  void setStartDate(DateTime monday) {
+    final plan = currentPlan;
+    if (plan == null) return;
+    for (final week in plan.weeks) {
+      for (var i = 0; i < week.days.length; i++) {
+        final day = week.days[i];
+        week.days[i] = DayEntry(
+          date: monday.add(Duration(days: (week.weekNumber - 1) * 7 + i)),
+          exercises: day.exercises,
+        );
+      }
+    }
+    currentPlan = plan.copyWith(startDate: monday);
     notifyListeners();
   }
 

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -372,6 +372,15 @@ class _PlannedTable extends StatelessWidget {
         while (prov.sets.length < entry.totalSets) {
           prov.addSet();
         }
+        for (var i = 0; i < prov.sets.length; i++) {
+          final set = prov.sets[i];
+          if ((set['reps'] ?? '').isEmpty) {
+            prov.updateSet(i, reps: entry.reps?.toString() ?? '');
+          }
+          if ((set['rir'] ?? '').isEmpty) {
+            prov.updateSet(i, rir: entry.rir.toString());
+          }
+        }
       });
     }
 


### PR DESCRIPTION
## Summary
- let user pick the Monday start date for a plan
- simplify plan entry editor to just work sets, reps and RIR
- prefill session table with plan values

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6860c7d1d3e083209ccfb6744cb22953