### PR TITLE
Add training plan exercise management functions

### DIFF
--- a/lib/features/training_plan/data/repositories/training_plan_repository_impl.dart
+++ b/lib/features/training_plan/data/repositories/training_plan_repository_impl.dart
@@ -33,4 +33,15 @@ class TrainingPlanRepositoryImpl implements TrainingPlanRepository {
   Future<void> deletePlan(String gymId, String planId) async {
     await _source.deletePlan(gymId, planId);
   }
+
+  @override
+  Future<void> deleteExercise(
+    String gymId,
+    String planId,
+    int weekNumber,
+    DateTime day,
+    int index,
+  ) async {
+    await _source.deleteExercise(gymId, planId, weekNumber, day, index);
+  }
 }

--- a/lib/features/training_plan/domain/repositories/training_plan_repository.dart
+++ b/lib/features/training_plan/domain/repositories/training_plan_repository.dart
@@ -10,4 +10,12 @@ abstract class TrainingPlanRepository {
   );
 
   Future<void> deletePlan(String gymId, String planId);
+
+  Future<void> deleteExercise(
+    String gymId,
+    String planId,
+    int weekNumber,
+    DateTime day,
+    int index,
+  );
 }


### PR DESCRIPTION
## Summary
- clean Firestore weeks before saving plans to ensure removed entries disappear
- allow deleting single exercises with reindexing
- add provider helpers to copy week entries and move exercises
- expose deleteExercise in repository
- add duplication for day exercises and batch write during plan save for speed

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `npm ci` *(fails due to network restrictions)*
- `npx mocha firestore-tests/security_rules.test.js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68639684ec408320b13a5466e5d4a294