### PR TITLE
Show device IDs in lists

### DIFF
--- a/lib/features/admin/presentation/widgets/device_list_item.dart
+++ b/lib/features/admin/presentation/widgets/device_list_item.dart
@@ -28,21 +28,7 @@ class DeviceListItem extends StatelessWidget {
     return ListTile(
       leading: Text('${device.id}'),
       title: Text(device.name),
-      subtitle: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(device.description),
-          Wrap(
-            spacing: 4,
-            children: [
-              for (final m in device.primaryMuscleGroups)
-                Text(m, style: const TextStyle(color: Colors.blue)),
-              for (final m in device.secondaryMuscleGroups)
-                Text(m, style: const TextStyle(color: Colors.white)),
-            ],
-          ),
-        ],
-      ),
+      subtitle: device.description.isNotEmpty ? Text(device.description) : null,
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/lib/features/gym/presentation/widgets/device_card.dart
+++ b/lib/features/gym/presentation/widgets/device_card.dart
@@ -15,6 +15,7 @@ class DeviceCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       child: ListTile(
+        leading: Text('${device.id}'),
         title: Text(device.name),
         subtitle: device.description.isNotEmpty ? Text(device.description) : null,
         onTap: onTap,

--- a/lib/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart
@@ -259,6 +259,7 @@ class _MuscleGroupAdminScreenState extends State<MuscleGroupAdminScreen> {
                 return Card(
                   margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                   child: ListTile(
+                    leading: Text('${device.id}'),
                     title: Text(device.name),
                     subtitle: Wrap(
                       spacing: 4,


### PR DESCRIPTION
## Summary
- add device ID to gym device cards
- add device ID to device list in muscle group admin
- remove muscle groups from admin device list and show ID

## Testing
- `dart format lib/features/gym/presentation/widgets/device_card.dart lib/features/admin/presentation/widgets/device_list_item.dart lib/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart` *(fails: command not found)*
- `apt-get update` *(fails: repository signatures not verified)*

------
https://chatgpt.com/codex/tasks/task_e_687ec4694208832092f9a83bcc45cf85