### PR TITLE
feat(auth): Suchoptimierte Nutzer-Dokumente

### DIFF
--- a/docs/data_model/data_model.md
+++ b/docs/data_model/data_model.md
@@ -4,3 +4,12 @@ gyms/{gymId}/training_history/{sessionId}
 gyms/{gymId}/users/{userId}
 gyms/{gymId}/affiliateOffers/{offerId}
 ...
+
+### Users
+
+- **users/{userId}** – zentrales Profil-Dokument.
+  - `email` und `emailLower` für case-insensitive Suche
+  - `gymCodes`: Liste beigetretener Gyms
+  - `role`, `createdAt`, `showInLeaderboard`
+- **gyms/{gymId}/users/{userId}** – Referenz im jeweiligen Gym für schnelle Gym-Abfragen
+  - enthält nur `role` und `createdAt`

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,5 +1,13 @@
 {
-    "indexes": [],
-    "fieldOverrides": []
-  }
+  "indexes": [
+    {
+      "collectionGroup": "users",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "emailLower", "order": "ASCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}
   

--- a/lib/features/auth/data/dtos/user_data_dto.dart
+++ b/lib/features/auth/data/dtos/user_data_dto.dart
@@ -4,6 +4,7 @@ import 'package:tapem/features/auth/domain/models/user_data.dart';
 class UserDataDto {
   final String userId;
   final String email;
+  final String emailLower;
   final List<String> gymCodes;
   final bool showInLeaderboard;
   final String role;
@@ -12,6 +13,7 @@ class UserDataDto {
   UserDataDto({
     required this.userId,
     required this.email,
+    required this.emailLower,
     required this.gymCodes,
     required this.showInLeaderboard,
     required this.role,
@@ -23,6 +25,8 @@ class UserDataDto {
     return UserDataDto(
       userId: doc.id,
       email: data['email'] as String,
+      emailLower: data['emailLower'] as String? ??
+          (data['email'] as String).toLowerCase(),
       gymCodes: List<String>.from(data['gymCodes'] ?? []),
       showInLeaderboard: data['showInLeaderboard'] as bool? ?? true,
       role: data['role'] as String,
@@ -32,6 +36,7 @@ class UserDataDto {
 
   Map<String, dynamic> toJson() => {
     'email': email,
+    'emailLower': emailLower,
     'gymCodes': gymCodes,
     'showInLeaderboard': showInLeaderboard,
     'role': role,

--- a/lib/features/auth/data/sources/firestore_auth_source.dart
+++ b/lib/features/auth/data/sources/firestore_auth_source.dart
@@ -42,12 +42,25 @@ class FirestoreAuthSource {
     final dto = UserDataDto(
       userId: uid,
       email: email,
+      emailLower: email.toLowerCase(),
       gymCodes: [gym.id],
       showInLeaderboard: true,
       role: 'member',
       createdAt: now,
     );
     await _firestore.collection('users').doc(uid).set(dto.toJson());
+
+    // Nutzer zusätzlich unterhalb des Gyms referenzieren
+    await _firestore
+        .collection('gyms')
+        .doc(gym.id)
+        .collection('users')
+        .doc(uid)
+        .set({
+      'role': 'member',
+      'createdAt': Timestamp.fromDate(now),
+    });
+
     return dto;
   }
 


### PR DESCRIPTION
## Summary
- erweitere `UserDataDto` um ein `emailLower` Feld
- erfasse bei Registrierung ein `gyms/{gymId}/users/{userId}`-Dokument
- ergänze Indexdefinition für `emailLower`
- dokumentiere überarbeitete Nutzerstruktur

## Testing
- `npx mocha firestore-tests/security_rules.test.js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6861c9f7201083209286366699be5824