### PR TITLE
Implement leaderboard and XP screens

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -13,6 +13,9 @@ import 'package:tapem/features/splash/presentation/screens/splash_screen.dart';
 import 'package:tapem/features/gym/presentation/screens/select_gym_screen.dart';
 import 'package:tapem/features/training_details/presentation/screens/training_details_screen.dart';
 import 'package:tapem/features/rank/presentation/screens/rank_screen.dart';
+import 'package:tapem/features/xp/presentation/screens/xp_muscle_groups_screen.dart';
+import 'package:tapem/features/xp/presentation/screens/experience_screen.dart';
+import 'package:tapem/features/xp/presentation/screens/device_xp_screen.dart';
 import 'package:tapem/features/training_plan/presentation/screens/plan_overview_screen.dart';
 
 class AppRouter {
@@ -28,6 +31,9 @@ class AppRouter {
   static const rank = '/rank';
   // Deprecated alias for backward compatibility
   static const rankScreen = rank;
+  static const xpMuscleGroups = '/xp_muscle_groups';
+  static const experience = '/experience';
+  static const deviceXp = '/device_xp';
   static const trainingDetails = '/training_details';
   static const selectGym = '/select_gym';
   static const planOverview = '/plan_overview';
@@ -97,6 +103,18 @@ class AppRouter {
 
       case planOverview:
         return MaterialPageRoute(builder: (_) => const PlanOverviewScreen());
+
+      case xpMuscleGroups:
+        return MaterialPageRoute(builder: (_) => const XPMuscleGroupsScreen());
+
+      case experience:
+        final userName = settings.arguments as String? ?? '';
+        return MaterialPageRoute(
+          builder: (_) => ExperienceScreen(userName: userName),
+        );
+
+      case deviceXp:
+        return MaterialPageRoute(builder: (_) => const DeviceXpScreen());
 
       default:
         return MaterialPageRoute(

--- a/lib/features/rank/presentation/screens/rank_screen.dart
+++ b/lib/features/rank/presentation/screens/rank_screen.dart
@@ -10,36 +10,105 @@ class RankScreen extends StatefulWidget {
   _RankScreenState createState() => _RankScreenState();
 }
 
-class _RankScreenState extends State<RankScreen> {
+class _RankScreenState extends State<RankScreen>
+    with SingleTickerProviderStateMixin {
   late RankProvider _provider;
+  late TabController _tabController;
+  String _selectedChallenge = 'monthly';
 
   @override
   void initState() {
     super.initState();
     _provider = Provider.of<RankProvider>(context, listen: false);
     _provider.watch(widget.gymId);
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Leaderboard')),
-      body: Consumer<RankProvider>(
-        builder: (context, prov, _) {
-          final entries = prov.entries;
-          return ListView.builder(
-            itemCount: entries.length,
-            itemBuilder: (context, i) {
-              final e = entries[i];
-              return ListTile(
-                leading: Text('#${i + 1}'),
-                title: Text(e['userId']),
-                trailing: Text('${e['xp']} XP'),
-              );
-            },
-          );
-        },
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Leaderboard'),
+          bottom: TabBar(
+            controller: _tabController,
+            tabs: const [
+              Tab(text: 'Rank'),
+              Tab(text: 'Challenges'),
+            ],
+          ),
+        ),
+        body: TabBarView(
+          controller: _tabController,
+          children: [
+            _buildRankTab(),
+            _buildChallengesTab(),
+          ],
+        ),
       ),
+    );
+  }
+
+  Widget _xpWidget(String title) {
+    return Container(
+      height: 100,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: Colors.blueGrey.shade50,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(title),
+    );
+  }
+
+  Widget _buildRankTab() {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        _xpWidget('XP je Muskelgruppe'),
+        const SizedBox(height: 16),
+        _xpWidget('XP je Trainingstag'),
+        const SizedBox(height: 16),
+        _xpWidget('XP je Gerät'),
+      ],
+    );
+  }
+
+  Widget _buildChallengesTab() {
+    return Column(
+      children: [
+        const SizedBox(height: 16),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            ElevatedButton(
+              onPressed: () => setState(() => _selectedChallenge = 'monthly'),
+              child: const Text('Monthly'),
+            ),
+            ElevatedButton(
+              onPressed: () => setState(() => _selectedChallenge = 'weekly'),
+              child: const Text('Weekly'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        Expanded(
+          child: ListView(
+            children: const [
+              ListTile(title: Text('Challenge A')),
+              ListTile(title: Text('Challenge B')),
+              ListTile(title: Text('Challenge C')),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/xp/presentation/screens/device_xp_screen.dart
+++ b/lib/features/xp/presentation/screens/device_xp_screen.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class DeviceXpScreen extends StatelessWidget {
+  const DeviceXpScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final devices = ['Gerät A', 'Gerät B', 'Gerät C'];
+    return Scaffold(
+      appBar: AppBar(title: const Text('Geräte XP')),
+      body: ListView.builder(
+        itemCount: devices.length,
+        itemBuilder: (context, i) {
+          final d = devices[i];
+          return ListTile(
+            title: Text(d),
+            trailing: const Text('0 XP'),
+            onTap: () {
+              showModalBottomSheet(
+                context: context,
+                builder: (_) => ListView(
+                  children: const [
+                    ListTile(title: Text('User 1'), trailing: Text('50 XP')),
+                    ListTile(title: Text('User 2'), trailing: Text('40 XP')),
+                    ListTile(title: Text('User 3'), trailing: Text('30 XP')),
+                    ListTile(title: Text('User 4'), trailing: Text('20 XP')),
+                    ListTile(title: Text('User 5'), trailing: Text('10 XP')),
+                  ],
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/xp/presentation/screens/experience_screen.dart
+++ b/lib/features/xp/presentation/screens/experience_screen.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+class ExperienceScreen extends StatelessWidget {
+  final String userName;
+  const ExperienceScreen({Key? key, required this.userName}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final users = List.generate(
+      10,
+      (i) => {'name': 'User ${i + 1}', 'xp': 100 - i * 5},
+    );
+    return Scaffold(
+      appBar: AppBar(title: const Text('Erfahrung')),
+      body: Column(
+        children: [
+          ListTile(title: Text(userName)),
+          Expanded(
+            child: ListView.builder(
+              itemCount: users.length,
+              itemBuilder: (context, i) {
+                final u = users[i];
+                return ListTile(
+                  leading: Text('#${i + 1}'),
+                  title: Text(u['name'] as String),
+                  trailing: Text('${u['xp']} XP'),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/xp/presentation/screens/xp_muscle_groups_screen.dart
+++ b/lib/features/xp/presentation/screens/xp_muscle_groups_screen.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class XPMuscleGroupsScreen extends StatelessWidget {
+  const XPMuscleGroupsScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final muscleGroups = <String, int>{
+      'chest': 0,
+      'back': 0,
+      'shoulders': 0,
+      'arms': 0,
+      'core': 0,
+      'legs': 0,
+    };
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('XP Muskelgruppen')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: muscleGroups.entries
+            .map(
+              (e) => ListTile(
+                title: Text(e.key),
+                trailing: Text('${e.value} XP'),
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- revamp `RankScreen` with Rank and Challenges tabs
- add widgets for XP overview and challenge lists
- create placeholder XP detail screens
- wire new screens into `AppRouter`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688028fcfb288320bc60cee8a85de7aa