### PR TITLE
Use level images for device widgets

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -153,10 +153,12 @@ class _DeviceScreenState extends State<DeviceScreen> {
                     if (prov.lastSessionSets.isNotEmpty) ...[
                       Card(
                         margin: const EdgeInsets.symmetric(vertical: 8),
-                        color: DeviceLevelStyle.widgetColorFor(
-                          prov.level,
-                        ),
-                        child: Padding(
+                        color: Colors.transparent,
+                        clipBehavior: Clip.antiAlias,
+                        child: Container(
+                          decoration: DeviceLevelStyle.widgetDecorationFor(
+                            prov.level,
+                          ),
                           padding: const EdgeInsets.all(12),
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -215,10 +217,12 @@ class _DeviceScreenState extends State<DeviceScreen> {
                     else ...[
                       Card(
                         margin: const EdgeInsets.symmetric(vertical: 8),
-                        color: DeviceLevelStyle.widgetColorFor(
-                          prov.level,
-                        ),
-                        child: Padding(
+                        color: Colors.transparent,
+                        clipBehavior: Clip.antiAlias,
+                        child: Container(
+                          decoration: DeviceLevelStyle.widgetDecorationFor(
+                            prov.level,
+                          ),
                           padding: const EdgeInsets.all(12),
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -438,8 +442,10 @@ class _PlannedTable extends StatelessWidget {
 
     return Card(
       margin: const EdgeInsets.symmetric(vertical: 8),
-      color: DeviceLevelStyle.widgetColorFor(prov.level),
-      child: Padding(
+      color: Colors.transparent,
+      clipBehavior: Clip.antiAlias,
+      child: Container(
+        decoration: DeviceLevelStyle.widgetDecorationFor(prov.level),
         padding: const EdgeInsets.all(12),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/features/rank/presentation/device_level_style.dart
+++ b/lib/features/rank/presentation/device_level_style.dart
@@ -1,11 +1,16 @@
 import 'package:flutter/material.dart';
 
-/// Provides widget colors for the device page depending on a user's level.
+/// Provides widget styling for the device page depending on a user's level.
 class DeviceLevelStyle {
-  // Use more saturated colors so the user level is clearly visible.
+  // Keep the old colors for potential fallback usage.
   static const Color level1Widget = Color(0xFF42A5F5); // vivid blue
   static const Color level2Widget = Color(0xFF66BB6A); // vivid green
   static const Color level3Widget = Color(0xFFFFCA28); // vivid amber
+
+  // Image assets used as background for widgets depending on the level.
+  static const String level1Image = 'assets/images/lvl1.png';
+  static const String level2Image = 'assets/images/lvl2.png';
+  static const String level3Image = 'assets/images/lvl3.png';
 
   /// Returns the widget color for the given level.
   /// Levels above 3 reuse the color of level 3 for now.
@@ -13,6 +18,24 @@ class DeviceLevelStyle {
     if (level <= 1) return level1Widget;
     if (level == 2) return level2Widget;
     return level3Widget;
+  }
+
+  /// Returns the background image path for the given level.
+  /// Levels above 3 reuse the image of level 3 for now.
+  static String _imageFor(int level) {
+    if (level <= 1) return level1Image;
+    if (level == 2) return level2Image;
+    return level3Image;
+  }
+
+  /// Decoration that applies the appropriate background image.
+  static BoxDecoration widgetDecorationFor(int level) {
+    return BoxDecoration(
+      image: DecorationImage(
+        image: AssetImage(_imageFor(level)),
+        fit: BoxFit.cover,
+      ),
+    );
   }
 
   // Deprecated background method for backward compatibility.


### PR DESCRIPTION
## Summary
- add level image decoration helper
- apply level background images on device page widgets

## Testing
- `flutter format lib/features/rank/presentation/device_level_style.dart lib/features/device/presentation/screens/device_screen.dart` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864f55ed3308320a8baef8afc655421