### PR TITLE
Implement username creation prompt

### DIFF
--- a/lib/features/auth/data/dtos/user_data_dto.dart
+++ b/lib/features/auth/data/dtos/user_data_dto.dart
@@ -5,6 +5,8 @@ class UserDataDto {
   final String userId;
   final String email;
   final String emailLower;
+  final String? userName;
+  final String? userNameLower;
   final List<String> gymCodes;
   final bool showInLeaderboard;
   final String role;
@@ -14,6 +16,8 @@ class UserDataDto {
     required this.userId,
     required this.email,
     required this.emailLower,
+    this.userName,
+    this.userNameLower,
     required this.gymCodes,
     required this.showInLeaderboard,
     required this.role,
@@ -27,6 +31,8 @@ class UserDataDto {
       email: data['email'] as String,
       emailLower: data['emailLower'] as String? ??
           (data['email'] as String).toLowerCase(),
+      userName: data['username'] as String?,
+      userNameLower: data['usernameLower'] as String?,
       gymCodes: List<String>.from(data['gymCodes'] ?? []),
       showInLeaderboard: data['showInLeaderboard'] as bool? ?? true,
       role: data['role'] as String,
@@ -37,6 +43,8 @@ class UserDataDto {
   Map<String, dynamic> toJson() => {
     'email': email,
     'emailLower': emailLower,
+    if (userName != null) 'username': userName,
+    if (userNameLower != null) 'usernameLower': userNameLower,
     'gymCodes': gymCodes,
     'showInLeaderboard': showInLeaderboard,
     'role': role,
@@ -47,6 +55,7 @@ class UserDataDto {
     return UserData(
       id: userId,
       email: email,
+      userName: userName,
       gymCodes: gymCodes,
       showInLeaderboard: showInLeaderboard,
       role: role,

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -32,4 +32,14 @@ class AuthRepositoryImpl implements AuthRepository {
     final UserDataDto? dto = await _source.getCurrentUser();
     return dto?.toModel();
   }
+
+  @override
+  Future<void> setUsername(String userId, String username) {
+    return _source.setUsername(userId, username);
+  }
+
+  @override
+  Future<bool> isUsernameAvailable(String username) {
+    return _source.isUsernameAvailable(username);
+  }
 }

--- a/lib/features/auth/data/sources/firestore_auth_source.dart
+++ b/lib/features/auth/data/sources/firestore_auth_source.dart
@@ -43,6 +43,8 @@ class FirestoreAuthSource {
       userId: uid,
       email: email,
       emailLower: email.toLowerCase(),
+      userName: null,
+      userNameLower: null,
       gymCodes: [gym.id],
       showInLeaderboard: true,
       role: 'member',
@@ -72,5 +74,23 @@ class FirestoreAuthSource {
     final doc = await _firestore.collection('users').doc(user.uid).get();
     if (!doc.exists) return null;
     return UserDataDto.fromDocument(doc);
+  }
+
+  Future<bool> isUsernameAvailable(String username) async {
+    final lower = username.toLowerCase();
+    final query = await _firestore
+        .collection('users')
+        .where('usernameLower', isEqualTo: lower)
+        .limit(1)
+        .get();
+    return query.docs.isEmpty;
+  }
+
+  Future<void> setUsername(String userId, String username) async {
+    final lower = username.toLowerCase();
+    await _firestore.collection('users').doc(userId).update({
+      'username': username,
+      'usernameLower': lower,
+    });
   }
 }

--- a/lib/features/auth/domain/models/user_data.dart
+++ b/lib/features/auth/domain/models/user_data.dart
@@ -1,6 +1,7 @@
 class UserData {
   final String id;
   final String email;
+  final String? userName;
   final List<String> gymCodes;
   final bool showInLeaderboard;
   final String role;
@@ -9,6 +10,7 @@ class UserData {
   const UserData({
     required this.id,
     required this.email,
+    this.userName,
     required this.gymCodes,
     required this.showInLeaderboard,
     required this.role,
@@ -18,6 +20,7 @@ class UserData {
   UserData copyWith({
     String? id,
     String? email,
+    String? userName,
     List<String>? gymCodes,
     bool? showInLeaderboard,
     String? role,
@@ -26,6 +29,7 @@ class UserData {
     return UserData(
       id: id ?? this.id,
       email: email ?? this.email,
+      userName: userName ?? this.userName,
       gymCodes: gymCodes ?? this.gymCodes,
       showInLeaderboard: showInLeaderboard ?? this.showInLeaderboard,
       role: role ?? this.role,

--- a/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/features/auth/domain/repositories/auth_repository.dart
@@ -6,4 +6,6 @@ abstract class AuthRepository {
       String email, String password, String gymId);
   Future<void> logout();
   Future<UserData?> getCurrentUser();
+  Future<void> setUsername(String userId, String username);
+  Future<bool> isUsernameAvailable(String username);
 }

--- a/lib/features/auth/domain/usecases/check_username_available.dart
+++ b/lib/features/auth/domain/usecases/check_username_available.dart
@@ -1,0 +1,11 @@
+import '../repositories/auth_repository.dart';
+import '../../data/repositories/auth_repository_impl.dart';
+
+class CheckUsernameAvailable {
+  final AuthRepository _repo;
+  CheckUsernameAvailable([AuthRepository? repo]) : _repo = repo ?? AuthRepositoryImpl();
+
+  Future<bool> execute(String username) {
+    return _repo.isUsernameAvailable(username);
+  }
+}

--- a/lib/features/auth/domain/usecases/set_username.dart
+++ b/lib/features/auth/domain/usecases/set_username.dart
@@ -1,0 +1,11 @@
+import '../repositories/auth_repository.dart';
+import '../../data/repositories/auth_repository_impl.dart';
+
+class SetUsernameUseCase {
+  final AuthRepository _repo;
+  SetUsernameUseCase([AuthRepository? repo]) : _repo = repo ?? AuthRepositoryImpl();
+
+  Future<void> execute(String userId, String username) {
+    return _repo.setUsername(userId, username);
+  }
+}

--- a/lib/features/auth/presentation/widgets/username_dialog.dart
+++ b/lib/features/auth/presentation/widgets/username_dialog.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import '../../../../core/providers/auth_provider.dart';
+
+Future<void> showUsernameDialog(BuildContext context) async {
+  final loc = AppLocalizations.of(context)!;
+  final ctr = TextEditingController();
+  final auth = context.read<AuthProvider>();
+  String? error;
+  await showDialog(
+    context: context,
+    barrierDismissible: false,
+    builder: (_) => StatefulBuilder(
+      builder: (ctx, setState) => AlertDialog(
+        title: Text(loc.usernameDialogTitle),
+        content: TextField(
+          controller: ctr,
+          decoration: InputDecoration(
+            labelText: loc.usernameFieldLabel,
+            errorText: error,
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            onPressed: () async {
+              final name = ctr.text.trim();
+              if (name.isEmpty) return;
+              final success = await auth.setUsername(name);
+              if (success) {
+                // ignore: use_build_context_synchronously
+                Navigator.pop(ctx);
+              } else {
+                setState(() => error = auth.error ?? loc.usernameTaken);
+              }
+            },
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    ),
+  );
+}

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -13,6 +13,8 @@ import 'package:tapem/features/affiliate/presentation/screens/affiliate_screen.d
 import 'package:tapem/app_router.dart';
 import 'package:tapem/features/rank/presentation/screens/rank_screen.dart';
 import 'package:tapem/features/training_plan/presentation/screens/plan_overview_screen.dart';
+import 'package:tapem/features/auth/presentation/widgets/username_dialog.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class HomeScreen extends StatefulWidget {
   final int initialIndex;
@@ -54,15 +56,20 @@ class _HomeScreenState extends State<HomeScreen> {
           reportProv.loadReport(id);
         });
       }
+      if (authProv.userName == null || authProv.userName!.isEmpty) {
+        showUsernameDialog(context);
+      }
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    final userEmail = context.watch<AuthProvider>().userEmail ?? 'Gast';
+    final authProv = context.watch<AuthProvider>();
+    final loc = AppLocalizations.of(context)!;
+    final userDisplay = authProv.userName ?? authProv.userEmail ?? loc.genericUser;
     return Scaffold(
       appBar: AppBar(
-        title: Text('Willkommen, $userEmail'),
+        title: Text(loc.homeWelcome(userDisplay)),
         actions: [
           IconButton(
             icon: const Icon(Icons.logout),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -313,5 +313,11 @@
   "englishLanguage": "Englisch",
   "@englishLanguage": {
     "description": "Bezeichnung für englische Sprache"
-  }
+  },
+  "usernameDialogTitle": "Nutzernamen wählen",
+  "@usernameDialogTitle": {"description": "Titel des Dialogs zur Wahl des Nutzernamens"},
+  "usernameFieldLabel": "Nutzername",
+  "@usernameFieldLabel": {"description": "Beschriftung für das Nutzername-Feld"},
+  "usernameTaken": "Dieser Nutzername ist bereits vergeben.",
+  "@usernameTaken": {"description": "Fehler wenn Nutzername existiert"}
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -313,5 +313,11 @@
   "englishLanguage": "English",
   "@englishLanguage": {
     "description": "Label for English language"
-  }
+  },
+  "usernameDialogTitle": "Choose username",
+  "@usernameDialogTitle": {"description": "Title of the username dialog"},
+  "usernameFieldLabel": "Username",
+  "@usernameFieldLabel": {"description": "Label for username field"},
+  "usernameTaken": "This username is already taken.",
+  "@usernameTaken": {"description": "Error when username exists"}
 }


### PR DESCRIPTION
## Beschreibung
Implementiert Benutzernamen nach Registrierung. Beim ersten Login erscheint ein Dialog zur Auswahl eines Namens. Dieser wird in Firestore gespeichert und im Header angezeigt.

## Typ der Änderung
- [x] feat: neues Feature
- [ ] fix: Bugfix
- [ ] chore: Wartung
- [ ] docs: Dokumentation

## Checkliste
- [ ] flutter analyze läuft fehlerfrei
- [ ] flutter test ist erfolgreich
- [x] Keine sensiblen Daten in Commits

------
https://chatgpt.com/codex/tasks/task_e_6862856d13bc832087af7af8c57527c3