### PR TITLE
Implement branding-based theming

### DIFF
--- a/lib/core/providers/branding_provider.dart
+++ b/lib/core/providers/branding_provider.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/foundation.dart';
+import 'package:tapem/features/gym/data/sources/firestore_gym_source.dart';
+import 'package:tapem/features/gym/domain/models/branding.dart';
+
+class BrandingProvider extends ChangeNotifier {
+  final FirestoreGymSource _source;
+
+  BrandingProvider({FirestoreGymSource? source})
+      : _source = source ?? FirestoreGymSource();
+
+  Branding? _branding;
+  bool _isLoading = false;
+  String? _error;
+
+  Branding? get branding => _branding;
+  bool get isLoading => _isLoading;
+  String? get error => _error;
+
+  Future<void> loadBranding(String gymId) async {
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      _branding = await _source.getBranding(gymId);
+    } catch (e, st) {
+      _error = 'Fehler beim Laden: ${e.toString()}';
+      debugPrintStack(label: 'BrandingProvider.loadBranding', stackTrace: st);
+      _branding = null;
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  void loadBrandingWithGym(String? gymId) {
+    if (gymId == null || gymId.isEmpty) {
+      _branding = null;
+      notifyListeners();
+      return;
+    }
+    loadBranding(gymId);
+  }
+}

--- a/lib/core/theme/theme_loader.dart
+++ b/lib/core/theme/theme_loader.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../../features/gym/domain/models/branding.dart';
 import 'theme.dart';
 
 /// Lädt dynamisch Themes je nach Gym.
@@ -13,27 +14,17 @@ class ThemeLoader extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// Lädt Theme-Konfiguration aus Firestore anhand der Gym-ID.
-  Future<void> loadGymTheme(String gymId) async {
-    if (gymId.isEmpty) {
+  /// Wendet Branding-Daten auf das aktuelle Theme an.
+  void applyBranding(Branding? branding) {
+    if (branding == null ||
+        branding.primaryColor == null ||
+        branding.secondaryColor == null) {
       loadDefault();
       return;
     }
-    final doc =
-        await FirebaseFirestore.instance.collection('gyms').doc(gymId).get();
-    if (doc.exists) {
-      final data = doc.data()!;
-      final primaryHex = data['primaryColor'] as String?;
-      final accentHex = data['accentColor'] as String?;
-      if (primaryHex != null && accentHex != null) {
-        final primary = _parseHex(primaryHex);
-        final accent = _parseHex(accentHex);
-        _currentTheme = AppTheme.customTheme(primary: primary, secondary: accent);
-        notifyListeners();
-        return;
-      }
-    }
-    _currentTheme = AppTheme.darkTheme;
+    final primary = _parseHex(branding.primaryColor!);
+    final accent = _parseHex(branding.secondaryColor!);
+    _currentTheme = AppTheme.customTheme(primary: primary, secondary: accent);
     notifyListeners();
   }
 

--- a/lib/features/gym/data/sources/firestore_gym_source.dart
+++ b/lib/features/gym/data/sources/firestore_gym_source.dart
@@ -1,6 +1,7 @@
 // lib/features/gym/data/sources/firestore_gym_source.dart
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../domain/models/gym_config.dart';
+import '../../domain/models/branding.dart';
 
 class FirestoreGymSource {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
@@ -24,5 +25,17 @@ class FirestoreGymSource {
     final doc = await _firestore.collection('gyms').doc(id).get();
     if (!doc.exists) return null;
     return GymConfig.fromMap(doc.id, doc.data()!);
+  }
+
+  /// Gibt die Branding-Konfiguration des Gyms zurück.
+  Future<Branding?> getBranding(String gymId) async {
+    final doc = await _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('config')
+        .doc('branding')
+        .get();
+    if (!doc.exists) return null;
+    return Branding.fromMap(doc.data()!);
   }
 }

--- a/lib/features/gym/domain/models/branding.dart
+++ b/lib/features/gym/domain/models/branding.dart
@@ -1,0 +1,23 @@
+class Branding {
+  final String? logoUrl;
+  final String? primaryColor;
+  final String? secondaryColor;
+
+  Branding({
+    this.logoUrl,
+    this.primaryColor,
+    this.secondaryColor,
+  });
+
+  factory Branding.fromMap(Map<String, dynamic> map) => Branding(
+        logoUrl: map['logoUrl'] as String?,
+        primaryColor: map['primaryColor'] as String?,
+        secondaryColor: map['secondaryColor'] as String?,
+      );
+
+  Map<String, dynamic> toMap() => {
+        if (logoUrl != null) 'logoUrl': logoUrl,
+        if (primaryColor != null) 'primaryColor': primaryColor,
+        if (secondaryColor != null) 'secondaryColor': secondaryColor,
+      };
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,7 @@ import 'package:tapem/core/providers/exercise_provider.dart';
 import 'package:tapem/core/providers/report_provider.dart';
 import 'package:tapem/core/providers/rank_provider.dart';
 import 'package:tapem/core/providers/training_plan_provider.dart';
+import 'package:tapem/core/providers/branding_provider.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
 
 import 'features/nfc/data/nfc_service.dart';
@@ -141,12 +142,20 @@ class AppEntry extends StatelessWidget {
         // App state
         ChangeNotifierProvider(create: (_) => AppProvider()),
         ChangeNotifierProvider(create: (_) => AuthProvider()),
-        ChangeNotifierProxyProvider<AuthProvider, ThemeLoader>(
+        ChangeNotifierProxyProvider<AuthProvider, BrandingProvider>(
+          create: (_) => BrandingProvider(),
+          update: (_, auth, prov) {
+            final p = prov ?? BrandingProvider();
+            p.loadBrandingWithGym(auth.gymCode);
+            return p;
+          },
+        ),
+        ChangeNotifierProxyProvider<BrandingProvider, ThemeLoader>(
           create: (_) => ThemeLoader()..loadDefault(),
-          update: (ctx, auth, prev) {
-            final loader = prev ?? (ThemeLoader()..loadDefault());
-            loader.loadGymTheme(auth.gymCode ?? '');
-            return loader;
+          update: (_, branding, loader) {
+            final l = loader ?? (ThemeLoader()..loadDefault());
+            l.applyBranding(branding.branding);
+            return l;
           },
         ),
         ChangeNotifierProvider(create: (_) => GymProvider()),


### PR DESCRIPTION
## Summary
- add `Branding` model
- fetch branding document from Firestore
- load theme from `Branding`
- manage branding state via new provider
- wire branding and theming providers

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d32f96ec88320b66e1b4ef16e0bd0