### PR TITLE
Fix subdocument rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -5,7 +5,7 @@ service cloud.firestore {
       match /trainingPlans/{planId}/{document=**} {
         allow read, write: if request.auth != null &&
           request.auth.token.gymId == gymId &&
-          request.auth.uid == resource.data.createdBy;
+          request.auth.uid == request.resource.data.createdBy;
       }
       match /trainingPlans/{planId} {
         allow create: if request.auth != null &&

--- a/lib/features/training_plan/data/sources/firestore_training_plan_source.dart
+++ b/lib/features/training_plan/data/sources/firestore_training_plan_source.dart
@@ -74,16 +74,24 @@ class FirestoreTrainingPlanSource {
       final weekRef = planRef
           .collection('weeks')
           .doc(week.weekNumber.toString());
-      await weekRef.set({'weekNumber': week.weekNumber});
+      await weekRef.set({
+        'weekNumber': week.weekNumber,
+        'createdBy': plan.createdBy,
+      });
       for (final day in week.days) {
         final id =
             '${day.date.year}-${day.date.month.toString().padLeft(2, '0')}-${day.date.day.toString().padLeft(2, '0')}';
         final dayRef = weekRef.collection('days').doc(id);
-        await dayRef.set({'date': Timestamp.fromDate(day.date)});
+        await dayRef.set({
+          'date': Timestamp.fromDate(day.date),
+          'createdBy': plan.createdBy,
+        });
         final exCol = dayRef.collection('exercises');
         for (var i = 0; i < day.exercises.length; i++) {
           final ex = day.exercises[i];
-          await exCol.doc('$i').set(ex.toMap());
+          final data = ex.toMap();
+          data['createdBy'] = plan.createdBy;
+          await exCol.doc('$i').set(data);
         }
       }
     }


### PR DESCRIPTION
## Beschreibung
- firestore-Regel für Unterdokumente prüft nun `request.resource.data.createdBy`
- Unterdokumente erhalten beim Speichern `createdBy`

## Typ der Änderung
- [ ] feat: neues Feature
- [x] fix: Bugfix
- [ ] chore: Wartung
- [ ] docs: Dokumentation

## Checkliste
- [ ] flutter analyze läuft fehlerfrei
- [ ] flutter test ist erfolgreich
- [x] Keine sensiblen Daten in Commits

------
https://chatgpt.com/codex/tasks/task_e_6861a06661e08320a48f0e861ae14a8d