### PR TITLE
Fix type mismatch in admin screen

### DIFF
--- a/lib/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart
@@ -191,9 +191,10 @@ class _MuscleGroupAdminScreenState extends State<MuscleGroupAdminScreen> {
             ),
             ElevatedButton(
               onPressed: () async {
-                final primary = selected.isNotEmpty ? [selected.first] : [];
-                final secondary =
-                    selected.length > 1 ? selected.sublist(1) : [];
+                final List<String> primary =
+                    selected.isNotEmpty ? [selected.first] : <String>[];
+                final List<String> secondary =
+                    selected.length > 1 ? selected.sublist(1) : <String>[];
                 await prov.updateDeviceAssignments(
                   context,
                   deviceId,


### PR DESCRIPTION
## Summary
- fix `List<String>` typing in muscle group admin dialog

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ecb03424883208b32318b50cc2004