### PR TITLE
Add numeric device IDs

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -69,7 +69,7 @@ class DeviceProvider extends ChangeNotifier {
     try {
       final devices = await _getDevicesForGym.execute(gymId);
       _device = devices.firstWhere(
-        (d) => d.id == deviceId,
+        (d) => d.uid == deviceId,
         orElse: () => throw Exception('Device not found'),
       );
       _currentExerciseId = exerciseId;
@@ -175,7 +175,7 @@ class DeviceProvider extends ChangeNotifier {
               .collection('gyms')
               .doc(gymId)
               .collection('devices')
-              .doc(_device!.id)
+              .doc(_device!.uid)
               .collection('logs')
               .doc();
       final data = <String, dynamic>{
@@ -201,7 +201,7 @@ class DeviceProvider extends ChangeNotifier {
         .collection('gyms')
         .doc(gymId)
         .collection('devices')
-        .doc(_device!.id)
+        .doc(_device!.uid)
         .collection('userNotes')
         .doc(userId);
     batch.set(noteDoc, {'note': _note, 'updatedAt': ts});
@@ -243,7 +243,7 @@ class DeviceProvider extends ChangeNotifier {
         '${now.year.toString().padLeft(4, '0')}-'
         '${now.month.toString().padLeft(2, '0')}-'
         '${now.day.toString().padLeft(2, '0')}';
-    final deviceId = _device!.id;
+    final deviceId = _device!.uid;
 
     final lbRef = _firestore
         .collection('gyms')

--- a/lib/core/providers/profile_provider.dart
+++ b/lib/core/providers/profile_provider.dart
@@ -46,7 +46,7 @@ class ProfileProvider extends ChangeNotifier {
         // Hier nutzen wir jetzt die benannten Parameter:
         final logs = await _getHistory.execute(
           gymId: gymId,
-          deviceId: device.id,
+          deviceId: device.uid,
           userId: userId,
         );
         for (final log in logs) {

--- a/lib/features/admin/presentation/screens/admin_dashboard_screen.dart
+++ b/lib/features/admin/presentation/screens/admin_dashboard_screen.dart
@@ -3,6 +3,7 @@
 import 'package:firebase_auth/firebase_auth.dart' as fb_auth;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'dart:math';
 import 'package:uuid/uuid.dart';
 
 import 'package:tapem/core/providers/auth_provider.dart';
@@ -51,7 +52,9 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen> {
     final gymId = context.read<AuthProvider>().gymCode!;
     final nameCtrl = TextEditingController();
     final descCtrl = TextEditingController();
-    final newId = _uuid.v4();
+    final newUid = _uuid.v4();
+    final newId =
+        _devices.isEmpty ? 1 : _devices.map((d) => d.id).reduce(max) + 1;
     bool isMulti = false;
 
     showDialog<bool>(
@@ -100,6 +103,7 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen> {
                 }
 
                 final device = Device(
+                  uid: newUid,
                   id: newId,
                   name: nameCtrl.text.trim(),
                   description: descCtrl.text.trim(),

--- a/lib/features/admin/presentation/widgets/device_list_item.dart
+++ b/lib/features/admin/presentation/widgets/device_list_item.dart
@@ -26,6 +26,7 @@ class DeviceListItem extends StatelessWidget {
     final gymId    = context.read<AuthProvider>().gymCode!;
 
     return ListTile(
+      leading: Text('${device.id}'),
       title: Text(device.name),
       subtitle: Text(device.description),
       trailing: Row(
@@ -79,7 +80,7 @@ class DeviceListItem extends StatelessWidget {
               final fbUser = fb_auth.FirebaseAuth.instance.currentUser;
               if (fbUser != null) await fbUser.getIdToken(true);
 
-              await deleteUC.execute(gymId: gymId, deviceId: device.id);
+              await deleteUC.execute(gymId: gymId, deviceId: device.uid);
               onDeleted();
 
               ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/device/data/dtos/device_dto.dart
+++ b/lib/features/device/data/dtos/device_dto.dart
@@ -4,13 +4,15 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
 
 class DeviceDto {
-  late final String id;
+  late final String uid;
+  final int id;
   final String name;
   final String description;
   final String? nfcCode;
   final bool isMulti;
 
   DeviceDto({
+    required this.uid,
     required this.id,
     required this.name,
     required this.description,
@@ -21,7 +23,8 @@ class DeviceDto {
   factory DeviceDto.fromDocument(DocumentSnapshot<Map<String, dynamic>> doc) {
     final data = doc.data()!;
     return DeviceDto(
-      id: doc.id,
+      uid: doc.id,
+      id: (data['id'] as num?)?.toInt() ?? 0,
       name: data['name'] as String? ?? '',
       description: data['description'] as String? ?? '',
       nfcCode: data['nfcCode'] as String?,
@@ -32,6 +35,7 @@ class DeviceDto {
 
   /// Convert to your domain model
   Device toModel() => Device(
+    uid: uid,
     id: id,
     name: name,
     description: description,

--- a/lib/features/device/data/sources/firestore_device_source.dart
+++ b/lib/features/device/data/sources/firestore_device_source.dart
@@ -11,7 +11,7 @@ class FirestoreDeviceSource {
     final snap = await _firestore
       .collection('gyms').doc(gymId)
       .collection('devices')
-      .orderBy('name')
+      .orderBy('id')
       .get();
     return snap.docs.map((doc) => DeviceDto.fromDocument(doc)).toList();
   }
@@ -19,7 +19,7 @@ class FirestoreDeviceSource {
   Future<void> createDevice(String gymId, Device device) {
     return _firestore
       .collection('gyms').doc(gymId)
-      .collection('devices').doc(device.id)
+      .collection('devices').doc(device.uid)
       .set(device.toJson());
   }
 

--- a/lib/features/device/domain/models/device.dart
+++ b/lib/features/device/domain/models/device.dart
@@ -1,13 +1,15 @@
 // lib/features/device/domain/models/device.dart
 
 class Device {
-  final String id;
+  final String uid;
+  final int id;
   final String name;
   final String description;
   final String? nfcCode;
   final bool isMulti;
 
   Device({
+    required this.uid,
     required this.id,
     required this.name,
     this.description = '',
@@ -16,12 +18,14 @@ class Device {
   });
 
   Device copyWith({
-    String? id,
+    String? uid,
+    int? id,
     String? name,
     String? description,
     String? nfcCode,
     bool? isMulti,
   }) => Device(
+    uid:         uid         ?? this.uid,
     id:          id          ?? this.id,
     name:        name        ?? this.name,
     description: description ?? this.description,
@@ -30,7 +34,8 @@ class Device {
   );
 
   factory Device.fromJson(Map<String, dynamic> json) => Device(
-    id:          json['id']        as String,
+    uid:         json['uid']       as String,
+    id:          json['id']        as int? ?? 0,
     name:        json['name']      as String,
     description: json['description'] as String? ?? '',
     nfcCode:     json['nfcCode']   as String?,
@@ -38,6 +43,7 @@ class Device {
   );
 
   Map<String, dynamic> toJson() => {
+    'id':          id,
     'name':        name,
     'description': description,
     'nfcCode':     nfcCode,

--- a/lib/features/device/domain/usecases/create_device_usecase.dart
+++ b/lib/features/device/domain/usecases/create_device_usecase.dart
@@ -21,8 +21,18 @@ class CreateDeviceUseCase {
     required Device device,
     required bool isMulti,
   }) async {
+    final existing = await _repo.getDevicesForGym(gymId);
+    final maxId = existing.isEmpty
+        ? 0
+        : existing.map((d) => d.id).reduce((a, b) => a > b ? a : b);
+    final nextId = maxId + 1;
+
     final code   = _generateNfcCode();
-    final toSave = device.copyWith(nfcCode: code, isMulti: isMulti);
+    final toSave = device.copyWith(
+      id: nextId,
+      nfcCode: code,
+      isMulti: isMulti,
+    );
     await _repo.createDevice(gymId, toSave);
   }
 }

--- a/lib/features/gym/presentation/screens/gym_screen.dart
+++ b/lib/features/gym/presentation/screens/gym_screen.dart
@@ -111,10 +111,10 @@ class _GymScreenState extends State<GymScreen> {
                           onTap: () {
                             final args = {
                               'gymId': gymCode,
-                              'deviceId': device.id,
+                              'deviceId': device.uid,
                               // Bei Single-Geräten entspricht exerciseId der deviceId
                               'exerciseId':
-                                  device.isMulti ? device.id : device.id,
+                                  device.isMulti ? device.uid : device.uid,
                             };
                             Navigator.of(
                               ctx,

--- a/lib/features/report/presentation/widgets/device_usage_chart.dart
+++ b/lib/features/report/presentation/widgets/device_usage_chart.dart
@@ -8,7 +8,7 @@ class DeviceUsageChart extends StatelessWidget {
   /// Liste aller Geräte im aktuellen Gym
   final List<Device> devices;
 
-  /// Nutzungszahlen, key = device.id, value = Anzahl aller Sessions
+  /// Nutzungszahlen, key = device.uid, value = Anzahl aller Sessions
   final Map<String, int> usageCounts;
 
   const DeviceUsageChart({
@@ -23,7 +23,7 @@ class DeviceUsageChart extends StatelessWidget {
     final bars = <BarChartGroupData>[];
     for (var i = 0; i < devices.length; i++) {
       final device   = devices[i];
-      final count    = usageCounts[device.id] ?? 0;
+      final count    = usageCounts[device.uid] ?? 0;
       final barColor = Theme.of(context).colorScheme.primary;
 
       bars.add(

--- a/lib/features/training_plan/presentation/widgets/device_selection_dialog.dart
+++ b/lib/features/training_plan/presentation/widgets/device_selection_dialog.dart
@@ -25,14 +25,14 @@ Future<ExerciseEntry?> showDeviceSelectionDialog(
 
   // Vorbelegung basierend auf vorhandenem Eintrag
   try {
-    selectedDevice = devices.firstWhere((d) => d.id == entry.deviceId);
+    selectedDevice = devices.firstWhere((d) => d.uid == entry.deviceId);
   } catch (_) {
     if (devices.isNotEmpty) selectedDevice = devices.first;
   }
 
   if (selectedDevice?.isMulti == true) {
     exerciseFuture = exProv
-        .loadExercises(gymId, selectedDevice!.id, userId)
+        .loadExercises(gymId, selectedDevice!.uid, userId)
         .then((_) => exProv.exercises);
     final exList = await exerciseFuture;
     try {
@@ -69,7 +69,7 @@ Future<ExerciseEntry?> showDeviceSelectionDialog(
                             exerciseFuture = exProv
                                 .loadExercises(
                                   gymId,
-                                  selectedDevice!.id,
+                                  selectedDevice!.uid,
                                   userId,
                                 )
                                 .then((_) => exProv.exercises);
@@ -112,11 +112,11 @@ Future<ExerciseEntry?> showDeviceSelectionDialog(
               onPressed: () {
                 if (selectedDevice == null) return;
                 final result = ExerciseEntry(
-                  deviceId: selectedDevice!.id,
+                  deviceId: selectedDevice!.uid,
                   exerciseId:
                       selectedDevice!.isMulti
                           ? (selectedExercise?.id ?? '')
-                          : selectedDevice!.id,
+                          : selectedDevice!.uid,
                   exerciseName:
                       selectedDevice!.isMulti
                           ? (selectedExercise?.name ?? selectedDevice!.name)


### PR DESCRIPTION
## Summary
- store numeric `id` alongside document `uid`
- show `id` when creating/viewing devices in the admin dashboard
- increment device `id` automatically when creating a new device
- adjust providers and dialogs to use new `uid` field

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861f6dab3f4832093c269434630c766