### PR TITLE
feat(rank): award XP per session

### DIFF
--- a/lib/core/providers/rank_provider.dart
+++ b/lib/core/providers/rank_provider.dart
@@ -26,9 +26,16 @@ class RankProvider extends ChangeNotifier {
     String gymId,
     String userId,
     String deviceId,
+    String sessionId,
     bool showInLeaderboard,
   ) {
-    return _repository.addXp(gymId, userId, deviceId, showInLeaderboard);
+    return _repository.addXp(
+      gymId,
+      userId,
+      deviceId,
+      sessionId,
+      showInLeaderboard,
+    );
   }
 
   @override

--- a/lib/features/rank/data/repositories/rank_repository_impl.dart
+++ b/lib/features/rank/data/repositories/rank_repository_impl.dart
@@ -11,12 +11,14 @@ class RankRepositoryImpl implements RankRepository {
     String gymId,
     String userId,
     String deviceId,
+    String sessionId,
     bool showInLeaderboard,
   ) {
     return _source.addXp(
       gymId: gymId,
       userId: userId,
       deviceId: deviceId,
+      sessionId: sessionId,
       showInLeaderboard: showInLeaderboard,
     );
   }

--- a/lib/features/rank/data/sources/firestore_rank_source.dart
+++ b/lib/features/rank/data/sources/firestore_rank_source.dart
@@ -14,6 +14,7 @@ class FirestoreRankSource {
     required String gymId,
     required String userId,
     required String deviceId,
+    required String sessionId,
     required bool showInLeaderboard,
   }) async {
     final now = DateTime.now();
@@ -26,8 +27,8 @@ class FirestoreRankSource {
         .collection('leaderboard')
         .doc(userId);
     final sessionRef = lbRef
-        .collection('dailySessions')
-        .doc(dateStr);
+        .collection('sessions')
+        .doc(sessionId);
 
     await _firestore.runTransaction((tx) async {
       final lbSnap = await tx.get(lbRef);
@@ -43,8 +44,11 @@ class FirestoreRankSource {
 
       final sessSnap = await tx.get(sessionRef);
       if (!sessSnap.exists) {
-        info = LevelService().addXp(info, 1);
-        tx.set(sessionRef, {'deviceId': deviceId, 'date': dateStr});
+        info = LevelService().addXp(info, 50);
+        tx.set(sessionRef, {
+          'deviceId': deviceId,
+          'date': dateStr,
+        });
         tx.update(lbRef, {
           'xp': info.xp,
           'level': info.level,

--- a/lib/features/rank/domain/rank_repository.dart
+++ b/lib/features/rank/domain/rank_repository.dart
@@ -3,6 +3,7 @@ abstract class RankRepository {
     String gymId,
     String userId,
     String deviceId,
+    String sessionId,
     bool showInLeaderboard,
   );
 


### PR DESCRIPTION
## Beschreibung
- verleihe 50 XP pro gespeicherter Session
- Sessions werden in eigener Subcollection `sessions` abgelegt
- Repository/Provider Signaturen um `sessionId` erweitert

## Typ der Änderung
- [x] feat: neues Feature

## Checkliste
- [ ] flutter analyze läuft fehlerfrei
- [ ] flutter test ist erfolgreich
- [x] Keine sensiblen Daten in Commits

------
https://chatgpt.com/codex/tasks/task_e_68650df542b88320abcf6a71b176c4e1