### PR TITLE
Implement muscle group admin management

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -8,6 +8,7 @@ import 'package:tapem/features/device/presentation/screens/device_screen.dart';
 import 'package:tapem/features/device/presentation/screens/exercise_list_screen.dart';
 import 'package:tapem/features/history/presentation/screens/history_screen.dart';
 import 'package:tapem/features/muscle_group/presentation/screens/muscle_group_screen.dart';
+import 'package:tapem/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart';
 import 'package:tapem/features/home/presentation/screens/home_screen.dart';
 import 'package:tapem/features/report/presentation/screens/report_screen.dart';
 import 'package:tapem/features/splash/presentation/screens/splash_screen.dart';
@@ -33,6 +34,7 @@ class AppRouter {
   static const selectGym = '/select_gym';
   static const planOverview = '/plan_overview';
   static const muscleGroups = '/muscle_groups';
+  static const manageMuscleGroups = '/manage_muscle_groups';
 
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
     switch (settings.name) {
@@ -80,6 +82,9 @@ class AppRouter {
 
       case muscleGroups:
         return MaterialPageRoute(builder: (_) => const MuscleGroupScreen());
+
+      case manageMuscleGroups:
+        return MaterialPageRoute(builder: (_) => const MuscleGroupAdminScreen());
 
       case admin:
         return MaterialPageRoute(builder: (_) => const AdminDashboardScreen());

--- a/lib/core/providers/muscle_group_provider.dart
+++ b/lib/core/providers/muscle_group_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import "../../main.dart";
@@ -38,7 +39,7 @@ class MuscleGroupProvider extends ChangeNotifier {
   bool _isLoading = false;
   String? _error;
   List<MuscleGroup> _groups = [];
-  Map<String, int> _counts = {};
+  final Map<String, int> _counts = {};
 
   bool get isLoading => _isLoading;
   String? get error => _error;
@@ -80,7 +81,6 @@ class MuscleGroupProvider extends ChangeNotifier {
   Future<void> _loadCounts(String gymId, String userId) async {
     final ctx = navigatorKey.currentContext;
     if (ctx == null) return;
-    final devices = Provider.of<GymProvider>(ctx, listen: false).devices;
     _counts.clear();
     for (final group in _groups) {
       int sum = 0;

--- a/lib/features/admin/presentation/screens/admin_dashboard_screen.dart
+++ b/lib/features/admin/presentation/screens/admin_dashboard_screen.dart
@@ -11,6 +11,7 @@ import 'package:tapem/features/admin/presentation/widgets/device_list_item.dart'
 import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/features/device/domain/usecases/create_device_usecase.dart';
 import 'package:tapem/features/device/domain/usecases/get_devices_for_gym.dart';
+import 'package:tapem/app_router.dart';
 
 class AdminDashboardScreen extends StatefulWidget {
   const AdminDashboardScreen({Key? key}) : super(key: key);
@@ -147,6 +148,14 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen> {
                     icon: const Icon(Icons.add),
                     label: const Text('Gerät anlegen'),
                     onPressed: _showCreateDialog,
+                  ),
+                  const SizedBox(height: 8),
+                  ElevatedButton.icon(
+                    icon: const Icon(Icons.fitness_center),
+                    label: const Text('Muskelgruppen'),
+                    onPressed: () {
+                      Navigator.of(context).pushNamed(AppRouter.manageMuscleGroups);
+                    },
                   ),
                   const SizedBox(height: 24),
                   Expanded(

--- a/lib/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../../../core/providers/gym_provider.dart';
+import '../../../../core/providers/muscle_group_provider.dart';
+import '../../domain/models/muscle_group.dart';
+
+class MuscleGroupAdminScreen extends StatefulWidget {
+  const MuscleGroupAdminScreen({Key? key}) : super(key: key);
+
+  @override
+  State<MuscleGroupAdminScreen> createState() => _MuscleGroupAdminScreenState();
+}
+
+class _MuscleGroupAdminScreenState extends State<MuscleGroupAdminScreen> {
+  final Uuid _uuid = const Uuid();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<MuscleGroupProvider>().loadGroups(context);
+    });
+  }
+
+  void _showEditDialog({MuscleGroup? group}) {
+    final nameCtrl = TextEditingController(text: group?.name ?? '');
+    final devices = context.read<GymProvider>().devices;
+    final selected = group == null
+        ? <String>{}
+        : group.deviceIds.toSet();
+
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx2, setSt) => AlertDialog(
+          title: Text(group == null
+              ? 'Gruppe erstellen'
+              : 'Gruppe bearbeiten'),
+          content: SizedBox(
+            width: 300,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  controller: nameCtrl,
+                  decoration: const InputDecoration(labelText: 'Name'),
+                ),
+                const SizedBox(height: 8),
+                SizedBox(
+                  height: 200,
+                  child: ListView(
+                    children: [
+                      for (final d in devices)
+                        CheckboxListTile(
+                          value: selected.contains(d.uid),
+                          title: Text(d.name),
+                          onChanged: (v) => setSt(() {
+                            if (v == true) {
+                              selected.add(d.uid);
+                            } else {
+                              selected.remove(d.uid);
+                            }
+                          }),
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx2).pop(),
+              child: const Text('Abbrechen'),
+            ),
+            ElevatedButton(
+              onPressed: () async {
+                final id = group?.id ?? _uuid.v4();
+                final newGroup = MuscleGroup(
+                  id: id,
+                  name: nameCtrl.text.trim(),
+                  deviceIds: selected.toList(),
+                );
+                await context
+                    .read<MuscleGroupProvider>()
+                    .saveGroup(context, newGroup);
+                if (!mounted) return;
+                Navigator.of(ctx2).pop();
+              },
+              child: const Text('Speichern'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final prov = context.watch<MuscleGroupProvider>();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Muskelgruppen verwalten')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _showEditDialog(),
+        child: const Icon(Icons.add),
+      ),
+      body: prov.isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView.builder(
+              itemCount: prov.groups.length,
+              itemBuilder: (_, i) {
+                final g = prov.groups[i];
+                return ListTile(
+                  title: Text(g.name),
+                  subtitle: Text('${g.deviceIds.length} Geräte'),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.edit),
+                    onPressed: () => _showEditDialog(group: g),
+                  ),
+                );
+              },
+            ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- fix imports and lints in `MuscleGroupProvider`
- add admin UI for creating and editing muscle groups
- expose `/manage_muscle_groups` route
- link new admin screen from dashboard

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687597f2c0e48320bb9505ee8ebf9554