### PR TITLE
Update rank and XP screens

### DIFF
--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -12,7 +12,7 @@ import 'package:tapem/features/report/presentation/screens/report_screen.dart';
 import 'package:tapem/features/admin/presentation/screens/admin_dashboard_screen.dart';
 import 'package:tapem/features/affiliate/presentation/screens/affiliate_screen.dart';
 import 'package:tapem/app_router.dart';
-import 'package:tapem/features/rank/presentation/screens/device_leaderboard_list_screen.dart';
+import 'package:tapem/features/rank/presentation/screens/rank_screen.dart';
 import 'package:tapem/features/training_plan/presentation/screens/plan_overview_screen.dart';
 import 'package:tapem/features/auth/presentation/widgets/username_dialog.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -29,14 +29,18 @@ class _HomeScreenState extends State<HomeScreen> {
   late int _currentIndex;
 
   List<Widget> _buildPages(BuildContext context) {
-    final gymId = context.watch<GymProvider>().currentGymId;
+    final gymProv = context.watch<GymProvider>();
+    final gymId = gymProv.currentGymId;
+    final devices = gymProv.devices.where((d) => !d.isMulti).toList();
+    final deviceId = devices.isNotEmpty ? devices.first.uid : '';
+
     return [
       const GymScreen(),
       const ProfileScreen(),
       const ReportScreen(),
       const MuscleGroupScreen(),
       const AdminDashboardScreen(),
-      DeviceLeaderboardListScreen(gymId: gymId),
+      RankScreen(gymId: gymId, deviceId: deviceId),
       const AffiliateScreen(),
       const PlanOverviewScreen(),
     ];

--- a/lib/features/xp/presentation/screens/day_xp_screen.dart
+++ b/lib/features/xp/presentation/screens/day_xp_screen.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/xp_provider.dart';
 
@@ -11,6 +14,9 @@ class DayXpScreen extends StatefulWidget {
 }
 
 class _DayXpScreenState extends State<DayXpScreen> {
+  StreamSubscription? _lbSub;
+  List<Map<String, dynamic>> _lbEntries = [];
+
   @override
   void initState() {
     super.initState();
@@ -19,7 +25,45 @@ class _DayXpScreenState extends State<DayXpScreen> {
     final uid = auth.userId;
     if (uid != null) {
       xpProv.watchTrainingDays(uid);
+      _listenLeaderboard(auth.gymCode ?? '');
     }
+  }
+
+  void _listenLeaderboard(String gymId) {
+    if (gymId.isEmpty) return;
+    final fs = FirebaseFirestore.instance;
+    _lbSub = fs
+        .collection('gyms')
+        .doc(gymId)
+        .collection('users')
+        .snapshots()
+        .listen((snap) async {
+      final List<Map<String, dynamic>> data = [];
+      for (final doc in snap.docs) {
+        final uid = doc.id;
+        final userDoc = await fs.collection('users').doc(uid).get();
+        if (!(userDoc.data()?['showInLeaderboard'] as bool? ?? true)) continue;
+        final username = userDoc.data()?['username'] as String?;
+        final dayDocs = await fs
+            .collection('users')
+            .doc(uid)
+            .collection('trainingDays')
+            .get();
+        var xp = 0;
+        for (final d in dayDocs.docs) {
+          xp += (d.data()['xp'] as int? ?? 0);
+        }
+        data.add({'userId': uid, 'username': username, 'xp': xp});
+      }
+      data.sort((a, b) => (b['xp'] as int).compareTo(a['xp'] as int));
+      setState(() => _lbEntries = data);
+    });
+  }
+
+  @override
+  void dispose() {
+    _lbSub?.cancel();
+    super.dispose();
   }
 
   @override
@@ -27,15 +71,32 @@ class _DayXpScreenState extends State<DayXpScreen> {
     final xpProv = context.watch<XpProvider>();
     final entries = xpProv.dayListXp.entries.toList()
       ..sort((a, b) => b.key.compareTo(a.key));
+    final totalXp = xpProv.dayListXp.values.fold<int>(0, (a, b) => a + b);
+
     return Scaffold(
       appBar: AppBar(title: const Text('Trainingstage XP')),
       body: ListView(
-        children: entries
-            .map((e) => ListTile(
-                  title: Text(e.key),
-                  trailing: Text('${e.value} XP'),
-                ))
-            .toList(),
+        children: [
+          ListTile(
+            title: const Text('Gesamt XP'),
+            trailing: Text('$totalXp'),
+          ),
+          const Divider(),
+          ..._lbEntries.asMap().entries.map(
+                (e) => ListTile(
+                  leading: Text('#${e.key + 1}'),
+                  title: Text(e.value['username'] ?? e.value['userId']),
+                  trailing: Text('${e.value['xp']} XP'),
+                ),
+              ),
+          const Divider(),
+          ...entries.map(
+            (e) => ListTile(
+              title: Text(e.key),
+              trailing: Text('${e.value} XP'),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/xp/presentation/screens/xp_overview_screen.dart
+++ b/lib/features/xp/presentation/screens/xp_overview_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/xp_provider.dart';
+import '../../../../core/providers/muscle_group_provider.dart';
+import '../../../muscle_group/domain/models/muscle_group.dart';
 
 class XpOverviewScreen extends StatefulWidget {
   const XpOverviewScreen({Key? key}) : super(key: key);
@@ -16,18 +18,31 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
     super.initState();
     final auth = context.read<AuthProvider>();
     final xpProv = context.read<XpProvider>();
+    final muscleProv = context.read<MuscleGroupProvider>();
     final uid = auth.userId;
     if (uid != null) {
       xpProv.watchDayXp(uid, DateTime.now());
       xpProv.watchMuscleXp(uid);
+      muscleProv.loadGroups(context);
     }
   }
 
   @override
   Widget build(BuildContext context) {
     final xpProv = context.watch<XpProvider>();
-    final muscleEntries = xpProv.muscleXp.entries.toList()
-      ..sort((a, b) => b.value.compareTo(a.value));
+    final muscleProv = context.watch<MuscleGroupProvider>();
+
+    final regionXp = <MuscleRegion, int>{};
+    for (final entry in xpProv.muscleXp.entries) {
+      final group = muscleProv.groups.firstWhere(
+        (g) => g.id == entry.key,
+        orElse: () => null,
+      );
+      if (group != null) {
+        regionXp[group.region] =
+            (regionXp[group.region] ?? 0) + entry.value;
+      }
+    }
 
     return Scaffold(
       appBar: AppBar(title: const Text('XP Übersicht')),
@@ -38,12 +53,11 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
             trailing: Text('${xpProv.dayXp}'),
           ),
           const Divider(),
-          ...muscleEntries.map(
-            (e) => ListTile(
-              title: Text(e.key),
-              trailing: Text('${e.value} XP'),
+          for (final region in MuscleRegion.values)
+            ListTile(
+              title: Text(region.name),
+              trailing: Text('${regionXp[region] ?? 0} XP'),
             ),
-          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- skip device selection and open leaderboard directly from Rank tab
- aggregate muscle XP by region
- show overall XP and leaderboard for training days

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_68800617be588320ab52eb452bd67a72