### PR TITLE
Fix active plan loading

### DIFF
--- a/lib/core/providers/training_plan_provider.dart
+++ b/lib/core/providers/training_plan_provider.dart
@@ -29,6 +29,7 @@ class TrainingPlanProvider extends ChangeNotifier {
   Future<void> _loadActivePlanId() async {
     final prefs = await SharedPreferences.getInstance();
     activePlanId = prefs.getString('activePlanId');
+    notifyListeners();
   }
 
   Future<void> setActivePlan(String id) async {


### PR DESCRIPTION
## Summary
- notify the UI once the active training plan id is loaded

## Testing
- `dart format lib/core/providers/training_plan_provider.dart` *(fails: command not found)*
- `flutter format lib/core/providers/training_plan_provider.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e91a7e6c83209a461e2752afa2f8