### PR TITLE
Remove obsolete leaderboards

### DIFF
--- a/lib/core/providers/rank_provider.dart
+++ b/lib/core/providers/rank_provider.dart
@@ -7,41 +7,17 @@ import 'package:tapem/features/rank/data/repositories/rank_repository_impl.dart'
 class RankProvider extends ChangeNotifier {
   final RankRepository _repository;
   List<Map<String, dynamic>> _deviceEntries = [];
-  List<Map<String, dynamic>> _weeklyEntries = [];
-  List<Map<String, dynamic>> _monthlyEntries = [];
   StreamSubscription? _deviceSub;
-  StreamSubscription? _weeklySub;
-  StreamSubscription? _monthlySub;
 
   RankProvider({RankRepository? repository})
     : _repository = repository ?? RankRepositoryImpl(FirestoreRankSource());
 
   List<Map<String, dynamic>> get deviceEntries => _deviceEntries;
-  List<Map<String, dynamic>> get weeklyEntries => _weeklyEntries;
-  List<Map<String, dynamic>> get monthlyEntries => _monthlyEntries;
 
   void watchDevice(String gymId, String deviceId) {
     _deviceSub?.cancel();
     _deviceSub = _repository.watchLeaderboard(gymId, deviceId).listen((list) {
       _deviceEntries = list;
-      notifyListeners();
-    });
-  }
-
-  void watchWeekly(String gymId, String weekId) {
-    _weeklySub?.cancel();
-    _weeklySub =
-        _repository.watchWeeklyLeaderboard(gymId, weekId).listen((list) {
-      _weeklyEntries = list;
-      notifyListeners();
-    });
-  }
-
-  void watchMonthly(String gymId, String monthId) {
-    _monthlySub?.cancel();
-    _monthlySub =
-        _repository.watchMonthlyLeaderboard(gymId, monthId).listen((list) {
-      _monthlyEntries = list;
       notifyListeners();
     });
   }
@@ -65,8 +41,6 @@ class RankProvider extends ChangeNotifier {
   @override
   void dispose() {
     _deviceSub?.cancel();
-    _weeklySub?.cancel();
-    _monthlySub?.cancel();
     super.dispose();
   }
 }

--- a/lib/features/challenges/presentation/screens/challenge_screen.dart
+++ b/lib/features/challenges/presentation/screens/challenge_screen.dart
@@ -1,50 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import '../../../../core/providers/challenge_provider.dart';
-import '../../../../core/providers/auth_provider.dart';
+import 'package:tapem/features/challenges/presentation/screens/challenge_tab.dart';
 
-class ChallengeScreen extends StatefulWidget {
+class ChallengeScreen extends StatelessWidget {
   const ChallengeScreen({Key? key}) : super(key: key);
 
   @override
-  State<ChallengeScreen> createState() => _ChallengeScreenState();
-}
-
-class _ChallengeScreenState extends State<ChallengeScreen> {
-  @override
-  void initState() {
-    super.initState();
-    final prov = context.read<ChallengeProvider>();
-    final auth = context.read<AuthProvider>();
-    prov.watchChallenges();
-    final uid = auth.userId;
-    if (uid != null) prov.watchBadges(uid);
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final prov = context.watch<ChallengeProvider>();
-    return Scaffold(
-      appBar: AppBar(title: const Text('Challenges')),
-      body: ListView(
-        children: [
-          const ListTile(title: Text('Aktive Challenges')),
-          for (final c in prov.challenges)
-            ListTile(
-              title: Text(c.title),
-              subtitle: Text(
-                  '${c.start.toLocal().toIso8601String().split('T').first} - ${c.end.toLocal().toIso8601String().split('T').first}'),
-              trailing: Text('${c.goalXp} XP'),
-            ),
-          const Divider(),
-          const ListTile(title: Text('Badges')),
-          for (final b in prov.badges)
-            ListTile(
-              title: Text(b.challengeId),
-              subtitle: Text(b.awardedAt.toLocal().toIso8601String().split('T').first),
-            ),
-        ],
-      ),
+    return const Scaffold(
+      appBar: AppBar(title: Text('Challenges')),
+      body: ChallengeTab(),
     );
   }
 }

--- a/lib/features/challenges/presentation/screens/challenge_tab.dart
+++ b/lib/features/challenges/presentation/screens/challenge_tab.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../../core/providers/challenge_provider.dart';
+import '../../../../core/providers/auth_provider.dart';
+
+class ChallengeTab extends StatefulWidget {
+  const ChallengeTab({Key? key}) : super(key: key);
+
+  @override
+  State<ChallengeTab> createState() => _ChallengeTabState();
+}
+
+class _ChallengeTabState extends State<ChallengeTab> {
+  @override
+  void initState() {
+    super.initState();
+    final prov = context.read<ChallengeProvider>();
+    final auth = context.read<AuthProvider>();
+    prov.watchChallenges();
+    final uid = auth.userId;
+    if (uid != null) prov.watchBadges(uid);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final prov = context.watch<ChallengeProvider>();
+    return ListView(
+      children: [
+        const ListTile(title: Text('Aktive Challenges')),
+        for (final c in prov.challenges)
+          ListTile(
+            title: Text(c.title),
+            subtitle: Text(
+                '${c.start.toLocal().toIso8601String().split('T').first} - '
+                '${c.end.toLocal().toIso8601String().split('T').first}'),
+            trailing: Text('${c.goalXp} XP'),
+          ),
+        const Divider(),
+        const ListTile(title: Text('Badges')),
+        for (final b in prov.badges)
+          ListTile(
+            title: Text(b.challengeId),
+            subtitle:
+                Text(b.awardedAt.toLocal().toIso8601String().split('T').first),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/features/rank/data/repositories/rank_repository_impl.dart
+++ b/lib/features/rank/data/repositories/rank_repository_impl.dart
@@ -31,19 +31,5 @@ class RankRepositoryImpl implements RankRepository {
     return _source.watchLeaderboard(gymId, deviceId);
   }
 
-  @override
-  Stream<List<Map<String, dynamic>>> watchWeeklyLeaderboard(
-    String gymId,
-    String weekId,
-  ) {
-    return _source.watchWeeklyLeaderboard(gymId, weekId);
-  }
-
-  @override
-  Stream<List<Map<String, dynamic>>> watchMonthlyLeaderboard(
-    String gymId,
-    String monthId,
-  ) {
-    return _source.watchMonthlyLeaderboard(gymId, monthId);
-  }
+  // Weekly and monthly leaderboards were removed
 }

--- a/lib/features/rank/data/sources/firestore_rank_source.dart
+++ b/lib/features/rank/data/sources/firestore_rank_source.dart
@@ -1,6 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'dart:async';
-import 'package:intl/intl.dart';
 
 import '../../domain/models/level_info.dart';
 import '../../domain/services/level_service.dart';
@@ -20,8 +19,6 @@ class FirestoreRankSource {
   }) async {
     final now = DateTime.now();
     final dateStr = now.toIso8601String().split('T').first;
-    final weekId = DateFormat('yyyy-ww').format(now);
-    final monthId = DateFormat('yyyy-MM').format(now);
     final lbRef = _firestore
         .collection('gyms')
         .doc(gymId)
@@ -32,22 +29,10 @@ class FirestoreRankSource {
     final sessionRef = lbRef
         .collection('sessions')
         .doc(sessionId);
-    final weeklyRef = _firestore
-        .collection('leaderboards_weekly')
-        .doc(weekId)
-        .collection('users')
-        .doc(userId);
-    final monthlyRef = _firestore
-        .collection('leaderboards_monthly')
-        .doc(monthId)
-        .collection('users')
-        .doc(userId);
 
     await _firestore.runTransaction((tx) async {
       final lbSnap = await tx.get(lbRef);
       final sessSnap = await tx.get(sessionRef);
-      final wSnap = await tx.get(weeklyRef);
-      final mSnap = await tx.get(monthlyRef);
 
       var info = LevelInfo.fromMap(lbSnap.data());
 
@@ -70,31 +55,7 @@ class FirestoreRankSource {
           'level': info.level,
           'updatedAt': FieldValue.serverTimestamp(),
         });
-        final increment = FieldValue.increment(LevelService.xpPerSession);
-        if (wSnap.exists) {
-          tx.update(weeklyRef, {
-            'xp': increment,
-            'updatedAt': FieldValue.serverTimestamp(),
-          });
-        } else {
-          tx.set(weeklyRef, {
-            'xp': LevelService.xpPerSession,
-            'gymId': gymId,
-            'updatedAt': FieldValue.serverTimestamp(),
-          });
-        }
-        if (mSnap.exists) {
-          tx.update(monthlyRef, {
-            'xp': increment,
-            'updatedAt': FieldValue.serverTimestamp(),
-          });
-        } else {
-          tx.set(monthlyRef, {
-            'xp': LevelService.xpPerSession,
-            'gymId': gymId,
-            'updatedAt': FieldValue.serverTimestamp(),
-          });
-        }
+        // previously weekly and monthly leaderboards were updated here
       }
     });
   }
@@ -124,43 +85,5 @@ class FirestoreRankSource {
     });
   }
 
-  Stream<List<Map<String, dynamic>>> watchWeeklyLeaderboard(
-    String gymId,
-    String weekId,
-  ) {
-    final query = _firestore
-        .collection('leaderboards_weekly')
-        .doc(weekId)
-        .collection('users')
-        .where('gymId', isEqualTo: gymId)
-        .orderBy('xp', descending: true);
-    return query.snapshots().asyncMap((snap) async {
-      final futures = snap.docs.map((d) async {
-        final userSnap = await _firestore.collection('users').doc(d.id).get();
-        final username = userSnap.data()?['username'] as String?;
-        return {'userId': d.id, 'username': username, ...d.data()};
-      });
-      return Future.wait(futures);
-    });
-  }
-
-  Stream<List<Map<String, dynamic>>> watchMonthlyLeaderboard(
-    String gymId,
-    String monthId,
-  ) {
-    final query = _firestore
-        .collection('leaderboards_monthly')
-        .doc(monthId)
-        .collection('users')
-        .where('gymId', isEqualTo: gymId)
-        .orderBy('xp', descending: true);
-    return query.snapshots().asyncMap((snap) async {
-      final futures = snap.docs.map((d) async {
-        final userSnap = await _firestore.collection('users').doc(d.id).get();
-        final username = userSnap.data()?['username'] as String?;
-        return {'userId': d.id, 'username': username, ...d.data()};
-      });
-      return Future.wait(futures);
-    });
-  }
+  // Removed weekly and monthly leaderboard watchers
 }

--- a/lib/features/rank/domain/rank_repository.dart
+++ b/lib/features/rank/domain/rank_repository.dart
@@ -12,13 +12,4 @@ abstract class RankRepository {
     String deviceId,
   );
 
-  Stream<List<Map<String, dynamic>>> watchWeeklyLeaderboard(
-    String gymId,
-    String weekId,
-  );
-
-  Stream<List<Map<String, dynamic>>> watchMonthlyLeaderboard(
-    String gymId,
-    String monthId,
-  );
 }

--- a/lib/features/rank/presentation/screens/rank_screen.dart
+++ b/lib/features/rank/presentation/screens/rank_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/rank_provider.dart';
 import 'package:tapem/app_router.dart';
-import 'package:intl/intl.dart';
+import 'package:tapem/features/challenges/presentation/screens/challenge_tab.dart';
 
 class RankScreen extends StatefulWidget {
   final String gymId;
@@ -23,13 +23,8 @@ class _RankScreenState extends State<RankScreen>
   void initState() {
     super.initState();
     _provider = Provider.of<RankProvider>(context, listen: false);
-    _tabController = TabController(length: 3, vsync: this);
+    _tabController = TabController(length: 2, vsync: this);
     _provider.watchDevice(widget.gymId, widget.deviceId);
-    final now = DateTime.now();
-    final weekId = DateFormat('yyyy-ww').format(now);
-    final monthId = DateFormat('yyyy-MM').format(now);
-    _provider.watchWeekly(widget.gymId, weekId);
-    _provider.watchMonthly(widget.gymId, monthId);
   }
 
   @override
@@ -47,8 +42,7 @@ class _RankScreenState extends State<RankScreen>
           controller: _tabController,
           tabs: const [
             Tab(text: 'Gerät'),
-            Tab(text: 'Woche'),
-            Tab(text: 'Monat'),
+            Tab(text: 'Challenges'),
           ],
         ),
       ),
@@ -104,8 +98,7 @@ class _RankScreenState extends State<RankScreen>
                   controller: _tabController,
                   children: [
                     buildList(prov.deviceEntries),
-                    buildList(prov.weeklyEntries),
-                    buildList(prov.monthlyEntries),
+                    const ChallengeTab(),
                   ],
                 );
               },


### PR DESCRIPTION
## Summary
- drop weekly/monthly leaderboard code
- introduce challenge tab and update challenge screen
- show challenges alongside device leaderboard
- clean up leaderboard dashboard script

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68801bf87e3c8320909e3f59708dea18