### PR TITLE
Allow editing sessions on device page

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -185,10 +185,16 @@ class _DeviceScreenState extends State<DeviceScreen> {
                                 const SizedBox(height: 8),
                                 Text('Notiz: ${prov.lastSessionNote}'),
                               ],
-                            ],
+                          ],
                           ),
                         ),
                       ),
+                      if (prov.hasSessionToday)
+                        OutlinedButton.icon(
+                          onPressed: prov.startEditLastSession,
+                          icon: const Icon(Icons.edit),
+                          label: const Text('Session bearbeiten'),
+                        ),
                     ],
                     const Divider(),
                     if (plannedEntry != null)
@@ -331,10 +337,9 @@ class _DeviceScreenState extends State<DeviceScreen> {
                             gymId: widget.gymId,
                             userId: context.read<AuthProvider>().userId!,
                             showInLeaderboard:
-                                context
-                                    .read<AuthProvider>()
-                                    .showInLeaderboard ??
-                                true,
+                                context.read<AuthProvider>().showInLeaderboard ??
+                                    true,
+                            overwrite: prov.editingLastSession,
                           );
                           ScaffoldMessenger.of(context).showSnackBar(
                             const SnackBar(


### PR DESCRIPTION
## Summary
- add ability to re-open the last session for editing
- store last session id and editing state in `DeviceProvider`
- delete existing logs when saving an updated session
- show an edit button on the device page if today's session exists

## Testing
- `flutter test --coverage` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68649d7414348320b19ef2287900b53d