### PR TITLE
Fix color helper usage

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -154,7 +154,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                       Card(
                         margin: const EdgeInsets.symmetric(vertical: 8),
                         color: DeviceLevelStyle.widgetColorFor(
-                          level: prov.level,
+                          prov.level,
                         ),
                         child: Padding(
                           padding: const EdgeInsets.all(12),
@@ -216,7 +216,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                       Card(
                         margin: const EdgeInsets.symmetric(vertical: 8),
                         color: DeviceLevelStyle.widgetColorFor(
-                          level: prov.level,
+                          prov.level,
                         ),
                         child: Padding(
                           padding: const EdgeInsets.all(12),
@@ -438,7 +438,7 @@ class _PlannedTable extends StatelessWidget {
 
     return Card(
       margin: const EdgeInsets.symmetric(vertical: 8),
-      color: DeviceLevelStyle.widgetColorFor(level: prov.level),
+      color: DeviceLevelStyle.widgetColorFor(prov.level),
       child: Padding(
         padding: const EdgeInsets.all(12),
         child: Column(


### PR DESCRIPTION
## Beschreibung
Korrigiert Aufrufe von `DeviceLevelStyle.widgetColorFor` in `device_screen.dart`. Die Methode erwartet einen Positionsparameter, daher wurde der nicht existierende benannte Parameter entfernt.

## Typ der Änderung
- [x] fix: Bugfix

## Checkliste
- [ ] flutter analyze läuft fehlerfrei
- [ ] flutter test ist erfolgreich
- [x] Keine sensiblen Daten in Commits

------
https://chatgpt.com/codex/tasks/task_e_6864d89ac32083209f112eab7f0f7f60