### PR TITLE
feat(muscle): filter devices and add muscleGroups

### DIFF
--- a/lib/features/device/data/dtos/device_dto.dart
+++ b/lib/features/device/data/dtos/device_dto.dart
@@ -11,6 +11,7 @@ class DeviceDto {
   final String description;
   final String? nfcCode;
   final bool isMulti;
+  final List<String> muscleGroups;
 
   DeviceDto({
     required this.uid,
@@ -20,7 +21,9 @@ class DeviceDto {
     required this.description,
     this.nfcCode,
     required this.isMulti,
-  }) : muscleGroupIds = List.from(muscleGroupIds ?? []);
+    List<String>? muscleGroups,
+  })  : muscleGroupIds = List.from(muscleGroupIds ?? []),
+        muscleGroups   = List.from(muscleGroups ?? []);
 
   factory DeviceDto.fromDocument(DocumentSnapshot<Map<String, dynamic>> doc) {
     final data = doc.data()!;
@@ -35,6 +38,9 @@ class DeviceDto {
       muscleGroupIds: (data['muscleGroupIds'] as List<dynamic>? ?? [])
           .map((e) => e.toString())
           .toList(),
+      muscleGroups: (data['muscleGroups'] as List<dynamic>? ?? [])
+          .map((e) => e.toString())
+          .toList(),
     );
   }
 
@@ -44,6 +50,7 @@ class DeviceDto {
     id: id,
     name: name,
     muscleGroupIds: muscleGroupIds,
+    muscleGroups:   muscleGroups,
     description: description,
     nfcCode: nfcCode,
     isMulti: isMulti,

--- a/lib/features/device/data/repositories/device_repository_impl.dart
+++ b/lib/features/device/data/repositories/device_repository_impl.dart
@@ -35,4 +35,13 @@ class DeviceRepositoryImpl implements DeviceRepository {
   Future<void> deleteDevice(String gymId, String deviceId) {
     return _source.deleteDevice(gymId, deviceId);
   }
+
+  @override
+  Future<void> updateMuscleGroups(
+    String gymId,
+    String deviceId,
+    List<String> groups,
+  ) {
+    return _source.updateMuscleGroups(gymId, deviceId, groups);
+  }
 }

--- a/lib/features/device/data/sources/firestore_device_source.dart
+++ b/lib/features/device/data/sources/firestore_device_source.dart
@@ -30,4 +30,17 @@ class FirestoreDeviceSource {
       .collection('devices').doc(deviceId)
       .delete();
   }
+
+  Future<void> updateMuscleGroups(
+    String gymId,
+    String deviceId,
+    List<String> groups,
+  ) {
+    return _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('devices')
+        .doc(deviceId)
+        .update({'muscleGroups': FieldValue.arrayUnion(groups)});
+  }
 }

--- a/lib/features/device/domain/models/device.dart
+++ b/lib/features/device/domain/models/device.dart
@@ -8,6 +8,7 @@ class Device {
   final String description;
   final String? nfcCode;
   final bool isMulti;
+  final List<String> muscleGroups;
 
   Device({
     required this.uid,
@@ -17,7 +18,9 @@ class Device {
     this.description = '',
     this.nfcCode,
     this.isMulti = false,
-  }) : muscleGroupIds = List.unmodifiable(muscleGroupIds ?? []);
+    List<String>? muscleGroups,
+  })  : muscleGroupIds = List.unmodifiable(muscleGroupIds ?? []),
+        muscleGroups   = List.unmodifiable(muscleGroups ?? []);
 
   Device copyWith({
     String? uid,
@@ -27,6 +30,7 @@ class Device {
     String? nfcCode,
     bool? isMulti,
     List<String>? muscleGroupIds,
+    List<String>? muscleGroups,
   }) => Device(
     uid:         uid         ?? this.uid,
     id:          id          ?? this.id,
@@ -35,6 +39,7 @@ class Device {
     nfcCode:     nfcCode     ?? this.nfcCode,
     isMulti:     isMulti     ?? this.isMulti,
     muscleGroupIds: muscleGroupIds ?? this.muscleGroupIds,
+    muscleGroups:   muscleGroups   ?? this.muscleGroups,
   );
 
   factory Device.fromJson(Map<String, dynamic> json) => Device(
@@ -47,6 +52,9 @@ class Device {
     muscleGroupIds: (json['muscleGroupIds'] as List<dynamic>? ?? [])
         .map((e) => e.toString())
         .toList(),
+    muscleGroups: (json['muscleGroups'] as List<dynamic>? ?? [])
+        .map((e) => e.toString())
+        .toList(),
   );
 
   Map<String, dynamic> toJson() => {
@@ -56,5 +64,6 @@ class Device {
     'nfcCode':     nfcCode,
     'isMulti':     isMulti,
     'muscleGroupIds': muscleGroupIds,
+    'muscleGroups':   muscleGroups,
   };
 }

--- a/lib/features/device/domain/repositories/device_repository.dart
+++ b/lib/features/device/domain/repositories/device_repository.dart
@@ -9,4 +9,10 @@ abstract class DeviceRepository {
 
   // Neu: Gerät löschen
   Future<void> deleteDevice(String gymId, String deviceId);
+
+  Future<void> updateMuscleGroups(
+    String gymId,
+    String deviceId,
+    List<String> groups,
+  );
 }

--- a/lib/features/device/domain/usecases/update_device_muscle_groups_usecase.dart
+++ b/lib/features/device/domain/usecases/update_device_muscle_groups_usecase.dart
@@ -1,0 +1,12 @@
+import '../repositories/device_repository.dart';
+
+class UpdateDeviceMuscleGroupsUseCase {
+  final DeviceRepository _repo;
+  UpdateDeviceMuscleGroupsUseCase(this._repo);
+
+  Future<void> execute(
+    String gymId,
+    String deviceId,
+    List<String> groups,
+  ) => _repo.updateMuscleGroups(gymId, deviceId, groups);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,6 +43,7 @@ import 'features/device/domain/usecases/create_device_usecase.dart';
 import 'features/device/domain/usecases/get_devices_for_gym.dart';
 import 'features/device/domain/usecases/get_device_by_nfc_code.dart';
 import 'features/device/domain/usecases/delete_device_usecase.dart';
+import 'features/device/domain/usecases/update_device_muscle_groups_usecase.dart';
 
 import 'features/device/data/sources/firestore_exercise_source.dart';
 import 'features/device/data/repositories/exercise_repository_impl.dart';
@@ -123,6 +124,10 @@ class AppEntry extends StatelessWidget {
         ),
         Provider<DeleteDeviceUseCase>(
           create: (c) => DeleteDeviceUseCase(c.read<DeviceRepository>()),
+        ),
+        Provider<UpdateDeviceMuscleGroupsUseCase>(
+          create: (c) =>
+              UpdateDeviceMuscleGroupsUseCase(c.read<DeviceRepository>()),
         ),
 
         // Exercise


### PR DESCRIPTION
## Summary
- allow storing muscleGroups on a device
- update muscle groups admin UI to only show single devices
- add device update logic when saving muscle groups

## Testing
- `flutter --version` *(fails: command not found)*
- `npm ci` *(fails: network access blocked)*
- `npx mocha firestore-tests/security_rules.test.js` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687d9f45835c8320a876abc173035536