### PR TITLE
Fix XP tracking paths

### DIFF
--- a/lib/features/xp/data/sources/firestore_xp_source.dart
+++ b/lib/features/xp/data/sources/firestore_xp_source.dart
@@ -22,9 +22,9 @@ class FirestoreXpSource {
     final now = DateTime.now();
     final dateStr = now.toIso8601String().split('T').first;
     final userRef = _firestore.collection('users').doc(userId);
-    final dayRef = userRef.collection('trainingDays').doc(dateStr);
+    final dayRef = userRef.collection('trainingDayXP').doc(dateStr);
     final muscleRefs = primaryMuscleGroupIds
-        .map((id) => userRef.collection('muscles').doc(id))
+        .map((id) => userRef.collection('muscleGroupXP').doc(id))
         .toList();
 
     await _firestore.runTransaction((tx) async {
@@ -65,13 +65,13 @@ class FirestoreXpSource {
     final ref = _firestore
         .collection('users')
         .doc(userId)
-        .collection('trainingDays')
+        .collection('trainingDayXP')
         .doc(dateStr);
     return ref.snapshots().map((snap) => (snap.data()?['xp'] as int?) ?? 0);
   }
 
   Stream<Map<String, int>> watchMuscleXp(String userId) {
-    final col = _firestore.collection('users').doc(userId).collection('muscles');
+    final col = _firestore.collection('users').doc(userId).collection('muscleGroupXP');
     return col.snapshots().map((snap) {
       final map = <String, int>{};
       for (final doc in snap.docs) {
@@ -85,7 +85,7 @@ class FirestoreXpSource {
     final col = _firestore
         .collection('users')
         .doc(userId)
-        .collection('trainingDays');
+        .collection('trainingDayXP');
     return col.snapshots().map((snap) {
       final map = <String, int>{};
       for (final doc in snap.docs) {

--- a/lib/features/xp/presentation/screens/day_xp_screen.dart
+++ b/lib/features/xp/presentation/screens/day_xp_screen.dart
@@ -44,11 +44,11 @@ class _DayXpScreenState extends State<DayXpScreen> {
         final userDoc = await fs.collection('users').doc(uid).get();
         if (!(userDoc.data()?['showInLeaderboard'] as bool? ?? true)) continue;
         final username = userDoc.data()?['username'] as String?;
-        final dayDocs = await fs
-            .collection('users')
-            .doc(uid)
-            .collection('trainingDays')
-            .get();
+          final dayDocs = await fs
+              .collection('users')
+              .doc(uid)
+              .collection('trainingDayXP')
+              .get();
         var xp = 0;
         for (final d in dayDocs.docs) {
           xp += (d.data()['xp'] as int? ?? 0);


### PR DESCRIPTION
## Summary
- write daily XP data to `trainingDayXP`
- write muscle XP data to `muscleGroupXP`
- adapt leaderboard logic for new daily XP path

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688041b23af483208cf2d41928490a3c