### PR TITLE
Add XP info button widget

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -13,6 +13,7 @@ import '../../../training_plan/domain/models/exercise_entry.dart';
 import '../widgets/rest_timer_widget.dart';
 import '../widgets/note_button_widget.dart';
 import 'package:tapem/features/rank/presentation/device_level_style.dart';
+import 'package:tapem/features/rank/presentation/widgets/xp_info_button.dart';
 
 class DeviceScreen extends StatefulWidget {
   final String gymId;
@@ -101,27 +102,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
           if (!prov.device!.isMulti)
             Padding(
               padding: const EdgeInsets.only(right: 8.0),
-              child: CircleAvatar(
-                backgroundColor: Colors.greenAccent,
-                foregroundColor: Colors.black,
-                radius: 12,
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Text(
-                      'L${prov.level}',
-                      style: const TextStyle(
-                        fontSize: 10,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    Text(
-                      '${prov.xp} XP',
-                      style: const TextStyle(fontSize: 10),
-                    ),
-                  ],
-                ),
-              ),
+              child: XpInfoButton(xp: prov.xp, level: prov.level),
             ),
           IconButton(
             icon: const Icon(Icons.history),

--- a/lib/features/rank/presentation/widgets/xp_info_button.dart
+++ b/lib/features/rank/presentation/widgets/xp_info_button.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+class XpInfoButton extends StatelessWidget {
+  final int xp;
+  final int level;
+
+  const XpInfoButton({
+    Key? key,
+    required this.xp,
+    required this.level,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: const Icon(Icons.auto_awesome),
+      tooltip: 'XP',
+      onPressed: () => _showInfo(context),
+    );
+  }
+
+  void _showInfo(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('XP Info'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('XP: $xp'),
+            Text('Level: ${_toRoman(level)}'),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _toRoman(int number) {
+    const Map<int, String> romans = {
+      1000: 'M',
+      900: 'CM',
+      500: 'D',
+      400: 'CD',
+      100: 'C',
+      90: 'XC',
+      50: 'L',
+      40: 'XL',
+      10: 'X',
+      9: 'IX',
+      5: 'V',
+      4: 'IV',
+      1: 'I',
+    };
+    var result = '';
+    var remaining = number;
+    romans.forEach((value, numeral) {
+      while (remaining >= value) {
+        result += numeral;
+        remaining -= value;
+      }
+    });
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable XP info button widget that shows XP and level info
- replace old circle avatar in `DeviceScreen` with the new widget

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686527769f7c8320bc7140e91fc0d4fd