### PR TITLE
Add XP badge on device screen

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -97,6 +97,19 @@ class _DeviceScreenState extends State<DeviceScreen> {
         title: Text(prov.device!.name),
         centerTitle: true,
         actions: [
+          if (!prov.device!.isMulti)
+            Padding(
+              padding: const EdgeInsets.only(right: 8.0),
+              child: CircleAvatar(
+                backgroundColor: Colors.greenAccent,
+                foregroundColor: Colors.black,
+                radius: 12,
+                child: Text(
+                  '${prov.xp}',
+                  style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
+                ),
+              ),
+            ),
           IconButton(
             icon: const Icon(Icons.history),
             tooltip: 'Verlauf',


### PR DESCRIPTION
## Summary
- show user XP in device header for single devices
- store XP in DeviceProvider and load from Firestore
- refresh XP after saving a session

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6863c451d4c88320afdb28d627a43ffd