### PR TITLE
Improve level widget colors

### DIFF
--- a/lib/features/rank/presentation/device_level_style.dart
+++ b/lib/features/rank/presentation/device_level_style.dart
@@ -2,9 +2,10 @@ import 'package:flutter/material.dart';
 
 /// Provides widget colors for the device page depending on a user's level.
 class DeviceLevelStyle {
-  static const Color level1Widget = Color(0xFFE3F2FD); // light blue
-  static const Color level2Widget = Color(0xFFE8F5E9); // light green
-  static const Color level3Widget = Color(0xFFFFF8E1); // light gold
+  // Use more saturated colors so the user level is clearly visible.
+  static const Color level1Widget = Color(0xFF42A5F5); // vivid blue
+  static const Color level2Widget = Color(0xFF66BB6A); // vivid green
+  static const Color level3Widget = Color(0xFFFFCA28); // vivid amber
 
   /// Returns the widget color for the given level.
   /// Levels above 3 reuse the color of level 3 for now.


### PR DESCRIPTION
## Summary
- update `DeviceLevelStyle` with more saturated colors so level indications are clearer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864eaf100008320a56963276bc0cb4b