### PR TITLE
Fix const usage in ChallengeScreen

### DIFF
--- a/lib/features/challenges/presentation/screens/challenge_screen.dart
+++ b/lib/features/challenges/presentation/screens/challenge_screen.dart
@@ -6,7 +6,7 @@ class ChallengeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
       appBar: AppBar(title: Text('Challenges')),
       body: ChallengeTab(),
     );


### PR DESCRIPTION
## Summary
- remove `const` from `Scaffold` in `ChallengeScreen`

## Testing
- `flutter --version` *(fails: command not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_688022bf6ba883208e11a59503cb42be