### PR TITLE
Add password reset flow

### DIFF
--- a/lib/core/providers/auth_provider.dart
+++ b/lib/core/providers/auth_provider.dart
@@ -9,6 +9,7 @@ import 'package:tapem/features/auth/domain/usecases/logout.dart';
 import 'package:tapem/features/auth/domain/usecases/register.dart';
 import 'package:tapem/features/auth/domain/usecases/set_username.dart';
 import 'package:tapem/features/auth/domain/usecases/check_username_available.dart';
+import 'package:tapem/features/auth/domain/usecases/reset_password.dart';
 
 class AuthProvider extends ChangeNotifier {
   final LoginUseCase _loginUC;
@@ -17,6 +18,7 @@ class AuthProvider extends ChangeNotifier {
   final GetCurrentUserUseCase _currentUC;
   final SetUsernameUseCase _setUsernameUC;
   final CheckUsernameAvailable _checkUsernameUC;
+  final ResetPasswordUseCase _resetPasswordUC;
 
   UserData? _user;
   bool _isLoading = false;
@@ -29,7 +31,8 @@ class AuthProvider extends ChangeNotifier {
       _logoutUC = LogoutUseCase(repo),
       _currentUC = GetCurrentUserUseCase(repo),
       _setUsernameUC = SetUsernameUseCase(repo),
-      _checkUsernameUC = CheckUsernameAvailable(repo) {
+      _checkUsernameUC = CheckUsernameAvailable(repo),
+      _resetPasswordUC = ResetPasswordUseCase(repo) {
     _loadCurrentUser();
   }
 
@@ -150,6 +153,18 @@ class AuthProvider extends ChangeNotifier {
     } catch (e) {
       _error = e.toString();
       return false;
+    } finally {
+      _setLoading(false);
+    }
+  }
+
+  Future<void> resetPassword(String email) async {
+    _setLoading(true);
+    _error = null;
+    try {
+      await _resetPasswordUC.execute(email);
+    } catch (e) {
+      _error = (e is fb_auth.FirebaseAuthException) ? e.message : e.toString();
     } finally {
       _setLoading(false);
     }

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -42,4 +42,9 @@ class AuthRepositoryImpl implements AuthRepository {
   Future<bool> isUsernameAvailable(String username) {
     return _source.isUsernameAvailable(username);
   }
+
+  @override
+  Future<void> sendPasswordResetEmail(String email) {
+    return _source.sendPasswordResetEmail(email);
+  }
 }

--- a/lib/features/auth/data/sources/firestore_auth_source.dart
+++ b/lib/features/auth/data/sources/firestore_auth_source.dart
@@ -93,4 +93,8 @@ class FirestoreAuthSource {
       'usernameLower': lower,
     });
   }
+
+  Future<void> sendPasswordResetEmail(String email) {
+    return _auth.sendPasswordResetEmail(email: email);
+  }
 }

--- a/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/features/auth/domain/repositories/auth_repository.dart
@@ -8,4 +8,5 @@ abstract class AuthRepository {
   Future<UserData?> getCurrentUser();
   Future<void> setUsername(String userId, String username);
   Future<bool> isUsernameAvailable(String username);
+  Future<void> sendPasswordResetEmail(String email);
 }

--- a/lib/features/auth/domain/usecases/reset_password.dart
+++ b/lib/features/auth/domain/usecases/reset_password.dart
@@ -1,0 +1,9 @@
+import '../../data/repositories/auth_repository_impl.dart';
+import '../repositories/auth_repository.dart';
+
+class ResetPasswordUseCase {
+  final AuthRepository _repo;
+  ResetPasswordUseCase([AuthRepository? repo]) : _repo = repo ?? AuthRepositoryImpl();
+
+  Future<void> execute(String email) => _repo.sendPasswordResetEmail(email);
+}

--- a/lib/features/auth/presentation/widgets/login_form.dart
+++ b/lib/features/auth/presentation/widgets/login_form.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/features/auth/presentation/widgets/password_reset_dialog.dart';
 
 class LoginForm extends StatefulWidget {
   const LoginForm({Key? key}) : super(key: key);
@@ -75,6 +76,10 @@ class _LoginFormState extends State<LoginForm> {
                       child: CircularProgressIndicator(strokeWidth: 2),
                     )
                   : Text(loc.loginButton),
+            ),
+            TextButton(
+              onPressed: () => showPasswordResetDialog(context),
+              child: Text(loc.forgotPassword),
             ),
           ],
         ),

--- a/lib/features/auth/presentation/widgets/password_reset_dialog.dart
+++ b/lib/features/auth/presentation/widgets/password_reset_dialog.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import '../../../../core/providers/auth_provider.dart';
+
+Future<void> showPasswordResetDialog(BuildContext context) async {
+  final loc = AppLocalizations.of(context)!;
+  final ctr = TextEditingController();
+  final auth = context.read<AuthProvider>();
+  String? error;
+  await showDialog(
+    context: context,
+    builder: (_) => StatefulBuilder(
+      builder: (ctx, setState) => AlertDialog(
+        title: Text(loc.passwordResetDialogTitle),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(loc.passwordResetHint),
+            TextField(
+              controller: ctr,
+              keyboardType: TextInputType.emailAddress,
+              decoration: InputDecoration(
+                labelText: loc.emailFieldLabel,
+                errorText: error,
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            onPressed: () async {
+              final email = ctr.text.trim();
+              if (email.isEmpty || !email.contains('@')) {
+                setState(() => error = loc.emailInvalid);
+                return;
+              }
+              await auth.resetPassword(email);
+              if (auth.error == null) {
+                // ignore: use_build_context_synchronously
+                Navigator.pop(ctx);
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text(loc.passwordResetSent)),
+                );
+              } else {
+                setState(() => error = auth.error);
+              }
+            },
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    ),
+  );
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -329,5 +329,13 @@
   "usernameFieldLabel": "Nutzername",
   "@usernameFieldLabel": {"description": "Beschriftung für das Nutzername-Feld"},
   "usernameTaken": "Dieser Nutzername ist bereits vergeben.",
-  "@usernameTaken": {"description": "Fehler wenn Nutzername existiert"}
+  "@usernameTaken": {"description": "Fehler wenn Nutzername existiert"},
+  "forgotPassword": "Passwort vergessen?",
+  "@forgotPassword": {"description": "Link zum Passwort-Reset"},
+  "passwordResetDialogTitle": "Passwort zurücksetzen",
+  "@passwordResetDialogTitle": {"description": "Titel des Passwort-Reset-Dialogs"},
+  "passwordResetHint": "E-Mail eingeben, um einen Reset-Link zu erhalten.",
+  "@passwordResetHint": {"description": "Hinweistext im Reset-Dialog"},
+  "passwordResetSent": "Passwort-Reset-E-Mail wurde gesendet.",
+  "@passwordResetSent": {"description": "Snackbar nach Senden des Reset-Links"}
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -329,5 +329,13 @@
   "usernameFieldLabel": "Username",
   "@usernameFieldLabel": {"description": "Label for username field"},
   "usernameTaken": "This username is already taken.",
-  "@usernameTaken": {"description": "Error when username exists"}
+  "@usernameTaken": {"description": "Error when username exists"},
+  "forgotPassword": "Forgot password?",
+  "@forgotPassword": {"description": "Link to open password reset dialog"},
+  "passwordResetDialogTitle": "Reset password",
+  "@passwordResetDialogTitle": {"description": "Title for password reset dialog"},
+  "passwordResetHint": "Enter your e-mail to receive a reset link.",
+  "@passwordResetHint": {"description": "Hint text in password reset dialog"},
+  "passwordResetSent": "Password reset email sent.",
+  "@passwordResetSent": {"description": "Snackbar message after sending reset email"}
 }


### PR DESCRIPTION
## Summary
- add ResetPassword use case and repository support
- expose resetPassword in AuthProvider
- add dialog and link in login form to trigger reset
- update localization files

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `npm ci` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687ee11783908320991c34e04fdacab9