### PR TITLE
Add profile privacy setting

### DIFF
--- a/lib/core/providers/auth_provider.dart
+++ b/lib/core/providers/auth_provider.dart
@@ -10,6 +10,7 @@ import 'package:tapem/features/auth/domain/usecases/register.dart';
 import 'package:tapem/features/auth/domain/usecases/set_username.dart';
 import 'package:tapem/features/auth/domain/usecases/check_username_available.dart';
 import 'package:tapem/features/auth/domain/usecases/reset_password.dart';
+import 'package:tapem/features/auth/domain/usecases/set_show_in_leaderboard.dart';
 
 class AuthProvider extends ChangeNotifier {
   final LoginUseCase _loginUC;
@@ -17,6 +18,7 @@ class AuthProvider extends ChangeNotifier {
   final LogoutUseCase _logoutUC;
   final GetCurrentUserUseCase _currentUC;
   final SetUsernameUseCase _setUsernameUC;
+  final SetShowInLeaderboardUseCase _setShowInLbUC;
   final CheckUsernameAvailable _checkUsernameUC;
   final ResetPasswordUseCase _resetPasswordUC;
 
@@ -31,6 +33,7 @@ class AuthProvider extends ChangeNotifier {
       _logoutUC = LogoutUseCase(repo),
       _currentUC = GetCurrentUserUseCase(repo),
       _setUsernameUC = SetUsernameUseCase(repo),
+      _setShowInLbUC = SetShowInLeaderboardUseCase(repo),
       _checkUsernameUC = CheckUsernameAvailable(repo),
       _resetPasswordUC = ResetPasswordUseCase(repo) {
     _loadCurrentUser();
@@ -153,6 +156,20 @@ class AuthProvider extends ChangeNotifier {
     } catch (e) {
       _error = e.toString();
       return false;
+    } finally {
+      _setLoading(false);
+    }
+  }
+
+  Future<void> setShowInLeaderboard(bool value) async {
+    if (_user == null) return;
+    _setLoading(true);
+    _error = null;
+    try {
+      await _setShowInLbUC.execute(_user!.id, value);
+      _user = _user!.copyWith(showInLeaderboard: value);
+    } catch (e) {
+      _error = e.toString();
     } finally {
       _setLoading(false);
     }

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -39,6 +39,11 @@ class AuthRepositoryImpl implements AuthRepository {
   }
 
   @override
+  Future<void> setShowInLeaderboard(String userId, bool value) {
+    return _source.setShowInLeaderboard(userId, value);
+  }
+
+  @override
   Future<bool> isUsernameAvailable(String username) {
     return _source.isUsernameAvailable(username);
   }

--- a/lib/features/auth/data/sources/firestore_auth_source.dart
+++ b/lib/features/auth/data/sources/firestore_auth_source.dart
@@ -94,6 +94,12 @@ class FirestoreAuthSource {
     });
   }
 
+  Future<void> setShowInLeaderboard(String userId, bool value) async {
+    await _firestore.collection('users').doc(userId).update({
+      'showInLeaderboard': value,
+    });
+  }
+
   Future<void> sendPasswordResetEmail(String email) {
     final settings = ActionCodeSettings(
       url: 'https://tapem.page.link/reset',

--- a/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/features/auth/domain/repositories/auth_repository.dart
@@ -7,6 +7,7 @@ abstract class AuthRepository {
   Future<void> logout();
   Future<UserData?> getCurrentUser();
   Future<void> setUsername(String userId, String username);
+  Future<void> setShowInLeaderboard(String userId, bool value);
   Future<bool> isUsernameAvailable(String username);
   Future<void> sendPasswordResetEmail(String email);
 }

--- a/lib/features/auth/domain/usecases/set_show_in_leaderboard.dart
+++ b/lib/features/auth/domain/usecases/set_show_in_leaderboard.dart
@@ -1,0 +1,12 @@
+import '../repositories/auth_repository.dart';
+import '../../data/repositories/auth_repository_impl.dart';
+
+class SetShowInLeaderboardUseCase {
+  final AuthRepository _repo;
+  SetShowInLeaderboardUseCase([AuthRepository? repo])
+      : _repo = repo ?? AuthRepositoryImpl();
+
+  Future<void> execute(String userId, bool value) {
+    return _repo.setShowInLeaderboard(userId, value);
+  }
+}

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -72,7 +72,7 @@ class _HomeScreenState extends State<HomeScreen> {
         authProv.userName ?? authProv.userEmail ?? loc.genericUser;
     return Scaffold(
       appBar: AppBar(
-        title: Text(loc.homeWelcome(userDisplay)),
+        title: Text(userDisplay),
         actions: [
           IconButton(
             icon: const Icon(Icons.logout),

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -4,7 +4,9 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/app_provider.dart' as app;
 import 'package:tapem/core/providers/profile_provider.dart';
+import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/features/nfc/widgets/nfc_scan_button.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import '../widgets/calendar.dart';
 import '../widgets/calendar_popup.dart';
 
@@ -26,17 +28,18 @@ class _ProfileScreenState extends State<ProfileScreen> {
 
   void _showLanguageDialog() {
     final appProv = context.read<app.AppProvider>();
+    final loc = AppLocalizations.of(context)!;
     final currentLocale = appProv.locale ?? Localizations.localeOf(context);
     showDialog(
       context: context,
       builder:
           (_) => AlertDialog(
-            title: const Text('Sprache wählen'),
+            title: Text(loc.languageDialogTitle),
             content: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
                 RadioListTile<Locale>(
-                  title: const Text('Deutsch'),
+                  title: Text(loc.germanLanguage),
                   value: const Locale('de'),
                   groupValue: currentLocale,
                   onChanged: (l) {
@@ -45,7 +48,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   },
                 ),
                 RadioListTile<Locale>(
-                  title: const Text('English'),
+                  title: Text(loc.englishLanguage),
                   value: const Locale('en'),
                   groupValue: currentLocale,
                   onChanged: (l) {
@@ -58,10 +61,77 @@ class _ProfileScreenState extends State<ProfileScreen> {
             actions: [
               TextButton(
                 onPressed: () => Navigator.pop(context),
-                child: const Text('Abbrechen'),
+                child: Text(loc.cancelButton),
               ),
             ],
           ),
+    );
+  }
+
+  void _showPrivacyDialog() {
+    final authProv = context.read<AuthProvider>();
+    final loc = AppLocalizations.of(context)!;
+    final current = authProv.showInLeaderboard ?? true;
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: Text(loc.publicProfileDialogTitle),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            RadioListTile<bool>(
+              title: Text(loc.publicProfilePublic),
+              value: true,
+              groupValue: current,
+              onChanged: (v) {
+                authProv.setShowInLeaderboard(v!);
+                Navigator.pop(context);
+              },
+            ),
+            RadioListTile<bool>(
+              title: Text(loc.publicProfilePrivate),
+              value: false,
+              groupValue: current,
+              onChanged: (v) {
+                authProv.setShowInLeaderboard(v!);
+                Navigator.pop(context);
+              },
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text(loc.cancelButton),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showSettingsDialog() {
+    final loc = AppLocalizations.of(context)!;
+    showDialog(
+      context: context,
+      builder: (_) => SimpleDialog(
+        title: Text(loc.settingsDialogTitle),
+        children: [
+          SimpleDialogOption(
+            onPressed: () {
+              Navigator.pop(context);
+              _showLanguageDialog();
+            },
+            child: Text(loc.settingsOptionLanguage),
+          ),
+          SimpleDialogOption(
+            onPressed: () {
+              Navigator.pop(context);
+              _showPrivacyDialog();
+            },
+            child: Text(loc.settingsOptionPublicProfile),
+          ),
+        ],
+      ),
     );
   }
 
@@ -84,13 +154,13 @@ class _ProfileScreenState extends State<ProfileScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Profil'),
+        title: Text(AppLocalizations.of(context)!.profileTitle),
         actions: [
           const NfcScanButton(),
           IconButton(
             icon: const Icon(Icons.settings),
-            tooltip: 'Sprache',
-            onPressed: _showLanguageDialog,
+            tooltip: AppLocalizations.of(context)!.settingsIconTooltip,
+            onPressed: _showSettingsDialog,
           ),
         ],
       ),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -346,4 +346,16 @@
   "@confirmPasswordButton": {"description": "Button zum Passwort aktualisieren"},
   "passwordResetSuccess": "Passwort geändert.",
   "@passwordResetSuccess": {"description": "Snackbar nach erfolgreichem Reset"}
+  "settingsDialogTitle": "Einstellungen",
+  "@settingsDialogTitle": {"description": "Titel des Einstellungsdialogs"},
+  "settingsOptionLanguage": "Sprache",
+  "@settingsOptionLanguage": {"description": "Option zum Sprachauswahl"},
+  "settingsOptionPublicProfile": "Öffentliches Profil",
+  "@settingsOptionPublicProfile": {"description": "Option zur Sichtbarkeit des Profils"},
+  "publicProfileDialogTitle": "Profil-Sichtbarkeit",
+  "@publicProfileDialogTitle": {"description": "Titel des Dialogs für öffentliche Profil-Option"},
+  "publicProfilePublic": "Öffentlich",
+  "@publicProfilePublic": {"description": "Option für öffentliches Profil"},
+  "publicProfilePrivate": "Privat",
+  "@publicProfilePrivate": {"description": "Option für privates Profil"}
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -346,4 +346,16 @@
   "@confirmPasswordButton": {"description": "Button to confirm new password"},
   "passwordResetSuccess": "Password changed.",
   "@passwordResetSuccess": {"description": "Snackbar after successful password reset"}
+  "settingsDialogTitle": "Settings",
+  "@settingsDialogTitle": {"description": "Title for the settings dialog"},
+  "settingsOptionLanguage": "Language",
+  "@settingsOptionLanguage": {"description": "Settings option to change language"},
+  "settingsOptionPublicProfile": "Public profile",
+  "@settingsOptionPublicProfile": {"description": "Settings option to toggle profile visibility"},
+  "publicProfileDialogTitle": "Profile visibility",
+  "@publicProfileDialogTitle": {"description": "Title for public profile dialog"},
+  "publicProfilePublic": "Public",
+  "@publicProfilePublic": {"description": "Option label for public profile"},
+  "publicProfilePrivate": "Private",
+  "@publicProfilePrivate": {"description": "Option label for private profile"}
 }


### PR DESCRIPTION
## Summary
- add a settings dialog on the profile screen with language and privacy options
- store the public/private choice in Firestore
- show just the username in the home screen header
- update translations for new settings labels

## Testing
- `npm test` *(fails: Error: no test specified)*
- `flutter gen-l10n` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687efb614320832096eff023c2cb0c12