### PR TITLE
Remove unused provider variable

### DIFF
--- a/lib/features/muscle_group/presentation/widgets/body_heatmap_3d.dart
+++ b/lib/features/muscle_group/presentation/widgets/body_heatmap_3d.dart
@@ -1,15 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_cube/flutter_cube.dart' as cube;
-import '../../../../core/providers/muscle_group_provider.dart';
-import 'package:provider/provider.dart';
 
 class BodyHeatmap3D extends StatelessWidget {
   const BodyHeatmap3D({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final prov = context.watch<MuscleGroupProvider>();
-
 
     return SizedBox(
       height: 300,


### PR DESCRIPTION
## Summary
- clean up `BodyHeatmap3D` by removing the unused provider import and variable

## Testing
- `flutter --version` *(fails: command not found)*
- `npm ci` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6878788bb0a48320a64b1342ad1d92ad