### PR TITLE
Add XP-based level system

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -104,10 +104,20 @@ class _DeviceScreenState extends State<DeviceScreen> {
                 backgroundColor: Colors.greenAccent,
                 foregroundColor: Colors.black,
                 radius: 12,
-                child: Text(
-                  '${prov.xp}',
-                  style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold),
-                ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    'L${prov.level}',
+                    style: const TextStyle(
+                        fontSize: 10, fontWeight: FontWeight.bold),
+                  ),
+                  Text(
+                    '${prov.xp}',
+                    style: const TextStyle(fontSize: 10),
+                  ),
+                ],
+              ),
               ),
             ),
           IconButton(

--- a/lib/features/rank/domain/models/level_info.dart
+++ b/lib/features/rank/domain/models/level_info.dart
@@ -1,0 +1,20 @@
+class LevelInfo {
+  final int level;
+  final int xp;
+  LevelInfo({required this.level, required this.xp});
+
+  LevelInfo copyWith({int? level, int? xp}) =>
+      LevelInfo(level: level ?? this.level, xp: xp ?? this.xp);
+
+  factory LevelInfo.initial() => LevelInfo(level: 1, xp: 0);
+
+  factory LevelInfo.fromMap(Map<String, dynamic>? map) {
+    if (map == null) return LevelInfo.initial();
+    return LevelInfo(
+      level: map['level'] as int? ?? 1,
+      xp: map['xp'] as int? ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toMap() => {'level': level, 'xp': xp};
+}

--- a/lib/features/rank/domain/services/level_service.dart
+++ b/lib/features/rank/domain/services/level_service.dart
@@ -1,0 +1,23 @@
+import '../models/level_info.dart';
+
+class LevelService {
+  static const int xpPerLevel = 1000;
+  static const int maxLevel = 30;
+
+  LevelInfo addXp(LevelInfo info, int delta) {
+    if (info.level >= maxLevel) {
+      return info.copyWith(xp: 0);
+    }
+    var totalXp = info.xp + delta;
+    var level = info.level;
+    while (totalXp >= xpPerLevel && level < maxLevel) {
+      totalXp -= xpPerLevel;
+      level++;
+    }
+    if (level >= maxLevel) {
+      level = maxLevel;
+      totalXp = 0;
+    }
+    return LevelInfo(level: level, xp: totalXp);
+  }
+}

--- a/lib/features/rank/presentation/screens/rank_screen.dart
+++ b/lib/features/rank/presentation/screens/rank_screen.dart
@@ -36,7 +36,13 @@ class _RankScreenState extends State<RankScreen> {
               return ListTile(
                 leading: Text('#${i + 1}'),
                 title: Text(e['username'] ?? e['userId']),
-                trailing: Text('${e['xp']} XP'),
+                trailing: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text('L${e['level'] ?? 1}'),
+                    Text('${e['xp']} XP'),
+                  ],
+                ),
               );
             },
           );


### PR DESCRIPTION
## Summary
- implement `LevelInfo` model and `LevelService`
- track level data when adding XP in Firestore
- display level in device screen and leaderboard
- keep level information in `DeviceProvider`

## Testing
- `dart format -o none lib/features/rank/domain/models/level_info.dart` *(fails: dart not found)*
- `dart format -o none lib/features/rank/domain/services/level_service.dart` *(fails: dart not found)*
- `dart format -o none lib/features/rank/data/sources/firestore_rank_source.dart` *(fails: dart not found)*
- `dart format -o none lib/core/providers/device_provider.dart` *(fails: dart not found)*
- `dart format -o none lib/features/device/presentation/screens/device_screen.dart` *(fails: dart not found)*
- `dart format -o none lib/features/rank/presentation/screens/rank_screen.dart` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b16e193483208908f86e701411bb