### PR TITLE
feat(muscle): add vector muscle paths and integrate

### DIFF
--- a/lib/features/muscle_group/presentation/widgets/advanced_body_heatmap.dart
+++ b/lib/features/muscle_group/presentation/widgets/advanced_body_heatmap.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:vector_math/vector_math_64.dart' show Matrix4;
 
 import '../../../../core/providers/muscle_group_provider.dart';
 import '../../domain/models/muscle_group.dart';
+import 'muscle_paths.dart';
 
 class _AdvancedHeatmapPainter extends CustomPainter {
   final Map<MuscleRegion, double> intensities;
@@ -18,6 +20,13 @@ class _AdvancedHeatmapPainter extends CustomPainter {
     if (value > 0.66) return _primaryColor;
     if (value > 0) return _secondaryColor;
     return _mutedColor;
+  }
+
+  Path _mirror(Path path, double width) {
+    final matrix = Matrix4.identity()
+      ..scale(-1.0, 1.0)
+      ..translate(width, 0.0);
+    return path.transform(matrix.storage);
   }
 
   @override
@@ -48,63 +57,50 @@ class _AdvancedHeatmapPainter extends CustomPainter {
     }
 
     // Shoulders
-    final leftShoulder = Path()..addOval(Rect.fromLTWH(w * 0.25, h * 0.18, w * 0.15, h * 0.09));
-    final rightShoulder = Path()..addOval(Rect.fromLTWH(w * 0.6, h * 0.18, w * 0.15, h * 0.09));
+    final leftShoulder = MusclePaths.deltoidPath(size);
+    final rightShoulder = _mirror(leftShoulder, w);
     drawRegion(leftShoulder, MuscleRegion.shoulders);
     drawRegion(rightShoulder, MuscleRegion.shoulders);
 
     // Chest
-    final chest = Path()
-      ..addRRect(RRect.fromRectAndRadius(Rect.fromLTWH(w * 0.37, h * 0.23, w * 0.26, h * 0.12), Radius.circular(w * 0.03)));
-    drawRegion(chest, MuscleRegion.chest);
+    drawRegion(MusclePaths.pectoralisPath(size), MuscleRegion.chest);
 
     // Biceps
-    final leftBiceps = Path()..addRRect(RRect.fromRectAndRadius(Rect.fromLTWH(w * 0.2, h * 0.28, w * 0.1, h * 0.14), Radius.circular(w * 0.03)));
-    final rightBiceps = Path()..addRRect(RRect.fromRectAndRadius(Rect.fromLTWH(w * 0.7, h * 0.28, w * 0.1, h * 0.14), Radius.circular(w * 0.03)));
+    final leftBiceps = MusclePaths.bicepsPath(size);
+    final rightBiceps = _mirror(leftBiceps, w);
     drawRegion(leftBiceps, MuscleRegion.arms);
     drawRegion(rightBiceps, MuscleRegion.arms);
 
     // Forearms
-    final leftForearm = Path()..addRRect(RRect.fromRectAndRadius(Rect.fromLTWH(w * 0.2, h * 0.42, w * 0.1, h * 0.22), Radius.circular(w * 0.03)));
-    final rightForearm = Path()..addRRect(RRect.fromRectAndRadius(Rect.fromLTWH(w * 0.7, h * 0.42, w * 0.1, h * 0.22), Radius.circular(w * 0.03)));
+    final leftForearm = MusclePaths.forearmFlexorsPath(size);
+    final rightForearm = _mirror(leftForearm, w);
     drawRegion(leftForearm, MuscleRegion.arms);
     drawRegion(rightForearm, MuscleRegion.arms);
 
     // Obliques
-    final leftOblique = Path()..addOval(Rect.fromLTWH(w * 0.35, h * 0.34, w * 0.07, h * 0.14));
-    final rightOblique = Path()..addOval(Rect.fromLTWH(w * 0.58, h * 0.34, w * 0.07, h * 0.14));
+    final leftOblique = MusclePaths.obliquesPath(size);
+    final rightOblique = _mirror(leftOblique, w);
     drawRegion(leftOblique, MuscleRegion.core);
     drawRegion(rightOblique, MuscleRegion.core);
 
     // Abs
-    for (int i = 0; i < 3; i++) {
-      final rectLeft = Path()..addRRect(RRect.fromRectAndRadius(Rect.fromLTWH(w * 0.46, h * (0.3 + 0.05 * i * 2), w * 0.04, h * 0.06), Radius.circular(w * 0.015)));
-      final rectRight = Path()..addRRect(RRect.fromRectAndRadius(Rect.fromLTWH(w * 0.5, h * (0.3 + 0.05 * i * 2), w * 0.04, h * 0.06), Radius.circular(w * 0.015)));
-      drawRegion(rectLeft, MuscleRegion.core);
-      drawRegion(rectRight, MuscleRegion.core);
-    }
+    drawRegion(MusclePaths.rectusAbdominisPath(size), MuscleRegion.core);
 
     // Quadriceps
-    final leftQuad = Path()..addRRect(RRect.fromRectAndRadius(Rect.fromLTWH(w * 0.44, h * 0.54, w * 0.1, h * 0.22), Radius.circular(w * 0.05)));
-    final rightQuad = Path()..addRRect(RRect.fromRectAndRadius(Rect.fromLTWH(w * 0.56, h * 0.54, w * 0.1, h * 0.22), Radius.circular(w * 0.05)));
-    drawRegion(leftQuad, MuscleRegion.legs);
-    drawRegion(rightQuad, MuscleRegion.legs);
+    drawRegion(MusclePaths.quadricepsPath(size), MuscleRegion.legs);
 
     // Vastus medialis (inner knee)
-    final leftVastus = Path()..addOval(Rect.fromLTWH(w * 0.47, h * 0.7, w * 0.05, h * 0.05));
-    final rightVastus = Path()..addOval(Rect.fromLTWH(w * 0.58, h * 0.7, w * 0.05, h * 0.05));
+    final leftVastus = MusclePaths.vastusMedialisPath(size);
+    final rightVastus = _mirror(leftVastus, w);
     drawRegion(leftVastus, MuscleRegion.legs);
     drawRegion(rightVastus, MuscleRegion.legs);
 
     // Tibialis anterior (shin)
-    final leftShin = Path()..addRRect(RRect.fromRectAndRadius(Rect.fromLTWH(w * 0.47, h * 0.75, w * 0.05, h * 0.12), Radius.circular(w * 0.02)));
-    final rightShin = Path()..addRRect(RRect.fromRectAndRadius(Rect.fromLTWH(w * 0.58, h * 0.75, w * 0.05, h * 0.12), Radius.circular(w * 0.02)));
-    drawRegion(leftShin, MuscleRegion.legs);
-    drawRegion(rightShin, MuscleRegion.legs);
+    drawRegion(MusclePaths.tibialisAnteriorPath(size), MuscleRegion.legs);
 
     // Calves
-    final leftCalf = Path()..addOval(Rect.fromLTWH(w * 0.46, h * 0.87, w * 0.06, h * 0.07));
-    final rightCalf = Path()..addOval(Rect.fromLTWH(w * 0.58, h * 0.87, w * 0.06, h * 0.07));
+    final leftCalf = MusclePaths.gastrocnemiusPath(size);
+    final rightCalf = _mirror(leftCalf, w);
     drawRegion(leftCalf, MuscleRegion.legs);
     drawRegion(rightCalf, MuscleRegion.legs);
   }

--- a/lib/features/muscle_group/presentation/widgets/muscle_paths.dart
+++ b/lib/features/muscle_group/presentation/widgets/muscle_paths.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/widgets.dart';
+
+/// Vector Path shapes for major front muscle groups used in the advanced heatmap.
+class MusclePaths {
+  /// Quadriceps (front thigh)
+  static Path quadricepsPath(Size size) {
+    final w = size.width;
+    final h = size.height;
+    return Path()
+      ..moveTo(w * 0.35, h * 0.55)
+      ..lineTo(w * 0.65, h * 0.55)
+      ..lineTo(w * 0.60, h * 0.85)
+      ..lineTo(w * 0.40, h * 0.85)
+      ..close();
+  }
+
+  /// Vastus Medialis (inner knee)
+  static Path vastusMedialisPath(Size size) {
+    final w = size.width;
+    final h = size.height;
+    return Path()
+      ..moveTo(w * 0.40, h * 0.83)
+      ..quadraticBezierTo(w * 0.38, h * 0.88, w * 0.42, h * 0.90)
+      ..quadraticBezierTo(w * 0.44, h * 0.88, w * 0.42, h * 0.83)
+      ..close();
+  }
+
+  /// Tibialis Anterior (shin)
+  static Path tibialisAnteriorPath(Size size) {
+    final w = size.width;
+    final h = size.height;
+    return Path()
+      ..moveTo(w * 0.45, h * 0.80)
+      ..lineTo(w * 0.55, h * 0.80)
+      ..lineTo(w * 0.53, h * 0.95)
+      ..lineTo(w * 0.47, h * 0.95)
+      ..close();
+  }
+
+  /// Gastrocnemius (calf)
+  static Path gastrocnemiusPath(Size size) {
+    final w = size.width;
+    final h = size.height;
+    return Path()
+      ..moveTo(w * 0.38, h * 0.85)
+      ..quadraticBezierTo(w * 0.30, h * 0.92, w * 0.35, h * 0.98)
+      ..quadraticBezierTo(w * 0.40, h * 0.92, w * 0.38, h * 0.85)
+      ..close();
+  }
+
+  /// Deltoid (shoulder)
+  static Path deltoidPath(Size size) {
+    final w = size.width;
+    final h = size.height;
+    return Path()
+      ..moveTo(w * 0.25, h * 0.18)
+      ..quadraticBezierTo(w * 0.20, h * 0.25, w * 0.28, h * 0.28)
+      ..quadraticBezierTo(w * 0.33, h * 0.25, w * 0.30, h * 0.18)
+      ..close();
+  }
+
+  /// Pectoralis Major (chest)
+  static Path pectoralisPath(Size size) {
+    final w = size.width;
+    final h = size.height;
+    return Path()
+      ..moveTo(w * 0.30, h * 0.25)
+      ..lineTo(w * 0.70, h * 0.25)
+      ..lineTo(w * 0.65, h * 0.40)
+      ..lineTo(w * 0.35, h * 0.40)
+      ..close();
+  }
+
+  /// Rectus Abdominis (abs)
+  static Path rectusAbdominisPath(Size size) {
+    final w = size.width;
+    final h = size.height;
+    return Path()
+      ..addRect(Rect.fromLTWH(w * 0.42, h * 0.40, w * 0.16, h * 0.20));
+  }
+
+  /// Obliques (side abs)
+  static Path obliquesPath(Size size) {
+    final w = size.width;
+    final h = size.height;
+    return Path()
+      ..moveTo(w * 0.25, h * 0.45)
+      ..quadraticBezierTo(w * 0.20, h * 0.55, w * 0.25, h * 0.65)
+      ..lineTo(w * 0.30, h * 0.60)
+      ..quadraticBezierTo(w * 0.27, h * 0.55, w * 0.30, h * 0.50)
+      ..close();
+  }
+
+  /// Biceps Brachii (upper arm front)
+  static Path bicepsPath(Size size) {
+    final w = size.width;
+    final h = size.height;
+    return Path()
+      ..moveTo(w * 0.20, h * 0.40)
+      ..quadraticBezierTo(w * 0.18, h * 0.50, w * 0.20, h * 0.60)
+      ..lineTo(w * 0.25, h * 0.58)
+      ..quadraticBezierTo(w * 0.23, h * 0.50, w * 0.25, h * 0.42)
+      ..close();
+  }
+
+  /// Forearm Flexors (lower arm front)
+  static Path forearmFlexorsPath(Size size) {
+    final w = size.width;
+    final h = size.height;
+    return Path()
+      ..moveTo(w * 0.20, h * 0.60)
+      ..lineTo(w * 0.20, h * 0.80)
+      ..lineTo(w * 0.28, h * 0.78)
+      ..lineTo(w * 0.28, h * 0.58)
+      ..close();
+  }
+}
+
+/// Usage example:
+/// canvas.drawPath(MusclePaths.quadricepsPath(size), paint);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   table_calendar: ^3.1.3
   flutter_cube: ^0.1.1
   flutter_heatmap_calendar: ^1.0.5
+  vector_math: ^2.1.4
 
   # Weitere Helfer
   flutter_dotenv: ^5.0.2


### PR DESCRIPTION
## Summary
- add `MusclePaths` with vector shapes for main front muscles
- use the new paths in `AdvancedBodyHeatmap`
- include `vector_math` dependency for path mirroring

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6879a4d4bd448320b40625e2a42ca0d2