### PR TITLE
Improve XP tracking for single devices

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -6,6 +6,15 @@
       "fields": [
         { "fieldPath": "emailLower", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "leaderboard",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "showInLeaderboard", "order": "ASCENDING" },
+        { "fieldPath": "level", "order": "DESCENDING" },
+        { "fieldPath": "xp", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -332,7 +332,7 @@ class DeviceProvider extends ChangeNotifier {
       }
 
       if (!sessSnap.exists) {
-        info = LevelService().addXp(info, 50);
+        info = LevelService().addXp(info, LevelService.xpPerSession);
         tx.set(sessionRef, {
           'deviceId': deviceId,
           'date': dateStr,

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -115,7 +115,10 @@ class _DeviceScreenState extends State<DeviceScreen> {
                         fontWeight: FontWeight.bold,
                       ),
                     ),
-                    Text('${prov.xp}', style: const TextStyle(fontSize: 10)),
+                    Text(
+                      '${prov.xp} XP',
+                      style: const TextStyle(fontSize: 10),
+                    ),
                   ],
                 ),
               ),

--- a/lib/features/rank/data/sources/firestore_rank_source.dart
+++ b/lib/features/rank/data/sources/firestore_rank_source.dart
@@ -45,7 +45,7 @@ class FirestoreRankSource {
       }
 
       if (!sessSnap.exists) {
-        info = LevelService().addXp(info, 50);
+        info = LevelService().addXp(info, LevelService.xpPerSession);
         tx.set(sessionRef, {
           'deviceId': deviceId,
           'date': dateStr,

--- a/lib/features/rank/domain/services/level_service.dart
+++ b/lib/features/rank/domain/services/level_service.dart
@@ -2,6 +2,7 @@ import '../models/level_info.dart';
 
 class LevelService {
   static const int xpPerLevel = 1000;
+  static const int xpPerSession = 50;
   static const int maxLevel = 30;
 
   LevelInfo addXp(LevelInfo info, int delta) {


### PR DESCRIPTION
## Summary
- add a dedicated `xpPerSession` constant in `LevelService`
- use the new constant in leaderboard updates
- show XP with units in single-device header
- index leaderboard queries for level and XP

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68651c5c1fe083209fc5c02378e6859b