### PR TITLE
Fix muscle group lookup in XP overview

### DIFF
--- a/lib/features/xp/presentation/screens/xp_overview_screen.dart
+++ b/lib/features/xp/presentation/screens/xp_overview_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:collection/collection.dart';
 import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/xp_provider.dart';
 import '../../../../core/providers/muscle_group_provider.dart';
@@ -34,10 +35,8 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
 
     final regionXp = <MuscleRegion, int>{};
     for (final entry in xpProv.muscleXp.entries) {
-      final group = muscleProv.groups.firstWhere(
-        (g) => g.id == entry.key,
-        orElse: () => null,
-      );
+      final group = muscleProv.groups
+          .firstWhereOrNull((g) => g.id == entry.key);
       if (group != null) {
         regionXp[group.region] =
             (regionXp[group.region] ?? 0) + entry.value;


### PR DESCRIPTION
## Summary
- avoid failing lookup in `XpOverviewScreen`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `npm ci` *(fails: network is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68800bbdcc8c8320938704efe4571979