### PR TITLE
Implement XP detail views

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -19,6 +19,8 @@ import 'package:tapem/features/rank/presentation/screens/rank_screen.dart';
 import 'package:tapem/features/training_plan/presentation/screens/plan_overview_screen.dart';
 import 'package:tapem/features/auth/presentation/screens/reset_password_screen.dart';
 import 'package:tapem/features/xp/presentation/screens/xp_overview_screen.dart';
+import 'package:tapem/features/xp/presentation/screens/day_xp_screen.dart';
+import 'package:tapem/features/xp/presentation/screens/device_xp_screen.dart';
 
 class AppRouter {
   static const splash = '/';
@@ -41,6 +43,8 @@ class AppRouter {
   static const branding = '/branding';
   static const resetPassword = '/reset_password';
   static const xpOverview = '/xp_overview';
+  static const dayXp = '/day_xp';
+  static const deviceXp = '/device_xp';
 
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
     switch (settings.name) {
@@ -130,6 +134,12 @@ class AppRouter {
 
       case xpOverview:
         return MaterialPageRoute(builder: (_) => const XpOverviewScreen());
+
+      case dayXp:
+        return MaterialPageRoute(builder: (_) => const DayXpScreen());
+
+      case deviceXp:
+        return MaterialPageRoute(builder: (_) => const DeviceXpScreen());
 
       default:
         return MaterialPageRoute(

--- a/lib/features/rank/presentation/screens/rank_screen.dart
+++ b/lib/features/rank/presentation/screens/rank_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/rank_provider.dart';
+import 'package:tapem/app_router.dart';
 
 class RankScreen extends StatefulWidget {
   final String gymId;
@@ -26,27 +27,57 @@ class _RankScreenState extends State<RankScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Leaderboard')),
-      body: Consumer<RankProvider>(
-        builder: (context, prov, _) {
-          final entries = prov.entries;
-          return ListView.builder(
-            itemCount: entries.length,
-            itemBuilder: (context, i) {
-              final e = entries[i];
-              return ListTile(
-                leading: Text('#${i + 1}'),
-                title: Text(e['username'] ?? e['userId']),
-                trailing: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text('L${e['level'] ?? 1}'),
-                    Text('${e['xp']} XP'),
-                  ],
-                ),
-              );
-            },
-          );
-        },
+      body: Column(
+        children: [
+          Card(
+            margin: const EdgeInsets.all(8),
+            child: ListTile(
+              title: const Text('XP je Muskelgruppe'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => Navigator.of(context).pushNamed(AppRouter.xpOverview),
+            ),
+          ),
+          Card(
+            margin: const EdgeInsets.symmetric(horizontal: 8),
+            child: ListTile(
+              title: const Text('XP je Trainingstag'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => Navigator.of(context).pushNamed(AppRouter.dayXp),
+            ),
+          ),
+          Card(
+            margin: const EdgeInsets.all(8),
+            child: ListTile(
+              title: const Text('XP je Gerät'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => Navigator.of(context).pushNamed(AppRouter.deviceXp),
+            ),
+          ),
+          Expanded(
+            child: Consumer<RankProvider>(
+              builder: (context, prov, _) {
+                final entries = prov.entries;
+                return ListView.builder(
+                  itemCount: entries.length,
+                  itemBuilder: (context, i) {
+                    final e = entries[i];
+                    return ListTile(
+                      leading: Text('#${i + 1}'),
+                      title: Text(e['username'] ?? e['userId']),
+                      trailing: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text('L${e['level'] ?? 1}'),
+                          Text('${e['xp']} XP'),
+                        ],
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/xp/data/repositories/xp_repository_impl.dart
+++ b/lib/features/xp/data/repositories/xp_repository_impl.dart
@@ -38,4 +38,22 @@ class XpRepositoryImpl implements XpRepository {
   Stream<Map<String, int>> watchMuscleXp(String userId) {
     return _source.watchMuscleXp(userId);
   }
+
+  @override
+  Stream<Map<String, int>> watchTrainingDaysXp(String userId) {
+    return _source.watchTrainingDaysXp(userId);
+  }
+
+  @override
+  Stream<int> watchDeviceXp({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+  }) {
+    return _source.watchDeviceXp(
+      gymId: gymId,
+      deviceId: deviceId,
+      userId: userId,
+    );
+  }
 }

--- a/lib/features/xp/data/sources/firestore_xp_source.dart
+++ b/lib/features/xp/data/sources/firestore_xp_source.dart
@@ -78,4 +78,33 @@ class FirestoreXpSource {
       return map;
     });
   }
+
+  Stream<Map<String, int>> watchTrainingDaysXp(String userId) {
+    final col = _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('trainingDays');
+    return col.snapshots().map((snap) {
+      final map = <String, int>{};
+      for (final doc in snap.docs) {
+        map[doc.id] = (doc.data()['xp'] as int? ?? 0);
+      }
+      return map;
+    });
+  }
+
+  Stream<int> watchDeviceXp({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+  }) {
+    final doc = _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('devices')
+        .doc(deviceId)
+        .collection('leaderboard')
+        .doc(userId);
+    return doc.snapshots().map((snap) => (snap.data()?['xp'] as int?) ?? 0);
+  }
 }

--- a/lib/features/xp/domain/xp_repository.dart
+++ b/lib/features/xp/domain/xp_repository.dart
@@ -15,4 +15,12 @@ abstract class XpRepository {
   });
 
   Stream<Map<String, int>> watchMuscleXp(String userId);
+
+  Stream<Map<String, int>> watchTrainingDaysXp(String userId);
+
+  Stream<int> watchDeviceXp({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+  });
 }

--- a/lib/features/xp/presentation/screens/day_xp_screen.dart
+++ b/lib/features/xp/presentation/screens/day_xp_screen.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../../core/providers/auth_provider.dart';
+import '../../../../core/providers/xp_provider.dart';
+
+class DayXpScreen extends StatefulWidget {
+  const DayXpScreen({Key? key}) : super(key: key);
+
+  @override
+  State<DayXpScreen> createState() => _DayXpScreenState();
+}
+
+class _DayXpScreenState extends State<DayXpScreen> {
+  @override
+  void initState() {
+    super.initState();
+    final auth = context.read<AuthProvider>();
+    final xpProv = context.read<XpProvider>();
+    final uid = auth.userId;
+    if (uid != null) {
+      xpProv.watchTrainingDays(uid);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final xpProv = context.watch<XpProvider>();
+    final entries = xpProv.dayListXp.entries.toList()
+      ..sort((a, b) => b.key.compareTo(a.key));
+    return Scaffold(
+      appBar: AppBar(title: const Text('Trainingstage XP')),
+      body: ListView(
+        children: entries
+            .map((e) => ListTile(
+                  title: Text(e.key),
+                  trailing: Text('${e.value} XP'),
+                ))
+            .toList(),
+      ),
+    );
+  }
+}

--- a/lib/features/xp/presentation/screens/device_xp_screen.dart
+++ b/lib/features/xp/presentation/screens/device_xp_screen.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../../core/providers/auth_provider.dart';
+import '../../../../core/providers/gym_provider.dart';
+import '../../../../core/providers/xp_provider.dart';
+
+class DeviceXpScreen extends StatefulWidget {
+  const DeviceXpScreen({Key? key}) : super(key: key);
+
+  @override
+  State<DeviceXpScreen> createState() => _DeviceXpScreenState();
+}
+
+class _DeviceXpScreenState extends State<DeviceXpScreen> {
+  @override
+  void initState() {
+    super.initState();
+    final auth = context.read<AuthProvider>();
+    final gymProv = context.read<GymProvider>();
+    final xpProv = context.read<XpProvider>();
+    final uid = auth.userId;
+    final gymId = gymProv.currentGymId;
+    if (uid != null && gymId.isNotEmpty) {
+      final deviceIds = gymProv.devices
+          .where((d) => !d.isMulti)
+          .map((d) => d.uid)
+          .toList();
+      xpProv.watchDeviceXp(gymId, uid, deviceIds);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final gymProv = context.watch<GymProvider>();
+    final xpProv = context.watch<XpProvider>();
+    final devices = gymProv.devices.where((d) => !d.isMulti).toList();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Geräte XP')),
+      body: ListView.builder(
+        itemCount: devices.length,
+        itemBuilder: (_, i) {
+          final d = devices[i];
+          final xp = xpProv.deviceXp[d.uid] ?? 0;
+          return ListTile(
+            title: Text(d.name),
+            trailing: Text('$xp XP'),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extend XP data sources and repositories with watchers for training days and device XP
- expose new data via `XpProvider`
- add XP overview pages for training days and devices
- link XP pages from leaderboard
- register routes for the new pages

## Testing
- `git commit -m "Add XP detail pages and navigation"` (no tests available)
- Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_687ffb223c2483208450ae1faacd00c7