### PR TITLE
Implement basic XP overview

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -18,6 +18,7 @@ import 'package:tapem/features/training_details/presentation/screens/training_de
 import 'package:tapem/features/rank/presentation/screens/rank_screen.dart';
 import 'package:tapem/features/training_plan/presentation/screens/plan_overview_screen.dart';
 import 'package:tapem/features/auth/presentation/screens/reset_password_screen.dart';
+import 'package:tapem/features/xp/presentation/screens/xp_overview_screen.dart';
 
 class AppRouter {
   static const splash = '/';
@@ -39,6 +40,7 @@ class AppRouter {
   static const manageMuscleGroups = '/manage_muscle_groups';
   static const branding = '/branding';
   static const resetPassword = '/reset_password';
+  static const xpOverview = '/xp_overview';
 
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
     switch (settings.name) {
@@ -125,6 +127,9 @@ class AppRouter {
         return MaterialPageRoute(
           builder: (_) => ResetPasswordScreen(oobCode: code),
         );
+
+      case xpOverview:
+        return MaterialPageRoute(builder: (_) => const XpOverviewScreen());
 
       default:
         return MaterialPageRoute(

--- a/lib/core/providers/xp_provider.dart
+++ b/lib/core/providers/xp_provider.dart
@@ -8,6 +8,14 @@ class XpProvider extends ChangeNotifier {
   XpProvider({XpRepository? repo})
       : _repo = repo ?? XpRepositoryImpl(FirestoreXpSource());
 
+  Map<String, int> _muscleXp = {};
+  int _dayXp = 0;
+  StreamSubscription<int>? _daySub;
+  StreamSubscription<Map<String, int>>? _muscleSub;
+
+  Map<String, int> get muscleXp => _muscleXp;
+  int get dayXp => _dayXp;
+
   Future<void> addSessionXp({
     required String gymId,
     required String userId,
@@ -26,5 +34,28 @@ class XpProvider extends ChangeNotifier {
       isMulti: isMulti,
       primaryMuscleGroupIds: primaryMuscleGroupIds,
     );
+  }
+
+  void watchDayXp(String userId, DateTime date) {
+    _daySub?.cancel();
+    _daySub = _repo.watchDayXp(userId: userId, date: date).listen((value) {
+      _dayXp = value;
+      notifyListeners();
+    });
+  }
+
+  void watchMuscleXp(String userId) {
+    _muscleSub?.cancel();
+    _muscleSub = _repo.watchMuscleXp(userId).listen((map) {
+      _muscleXp = map;
+      notifyListeners();
+    });
+  }
+
+  @override
+  void dispose() {
+    _daySub?.cancel();
+    _muscleSub?.cancel();
+    super.dispose();
   }
 }

--- a/lib/features/rank/presentation/widgets/xp_info_button.dart
+++ b/lib/features/rank/presentation/widgets/xp_info_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:tapem/features/rank/domain/services/level_service.dart';
+import 'package:tapem/app_router.dart';
 
 class XpInfoButton extends StatelessWidget {
   final int xp;
@@ -40,6 +41,13 @@ class XpInfoButton extends StatelessWidget {
           TextButton(
             onPressed: () => Navigator.of(context).pop(),
             child: const Text('OK'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              Navigator.of(context).pushNamed(AppRouter.xpOverview);
+            },
+            child: const Text('Details'),
           ),
         ],
       ),

--- a/lib/features/xp/data/repositories/xp_repository_impl.dart
+++ b/lib/features/xp/data/repositories/xp_repository_impl.dart
@@ -25,4 +25,17 @@ class XpRepositoryImpl implements XpRepository {
       primaryMuscleGroupIds: primaryMuscleGroupIds,
     );
   }
+
+  @override
+  Stream<int> watchDayXp({
+    required String userId,
+    required DateTime date,
+  }) {
+    return _source.watchDayXp(userId: userId, date: date);
+  }
+
+  @override
+  Stream<Map<String, int>> watchMuscleXp(String userId) {
+    return _source.watchMuscleXp(userId);
+  }
 }

--- a/lib/features/xp/data/sources/firestore_xp_source.dart
+++ b/lib/features/xp/data/sources/firestore_xp_source.dart
@@ -54,4 +54,28 @@ class FirestoreXpSource {
       );
     }
   }
+
+  Stream<int> watchDayXp({
+    required String userId,
+    required DateTime date,
+  }) {
+    final dateStr = date.toIso8601String().split('T').first;
+    final ref = _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('trainingDays')
+        .doc(dateStr);
+    return ref.snapshots().map((snap) => (snap.data()?['xp'] as int?) ?? 0);
+  }
+
+  Stream<Map<String, int>> watchMuscleXp(String userId) {
+    final col = _firestore.collection('users').doc(userId).collection('muscles');
+    return col.snapshots().map((snap) {
+      final map = <String, int>{};
+      for (final doc in snap.docs) {
+        map[doc.id] = (doc.data()['xp'] as int? ?? 0);
+      }
+      return map;
+    });
+  }
 }

--- a/lib/features/xp/domain/xp_repository.dart
+++ b/lib/features/xp/domain/xp_repository.dart
@@ -8,4 +8,11 @@ abstract class XpRepository {
     required bool isMulti,
     required List<String> primaryMuscleGroupIds,
   });
+
+  Stream<int> watchDayXp({
+    required String userId,
+    required DateTime date,
+  });
+
+  Stream<Map<String, int>> watchMuscleXp(String userId);
 }

--- a/lib/features/xp/presentation/screens/xp_overview_screen.dart
+++ b/lib/features/xp/presentation/screens/xp_overview_screen.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../../core/providers/auth_provider.dart';
+import '../../../../core/providers/xp_provider.dart';
+
+class XpOverviewScreen extends StatefulWidget {
+  const XpOverviewScreen({Key? key}) : super(key: key);
+
+  @override
+  State<XpOverviewScreen> createState() => _XpOverviewScreenState();
+}
+
+class _XpOverviewScreenState extends State<XpOverviewScreen> {
+  @override
+  void initState() {
+    super.initState();
+    final auth = context.read<AuthProvider>();
+    final xpProv = context.read<XpProvider>();
+    final uid = auth.userId;
+    if (uid != null) {
+      xpProv.watchDayXp(uid, DateTime.now());
+      xpProv.watchMuscleXp(uid);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final xpProv = context.watch<XpProvider>();
+    final muscleEntries = xpProv.muscleXp.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('XP Übersicht')),
+      body: ListView(
+        children: [
+          ListTile(
+            title: const Text('XP heute'),
+            trailing: Text('${xpProv.dayXp}'),
+          ),
+          const Divider(),
+          ...muscleEntries.map(
+            (e) => ListTile(
+              title: Text(e.key),
+              trailing: Text('${e.value} XP'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- expose XP streams in repository for days and muscles
- implement watchers in `XpProvider`
- add new `XpOverviewScreen`
- allow navigation to overview from XP info dialog
- wire route in `AppRouter`

## Testing
- `dart` and `flutter` commands were unavailable, so no formatting or analysis run

------
https://chatgpt.com/codex/tasks/task_e_687f7d672cd483209f8f237b573cd356