### PR TITLE
Add exerciseName to ExerciseEntry

### DIFF
--- a/lib/features/training_plan/domain/models/exercise_entry.dart
+++ b/lib/features/training_plan/domain/models/exercise_entry.dart
@@ -3,6 +3,7 @@ import 'planned_set.dart';
 class ExerciseEntry {
   final String deviceId;
   final String exerciseId;
+  final String exerciseName;
   final String setType; // z.B. Warmup, Arbeits-Satz
   final int totalSets;
   final int workSets;
@@ -16,6 +17,7 @@ class ExerciseEntry {
   ExerciseEntry({
     required this.deviceId,
     required this.exerciseId,
+    required this.exerciseName,
     required this.setType,
     required this.totalSets,
     required this.workSets,
@@ -30,6 +32,7 @@ class ExerciseEntry {
   factory ExerciseEntry.fromMap(Map<String, dynamic> map) => ExerciseEntry(
     deviceId: map['deviceId'] as String,
     exerciseId: map['exerciseId'] as String,
+    exerciseName: map['exerciseName'] as String? ?? '',
     setType: map['setType'] as String? ?? '',
     totalSets: (map['totalSets'] as num?)?.toInt() ?? 0,
     workSets: (map['workSets'] as num?)?.toInt() ?? 0,
@@ -46,6 +49,7 @@ class ExerciseEntry {
   Map<String, dynamic> toMap() => {
     'deviceId': deviceId,
     'exerciseId': exerciseId,
+    'exerciseName': exerciseName,
     'setType': setType,
     'totalSets': totalSets,
     'workSets': workSets,

--- a/lib/features/training_plan/presentation/screens/import_plan_screen.dart
+++ b/lib/features/training_plan/presentation/screens/import_plan_screen.dart
@@ -135,6 +135,7 @@ class _ImportPlanScreenState extends State<ImportPlanScreen> {
       final entry = ExerciseEntry(
         deviceId: '',
         exerciseId: row[headerMap['übung']!].toString(),
+        exerciseName: row[headerMap['übung']!].toString(),
         setType: row[headerMap['art des satzes']!].toString(),
         totalSets:
             int.tryParse(row[headerMap['arbeitssätze']!].toString()) ?? 0,

--- a/lib/features/training_plan/presentation/screens/plan_editor_screen.dart
+++ b/lib/features/training_plan/presentation/screens/plan_editor_screen.dart
@@ -108,6 +108,7 @@ class _PlanEditorScreenState extends State<PlanEditorScreen>
             final base = ExerciseEntry(
               deviceId: '',
               exerciseId: '',
+              exerciseName: '',
               setType: '',
               totalSets: 0,
               workSets: 0,
@@ -294,6 +295,7 @@ class _PlanEntryEditorState extends State<_PlanEntryEditor> {
       ExerciseEntry(
         deviceId: widget.entry.deviceId,
         exerciseId: widget.entry.exerciseId,
+        exerciseName: widget.entry.exerciseName,
         setType: '',
         totalSets: int.tryParse(_setsCtr.text) ?? 0,
         workSets: int.tryParse(_setsCtr.text) ?? 0,

--- a/lib/features/training_plan/presentation/widgets/device_selection_dialog.dart
+++ b/lib/features/training_plan/presentation/widgets/device_selection_dialog.dart
@@ -112,6 +112,9 @@ Future<ExerciseEntry?> showDeviceSelectionDialog(
                       selectedDevice!.isMulti
                           ? (selectedExercise?.id ?? '')
                           : selectedDevice!.id,
+                  exerciseName: selectedDevice!.isMulti
+                      ? (selectedExercise?.name ?? selectedDevice!.name)
+                      : selectedDevice!.name,
                   setType: entry.setType,
                   totalSets: entry.totalSets,
                   workSets: entry.workSets,


### PR DESCRIPTION
## Summary
- extend `ExerciseEntry` with `exerciseName`
- persist new field in import and editor screens
- populate exercise name when selecting devices

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a3ac46948320a9589cac4f0912b1