### PR TITLE
Fix device screen syntax errors

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -382,9 +382,12 @@ class _DeviceScreenState extends State<DeviceScreen> {
                 ],
               ),
             ),
-          ],
+          ),
         ),
-      );
+      ),
+    ),
+  ),
+);
   }
 }
 


### PR DESCRIPTION
## Summary
- fix unmatched parentheses in `DeviceScreen`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c9b3d1ec8320a708f80fdec9d38e