### PR TITLE
Implement basic XP tracking system

### DIFF
--- a/lib/core/providers/xp_provider.dart
+++ b/lib/core/providers/xp_provider.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/foundation.dart';
+import 'package:tapem/features/xp/domain/xp_repository.dart';
+import 'package:tapem/features/xp/data/sources/firestore_xp_source.dart';
+import 'package:tapem/features/xp/data/repositories/xp_repository_impl.dart';
+
+class XpProvider extends ChangeNotifier {
+  final XpRepository _repo;
+  XpProvider({XpRepository? repo})
+      : _repo = repo ?? XpRepositoryImpl(FirestoreXpSource());
+
+  Future<void> addSessionXp({
+    required String gymId,
+    required String userId,
+    required String deviceId,
+    required String sessionId,
+    required bool showInLeaderboard,
+    required bool isMulti,
+    required List<String> primaryMuscleGroupIds,
+  }) {
+    return _repo.addSessionXp(
+      gymId: gymId,
+      userId: userId,
+      deviceId: deviceId,
+      sessionId: sessionId,
+      showInLeaderboard: showInLeaderboard,
+      isMulti: isMulti,
+      primaryMuscleGroupIds: primaryMuscleGroupIds,
+    );
+  }
+}

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -360,6 +360,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                       if (_formKey.currentState!.validate()) {
                         try {
                           await prov.saveWorkoutSession(
+                            context: context,
                             gymId: widget.gymId,
                             userId: context.read<AuthProvider>().userId!,
                             showInLeaderboard:

--- a/lib/features/rank/presentation/widgets/xp_info_button.dart
+++ b/lib/features/rank/presentation/widgets/xp_info_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:tapem/features/rank/domain/services/level_service.dart';
 
 class XpInfoButton extends StatelessWidget {
   final int xp;
@@ -30,6 +31,9 @@ class XpInfoButton extends StatelessWidget {
           children: [
             Text('XP: $xp'),
             Text('Level: ${_toRoman(level)}'),
+            const SizedBox(height: 8),
+            LinearProgressIndicator(value: xp / LevelService.xpPerLevel),
+            Text('${LevelService.xpPerLevel - xp} XP bis Level ${level + 1}'),
           ],
         ),
         actions: [

--- a/lib/features/xp/data/repositories/xp_repository_impl.dart
+++ b/lib/features/xp/data/repositories/xp_repository_impl.dart
@@ -1,0 +1,28 @@
+import '../../domain/xp_repository.dart';
+import '../sources/firestore_xp_source.dart';
+
+class XpRepositoryImpl implements XpRepository {
+  final FirestoreXpSource _source;
+  XpRepositoryImpl(this._source);
+
+  @override
+  Future<void> addSessionXp({
+    required String gymId,
+    required String userId,
+    required String deviceId,
+    required String sessionId,
+    required bool showInLeaderboard,
+    required bool isMulti,
+    required List<String> primaryMuscleGroupIds,
+  }) {
+    return _source.addSessionXp(
+      gymId: gymId,
+      userId: userId,
+      deviceId: deviceId,
+      sessionId: sessionId,
+      showInLeaderboard: showInLeaderboard,
+      isMulti: isMulti,
+      primaryMuscleGroupIds: primaryMuscleGroupIds,
+    );
+  }
+}

--- a/lib/features/xp/data/sources/firestore_xp_source.dart
+++ b/lib/features/xp/data/sources/firestore_xp_source.dart
@@ -1,0 +1,57 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tapem/features/rank/data/sources/firestore_rank_source.dart';
+import 'package:tapem/features/rank/domain/services/level_service.dart';
+
+class FirestoreXpSource {
+  final FirebaseFirestore _firestore;
+  final FirestoreRankSource _rankSource;
+
+  FirestoreXpSource({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance,
+        _rankSource = FirestoreRankSource(firestore: firestore);
+
+  Future<void> addSessionXp({
+    required String gymId,
+    required String userId,
+    required String deviceId,
+    required String sessionId,
+    required bool showInLeaderboard,
+    required bool isMulti,
+    required List<String> primaryMuscleGroupIds,
+  }) async {
+    final now = DateTime.now();
+    final dateStr = now.toIso8601String().split('T').first;
+    final userRef = _firestore.collection('users').doc(userId);
+    final dayRef = userRef.collection('trainingDays').doc(dateStr);
+    final muscleRefs = primaryMuscleGroupIds
+        .map((id) => userRef.collection('muscles').doc(id))
+        .toList();
+
+    await _firestore.runTransaction((tx) async {
+      final daySnap = await tx.get(dayRef);
+      if (!daySnap.exists) {
+        tx.set(dayRef, {'xp': LevelService.xpPerSession});
+      }
+
+      for (final ref in muscleRefs) {
+        final snap = await tx.get(ref);
+        final xp = (snap.data()?['xp'] as int? ?? 0) + LevelService.xpPerSession;
+        if (!snap.exists) {
+          tx.set(ref, {'xp': xp});
+        } else {
+          tx.update(ref, {'xp': xp});
+        }
+      }
+    });
+
+    if (!isMulti && showInLeaderboard) {
+      await _rankSource.addXp(
+        gymId: gymId,
+        userId: userId,
+        deviceId: deviceId,
+        sessionId: sessionId,
+        showInLeaderboard: showInLeaderboard,
+      );
+    }
+  }
+}

--- a/lib/features/xp/domain/xp_repository.dart
+++ b/lib/features/xp/domain/xp_repository.dart
@@ -1,0 +1,11 @@
+abstract class XpRepository {
+  Future<void> addSessionXp({
+    required String gymId,
+    required String userId,
+    required String deviceId,
+    required String sessionId,
+    required bool showInLeaderboard,
+    required bool isMulti,
+    required List<String> primaryMuscleGroupIds,
+  });
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,7 @@ import 'package:tapem/core/providers/exercise_provider.dart';
 import 'package:tapem/core/providers/all_exercises_provider.dart';
 import 'package:tapem/core/providers/report_provider.dart';
 import 'package:tapem/core/providers/rank_provider.dart';
+import 'package:tapem/core/providers/xp_provider.dart';
 import 'package:tapem/core/providers/training_plan_provider.dart';
 import 'package:tapem/core/providers/branding_provider.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
@@ -196,6 +197,7 @@ class AppEntry extends StatelessWidget {
               ),
         ),
         ChangeNotifierProvider(create: (_) => RankProvider()),
+        ChangeNotifierProvider(create: (_) => XpProvider()),
       ],
       child: const MyApp(),
     );


### PR DESCRIPTION
## Summary
- add `XpProvider` with Firestore-based repository
- support session XP updates for muscles and training days
- integrate XP updates into `DeviceProvider`
- display XP progress bar in `XpInfoButton`
- register `XpProvider` in `main.dart`

## Testing
- `dart --version` *(fails: command not found)*
- `flutter format` *(fails: command not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687f7914ef7c832082b5d4dbe2db749d