### PR TITLE
Support decimal weights

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -230,7 +230,7 @@ class DeviceProvider extends ChangeNotifier {
         'exerciseId': _currentExerciseId,
         'sessionId': sessionId,
         'timestamp': ts,
-        'weight': int.parse(set['weight']!),
+        'weight': double.parse(set['weight']!.replaceAll(',', '.')),
         'reps': int.parse(set['reps']!),
         'note': _note,
       };

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -225,7 +225,9 @@ class _DeviceScreenState extends State<DeviceScreen> {
                                     labelText: 'kg',
                                     isDense: true,
                                   ),
-                                  keyboardType: TextInputType.number,
+                                  keyboardType:
+                                      const TextInputType.numberWithOptions(
+                                          decimal: true),
                                   onChanged: (v) {
                                     prov.updateSet(entry.key, weight: v);
                                   },
@@ -233,7 +235,9 @@ class _DeviceScreenState extends State<DeviceScreen> {
                                     if (v == null || v.isEmpty) {
                                       return 'Gewicht?';
                                     }
-                                    if (double.tryParse(v) == null) {
+                                    if (double.tryParse(
+                                            v.replaceAll(',', '.')) ==
+                                        null) {
                                       return 'Zahl eingeben';
                                     }
                                     return null;
@@ -410,8 +414,10 @@ class _PlannedTable extends StatelessWidget {
                       hintText: weightHint,
                       isDense: true,
                     ),
-                    keyboardType: TextInputType.number,
-                    onChanged: (v) => prov.updateSet(entrySet.key, weight: v),
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    onChanged: (v) =>
+                        prov.updateSet(entrySet.key, weight: v),
                   ),
                 ),
                 const SizedBox(width: 12),

--- a/lib/features/history/data/dtos/workout_log_dto.dart
+++ b/lib/features/history/data/dtos/workout_log_dto.dart
@@ -20,7 +20,7 @@ class WorkoutLogDto {
   )
   final DateTime timestamp;
 
-  final int weight;
+  final double weight;
   final int reps;
   final int? rir;
   final String? note;

--- a/lib/features/history/data/dtos/workout_log_dto.g.dart
+++ b/lib/features/history/data/dtos/workout_log_dto.g.dart
@@ -11,7 +11,7 @@ WorkoutLogDto _$WorkoutLogDtoFromJson(Map<String, dynamic> json) =>
       userId: json['userId'] as String,
       sessionId: json['sessionId'] as String,
       timestamp: WorkoutLogDto._timestampToDate(json['timestamp'] as Timestamp),
-      weight: (json['weight'] as num).toInt(),
+      weight: (json['weight'] as num).toDouble(),
       reps: (json['reps'] as num).toInt(),
       rir: json['rir'] as int?,
       note: json['setNote'] as String?,

--- a/lib/features/history/domain/models/workout_log.dart
+++ b/lib/features/history/domain/models/workout_log.dart
@@ -6,7 +6,7 @@ class WorkoutLog {
   final String userId;
   final String sessionId;
   final DateTime timestamp;
-  final int weight;
+  final double weight;
   final int reps;
   final int? rir;
   final String? note;

--- a/lib/features/training_details/data/dtos/session_dto.dart
+++ b/lib/features/training_details/data/dtos/session_dto.dart
@@ -7,7 +7,7 @@ class SessionDto {
   final String sessionId;
   final String deviceId;
   final DateTime timestamp;
-  final int weight;
+  final double weight;
   final int reps;
   final String note;
   final DocumentReference<Map<String, dynamic>> reference;
@@ -33,7 +33,7 @@ class SessionDto {
       sessionId: data['sessionId'] as String,
       deviceId: deviceId, // nicht mehr data['deviceId']
       timestamp: (data['timestamp'] as Timestamp).toDate(),
-      weight: (data['weight'] as num).toInt(),
+      weight: (data['weight'] as num).toDouble(),
       reps: (data['reps'] as num).toInt(),
       note: data['note'] as String? ?? '',
       reference: doc.reference,

--- a/lib/features/training_details/domain/models/session.dart
+++ b/lib/features/training_details/domain/models/session.dart
@@ -20,7 +20,7 @@ class Session {
 }
 
 class SessionSet {
-  final int weight;
+  final double weight;
   final int reps;
   SessionSet({ required this.weight, required this.reps });
 }

--- a/lib/features/training_plan/presentation/screens/import_plan_screen.dart
+++ b/lib/features/training_plan/presentation/screens/import_plan_screen.dart
@@ -150,11 +150,13 @@ class _ImportPlanScreenState extends State<ImportPlanScreen> {
                 : '',
         sets: [
           PlannedSet(
-            weight:
-                headerMap.containsKey('gewicht')
-                    ? double.tryParse(row[headerMap['gewicht']!].toString()) ??
-                        0
-                    : 0,
+              weight: headerMap.containsKey('gewicht')
+                  ? double.tryParse(
+                          row[headerMap['gewicht']!]
+                              .toString()
+                              .replaceAll(',', '.')) ??
+                      0
+                  : 0,
             reps: int.tryParse(row[repsIdx].toString()) ?? 0,
             rir: int.tryParse(row[headerMap['rir']!].toString()),
             note:


### PR DESCRIPTION
## Summary
- accept decimal numbers for session weights
- parse weights with comma values
- switch weight fields from int to double
- allow decimal input when importing training plans

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864a2600530832083ee72034b3927c9