### PR TITLE
Update device page widget colors

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -94,7 +94,6 @@ class _DeviceScreenState extends State<DeviceScreen> {
 
     // Single-Übung: hier bleiben
     return Scaffold(
-      backgroundColor: DeviceLevelStyle.backgroundFor(prov.level),
       appBar: AppBar(
         title: Text(prov.device!.name),
         centerTitle: true,
@@ -155,6 +154,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                     if (prov.lastSessionSets.isNotEmpty) ...[
                       Card(
                         margin: const EdgeInsets.symmetric(vertical: 8),
+                        color: DeviceLevelStyle.widgetColorFor(prov.level),
                         child: Padding(
                           padding: const EdgeInsets.all(12),
                           child: Column(
@@ -211,24 +211,33 @@ class _DeviceScreenState extends State<DeviceScreen> {
                     const Divider(),
                     if (plannedEntry != null)
                       _PlannedTable(entry: plannedEntry)
-                    else ...[
-                      const Text(
-                        'Neue Session',
-                        style: TextStyle(
-                          fontSize: 18,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      for (var entry in prov.sets.asMap().entries)
-                        Padding(
-                          padding: const EdgeInsets.symmetric(vertical: 4),
-                          child: Row(
+                    else
+                      Card(
+                        margin: const EdgeInsets.symmetric(vertical: 8),
+                        color: DeviceLevelStyle.widgetColorFor(prov.level),
+                        child: Padding(
+                          padding: const EdgeInsets.all(12),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
                             children: [
-                              SizedBox(
-                                width: 24,
-                                child: Text(entry.value['number']!),
+                              const Text(
+                                'Neue Session',
+                                style: TextStyle(
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.bold,
+                                ),
                               ),
+                              const SizedBox(height: 8),
+                              for (var entry in prov.sets.asMap().entries)
+                                Padding(
+                                  padding:
+                                      const EdgeInsets.symmetric(vertical: 4),
+                                  child: Row(
+                                    children: [
+                                      SizedBox(
+                                        width: 24,
+                                        child: Text(entry.value['number']!),
+                                      ),
                               const SizedBox(width: 12),
                               Expanded(
                                 child: TextFormField(
@@ -412,9 +421,14 @@ class _PlannedTable extends StatelessWidget {
     final repsHint = entry.reps?.toString();
     final rirHint = entry.rir > 0 ? entry.rir.toString() : null;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      color: DeviceLevelStyle.widgetColorFor(prov.level),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
         const Text(
           'Heute dran',
           style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
@@ -502,6 +516,7 @@ class _PlannedTable extends StatelessWidget {
         const Divider(),
         const RestTimerWidget(),
       ],
-    );
+    ),
+  );
   }
 }

--- a/lib/features/rank/presentation/device_level_style.dart
+++ b/lib/features/rank/presentation/device_level_style.dart
@@ -1,16 +1,19 @@
 import 'package:flutter/material.dart';
 
-/// Provides background colors for the device page depending on a user's level.
+/// Provides widget colors for the device page depending on a user's level.
 class DeviceLevelStyle {
-  static const Color level1Background = Color(0xFFE3F2FD); // light blue
-  static const Color level2Background = Color(0xFFE8F5E9); // light green
-  static const Color level3Background = Color(0xFFFFF8E1); // light gold
+  static const Color level1Widget = Color(0xFFE3F2FD); // light blue
+  static const Color level2Widget = Color(0xFFE8F5E9); // light green
+  static const Color level3Widget = Color(0xFFFFF8E1); // light gold
 
-  /// Returns the background color for the given level.
+  /// Returns the widget color for the given level.
   /// Levels above 3 reuse the color of level 3 for now.
-  static Color backgroundFor(int level) {
-    if (level <= 1) return level1Background;
-    if (level == 2) return level2Background;
-    return level3Background;
+  static Color widgetColorFor(int level) {
+    if (level <= 1) return level1Widget;
+    if (level == 2) return level2Widget;
+    return level3Widget;
   }
+
+  // Deprecated background method for backward compatibility.
+  static Color backgroundFor(int level) => widgetColorFor(level);
 }


### PR DESCRIPTION
## Summary
- color device page cards by user level instead of the whole background
- provide `widgetColorFor` in `DeviceLevelStyle`

## Testing
- `dart format lib/features/device/presentation/screens/device_screen.dart lib/features/rank/presentation/device_level_style.dart` *(fails: dart not found)*


------
https://chatgpt.com/codex/tasks/task_e_6864b972e5b08320a07c867632b4f91a