### PR TITLE
Fix closing parenthesis in device screen

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -517,6 +517,7 @@ class _PlannedTable extends StatelessWidget {
         const RestTimerWidget(),
       ],
     ),
-  );
+  ),
+);
   }
 }


### PR DESCRIPTION
## Summary
- fix missing closing parenthesis at the end of `_PlannedTable`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864bf9193308320baac67fa3a025a20