### PR TITLE
Fix Firestore transaction order

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -319,6 +319,8 @@ class DeviceProvider extends ChangeNotifier {
 
     await _firestore.runTransaction((tx) async {
       final lbSnap = await tx.get(lbRef);
+      final sessSnap = await tx.get(sessionRef);
+
       var info = LevelInfo.fromMap(lbSnap.data());
 
       if (!lbSnap.exists) {
@@ -329,7 +331,6 @@ class DeviceProvider extends ChangeNotifier {
         });
       }
 
-      final sessSnap = await tx.get(sessionRef);
       if (!sessSnap.exists) {
         info = LevelService().addXp(info, 50);
         tx.set(sessionRef, {

--- a/lib/features/rank/data/sources/firestore_rank_source.dart
+++ b/lib/features/rank/data/sources/firestore_rank_source.dart
@@ -32,6 +32,8 @@ class FirestoreRankSource {
 
     await _firestore.runTransaction((tx) async {
       final lbSnap = await tx.get(lbRef);
+      final sessSnap = await tx.get(sessionRef);
+
       var info = LevelInfo.fromMap(lbSnap.data());
 
       if (!lbSnap.exists) {
@@ -42,7 +44,6 @@ class FirestoreRankSource {
         });
       }
 
-      final sessSnap = await tx.get(sessionRef);
       if (!sessSnap.exists) {
         info = LevelService().addXp(info, 50);
         tx.set(sessionRef, {


### PR DESCRIPTION
## Summary
- ensure all reads happen before writes when updating leaderboard XP
- same fix for the rank data source

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6865158e8db083208f2a331533cf4bdd