### PR TITLE
Track XP per device

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -83,8 +83,13 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => const AffiliateScreen());
 
       case rank:
-        final gymId = settings.arguments as String? ?? '';
-        return MaterialPageRoute(builder: (_) => RankScreen(gymId: gymId));
+        final args = settings.arguments as Map<String, String>? ?? const {};
+        return MaterialPageRoute(
+          builder: (_) => RankScreen(
+            gymId: args['gymId'] ?? '',
+            deviceId: args['deviceId'] ?? '',
+          ),
+        );
 
       case selectGym:
         return MaterialPageRoute(builder: (_) => const SelectGymScreen());

--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -113,7 +113,7 @@ class DeviceProvider extends ChangeNotifier {
       await _loadLastSession(gymId, deviceId, exerciseId, userId);
       await _loadUserNote(gymId, deviceId, userId);
       if (!_device!.isMulti) {
-        await _loadUserXp(gymId, userId);
+        await _loadUserXp(gymId, deviceId, userId);
       }
     } catch (e, st) {
       _error = e.toString();
@@ -259,7 +259,7 @@ class DeviceProvider extends ChangeNotifier {
     if (!_device!.isMulti && showInLeaderboard) {
       try {
         await _updateLeaderboard(gymId, userId, showInLeaderboard);
-        await _loadUserXp(gymId, userId);
+        await _loadUserXp(gymId, _device!.uid, userId);
       } catch (e, st) {
         debugPrintStack(label: '_updateLeaderboard', stackTrace: st);
       }
@@ -298,11 +298,13 @@ class DeviceProvider extends ChangeNotifier {
     final lbRef = _firestore
         .collection('gyms')
         .doc(gymId)
+        .collection('devices')
+        .doc(deviceId)
         .collection('leaderboard')
         .doc(userId);
     final sessionRef = lbRef
         .collection('dailySessions')
-        .doc('${deviceId}_$dateStr');
+        .doc(dateStr);
 
     await _firestore.runTransaction((tx) async {
       final lbSnap = await tx.get(lbRef);
@@ -399,11 +401,14 @@ class DeviceProvider extends ChangeNotifier {
 
   Future<void> _loadUserXp(
     String gymId,
+    String deviceId,
     String userId,
   ) async {
     final xpDoc = await _firestore
         .collection('gyms')
         .doc(gymId)
+        .collection('devices')
+        .doc(deviceId)
         .collection('leaderboard')
         .doc(userId)
         .get();

--- a/lib/core/providers/rank_provider.dart
+++ b/lib/core/providers/rank_provider.dart
@@ -14,9 +14,9 @@ class RankProvider extends ChangeNotifier {
 
   List<Map<String, dynamic>> get entries => _entries;
 
-  void watch(String gymId) {
+  void watch(String gymId, String deviceId) {
     _sub?.cancel();
-    _sub = _repository.watchLeaderboard(gymId).listen((list) {
+    _sub = _repository.watchLeaderboard(gymId, deviceId).listen((list) {
       _entries = list;
       notifyListeners();
     });

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -11,7 +11,7 @@ import 'package:tapem/features/report/presentation/screens/report_screen.dart';
 import 'package:tapem/features/admin/presentation/screens/admin_dashboard_screen.dart';
 import 'package:tapem/features/affiliate/presentation/screens/affiliate_screen.dart';
 import 'package:tapem/app_router.dart';
-import 'package:tapem/features/rank/presentation/screens/rank_screen.dart';
+import 'package:tapem/features/rank/presentation/screens/device_leaderboard_list_screen.dart';
 import 'package:tapem/features/training_plan/presentation/screens/plan_overview_screen.dart';
 import 'package:tapem/features/auth/presentation/widgets/username_dialog.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -34,7 +34,7 @@ class _HomeScreenState extends State<HomeScreen> {
       const ProfileScreen(),
       const ReportScreen(),
       const AdminDashboardScreen(),
-      RankScreen(gymId: gymId),
+      DeviceLeaderboardListScreen(gymId: gymId),
       const AffiliateScreen(),
       const PlanOverviewScreen(),
     ];

--- a/lib/features/rank/data/repositories/rank_repository_impl.dart
+++ b/lib/features/rank/data/repositories/rank_repository_impl.dart
@@ -22,7 +22,10 @@ class RankRepositoryImpl implements RankRepository {
   }
 
   @override
-  Stream<List<Map<String, dynamic>>> watchLeaderboard(String gymId) {
-    return _source.watchLeaderboard(gymId);
+  Stream<List<Map<String, dynamic>>> watchLeaderboard(
+    String gymId,
+    String deviceId,
+  ) {
+    return _source.watchLeaderboard(gymId, deviceId);
   }
 }

--- a/lib/features/rank/data/sources/firestore_rank_source.dart
+++ b/lib/features/rank/data/sources/firestore_rank_source.dart
@@ -17,11 +17,13 @@ class FirestoreRankSource {
     final lbRef = _firestore
         .collection('gyms')
         .doc(gymId)
+        .collection('devices')
+        .doc(deviceId)
         .collection('leaderboard')
         .doc(userId);
     final sessionRef = lbRef
         .collection('dailySessions')
-        .doc('${deviceId}_$dateStr');
+        .doc(dateStr);
 
     await _firestore.runTransaction((tx) async {
       final lbSnap = await tx.get(lbRef);
@@ -43,10 +45,15 @@ class FirestoreRankSource {
     });
   }
 
-  Stream<List<Map<String, dynamic>>> watchLeaderboard(String gymId) {
+  Stream<List<Map<String, dynamic>>> watchLeaderboard(
+    String gymId,
+    String deviceId,
+  ) {
     return _firestore
         .collection('gyms')
         .doc(gymId)
+        .collection('devices')
+        .doc(deviceId)
         .collection('leaderboard')
         .where('showInLeaderboard', isEqualTo: true)
         .orderBy('xp', descending: true)

--- a/lib/features/rank/domain/rank_repository.dart
+++ b/lib/features/rank/domain/rank_repository.dart
@@ -5,5 +5,9 @@ abstract class RankRepository {
     String deviceId,
     bool showInLeaderboard,
   );
-  Stream<List<Map<String, dynamic>>> watchLeaderboard(String gymId);
+
+  Stream<List<Map<String, dynamic>>> watchLeaderboard(
+    String gymId,
+    String deviceId,
+  );
 }

--- a/lib/features/rank/presentation/screens/device_leaderboard_list_screen.dart
+++ b/lib/features/rank/presentation/screens/device_leaderboard_list_screen.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/gym_provider.dart';
 import 'package:tapem/app_router.dart';
-import 'package:tapem/features/rank/presentation/screens/rank_screen.dart';
 
 class DeviceLeaderboardListScreen extends StatelessWidget {
   final String gymId;
@@ -27,8 +26,11 @@ class DeviceLeaderboardListScreen extends StatelessWidget {
             subtitle: Text('Code: ${d.id}'),
             onTap: () {
               Navigator.of(context).pushNamed(
-                AppRouter.rank, // <-- hier angepasst
-                arguments: gymId,
+                AppRouter.rank,
+                arguments: {
+                  'gymId': gymId,
+                  'deviceId': d.uid,
+                },
               );
             },
           );

--- a/lib/features/rank/presentation/screens/rank_screen.dart
+++ b/lib/features/rank/presentation/screens/rank_screen.dart
@@ -4,7 +4,9 @@ import 'package:tapem/core/providers/rank_provider.dart';
 
 class RankScreen extends StatefulWidget {
   final String gymId;
-  const RankScreen({Key? key, required this.gymId}) : super(key: key);
+  final String deviceId;
+  const RankScreen({Key? key, required this.gymId, required this.deviceId})
+      : super(key: key);
 
   @override
   _RankScreenState createState() => _RankScreenState();
@@ -17,7 +19,7 @@ class _RankScreenState extends State<RankScreen> {
   void initState() {
     super.initState();
     _provider = Provider.of<RankProvider>(context, listen: false);
-    _provider.watch(widget.gymId);
+    _provider.watch(widget.gymId, widget.deviceId);
   }
 
   @override


### PR DESCRIPTION
## Summary
- show leaderboard per device
- adjust route to accept deviceId
- load device XP for each session
- update home screen to open device leaderboards

## Testing
- `npm test` *(fails: Error: no test specified)*
- `dart format lib` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68649fe175388320bf61fbd7ae814a1b