### PR TITLE
Fix UI for planned sets and training plan

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -356,7 +356,10 @@ class _PlannedTable extends StatelessWidget {
   Widget build(BuildContext context) {
     final prov = context.watch<DeviceProvider>();
 
-    if (prov.sets.length < entry.totalSets) {
+    final needsPrefill = prov.sets.any(
+      (s) => (s['reps'] ?? '').isEmpty || (s['rir'] ?? '').isEmpty,
+    );
+    if (prov.sets.length < entry.totalSets || needsPrefill) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         while (prov.sets.length < entry.totalSets) {
           prov.addSet();
@@ -390,6 +393,9 @@ class _PlannedTable extends StatelessWidget {
                 const SizedBox(width: 12),
                 Expanded(
                   child: TextFormField(
+                    key: ValueKey(
+                      'w-${entrySet.key}-${entrySet.value['weight']}',
+                    ),
                     initialValue: entrySet.value['weight'],
                     decoration: const InputDecoration(
                       labelText: 'kg',
@@ -402,6 +408,9 @@ class _PlannedTable extends StatelessWidget {
                 const SizedBox(width: 12),
                 Expanded(
                   child: TextFormField(
+                    key: ValueKey(
+                      'r-${entrySet.key}-${entrySet.value['reps']}',
+                    ),
                     initialValue: entrySet.value['reps'],
                     decoration: const InputDecoration(
                       labelText: 'x',
@@ -414,6 +423,9 @@ class _PlannedTable extends StatelessWidget {
                 const SizedBox(width: 12),
                 Expanded(
                   child: TextFormField(
+                    key: ValueKey(
+                      'rir-${entrySet.key}-${entrySet.value['rir']}',
+                    ),
                     initialValue: entrySet.value['rir'],
                     decoration: const InputDecoration(
                       labelText: 'RIR',
@@ -427,6 +439,9 @@ class _PlannedTable extends StatelessWidget {
                 Expanded(
                   flex: 2,
                   child: TextFormField(
+                    key: ValueKey(
+                      'n-${entrySet.key}-${entrySet.value['note']}',
+                    ),
                     initialValue: entrySet.value['note'],
                     decoration: const InputDecoration(
                       labelText: 'Notiz',

--- a/lib/features/training_plan/presentation/screens/plan_editor_screen.dart
+++ b/lib/features/training_plan/presentation/screens/plan_editor_screen.dart
@@ -322,7 +322,9 @@ class _PlanEntryEditorState extends State<_PlanEntryEditor> {
               children: [
                 Expanded(
                   child: Text(
-                    widget.entry.exerciseId,
+                    widget.entry.exerciseName.isNotEmpty
+                        ? widget.entry.exerciseName
+                        : widget.entry.exerciseId,
                     style: const TextStyle(fontWeight: FontWeight.bold),
                   ),
                 ),


### PR DESCRIPTION
## Summary
- prefill planned sets even when sets exist
- rebuild set inputs when values change
- show exercise name instead of ID in training plan editor

## Testing
- `npm ci` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6861bec33ce48320b286823a1edec3f4