### PR TITLE
Add customizable rest timer with reset

### DIFF
--- a/lib/features/device/presentation/widgets/rest_timer_widget.dart
+++ b/lib/features/device/presentation/widgets/rest_timer_widget.dart
@@ -12,6 +12,9 @@ class RestTimerWidget extends StatefulWidget {
 }
 
 class _RestTimerWidgetState extends State<RestTimerWidget> {
+  static const _presetDurations = [60, 90, 120, 150, 180];
+
+  late int _duration;
   late int _remaining;
   Timer? _timer;
   bool _running = false;
@@ -19,7 +22,8 @@ class _RestTimerWidgetState extends State<RestTimerWidget> {
   @override
   void initState() {
     super.initState();
-    _remaining = widget.initialSeconds;
+    _duration = widget.initialSeconds;
+    _remaining = _duration;
   }
 
   void _toggleTimer() {
@@ -38,6 +42,14 @@ class _RestTimerWidgetState extends State<RestTimerWidget> {
     setState(() => _running = !_running);
   }
 
+  void _resetTimer() {
+    _timer?.cancel();
+    setState(() {
+      _running = false;
+      _remaining = _duration;
+    });
+  }
+
   @override
   void dispose() {
     _timer?.cancel();
@@ -47,13 +59,58 @@ class _RestTimerWidgetState extends State<RestTimerWidget> {
   @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
-    return Row(
+    final progress = _remaining / _duration;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('${loc.timerPauseLabel}: $_remaining ${loc.secondsAbbreviation}'),
-        const SizedBox(width: 16),
-        ElevatedButton(
-          onPressed: _toggleTimer,
-          child: Text(_running ? loc.timerStop : loc.timerStart),
+        SizedBox(
+          width: 80,
+          height: 80,
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              CircularProgressIndicator(
+                value: 1 - progress,
+                strokeWidth: 6,
+              ),
+              Text('$_remaining${loc.secondsAbbreviation}'),
+            ],
+          ),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            Text('${loc.timerDuration}:'),
+            const SizedBox(width: 8),
+            DropdownButton<int>(
+              value: _duration,
+              items: [
+                for (final d in _presetDurations)
+                  DropdownMenuItem(
+                    value: d,
+                    child: Text('$d${loc.secondsAbbreviation}'),
+                  ),
+              ],
+              onChanged: (v) {
+                if (v == null) return;
+                setState(() {
+                  _duration = v;
+                  _remaining = v;
+                });
+              },
+            ),
+            const SizedBox(width: 16),
+            ElevatedButton(
+              onPressed: _toggleTimer,
+              child: Text(_running ? loc.timerStop : loc.timerStart),
+            ),
+            const SizedBox(width: 8),
+            OutlinedButton(
+              onPressed: _resetTimer,
+              child: Text(loc.timerReset),
+            ),
+          ],
         ),
       ],
     );

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -295,6 +295,16 @@
     "description": "Abkürzung für Sekunden"
   },
 
+  "timerReset": "Zurücksetzen",
+  "@timerReset": {
+    "description": "Beschriftung für Timer-Zurücksetzen-Button"
+  },
+
+  "timerDuration": "Dauer",
+  "@timerDuration": {
+    "description": "Beschriftung für Auswahl der Timer-Dauer"
+  },
+
   "userNotFound": "Nutzer nicht gefunden.",
   "@userNotFound": {
     "description": "Fehlermeldung, wenn Nutzer nicht gefunden wurde"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -295,6 +295,16 @@
     "description": "Abbreviation for seconds"
   },
 
+  "timerReset": "Reset",
+  "@timerReset": {
+    "description": "Label for timer reset button"
+  },
+
+  "timerDuration": "Duration",
+  "@timerDuration": {
+    "description": "Label for timer duration dropdown"
+  },
+
   "userNotFound": "User not found.",
   "@userNotFound": {
     "description": "Error when no user is found"


### PR DESCRIPTION
## Summary
- modernize rest timer widget with circular indicator
- add dropdown to choose preset timer durations
- implement reset functionality
- extend localizations for new timer labels

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862901a23bc8320b4a3a0063d1ff6e9