### PR TITLE
Fix compile errors in providers and 3D widget

### DIFF
--- a/lib/core/providers/exercise_provider.dart
+++ b/lib/core/providers/exercise_provider.dart
@@ -48,9 +48,9 @@ class ExerciseProvider extends ChangeNotifier {
     String gymId,
     String deviceId,
     String name,
-    String userId,
-    {List<String>? muscleGroupIds},
-  ) async {
+    String userId, {
+    List<String>? muscleGroupIds,
+  }) async {
     final ex = await _createEx.execute(
       gymId,
       deviceId,

--- a/lib/features/muscle_group/presentation/widgets/body_heatmap_3d.dart
+++ b/lib/features/muscle_group/presentation/widgets/body_heatmap_3d.dart
@@ -24,7 +24,7 @@ class BodyHeatmap3D extends StatelessWidget {
         final obj = cube.Object(fileName: 'assets/models/body.obj');
         // apply color based on overall intensity (placeholder)
         final intensity = maxCount > 0 ? prov.counts.values.reduce((a, b) => a + b) / (maxCount * prov.counts.length) : 0.0;
-        obj.updateTexture(cube.MeshTexture(color: intensityColor(intensity)));
+        // TODO: apply color when texture update API is available
         scene.world.add(obj);
         scene.camera.zoom = 10;
       }),


### PR DESCRIPTION
## Summary
- fix optional named parameter placement in `ExerciseProvider`
- comment out texture update call in heatmap widget since API isn't available

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6878729d372c8320b3be6b2d21c5f46f