### PR TITLE
Add branding config screen

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -10,6 +10,7 @@ import 'package:tapem/features/history/presentation/screens/history_screen.dart'
 import 'package:tapem/features/muscle_group/presentation/screens/muscle_group_screen.dart';
 import 'package:tapem/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart';
 import 'package:tapem/features/home/presentation/screens/home_screen.dart';
+import 'package:tapem/features/admin/presentation/screens/branding_screen.dart';
 import 'package:tapem/features/report/presentation/screens/report_screen.dart';
 import 'package:tapem/features/splash/presentation/screens/splash_screen.dart';
 import 'package:tapem/features/gym/presentation/screens/select_gym_screen.dart';
@@ -35,6 +36,7 @@ class AppRouter {
   static const planOverview = '/plan_overview';
   static const muscleGroups = '/muscle_groups';
   static const manageMuscleGroups = '/manage_muscle_groups';
+  static const branding = '/branding';
 
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
     switch (settings.name) {
@@ -85,6 +87,9 @@ class AppRouter {
 
       case manageMuscleGroups:
         return MaterialPageRoute(builder: (_) => const MuscleGroupAdminScreen());
+
+      case branding:
+        return MaterialPageRoute(builder: (_) => const BrandingScreen());
 
       case admin:
         return MaterialPageRoute(builder: (_) => const AdminDashboardScreen());

--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -40,6 +40,12 @@ class AppTheme {
     secondary: neutralAccent,
   );
 
+  /// Erstellt ein Theme mit beliebigen Farben.
+  static ThemeData customTheme({
+    required Color primary,
+    required Color secondary,
+  }) => _buildTheme(primary: primary, secondary: secondary);
+
   /// Baut ein ThemeData mit angegebenen Primär- und Sekundärfarben.
   static ThemeData _buildTheme({
     required Color primary,

--- a/lib/core/theme/theme_loader.dart
+++ b/lib/core/theme/theme_loader.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'theme.dart';
 
 /// Lädt dynamisch Themes je nach Gym.
@@ -12,16 +13,33 @@ class ThemeLoader extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Lädt je nach gymId entweder Blau- oder Grün-Theme.
-  void loadGymTheme(String gymId) {
-    switch (gymId) {
-      case 'gym_02':
-        _currentTheme = AppTheme.greenDarkTheme;
-        break;
-      case 'gym_01':
-      default:
-        _currentTheme = AppTheme.darkTheme;
+  /// Lädt Theme-Konfiguration aus Firestore anhand der Gym-ID.
+  Future<void> loadGymTheme(String gymId) async {
+    if (gymId.isEmpty) {
+      loadDefault();
+      return;
     }
+    final doc =
+        await FirebaseFirestore.instance.collection('gyms').doc(gymId).get();
+    if (doc.exists) {
+      final data = doc.data()!;
+      final primaryHex = data['primaryColor'] as String?;
+      final accentHex = data['accentColor'] as String?;
+      if (primaryHex != null && accentHex != null) {
+        final primary = _parseHex(primaryHex);
+        final accent = _parseHex(accentHex);
+        _currentTheme = AppTheme.customTheme(primary: primary, secondary: accent);
+        notifyListeners();
+        return;
+      }
+    }
+    _currentTheme = AppTheme.darkTheme;
     notifyListeners();
+  }
+
+  Color _parseHex(String hex) {
+    hex = hex.replaceFirst('#', '');
+    if (hex.length == 6) hex = 'FF$hex';
+    return Color(int.parse(hex, radix: 16));
   }
 }

--- a/lib/features/admin/presentation/screens/admin_dashboard_screen.dart
+++ b/lib/features/admin/presentation/screens/admin_dashboard_screen.dart
@@ -189,6 +189,14 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen> {
                       Navigator.of(context).pushNamed(AppRouter.manageMuscleGroups);
                     },
                   ),
+                  const SizedBox(height: 8),
+                  ElevatedButton.icon(
+                    icon: const Icon(Icons.brush),
+                    label: const Text('Branding'),
+                    onPressed: () {
+                      Navigator.of(context).pushNamed(AppRouter.branding);
+                    },
+                  ),
                   const SizedBox(height: 24),
                   Expanded(
                     child: ListView.separated(

--- a/lib/features/admin/presentation/screens/branding_screen.dart
+++ b/lib/features/admin/presentation/screens/branding_screen.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:firebase_functions/firebase_functions.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:tapem/core/providers/auth_provider.dart';
+
+class BrandingScreen extends StatefulWidget {
+  const BrandingScreen({Key? key}) : super(key: key);
+
+  @override
+  State<BrandingScreen> createState() => _BrandingScreenState();
+}
+
+class _BrandingScreenState extends State<BrandingScreen> {
+  Uint8List? _logoBytes;
+  final _primaryCtrl = TextEditingController();
+  final _accentCtrl = TextEditingController();
+  bool _loading = false;
+  String? _error;
+
+  final _hexReg = RegExp(r'^[0-9a-fA-F]{6}\$');
+
+  Future<void> _pickLogo() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.image,
+      withData: true,
+    );
+    if (result == null) return;
+    final bytes = result.files.single.bytes;
+    if (bytes == null) return;
+    if (bytes.length > 500 * 1024) {
+      setState(() => _error = 'Bild zu groß (max 500KB)');
+      return;
+    }
+    setState(() {
+      _logoBytes = bytes;
+      _error = null;
+    });
+  }
+
+  Future<void> _save() async {
+    final gymId = context.read<AuthProvider>().gymCode!;
+    final primary = _primaryCtrl.text.replaceAll('#', '');
+    final accent = _accentCtrl.text.replaceAll('#', '');
+
+    if (!_hexReg.hasMatch(primary) || !_hexReg.hasMatch(accent) || _logoBytes == null) {
+      setState(() => _error = 'Bitte gültige Farben und Logo wählen');
+      return;
+    }
+
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+
+    final callable = FirebaseFunctions.instance.httpsCallable('updateBranding');
+    try {
+      await callable.call(<String, dynamic>{
+        'gymId': gymId,
+        'logo': base64Encode(_logoBytes!),
+        'primaryColor': primary,
+        'accentColor': accent,
+      });
+      if (mounted) Navigator.of(context).pop(true);
+    } catch (e) {
+      setState(() => _error = 'Fehler: $e');
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Branding')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (_logoBytes != null)
+              Image.memory(_logoBytes!, height: 100),
+            ElevatedButton(
+              onPressed: _pickLogo,
+              child: const Text('Logo auswählen'),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _primaryCtrl,
+              decoration: const InputDecoration(labelText: 'Primärfarbe (hex)'),
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _accentCtrl,
+              decoration: const InputDecoration(labelText: 'Akzentfarbe (hex)'),
+            ),
+            if (_error != null) ...[
+              const SizedBox(height: 8),
+              Text(_error!, style: const TextStyle(color: Colors.red)),
+            ],
+            const Spacer(),
+            ElevatedButton(
+              onPressed: _loading ? null : _save,
+              child: _loading
+                  ? const SizedBox(
+                      height: 16,
+                      width: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Speichern'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/gym/domain/models/gym_config.dart
+++ b/lib/features/gym/domain/models/gym_config.dart
@@ -3,11 +3,17 @@ class GymConfig {
   final String id;
   final String code;
   final String name;
+  final String? logoUrl;
+  final String? primaryColor;
+  final String? accentColor;
 
   GymConfig({
     required this.id,
     required this.code,
     required this.name,
+    this.logoUrl,
+    this.primaryColor,
+    this.accentColor,
   });
 
   factory GymConfig.fromMap(String id, Map<String, dynamic> data) {
@@ -15,6 +21,9 @@ class GymConfig {
       id: id,
       code: data['code'] as String? ?? '',
       name: data['name'] as String? ?? '',
+      logoUrl: data['logoUrl'] as String?,
+      primaryColor: data['primaryColor'] as String?,
+      accentColor: data['accentColor'] as String?,
     );
   }
 
@@ -22,6 +31,9 @@ class GymConfig {
     return {
       'code': code,
       'name': name,
+      if (logoUrl != null) 'logoUrl': logoUrl,
+      if (primaryColor != null) 'primaryColor': primaryColor,
+      if (accentColor != null) 'accentColor': accentColor,
     };
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   firebase_auth: ^5.5.3
   cloud_firestore: ^5.6.7
   firebase_crashlytics: ^4.3.5
+  firebase_functions: ^5.5.3
+  firebase_storage: ^12.0.3
 
   # Charts & Kalender
   fl_chart: ^1.0.0
@@ -41,6 +43,7 @@ dependencies:
   flutter_cube: ^0.1.1
   flutter_heatmap_calendar: ^1.0.5
   vector_math: ^2.1.4
+  flutter_colorpicker: ^1.0.3
 
   # Weitere Helfer
   flutter_dotenv: ^5.0.2


### PR DESCRIPTION
## Summary
- allow admins to update branding colors and logo
- store additional branding fields in `GymConfig`
- fetch theme colors from Firestore in `ThemeLoader`
- route and button for new Branding screen
- add firebase functions, storage and color picker deps

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d2f8e2a1083208763fbd51f0d8129