### PR TITLE
Update leaderboard and XP screens

### DIFF
--- a/lib/features/challenges/presentation/screens/challenge_tab.dart
+++ b/lib/features/challenges/presentation/screens/challenge_tab.dart
@@ -1,7 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import '../../../../core/providers/challenge_provider.dart';
-import '../../../../core/providers/auth_provider.dart';
 
 class ChallengeTab extends StatefulWidget {
   const ChallengeTab({Key? key}) : super(key: key);
@@ -11,38 +8,41 @@ class ChallengeTab extends StatefulWidget {
 }
 
 class _ChallengeTabState extends State<ChallengeTab> {
-  @override
-  void initState() {
-    super.initState();
-    final prov = context.read<ChallengeProvider>();
-    final auth = context.read<AuthProvider>();
-    prov.watchChallenges();
-    final uid = auth.userId;
-    if (uid != null) prov.watchBadges(uid);
-  }
+  String _selection = 'Monthly';
 
   @override
   Widget build(BuildContext context) {
-    final prov = context.watch<ChallengeProvider>();
-    return ListView(
+    return Column(
       children: [
-        const ListTile(title: Text('Aktive Challenges')),
-        for (final c in prov.challenges)
-          ListTile(
-            title: Text(c.title),
-            subtitle: Text(
-                '${c.start.toLocal().toIso8601String().split('T').first} - '
-                '${c.end.toLocal().toIso8601String().split('T').first}'),
-            trailing: Text('${c.goalXp} XP'),
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Row(
+            children: [
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: () => setState(() => _selection = 'Monthly'),
+                  child: const Text('Monthly'),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: () => setState(() => _selection = 'Weekly'),
+                  child: const Text('Weekly'),
+                ),
+              ),
+            ],
           ),
-        const Divider(),
-        const ListTile(title: Text('Badges')),
-        for (final b in prov.badges)
-          ListTile(
-            title: Text(b.challengeId),
-            subtitle:
-                Text(b.awardedAt.toLocal().toIso8601String().split('T').first),
+        ),
+        Expanded(
+          child: ListView(
+            children: const [
+              ListTile(title: Text('Challenge A')),
+              ListTile(title: Text('Challenge B')),
+              ListTile(title: Text('Challenge C')),
+            ],
           ),
+        ),
       ],
     );
   }

--- a/lib/features/rank/presentation/screens/rank_screen.dart
+++ b/lib/features/rank/presentation/screens/rank_screen.dart
@@ -41,7 +41,7 @@ class _RankScreenState extends State<RankScreen>
         bottom: TabBar(
           controller: _tabController,
           tabs: const [
-            Tab(text: 'Gerät'),
+            Tab(text: 'Rank'),
             Tab(text: 'Challenges'),
           ],
         ),
@@ -75,30 +75,11 @@ class _RankScreenState extends State<RankScreen>
           Expanded(
             child: Consumer<RankProvider>(
               builder: (context, prov, _) {
-                Widget buildList(List<Map<String, dynamic>> entries) {
-                  return ListView.builder(
-                    itemCount: entries.length,
-                    itemBuilder: (context, i) {
-                      final e = entries[i];
-                      return ListTile(
-                        leading: Text('#${i + 1}'),
-                        title: Text(e['username'] ?? e['userId']),
-                        trailing: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text('L${e['level'] ?? 1}'),
-                            Text('${e['xp']} XP'),
-                          ],
-                        ),
-                      );
-                    },
-                  );
-                }
                 return TabBarView(
                   controller: _tabController,
-                  children: [
-                    buildList(prov.deviceEntries),
-                    const ChallengeTab(),
+                  children: const [
+                    SizedBox.shrink(),
+                    ChallengeTab(),
                   ],
                 );
               },

--- a/lib/features/xp/presentation/screens/day_xp_screen.dart
+++ b/lib/features/xp/presentation/screens/day_xp_screen.dart
@@ -73,16 +73,17 @@ class _DayXpScreenState extends State<DayXpScreen> {
       ..sort((a, b) => b.key.compareTo(a.key));
     final totalXp = xpProv.dayListXp.values.fold<int>(0, (a, b) => a + b);
 
+    final auth = context.watch<AuthProvider>();
     return Scaffold(
-      appBar: AppBar(title: const Text('Trainingstage XP')),
+      appBar: AppBar(title: const Text('Erfahrung')),
       body: ListView(
         children: [
           ListTile(
-            title: const Text('Gesamt XP'),
+            title: Text(auth.userName ?? ''),
             trailing: Text('$totalXp'),
           ),
           const Divider(),
-          ..._lbEntries.asMap().entries.map(
+          ..._lbEntries.asMap().entries.take(10).map(
                 (e) => ListTile(
                   leading: Text('#${e.key + 1}'),
                   title: Text(e.value['username'] ?? e.value['userId']),

--- a/lib/features/xp/presentation/screens/device_xp_screen.dart
+++ b/lib/features/xp/presentation/screens/device_xp_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/gym_provider.dart';
 import '../../../../core/providers/xp_provider.dart';
@@ -44,6 +45,42 @@ class _DeviceXpScreenState extends State<DeviceXpScreen> {
           return ListTile(
             title: Text(d.name),
             trailing: Text('$xp XP'),
+            onTap: () async {
+              final fs = FirebaseFirestore.instance;
+              final gymId = gymProv.currentGymId;
+              final snap = await fs
+                  .collection('gyms')
+                  .doc(gymId)
+                  .collection('devices')
+                  .doc(d.uid)
+                  .collection('leaderboard')
+                  .where('showInLeaderboard', isEqualTo: true)
+                  .orderBy('xp', descending: true)
+                  .limit(5)
+                  .get();
+              final entries = await Future.wait(snap.docs.map((doc) async {
+                final user = await fs.collection('users').doc(doc.id).get();
+                final name = user.data()?['username'] as String? ?? doc.id;
+                final xp = doc.data()['xp'] as int? ?? 0;
+                return {'username': name, 'xp': xp};
+              }));
+              showDialog(
+                context: context,
+                builder: (_) => AlertDialog(
+                  title: Text(d.name),
+                  content: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      for (final e in entries)
+                        ListTile(
+                          title: Text(e['username'] as String),
+                          trailing: Text('${e['xp']} XP'),
+                        ),
+                    ],
+                  ),
+                ),
+              );
+            },
           );
         },
       ),

--- a/lib/features/xp/presentation/screens/xp_overview_screen.dart
+++ b/lib/features/xp/presentation/screens/xp_overview_screen.dart
@@ -44,14 +44,9 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
     }
 
     return Scaffold(
-      appBar: AppBar(title: const Text('XP Übersicht')),
+      appBar: AppBar(title: const Text('XP Muskelgruppen')),
       body: ListView(
         children: [
-          ListTile(
-            title: const Text('XP heute'),
-            trailing: Text('${xpProv.dayXp}'),
-          ),
-          const Divider(),
           for (final region in MuscleRegion.values)
             ListTile(
               title: Text(region.name),


### PR DESCRIPTION
## Summary
- rename Rank tab and remove device leaderboard
- simplify challenges tab with sample buttons and list
- adjust XP overview to show only muscle groups
- tweak day XP screen layout and ranking
- show top users by device on tap

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68802c8e61dc8320ab06df73444d1a9e