### PR TITLE
Implement muscle group regions with body heatmap

### DIFF
--- a/lib/features/muscle_group/data/dtos/muscle_group_dto.dart
+++ b/lib/features/muscle_group/data/dtos/muscle_group_dto.dart
@@ -5,10 +5,12 @@ import '../../domain/models/muscle_group.dart';
 class MuscleGroupDto {
   late final String id;
   final String name;
+  final MuscleRegion region;
   final List<String> deviceIds;
 
   MuscleGroupDto({
     required this.name,
+    required this.region,
     List<String>? deviceIds,
   }) : deviceIds = List.from(deviceIds ?? []);
 
@@ -16,6 +18,10 @@ class MuscleGroupDto {
     final data = doc.data()!;
     return MuscleGroupDto(
       name: data['name'] as String? ?? '',
+      region: MuscleRegion.values.firstWhere(
+        (r) => r.name == data['region'],
+        orElse: () => MuscleRegion.core,
+      ),
       deviceIds: (data['deviceIds'] as List<dynamic>? ?? [])
           .map((e) => e.toString())
           .toList(),
@@ -25,16 +31,19 @@ class MuscleGroupDto {
   MuscleGroup toModel() => MuscleGroup(
         id: id,
         name: name,
+        region: region,
         deviceIds: deviceIds,
       );
 
   factory MuscleGroupDto.fromModel(MuscleGroup model) => MuscleGroupDto(
         name: model.name,
+        region: model.region,
         deviceIds: model.deviceIds,
       )..id = model.id;
 
   Map<String, dynamic> toJson() => {
         'name': name,
+        'region': region.name,
         'deviceIds': deviceIds,
       };
 }

--- a/lib/features/muscle_group/domain/models/muscle_group.dart
+++ b/lib/features/muscle_group/domain/models/muscle_group.dart
@@ -1,27 +1,37 @@
+enum MuscleRegion { chest, back, shoulders, arms, core, legs }
+
 class MuscleGroup {
   final String id;
   final String name;
+  final MuscleRegion region;
   final List<String> deviceIds;
 
   MuscleGroup({
     required this.id,
     required this.name,
+    this.region = MuscleRegion.core,
     List<String>? deviceIds,
   }) : deviceIds = List.unmodifiable(deviceIds ?? []);
 
   MuscleGroup copyWith({
     String? id,
     String? name,
+    MuscleRegion? region,
     List<String>? deviceIds,
   }) => MuscleGroup(
         id: id ?? this.id,
         name: name ?? this.name,
+        region: region ?? this.region,
         deviceIds: deviceIds ?? this.deviceIds,
       );
 
   factory MuscleGroup.fromJson(Map<String, dynamic> json, String id) => MuscleGroup(
         id: id,
         name: json['name'] as String? ?? '',
+        region: MuscleRegion.values.firstWhere(
+          (r) => r.name == json['region'],
+          orElse: () => MuscleRegion.core,
+        ),
         deviceIds: (json['deviceIds'] as List<dynamic>? ?? [])
             .map((e) => e.toString())
             .toList(),
@@ -29,6 +39,7 @@ class MuscleGroup {
 
   Map<String, dynamic> toJson() => {
         'name': name,
+        'region': region.name,
         'deviceIds': deviceIds,
       };
 }

--- a/lib/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart
@@ -30,6 +30,7 @@ class _MuscleGroupAdminScreenState extends State<MuscleGroupAdminScreen> {
     final selected = group == null
         ? <String>{}
         : group.deviceIds.toSet();
+    MuscleRegion region = group?.region ?? MuscleRegion.core;
 
     showDialog<void>(
       context: context,
@@ -46,6 +47,18 @@ class _MuscleGroupAdminScreenState extends State<MuscleGroupAdminScreen> {
                 TextField(
                   controller: nameCtrl,
                   decoration: const InputDecoration(labelText: 'Name'),
+                ),
+                const SizedBox(height: 8),
+                DropdownButtonFormField<MuscleRegion>(
+                  value: region,
+                  decoration: const InputDecoration(labelText: 'Körperregion'),
+                  onChanged: (v) => setSt(() => region = v ?? MuscleRegion.core),
+                  items: MuscleRegion.values
+                      .map((r) => DropdownMenuItem(
+                            value: r,
+                            child: Text(r.name),
+                          ))
+                      .toList(),
                 ),
                 const SizedBox(height: 8),
                 SizedBox(
@@ -81,6 +94,7 @@ class _MuscleGroupAdminScreenState extends State<MuscleGroupAdminScreen> {
                 final newGroup = MuscleGroup(
                   id: id,
                   name: nameCtrl.text.trim(),
+                  region: region,
                   deviceIds: selected.toList(),
                 );
                 await context
@@ -115,7 +129,7 @@ class _MuscleGroupAdminScreenState extends State<MuscleGroupAdminScreen> {
                 final g = prov.groups[i];
                 return ListTile(
                   title: Text(g.name),
-                  subtitle: Text('${g.deviceIds.length} Geräte'),
+                  subtitle: Text('${g.deviceIds.length} Geräte · ${g.region.name}'),
                   trailing: IconButton(
                     icon: const Icon(Icons.edit),
                     onPressed: () => _showEditDialog(group: g),

--- a/lib/features/muscle_group/presentation/widgets/body_heatmap.dart
+++ b/lib/features/muscle_group/presentation/widgets/body_heatmap.dart
@@ -2,6 +2,51 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../../../core/providers/muscle_group_provider.dart';
+import '../../domain/models/muscle_group.dart';
+
+class _BodyHeatmapPainter extends CustomPainter {
+  final Map<MuscleRegion, double> intensities;
+  _BodyHeatmapPainter(this.intensities);
+
+  Color _color(double value) =>
+      Color.lerp(Colors.grey.shade300, Colors.red, value) ?? Colors.red;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()..style = PaintingStyle.fill;
+    final w = size.width;
+    final h = size.height;
+
+    // Shoulders
+    paint.color = _color(intensities[MuscleRegion.shoulders] ?? 0);
+    canvas.drawRect(Rect.fromLTWH(w * 0.3, h * 0.05, w * 0.4, h * 0.1), paint);
+
+    // Chest
+    paint.color = _color(intensities[MuscleRegion.chest] ?? 0);
+    canvas.drawRect(Rect.fromLTWH(w * 0.3, h * 0.15, w * 0.4, h * 0.15), paint);
+
+    // Arms
+    paint.color = _color(intensities[MuscleRegion.arms] ?? 0);
+    canvas.drawRect(Rect.fromLTWH(w * 0.1, h * 0.15, w * 0.2, h * 0.4), paint);
+    canvas.drawRect(Rect.fromLTWH(w * 0.7, h * 0.15, w * 0.2, h * 0.4), paint);
+
+    // Core
+    paint.color = _color(intensities[MuscleRegion.core] ?? 0);
+    canvas.drawRect(Rect.fromLTWH(w * 0.4, h * 0.3, w * 0.2, h * 0.2), paint);
+
+    // Legs
+    paint.color = _color(intensities[MuscleRegion.legs] ?? 0);
+    canvas.drawRect(Rect.fromLTWH(w * 0.4, h * 0.5, w * 0.15, h * 0.45), paint);
+    canvas.drawRect(Rect.fromLTWH(w * 0.55, h * 0.5, w * 0.15, h * 0.45), paint);
+
+    // Back
+    paint.color = _color(intensities[MuscleRegion.back] ?? 0);
+    canvas.drawRect(Rect.fromLTWH(w * 0.3, h * 0.15, w * 0.4, h * 0.15), paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
+}
 
 class BodyHeatmap extends StatelessWidget {
   const BodyHeatmap({Key? key}) : super(key: key);
@@ -14,26 +59,37 @@ class BodyHeatmap extends StatelessWidget {
         ? 0
         : prov.counts.values.reduce((a, b) => a > b ? a : b);
 
+    final intensities = <MuscleRegion, double>{};
+    for (final g in prov.groups) {
+      final count = prov.counts[g.id] ?? 0;
+      final intensity = maxCount > 0 ? count / maxCount : 0.0;
+      final existing = intensities[g.region];
+      if (existing == null || intensity > existing) {
+        intensities[g.region] = intensity;
+      }
+    }
+
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: prov.groups.map((g) {
-        final count = prov.counts[g.id] ?? 0;
-        final intensity = maxCount > 0 ? count / maxCount : 0.0;
-        return Padding(
-          padding: const EdgeInsets.symmetric(vertical: 4),
-          child: Row(
-            children: [
-              Expanded(child: Text(g.name)),
-              Expanded(
-                flex: 3,
-                child: LinearProgressIndicator(value: intensity),
-              ),
-              const SizedBox(width: 8),
-              Text(count.toString()),
-            ],
+      children: [
+        SizedBox(
+          height: 300,
+          child: CustomPaint(
+            painter: _BodyHeatmapPainter(intensities),
+            child: const SizedBox.expand(),
           ),
-        );
-      }).toList(),
+        ),
+        const SizedBox(height: 16),
+        for (final g in prov.groups)
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: Row(
+              children: [
+                Expanded(child: Text(g.name)),
+                Text((prov.counts[g.id] ?? 0).toString()),
+              ],
+            ),
+          ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- extend `MuscleGroup` model with `MuscleRegion` enum
- include region in DTO serialization
- let admins assign a region to each muscle group
- visualize statistics with a simple body heatmap

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `npx mocha firestore-tests/security_rules.test.js` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6878598853dc8320b98a77c9309a5d7b