### PR TITLE
Fix compile issue by updating flutter_cube

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   # Charts & Kalender
   fl_chart: ^1.0.0
   table_calendar: ^3.1.3
-  flutter_cube: ^0.0.5
+  flutter_cube: ^0.1.1
   flutter_heatmap_calendar: ^1.0.5
 
   # Weitere Helfer


### PR DESCRIPTION
## Summary
- update `flutter_cube` to ^0.1.1 so the package resolves with null-safety

## Testing
- `flutter pub upgrade` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68786e0ccda48320a11759765e2646ec