### PR TITLE
Add training plan exercise management functions

### DIFF
--- a/lib/core/providers/training_plan_provider.dart
+++ b/lib/core/providers/training_plan_provider.dart
@@ -164,6 +164,44 @@ class TrainingPlanProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  void copyWeekExercises(int sourceWeek, List<int> targetWeeks) {
+    final src = currentPlan?.weeks.firstWhere((w) => w.weekNumber == sourceWeek);
+    if (src == null) return;
+    for (final weekNo in targetWeeks) {
+      final target =
+          currentPlan?.weeks.firstWhere((w) => w.weekNumber == weekNo);
+      if (target == null) continue;
+      for (var i = 0; i < src.days.length && i < target.days.length; i++) {
+        final exercises = [
+          for (final ex in src.days[i].exercises)
+            ExerciseEntry.fromMap(ex.toMap())
+        ];
+        target.days[i] =
+            DayEntry(date: target.days[i].date, exercises: exercises);
+      }
+    }
+    notifyListeners();
+  }
+
+  void moveExercise(
+    int srcWeek,
+    DateTime srcDay,
+    int index,
+    int destWeek,
+    DateTime destDay,
+  ) {
+    final srcW = currentPlan?.weeks.firstWhere((w) => w.weekNumber == srcWeek);
+    final destW =
+        currentPlan?.weeks.firstWhere((w) => w.weekNumber == destWeek);
+    if (srcW == null || destW == null) return;
+    final sDay = srcW.days.firstWhere((d) => d.date == srcDay);
+    final dDay = destW.days.firstWhere((d) => d.date == destDay);
+    if (index < 0 || index >= sDay.exercises.length) return;
+    final ex = sDay.exercises.removeAt(index);
+    dDay.exercises.add(ex);
+    notifyListeners();
+  }
+
   void notify() => notifyListeners();
 
   ExerciseEntry? entryForDate(

--- a/lib/features/training_plan/data/repositories/training_plan_repository_impl.dart
+++ b/lib/features/training_plan/data/repositories/training_plan_repository_impl.dart
@@ -33,4 +33,15 @@ class TrainingPlanRepositoryImpl implements TrainingPlanRepository {
   Future<void> deletePlan(String gymId, String planId) async {
     await _source.deletePlan(gymId, planId);
   }
+
+  @override
+  Future<void> deleteExercise(
+    String gymId,
+    String planId,
+    int weekNumber,
+    DateTime day,
+    int index,
+  ) async {
+    await _source.deleteExercise(gymId, planId, weekNumber, day, index);
+  }
 }

--- a/lib/features/training_plan/domain/repositories/training_plan_repository.dart
+++ b/lib/features/training_plan/domain/repositories/training_plan_repository.dart
@@ -10,4 +10,12 @@ abstract class TrainingPlanRepository {
   );
 
   Future<void> deletePlan(String gymId, String planId);
+
+  Future<void> deleteExercise(
+    String gymId,
+    String planId,
+    int weekNumber,
+    DateTime day,
+    int index,
+  );
 }


### PR DESCRIPTION
## Summary
- clean Firestore weeks before saving plans to ensure removed entries disappear
- allow deleting single exercises with reindexing
- add provider helpers to copy week entries and move exercises
- expose deleteExercise in repository

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `npm ci` *(fails due to missing internet access)*
- `npx mocha firestore-tests/security_rules.test.js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68639684ec408320b13a5466e5d4a294