### PR TITLE
Add XP widgets to Rank tab only and update challenges

### DIFF
--- a/lib/features/challenges/presentation/screens/challenge_tab.dart
+++ b/lib/features/challenges/presentation/screens/challenge_tab.dart
@@ -36,11 +36,17 @@ class _ChallengeTabState extends State<ChallengeTab> {
         ),
         Expanded(
           child: ListView(
-            children: const [
-              ListTile(title: Text('Challenge A')),
-              ListTile(title: Text('Challenge B')),
-              ListTile(title: Text('Challenge C')),
-            ],
+            children: _selection == 'Weekly'
+                ? const [
+                    ListTile(title: Text('Challenge A')),
+                    ListTile(title: Text('Challenge B')),
+                    ListTile(title: Text('Challenge C')),
+                  ]
+                : const [
+                    ListTile(title: Text('Challenge D')),
+                    ListTile(title: Text('Challenge E')),
+                    ListTile(title: Text('Challenge F')),
+                  ],
           ),
         ),
       ],

--- a/lib/features/rank/presentation/screens/rank_screen.dart
+++ b/lib/features/rank/presentation/screens/rank_screen.dart
@@ -46,46 +46,46 @@ class _RankScreenState extends State<RankScreen>
           ],
         ),
       ),
-      body: Column(
-        children: [
-          Card(
-            margin: const EdgeInsets.all(8),
-            child: ListTile(
-              title: const Text('XP je Muskelgruppe'),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () => Navigator.of(context).pushNamed(AppRouter.xpOverview),
-            ),
-          ),
-          Card(
-            margin: const EdgeInsets.symmetric(horizontal: 8),
-            child: ListTile(
-              title: const Text('XP je Trainingstag'),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () => Navigator.of(context).pushNamed(AppRouter.dayXp),
-            ),
-          ),
-          Card(
-            margin: const EdgeInsets.all(8),
-            child: ListTile(
-              title: const Text('XP je Gerät'),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: () => Navigator.of(context).pushNamed(AppRouter.deviceXp),
-            ),
-          ),
-          Expanded(
-            child: Consumer<RankProvider>(
-              builder: (context, prov, _) {
-                return TabBarView(
-                  controller: _tabController,
-                  children: const [
-                    SizedBox.shrink(),
-                    ChallengeTab(),
-                  ],
-                );
-              },
-            ),
-          ),
-        ],
+      body: Consumer<RankProvider>(
+        builder: (context, prov, _) {
+          return TabBarView(
+            controller: _tabController,
+            children: [
+              ListView(
+                children: [
+                  Card(
+                    margin: const EdgeInsets.all(8),
+                    child: ListTile(
+                      title: const Text('XP je Muskelgruppe'),
+                      trailing: const Icon(Icons.chevron_right),
+                      onTap: () =>
+                          Navigator.of(context).pushNamed(AppRouter.xpOverview),
+                    ),
+                  ),
+                  Card(
+                    margin: const EdgeInsets.symmetric(horizontal: 8),
+                    child: ListTile(
+                      title: const Text('XP je Trainingstag'),
+                      trailing: const Icon(Icons.chevron_right),
+                      onTap: () =>
+                          Navigator.of(context).pushNamed(AppRouter.dayXp),
+                    ),
+                  ),
+                  Card(
+                    margin: const EdgeInsets.all(8),
+                    child: ListTile(
+                      title: const Text('XP je Gerät'),
+                      trailing: const Icon(Icons.chevron_right),
+                      onTap: () =>
+                          Navigator.of(context).pushNamed(AppRouter.deviceXp),
+                    ),
+                  ),
+                ],
+              ),
+              const ChallengeTab(),
+            ],
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
## Beschreibung
- XP-Übersichten befinden sich jetzt ausschließlich im Tab **Rank**
- Challenges-Tab zeigt zwei Buttons **Weekly** und **Monthly** mit Dummy-Listen

## Typ der Änderung
- [x] feat: neues Feature

## Checkliste
- [ ] flutter analyze läuft fehlerfrei
- [ ] flutter test ist erfolgreich
- [x] Keine sensiblen Daten in Commits

------
https://chatgpt.com/codex/tasks/task_e_6880365027308320bddf2b7e11152747