### PR TITLE
Fix formatting in localization files

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -345,7 +345,7 @@
   "confirmPasswordButton": "Passwort ändern",
   "@confirmPasswordButton": {"description": "Button zum Passwort aktualisieren"},
   "passwordResetSuccess": "Passwort geändert.",
-  "@passwordResetSuccess": {"description": "Snackbar nach erfolgreichem Reset"}
+  "@passwordResetSuccess": {"description": "Snackbar nach erfolgreichem Reset"},
   "settingsDialogTitle": "Einstellungen",
   "@settingsDialogTitle": {"description": "Titel des Einstellungsdialogs"},
   "settingsOptionLanguage": "Sprache",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -345,7 +345,7 @@
   "confirmPasswordButton": "Update password",
   "@confirmPasswordButton": {"description": "Button to confirm new password"},
   "passwordResetSuccess": "Password changed.",
-  "@passwordResetSuccess": {"description": "Snackbar after successful password reset"}
+  "@passwordResetSuccess": {"description": "Snackbar after successful password reset"},
   "settingsDialogTitle": "Settings",
   "@settingsDialogTitle": {"description": "Title for the settings dialog"},
   "settingsOptionLanguage": "Language",


### PR DESCRIPTION
## Summary
- correct missing commas in `app_en.arb` and `app_de.arb`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f6c2ba6648320a86ce4747eb940bd