### PR TITLE
Implement daily XP constraints

### DIFF
--- a/lib/features/xp/data/sources/firestore_xp_source.dart
+++ b/lib/features/xp/data/sources/firestore_xp_source.dart
@@ -33,13 +33,15 @@ class FirestoreXpSource {
         tx.set(dayRef, {'xp': LevelService.xpPerSession});
       }
 
-      for (final ref in muscleRefs) {
-        final snap = await tx.get(ref);
-        final xp = (snap.data()?['xp'] as int? ?? 0) + LevelService.xpPerSession;
-        if (!snap.exists) {
-          tx.set(ref, {'xp': xp});
-        } else {
-          tx.update(ref, {'xp': xp});
+      if (!isMulti && muscleRefs.isNotEmpty) {
+        for (final ref in muscleRefs) {
+          final snap = await tx.get(ref);
+          final xp = (snap.data()?['xp'] as int? ?? 0) + LevelService.xpPerSession;
+          if (!snap.exists) {
+            tx.set(ref, {'xp': xp});
+          } else {
+            tx.update(ref, {'xp': xp});
+          }
         }
       }
     });


### PR DESCRIPTION
## Summary
- enforce XP grants for muscle groups only for single-target devices
- add per-day XP constraint to device leaderboards

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68803a8c50f48320984513c9a44fc6f8