### PR TITLE
Add primary/secondary muscle groups

### DIFF
--- a/lib/core/providers/muscle_group_provider.dart
+++ b/lib/core/providers/muscle_group_provider.dart
@@ -85,13 +85,28 @@ class MuscleGroupProvider extends ChangeNotifier {
     await _saveGroup.execute(gymId, group);
 
     final devices = Provider.of<GymProvider>(context, listen: false).devices;
-    for (final dId in group.deviceIds) {
+    for (final dId in group.primaryDeviceIds) {
       try {
         final dev = devices.firstWhere((d) => d.uid == dId);
         if (!dev.isMulti) {
           await _updateDeviceGroups.execute(
             gymId,
             dId,
+            [group.region.name],
+            const [],
+          );
+        }
+      } catch (_) {}
+    }
+
+    for (final dId in group.secondaryDeviceIds) {
+      try {
+        final dev = devices.firstWhere((d) => d.uid == dId);
+        if (!dev.isMulti) {
+          await _updateDeviceGroups.execute(
+            gymId,
+            dId,
+            const [],
             [group.region.name],
           );
         }
@@ -110,8 +125,11 @@ class MuscleGroupProvider extends ChangeNotifier {
     final gymId = auth.gymCode;
     if (gymId == null) return;
     for (final g in _groups) {
-      if (groupIds.contains(g.id) && !g.deviceIds.contains(deviceId)) {
-        final updated = g.copyWith(deviceIds: [...g.deviceIds, deviceId]);
+      if (groupIds.contains(g.id) &&
+          !g.primaryDeviceIds.contains(deviceId)) {
+        final updated = g.copyWith(
+          primaryDeviceIds: [...g.primaryDeviceIds, deviceId],
+        );
         await _saveGroup.execute(gymId, updated);
       }
     }

--- a/lib/features/admin/presentation/widgets/device_list_item.dart
+++ b/lib/features/admin/presentation/widgets/device_list_item.dart
@@ -28,7 +28,21 @@ class DeviceListItem extends StatelessWidget {
     return ListTile(
       leading: Text('${device.id}'),
       title: Text(device.name),
-      subtitle: Text(device.description),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(device.description),
+          Wrap(
+            spacing: 4,
+            children: [
+              for (final m in device.primaryMuscleGroups)
+                Text(m, style: const TextStyle(color: Colors.blue)),
+              for (final m in device.secondaryMuscleGroups)
+                Text(m, style: const TextStyle(color: Colors.white)),
+            ],
+          ),
+        ],
+      ),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/lib/features/device/data/dtos/device_dto.dart
+++ b/lib/features/device/data/dtos/device_dto.dart
@@ -12,6 +12,8 @@ class DeviceDto {
   final String? nfcCode;
   final bool isMulti;
   final List<String> muscleGroups;
+  final List<String> primaryMuscleGroups;
+  final List<String> secondaryMuscleGroups;
 
   DeviceDto({
     required this.uid,
@@ -22,8 +24,12 @@ class DeviceDto {
     this.nfcCode,
     required this.isMulti,
     List<String>? muscleGroups,
-  })  : muscleGroupIds = List.from(muscleGroupIds ?? []),
-        muscleGroups   = List.from(muscleGroups ?? []);
+    List<String>? primaryMuscleGroups,
+    List<String>? secondaryMuscleGroups,
+  })  : muscleGroupIds      = List.from(muscleGroupIds ?? []),
+        muscleGroups        = List.from(muscleGroups ?? []),
+        primaryMuscleGroups = List.from(primaryMuscleGroups ?? []),
+        secondaryMuscleGroups = List.from(secondaryMuscleGroups ?? []);
 
   factory DeviceDto.fromDocument(DocumentSnapshot<Map<String, dynamic>> doc) {
     final data = doc.data()!;
@@ -41,6 +47,13 @@ class DeviceDto {
       muscleGroups: (data['muscleGroups'] as List<dynamic>? ?? [])
           .map((e) => e.toString())
           .toList(),
+      primaryMuscleGroups: (data['primaryMuscleGroups'] as List<dynamic>? ?? [])
+          .map((e) => e.toString())
+          .toList(),
+      secondaryMuscleGroups:
+          (data['secondaryMuscleGroups'] as List<dynamic>? ?? [])
+              .map((e) => e.toString())
+              .toList(),
     );
   }
 
@@ -50,7 +63,9 @@ class DeviceDto {
     id: id,
     name: name,
     muscleGroupIds: muscleGroupIds,
-    muscleGroups:   muscleGroups,
+    muscleGroups: muscleGroups,
+    primaryMuscleGroups: primaryMuscleGroups,
+    secondaryMuscleGroups: secondaryMuscleGroups,
     description: description,
     nfcCode: nfcCode,
     isMulti: isMulti,

--- a/lib/features/device/data/repositories/device_repository_impl.dart
+++ b/lib/features/device/data/repositories/device_repository_impl.dart
@@ -40,8 +40,14 @@ class DeviceRepositoryImpl implements DeviceRepository {
   Future<void> updateMuscleGroups(
     String gymId,
     String deviceId,
-    List<String> groups,
+    List<String> primaryGroups,
+    List<String> secondaryGroups,
   ) {
-    return _source.updateMuscleGroups(gymId, deviceId, groups);
+    return _source.updateMuscleGroups(
+      gymId,
+      deviceId,
+      primaryGroups,
+      secondaryGroups,
+    );
   }
 }

--- a/lib/features/device/data/sources/firestore_device_source.dart
+++ b/lib/features/device/data/sources/firestore_device_source.dart
@@ -34,13 +34,25 @@ class FirestoreDeviceSource {
   Future<void> updateMuscleGroups(
     String gymId,
     String deviceId,
-    List<String> groups,
+    List<String> primaryGroups,
+    List<String> secondaryGroups,
   ) {
-    return _firestore
+    final ref = _firestore
         .collection('gyms')
         .doc(gymId)
         .collection('devices')
-        .doc(deviceId)
-        .update({'muscleGroups': FieldValue.arrayUnion(groups)});
+        .doc(deviceId);
+    final all = [...primaryGroups, ...secondaryGroups];
+    final data = <String, dynamic>{};
+    if (primaryGroups.isNotEmpty) {
+      data['primaryMuscleGroups'] = FieldValue.arrayUnion(primaryGroups);
+    }
+    if (secondaryGroups.isNotEmpty) {
+      data['secondaryMuscleGroups'] = FieldValue.arrayUnion(secondaryGroups);
+    }
+    if (all.isNotEmpty) {
+      data['muscleGroups'] = FieldValue.arrayUnion(all);
+    }
+    return ref.update(data);
   }
 }

--- a/lib/features/device/domain/models/device.dart
+++ b/lib/features/device/domain/models/device.dart
@@ -9,6 +9,8 @@ class Device {
   final String? nfcCode;
   final bool isMulti;
   final List<String> muscleGroups;
+  final List<String> primaryMuscleGroups;
+  final List<String> secondaryMuscleGroups;
 
   Device({
     required this.uid,
@@ -19,8 +21,15 @@ class Device {
     this.nfcCode,
     this.isMulti = false,
     List<String>? muscleGroups,
-  })  : muscleGroupIds = List.unmodifiable(muscleGroupIds ?? []),
-        muscleGroups   = List.unmodifiable(muscleGroups ?? []);
+    List<String>? primaryMuscleGroups,
+    List<String>? secondaryMuscleGroups,
+  })  : muscleGroupIds      = List.unmodifiable(muscleGroupIds ?? []),
+        primaryMuscleGroups = List.unmodifiable(primaryMuscleGroups ?? []),
+        secondaryMuscleGroups = List.unmodifiable(secondaryMuscleGroups ?? []),
+        muscleGroups = List.unmodifiable(
+          muscleGroups ??
+              [...(primaryMuscleGroups ?? []), ...(secondaryMuscleGroups ?? [])],
+        );
 
   Device copyWith({
     String? uid,
@@ -31,6 +40,8 @@ class Device {
     bool? isMulti,
     List<String>? muscleGroupIds,
     List<String>? muscleGroups,
+    List<String>? primaryMuscleGroups,
+    List<String>? secondaryMuscleGroups,
   }) => Device(
     uid:         uid         ?? this.uid,
     id:          id          ?? this.id,
@@ -39,7 +50,13 @@ class Device {
     nfcCode:     nfcCode     ?? this.nfcCode,
     isMulti:     isMulti     ?? this.isMulti,
     muscleGroupIds: muscleGroupIds ?? this.muscleGroupIds,
-    muscleGroups:   muscleGroups   ?? this.muscleGroups,
+    muscleGroups: muscleGroups ??
+        [
+          ...(primaryMuscleGroups ?? this.primaryMuscleGroups),
+          ...(secondaryMuscleGroups ?? this.secondaryMuscleGroups),
+        ],
+    primaryMuscleGroups: primaryMuscleGroups ?? this.primaryMuscleGroups,
+    secondaryMuscleGroups: secondaryMuscleGroups ?? this.secondaryMuscleGroups,
   );
 
   factory Device.fromJson(Map<String, dynamic> json) => Device(
@@ -50,6 +67,12 @@ class Device {
     nfcCode:     json['nfcCode']   as String?,
     isMulti:     json['isMulti']   as bool?   ?? false,
     muscleGroupIds: (json['muscleGroupIds'] as List<dynamic>? ?? [])
+        .map((e) => e.toString())
+        .toList(),
+    primaryMuscleGroups: (json['primaryMuscleGroups'] as List<dynamic>? ?? [])
+        .map((e) => e.toString())
+        .toList(),
+    secondaryMuscleGroups: (json['secondaryMuscleGroups'] as List<dynamic>? ?? [])
         .map((e) => e.toString())
         .toList(),
     muscleGroups: (json['muscleGroups'] as List<dynamic>? ?? [])
@@ -65,5 +88,7 @@ class Device {
     'isMulti':     isMulti,
     'muscleGroupIds': muscleGroupIds,
     'muscleGroups':   muscleGroups,
+    'primaryMuscleGroups': primaryMuscleGroups,
+    'secondaryMuscleGroups': secondaryMuscleGroups,
   };
 }

--- a/lib/features/device/domain/repositories/device_repository.dart
+++ b/lib/features/device/domain/repositories/device_repository.dart
@@ -13,6 +13,7 @@ abstract class DeviceRepository {
   Future<void> updateMuscleGroups(
     String gymId,
     String deviceId,
-    List<String> groups,
+    List<String> primaryGroups,
+    List<String> secondaryGroups,
   );
 }

--- a/lib/features/device/domain/usecases/update_device_muscle_groups_usecase.dart
+++ b/lib/features/device/domain/usecases/update_device_muscle_groups_usecase.dart
@@ -7,6 +7,13 @@ class UpdateDeviceMuscleGroupsUseCase {
   Future<void> execute(
     String gymId,
     String deviceId,
-    List<String> groups,
-  ) => _repo.updateMuscleGroups(gymId, deviceId, groups);
+    List<String> primaryGroups,
+    List<String> secondaryGroups,
+  ) =>
+      _repo.updateMuscleGroups(
+        gymId,
+        deviceId,
+        primaryGroups,
+        secondaryGroups,
+      );
 }

--- a/lib/features/muscle_group/data/dtos/muscle_group_dto.dart
+++ b/lib/features/muscle_group/data/dtos/muscle_group_dto.dart
@@ -6,15 +6,18 @@ class MuscleGroupDto {
   late final String id;
   final String name;
   final MuscleRegion region;
-  final List<String> deviceIds;
+  final List<String> primaryDeviceIds;
+  final List<String> secondaryDeviceIds;
   final List<String> exerciseIds;
 
   MuscleGroupDto({
     required this.name,
     required this.region,
-    List<String>? deviceIds,
+    List<String>? primaryDeviceIds,
+    List<String>? secondaryDeviceIds,
     List<String>? exerciseIds,
-  })  : deviceIds = List.from(deviceIds ?? []),
+  })  : primaryDeviceIds = List.from(primaryDeviceIds ?? []),
+        secondaryDeviceIds = List.from(secondaryDeviceIds ?? []),
         exerciseIds = List.from(exerciseIds ?? []);
 
   factory MuscleGroupDto.fromDocument(DocumentSnapshot<Map<String, dynamic>> doc) {
@@ -25,7 +28,10 @@ class MuscleGroupDto {
         (r) => r.name == data['region'],
         orElse: () => MuscleRegion.core,
       ),
-      deviceIds: (data['deviceIds'] as List<dynamic>? ?? [])
+      primaryDeviceIds: (data['primaryDeviceIds'] as List<dynamic>? ?? [])
+          .map((e) => e.toString())
+          .toList(),
+      secondaryDeviceIds: (data['secondaryDeviceIds'] as List<dynamic>? ?? [])
           .map((e) => e.toString())
           .toList(),
       exerciseIds: (data['exerciseIds'] as List<dynamic>? ?? [])
@@ -38,21 +44,24 @@ class MuscleGroupDto {
         id: id,
         name: name,
         region: region,
-        deviceIds: deviceIds,
+        primaryDeviceIds: primaryDeviceIds,
+        secondaryDeviceIds: secondaryDeviceIds,
         exerciseIds: exerciseIds,
       );
 
   factory MuscleGroupDto.fromModel(MuscleGroup model) => MuscleGroupDto(
         name: model.name,
         region: model.region,
-        deviceIds: model.deviceIds,
+        primaryDeviceIds: model.primaryDeviceIds,
+        secondaryDeviceIds: model.secondaryDeviceIds,
         exerciseIds: model.exerciseIds,
       )..id = model.id;
 
   Map<String, dynamic> toJson() => {
         'name': name,
         'region': region.name,
-        'deviceIds': deviceIds,
+        'primaryDeviceIds': primaryDeviceIds,
+        'secondaryDeviceIds': secondaryDeviceIds,
         'exerciseIds': exerciseIds,
       };
 }

--- a/lib/features/muscle_group/domain/models/muscle_group.dart
+++ b/lib/features/muscle_group/domain/models/muscle_group.dart
@@ -4,29 +4,38 @@ class MuscleGroup {
   final String id;
   final String name;
   final MuscleRegion region;
-  final List<String> deviceIds;
+  final List<String> primaryDeviceIds;
+  final List<String> secondaryDeviceIds;
   final List<String> exerciseIds;
 
   MuscleGroup({
     required this.id,
     required this.name,
     this.region = MuscleRegion.core,
-    List<String>? deviceIds,
+    List<String>? primaryDeviceIds,
+    List<String>? secondaryDeviceIds,
     List<String>? exerciseIds,
-  })  : deviceIds = List.unmodifiable(deviceIds ?? []),
+  })  : primaryDeviceIds = List.unmodifiable(primaryDeviceIds ?? []),
+        secondaryDeviceIds = List.unmodifiable(secondaryDeviceIds ?? []),
         exerciseIds = List.unmodifiable(exerciseIds ?? []);
+
+  /// Convenience getter combining both device lists
+  List<String> get deviceIds =>
+      List.unmodifiable([...primaryDeviceIds, ...secondaryDeviceIds]);
 
   MuscleGroup copyWith({
     String? id,
     String? name,
     MuscleRegion? region,
-    List<String>? deviceIds,
+    List<String>? primaryDeviceIds,
+    List<String>? secondaryDeviceIds,
     List<String>? exerciseIds,
   }) => MuscleGroup(
         id: id ?? this.id,
         name: name ?? this.name,
         region: region ?? this.region,
-        deviceIds: deviceIds ?? this.deviceIds,
+        primaryDeviceIds: primaryDeviceIds ?? this.primaryDeviceIds,
+        secondaryDeviceIds: secondaryDeviceIds ?? this.secondaryDeviceIds,
         exerciseIds: exerciseIds ?? this.exerciseIds,
       );
 
@@ -37,7 +46,10 @@ class MuscleGroup {
           (r) => r.name == json['region'],
           orElse: () => MuscleRegion.core,
         ),
-        deviceIds: (json['deviceIds'] as List<dynamic>? ?? [])
+        primaryDeviceIds: (json['primaryDeviceIds'] as List<dynamic>? ?? [])
+            .map((e) => e.toString())
+            .toList(),
+        secondaryDeviceIds: (json['secondaryDeviceIds'] as List<dynamic>? ?? [])
             .map((e) => e.toString())
             .toList(),
         exerciseIds: (json['exerciseIds'] as List<dynamic>? ?? [])
@@ -48,7 +60,8 @@ class MuscleGroup {
   Map<String, dynamic> toJson() => {
         'name': name,
         'region': region.name,
-        'deviceIds': deviceIds,
+        'primaryDeviceIds': primaryDeviceIds,
+        'secondaryDeviceIds': secondaryDeviceIds,
         'exerciseIds': exerciseIds,
       };
 }


### PR DESCRIPTION
## Summary
- allow selecting primäre/sekundäre Muskeln für Geräte
- store primary and secondary muscle IDs in Firestore
- show primary (blue) and secondary (white) muscles in device list
- refactor device and muscle group models to include new fields

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687daf21e21c8320bcf14a725bfe7544