### PR TITLE
Fix 3D heatmap linter warning

### DIFF
--- a/lib/features/muscle_group/presentation/widgets/body_heatmap_3d.dart
+++ b/lib/features/muscle_group/presentation/widgets/body_heatmap_3d.dart
@@ -10,9 +10,6 @@ class BodyHeatmap3D extends StatelessWidget {
   Widget build(BuildContext context) {
     final prov = context.watch<MuscleGroupProvider>();
 
-    final maxCount = prov.counts.values.isEmpty
-        ? 0
-        : prov.counts.values.reduce((a, b) => a > b ? a : b);
 
     return SizedBox(
       height: 300,


### PR DESCRIPTION
## Summary
- remove unused variable from `BodyHeatmap3D`

## Testing
- ❌ `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878774e73348320aa0a09097e5368bd