### PR TITLE
Add device page level styles

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -12,6 +12,7 @@ import 'package:tapem/core/providers/training_plan_provider.dart';
 import '../../../training_plan/domain/models/exercise_entry.dart';
 import '../widgets/rest_timer_widget.dart';
 import '../widgets/note_button_widget.dart';
+import 'package:tapem/features/rank/presentation/device_level_style.dart';
 
 class DeviceScreen extends StatefulWidget {
   final String gymId;
@@ -93,6 +94,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
 
     // Single-Übung: hier bleiben
     return Scaffold(
+      backgroundColor: DeviceLevelStyle.backgroundFor(prov.level),
       appBar: AppBar(
         title: Text(prov.device!.name),
         centerTitle: true,

--- a/lib/features/rank/presentation/device_level_style.dart
+++ b/lib/features/rank/presentation/device_level_style.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+/// Provides background colors for the device page depending on a user's level.
+class DeviceLevelStyle {
+  static const Color level1Background = Color(0xFFE3F2FD); // light blue
+  static const Color level2Background = Color(0xFFE8F5E9); // light green
+  static const Color level3Background = Color(0xFFFFF8E1); // light gold
+
+  /// Returns the background color for the given level.
+  /// Levels above 3 reuse the color of level 3 for now.
+  static Color backgroundFor(int level) {
+    if (level <= 1) return level1Background;
+    if (level == 2) return level2Background;
+    return level3Background;
+  }
+}


### PR DESCRIPTION
## Summary
- create `DeviceLevelStyle` to choose device page background by level
- use `DeviceLevelStyle.backgroundFor()` in `DeviceScreen`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864b552c6dc832090b31b8ccf0ccbdc