### PR TITLE
Implement basic muscle group management

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -7,6 +7,7 @@ import 'package:tapem/features/auth/presentation/screens/auth_screen.dart';
 import 'package:tapem/features/device/presentation/screens/device_screen.dart';
 import 'package:tapem/features/device/presentation/screens/exercise_list_screen.dart';
 import 'package:tapem/features/history/presentation/screens/history_screen.dart';
+import 'package:tapem/features/muscle_group/presentation/screens/muscle_group_screen.dart';
 import 'package:tapem/features/home/presentation/screens/home_screen.dart';
 import 'package:tapem/features/report/presentation/screens/report_screen.dart';
 import 'package:tapem/features/splash/presentation/screens/splash_screen.dart';
@@ -31,6 +32,7 @@ class AppRouter {
   static const trainingDetails = '/training_details';
   static const selectGym = '/select_gym';
   static const planOverview = '/plan_overview';
+  static const muscleGroups = '/muscle_groups';
 
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
     switch (settings.name) {
@@ -75,6 +77,9 @@ class AppRouter {
 
       case report:
         return MaterialPageRoute(builder: (_) => const ReportScreen());
+
+      case muscleGroups:
+        return MaterialPageRoute(builder: (_) => const MuscleGroupScreen());
 
       case admin:
         return MaterialPageRoute(builder: (_) => const AdminDashboardScreen());

--- a/lib/core/providers/muscle_group_provider.dart
+++ b/lib/core/providers/muscle_group_provider.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/foundation.dart';
+import 'package:provider/provider.dart';
+
+import "../../main.dart";
+import '../providers/auth_provider.dart';
+import '../providers/gym_provider.dart';
+import '../../features/muscle_group/data/repositories/muscle_group_repository_impl.dart';
+import '../../features/muscle_group/data/sources/firestore_muscle_group_source.dart';
+import '../../features/muscle_group/domain/models/muscle_group.dart';
+import '../../features/muscle_group/domain/usecases/get_muscle_groups_for_gym.dart';
+import '../../features/muscle_group/domain/usecases/save_muscle_group.dart';
+import '../../features/history/data/sources/firestore_history_source.dart';
+import '../../features/history/data/repositories/history_repository_impl.dart';
+import '../../features/history/domain/usecases/get_history_for_device.dart';
+
+class MuscleGroupProvider extends ChangeNotifier {
+  final GetMuscleGroupsForGym _getGroups;
+  final SaveMuscleGroup _saveGroup;
+  final GetHistoryForDevice _getHistory;
+
+  MuscleGroupProvider({
+    GetMuscleGroupsForGym? getGroups,
+    SaveMuscleGroup? saveGroup,
+    GetHistoryForDevice? getHistory,
+  })  : _getGroups = getGroups ??
+            GetMuscleGroupsForGym(
+              MuscleGroupRepositoryImpl(FirestoreMuscleGroupSource()),
+            ),
+        _saveGroup = saveGroup ??
+            SaveMuscleGroup(
+              MuscleGroupRepositoryImpl(FirestoreMuscleGroupSource()),
+            ),
+        _getHistory = getHistory ??
+            GetHistoryForDevice(
+              HistoryRepositoryImpl(FirestoreHistorySource()),
+            );
+
+  bool _isLoading = false;
+  String? _error;
+  List<MuscleGroup> _groups = [];
+  Map<String, int> _counts = {};
+
+  bool get isLoading => _isLoading;
+  String? get error => _error;
+  List<MuscleGroup> get groups => List.unmodifiable(_groups);
+  Map<String, int> get counts => Map.unmodifiable(_counts);
+
+  Future<void> loadGroups(BuildContext context) async {
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      final auth = Provider.of<AuthProvider>(context, listen: false);
+      final gymId = auth.gymCode;
+      final userId = auth.userId;
+      if (gymId == null || userId == null) {
+        throw Exception('Benutzer nicht eingeloggt');
+      }
+
+      _groups = await _getGroups.execute(gymId);
+      await _loadCounts(gymId, userId);
+    } catch (e, st) {
+      _error = e.toString();
+      debugPrintStack(label: 'MuscleGroupProvider.loadGroups', stackTrace: st);
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> saveGroup(BuildContext context, MuscleGroup group) async {
+    final auth = Provider.of<AuthProvider>(context, listen: false);
+    final gymId = auth.gymCode;
+    if (gymId == null) return;
+    await _saveGroup.execute(gymId, group);
+    await loadGroups(context);
+  }
+
+  Future<void> _loadCounts(String gymId, String userId) async {
+    final ctx = navigatorKey.currentContext;
+    if (ctx == null) return;
+    final devices = Provider.of<GymProvider>(ctx, listen: false).devices;
+    _counts.clear();
+    for (final group in _groups) {
+      int sum = 0;
+      for (final dId in group.deviceIds) {
+        final logs = await _getHistory.execute(
+          gymId: gymId,
+          deviceId: dId,
+          userId: userId,
+        );
+        sum += logs.length;
+      }
+      _counts[group.id] = sum;
+    }
+  }
+}

--- a/lib/features/device/data/dtos/device_dto.dart
+++ b/lib/features/device/data/dtos/device_dto.dart
@@ -7,6 +7,7 @@ class DeviceDto {
   late final String uid;
   final int id;
   final String name;
+  final List<String> muscleGroupIds;
   final String description;
   final String? nfcCode;
   final bool isMulti;
@@ -15,10 +16,11 @@ class DeviceDto {
     required this.uid,
     required this.id,
     required this.name,
+    List<String>? muscleGroupIds,
     required this.description,
     this.nfcCode,
     required this.isMulti,
-  });
+  }) : muscleGroupIds = List.from(muscleGroupIds ?? []);
 
   factory DeviceDto.fromDocument(DocumentSnapshot<Map<String, dynamic>> doc) {
     final data = doc.data()!;
@@ -30,6 +32,9 @@ class DeviceDto {
       nfcCode: data['nfcCode'] as String?,
       // if the field is missing or null, default to false
       isMulti: (data['isMulti'] as bool?) ?? false,
+      muscleGroupIds: (data['muscleGroupIds'] as List<dynamic>? ?? [])
+          .map((e) => e.toString())
+          .toList(),
     );
   }
 
@@ -38,6 +43,7 @@ class DeviceDto {
     uid: uid,
     id: id,
     name: name,
+    muscleGroupIds: muscleGroupIds,
     description: description,
     nfcCode: nfcCode,
     isMulti: isMulti,

--- a/lib/features/device/domain/models/device.dart
+++ b/lib/features/device/domain/models/device.dart
@@ -4,6 +4,7 @@ class Device {
   final String uid;
   final int id;
   final String name;
+  final List<String> muscleGroupIds;
   final String description;
   final String? nfcCode;
   final bool isMulti;
@@ -12,10 +13,11 @@ class Device {
     required this.uid,
     required this.id,
     required this.name,
+    List<String>? muscleGroupIds,
     this.description = '',
     this.nfcCode,
     this.isMulti = false,
-  });
+  }) : muscleGroupIds = List.unmodifiable(muscleGroupIds ?? []);
 
   Device copyWith({
     String? uid,
@@ -24,6 +26,7 @@ class Device {
     String? description,
     String? nfcCode,
     bool? isMulti,
+    List<String>? muscleGroupIds,
   }) => Device(
     uid:         uid         ?? this.uid,
     id:          id          ?? this.id,
@@ -31,6 +34,7 @@ class Device {
     description: description ?? this.description,
     nfcCode:     nfcCode     ?? this.nfcCode,
     isMulti:     isMulti     ?? this.isMulti,
+    muscleGroupIds: muscleGroupIds ?? this.muscleGroupIds,
   );
 
   factory Device.fromJson(Map<String, dynamic> json) => Device(
@@ -40,6 +44,9 @@ class Device {
     description: json['description'] as String? ?? '',
     nfcCode:     json['nfcCode']   as String?,
     isMulti:     json['isMulti']   as bool?   ?? false,
+    muscleGroupIds: (json['muscleGroupIds'] as List<dynamic>? ?? [])
+        .map((e) => e.toString())
+        .toList(),
   );
 
   Map<String, dynamic> toJson() => {
@@ -48,5 +55,6 @@ class Device {
     'description': description,
     'nfcCode':     nfcCode,
     'isMulti':     isMulti,
+    'muscleGroupIds': muscleGroupIds,
   };
 }

--- a/lib/features/device/domain/usecases/create_device_usecase.dart
+++ b/lib/features/device/domain/usecases/create_device_usecase.dart
@@ -20,6 +20,7 @@ class CreateDeviceUseCase {
     required String gymId,
     required Device device,
     required bool isMulti,
+    List<String>? muscleGroupIds,
   }) async {
     final existing = await _repo.getDevicesForGym(gymId);
     final maxId = existing.isEmpty
@@ -32,6 +33,7 @@ class CreateDeviceUseCase {
       id: nextId,
       nfcCode: code,
       isMulti: isMulti,
+      muscleGroupIds: muscleGroupIds,
     );
     await _repo.createDevice(gymId, toSave);
   }

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -7,6 +7,7 @@ import 'package:tapem/core/providers/gym_provider.dart';
 import 'package:tapem/core/providers/report_provider.dart';
 import 'package:tapem/features/gym/presentation/screens/gym_screen.dart';
 import 'package:tapem/features/profile/presentation/screens/profile_screen.dart';
+import 'package:tapem/features/muscle_group/presentation/screens/muscle_group_screen.dart';
 import 'package:tapem/features/report/presentation/screens/report_screen.dart';
 import 'package:tapem/features/admin/presentation/screens/admin_dashboard_screen.dart';
 import 'package:tapem/features/affiliate/presentation/screens/affiliate_screen.dart';
@@ -33,6 +34,7 @@ class _HomeScreenState extends State<HomeScreen> {
       const GymScreen(),
       const ProfileScreen(),
       const ReportScreen(),
+      const MuscleGroupScreen(),
       const AdminDashboardScreen(),
       DeviceLeaderboardListScreen(gymId: gymId),
       const AffiliateScreen(),
@@ -95,6 +97,10 @@ class _HomeScreenState extends State<HomeScreen> {
           BottomNavigationBarItem(
             icon: Icon(Icons.insert_chart),
             label: 'Report',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.accessibility_new),
+            label: 'Muskeln',
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.admin_panel_settings),

--- a/lib/features/muscle_group/data/dtos/muscle_group_dto.dart
+++ b/lib/features/muscle_group/data/dtos/muscle_group_dto.dart
@@ -1,0 +1,40 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../domain/models/muscle_group.dart';
+
+class MuscleGroupDto {
+  late final String id;
+  final String name;
+  final List<String> deviceIds;
+
+  MuscleGroupDto({
+    required this.name,
+    List<String>? deviceIds,
+  }) : deviceIds = List.from(deviceIds ?? []);
+
+  factory MuscleGroupDto.fromDocument(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data()!;
+    return MuscleGroupDto(
+      name: data['name'] as String? ?? '',
+      deviceIds: (data['deviceIds'] as List<dynamic>? ?? [])
+          .map((e) => e.toString())
+          .toList(),
+    )..id = doc.id;
+  }
+
+  MuscleGroup toModel() => MuscleGroup(
+        id: id,
+        name: name,
+        deviceIds: deviceIds,
+      );
+
+  factory MuscleGroupDto.fromModel(MuscleGroup model) => MuscleGroupDto(
+        name: model.name,
+        deviceIds: model.deviceIds,
+      )..id = model.id;
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'deviceIds': deviceIds,
+      };
+}

--- a/lib/features/muscle_group/data/repositories/muscle_group_repository_impl.dart
+++ b/lib/features/muscle_group/data/repositories/muscle_group_repository_impl.dart
@@ -1,0 +1,19 @@
+import '../sources/firestore_muscle_group_source.dart';
+import '../../domain/models/muscle_group.dart';
+import '../../domain/repositories/muscle_group_repository.dart';
+
+class MuscleGroupRepositoryImpl implements MuscleGroupRepository {
+  final FirestoreMuscleGroupSource _source;
+  MuscleGroupRepositoryImpl(this._source);
+
+  @override
+  Future<List<MuscleGroup>> getMuscleGroups(String gymId) async {
+    final dtos = await _source.getMuscleGroups(gymId);
+    return dtos.map((d) => d.toModel()).toList();
+  }
+
+  @override
+  Future<void> saveMuscleGroup(String gymId, MuscleGroup group) {
+    return _source.saveMuscleGroup(gymId, group);
+  }
+}

--- a/lib/features/muscle_group/data/sources/firestore_muscle_group_source.dart
+++ b/lib/features/muscle_group/data/sources/firestore_muscle_group_source.dart
@@ -1,0 +1,25 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../dtos/muscle_group_dto.dart';
+import '../../domain/models/muscle_group.dart';
+
+class FirestoreMuscleGroupSource {
+  final FirebaseFirestore _firestore;
+
+  FirestoreMuscleGroupSource([FirebaseFirestore? firestore])
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  CollectionReference<Map<String, dynamic>> _col(String gymId) {
+    return _firestore.collection('gyms').doc(gymId).collection('muscleGroups');
+  }
+
+  Future<List<MuscleGroupDto>> getMuscleGroups(String gymId) async {
+    final snap = await _col(gymId).get();
+    return snap.docs.map(MuscleGroupDto.fromDocument).toList();
+  }
+
+  Future<void> saveMuscleGroup(String gymId, MuscleGroup group) {
+    final dto = MuscleGroupDto.fromModel(group);
+    return _col(gymId).doc(dto.id).set(dto.toJson());
+  }
+}

--- a/lib/features/muscle_group/domain/models/muscle_group.dart
+++ b/lib/features/muscle_group/domain/models/muscle_group.dart
@@ -1,0 +1,34 @@
+class MuscleGroup {
+  final String id;
+  final String name;
+  final List<String> deviceIds;
+
+  MuscleGroup({
+    required this.id,
+    required this.name,
+    List<String>? deviceIds,
+  }) : deviceIds = List.unmodifiable(deviceIds ?? []);
+
+  MuscleGroup copyWith({
+    String? id,
+    String? name,
+    List<String>? deviceIds,
+  }) => MuscleGroup(
+        id: id ?? this.id,
+        name: name ?? this.name,
+        deviceIds: deviceIds ?? this.deviceIds,
+      );
+
+  factory MuscleGroup.fromJson(Map<String, dynamic> json, String id) => MuscleGroup(
+        id: id,
+        name: json['name'] as String? ?? '',
+        deviceIds: (json['deviceIds'] as List<dynamic>? ?? [])
+            .map((e) => e.toString())
+            .toList(),
+      );
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'deviceIds': deviceIds,
+      };
+}

--- a/lib/features/muscle_group/domain/repositories/muscle_group_repository.dart
+++ b/lib/features/muscle_group/domain/repositories/muscle_group_repository.dart
@@ -1,0 +1,6 @@
+import '../models/muscle_group.dart';
+
+abstract class MuscleGroupRepository {
+  Future<List<MuscleGroup>> getMuscleGroups(String gymId);
+  Future<void> saveMuscleGroup(String gymId, MuscleGroup group);
+}

--- a/lib/features/muscle_group/domain/usecases/get_muscle_groups_for_gym.dart
+++ b/lib/features/muscle_group/domain/usecases/get_muscle_groups_for_gym.dart
@@ -1,0 +1,9 @@
+import '../models/muscle_group.dart';
+import '../repositories/muscle_group_repository.dart';
+
+class GetMuscleGroupsForGym {
+  final MuscleGroupRepository _repo;
+  GetMuscleGroupsForGym(this._repo);
+
+  Future<List<MuscleGroup>> execute(String gymId) => _repo.getMuscleGroups(gymId);
+}

--- a/lib/features/muscle_group/domain/usecases/save_muscle_group.dart
+++ b/lib/features/muscle_group/domain/usecases/save_muscle_group.dart
@@ -1,0 +1,10 @@
+import '../models/muscle_group.dart';
+import '../repositories/muscle_group_repository.dart';
+
+class SaveMuscleGroup {
+  final MuscleGroupRepository _repo;
+  SaveMuscleGroup(this._repo);
+
+  Future<void> execute(String gymId, MuscleGroup group) =>
+      _repo.saveMuscleGroup(gymId, group);
+}

--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../../core/providers/muscle_group_provider.dart';
+import '../widgets/body_heatmap.dart';
+
+class MuscleGroupScreen extends StatefulWidget {
+  const MuscleGroupScreen({Key? key}) : super(key: key);
+
+  @override
+  State<MuscleGroupScreen> createState() => _MuscleGroupScreenState();
+}
+
+class _MuscleGroupScreenState extends State<MuscleGroupScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<MuscleGroupProvider>().loadGroups(context);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final prov = context.watch<MuscleGroupProvider>();
+
+    if (prov.isLoading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    if (prov.error != null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Muskelgruppen')),
+        body: Center(child: Text(prov.error!)),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Muskelgruppen')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: BodyHeatmap(),
+      ),
+    );
+  }
+}

--- a/lib/features/muscle_group/presentation/widgets/body_heatmap.dart
+++ b/lib/features/muscle_group/presentation/widgets/body_heatmap.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../../core/providers/muscle_group_provider.dart';
+
+class BodyHeatmap extends StatelessWidget {
+  const BodyHeatmap({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final prov = context.watch<MuscleGroupProvider>();
+
+    final maxCount = prov.counts.values.isEmpty
+        ? 0
+        : prov.counts.values.reduce((a, b) => a > b ? a : b);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: prov.groups.map((g) {
+        final count = prov.counts[g.id] ?? 0;
+        final intensity = maxCount > 0 ? count / maxCount : 0.0;
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: Row(
+            children: [
+              Expanded(child: Text(g.name)),
+              Expanded(
+                flex: 3,
+                child: LinearProgressIndicator(value: intensity),
+              ),
+              const SizedBox(width: 8),
+              Text(count.toString()),
+            ],
+          ),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,7 @@ import 'package:tapem/core/providers/exercise_provider.dart';
 import 'package:tapem/core/providers/report_provider.dart';
 import 'package:tapem/core/providers/rank_provider.dart';
 import 'package:tapem/core/providers/training_plan_provider.dart';
+import 'package:tapem/core/providers/muscle_group_provider.dart';
 
 import 'features/nfc/data/nfc_service.dart';
 import 'features/nfc/domain/usecases/read_nfc_code.dart';
@@ -153,6 +154,7 @@ class AppEntry extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => TrainingPlanProvider()),
         ChangeNotifierProvider(create: (_) => HistoryProvider()),
         ChangeNotifierProvider(create: (_) => ProfileProvider()),
+        ChangeNotifierProvider(create: (_) => MuscleGroupProvider()),
         ChangeNotifierProvider(
           create:
               (c) => ExerciseProvider(


### PR DESCRIPTION
## Summary
- add muscle group domain model, repository, Firestore source and use cases
- implement `MuscleGroupProvider` for loading groups and computing statistics
- create simple `BodyHeatmap` widget and screen
- extend `Device` model with `muscleGroupIds`
- update device DTO and creation use case
- add navigation route and tab for muscle groups
- register provider in `main.dart`

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6875923011588320910197f934b73ebf