### PR TITLE
feat(plan): allow copying exercises between days

### DIFF
--- a/docs/provider_structure.md
+++ b/docs/provider_structure.md
@@ -7,7 +7,7 @@ Dieses Dokument gibt einen kurzen Überblick über die wichtigsten Provider im P
 | `AuthProvider` | Hält Informationen zum aktuell angemeldeten Nutzer und zum ausgewählten Gym. |
 | `DeviceProvider` | Lädt die verfügbaren Geräte eines Gyms und verwaltet Gerätestate während einer Trainingseinheit. |
 | `ExerciseProvider` | Liefert zu einem Gerät die zugehörigen Übungen. |
-| `TrainingPlanProvider` | Zuständig für Erstellen, Bearbeiten und Speichern von Trainingsplänen. Speichert die aktuell geöffnete Planinstanz und verwaltet Laden/Speichern über das Repository. |
+| `TrainingPlanProvider` | Zuständig für Erstellen, Bearbeiten und Speichern von Trainingsplänen. Speichert die aktuell geöffnete Planinstanz und verwaltet Laden/Speichern über das Repository. Bietet Funktionen zum Kopieren ganzer Wochen oder einzelner Trainingstage. |
 | `GymProvider` | Enthält Metadaten zum Gym, z.B. Branding und verfügbare Geräte. |
 | `ProfileProvider` | Lädt die Trainingstage eines Nutzers für die Profilansicht. |
 | `ReportProvider` | Erstellt Auswertungen und Statistiken für Reports. |

--- a/lib/core/providers/training_plan_provider.dart
+++ b/lib/core/providers/training_plan_provider.dart
@@ -183,6 +183,44 @@ class TrainingPlanProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Copies all exercises from a specific day to multiple other days.
+  ///
+  /// [sourceWeek] and [sourceDay] identify the day to copy from. The
+  /// [targets] map uses the week number as key and the day index within that
+  /// week (0 = Monday) as value.
+  void copyDayExercises(
+    int sourceWeek,
+    int sourceDay,
+    Map<int, int> targets,
+  ) {
+    final srcWeek =
+        currentPlan?.weeks.firstWhere((w) => w.weekNumber == sourceWeek);
+    if (srcWeek == null || sourceDay < 0 || sourceDay >= srcWeek.days.length) {
+      return;
+    }
+    final srcDay = srcWeek.days[sourceDay];
+    final clone = [
+      for (final ex in srcDay.exercises)
+        ExerciseEntry.fromMap(ex.toMap()),
+    ];
+
+    targets.forEach((weekNo, dayIdx) {
+      final targetWeek =
+          currentPlan?.weeks.firstWhere((w) => w.weekNumber == weekNo);
+      if (targetWeek == null ||
+          dayIdx < 0 ||
+          dayIdx >= targetWeek.days.length) {
+        return;
+      }
+      final date = targetWeek.days[dayIdx].date;
+      targetWeek.days[dayIdx] = DayEntry(date: date, exercises: [
+        for (final ex in clone) ExerciseEntry.fromMap(ex.toMap()),
+      ]);
+    });
+
+    notifyListeners();
+  }
+
   void moveExercise(
     int srcWeek,
     DateTime srcDay,


### PR DESCRIPTION
## Summary
- allow copying exercises from one day to arbitrary other days with `copyDayExercises`
- document new capability in provider structure overview

## Testing
- `dart format lib/core/providers/training_plan_provider.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a76d295883209c5a507f712c15c9