### PR TITLE
Fix XP accumulation for daily and muscle leaderboards

### DIFF
--- a/lib/features/xp/data/sources/firestore_xp_source.dart
+++ b/lib/features/xp/data/sources/firestore_xp_source.dart
@@ -41,11 +41,15 @@ class FirestoreXpSource {
 
       final updates = <String, dynamic>{};
 
-      if (!daySnap.exists) {
-        tx.set(dayRef, {'xp': LevelService.xpPerSession});
-        updates['dailyXP'] =
-            (statsData['dailyXP'] as int? ?? 0) + LevelService.xpPerSession;
+      final currentDayXp = (daySnap.data()?['xp'] as int?) ?? 0;
+      final newDayXp = currentDayXp + LevelService.xpPerSession;
+      if (daySnap.exists) {
+        tx.update(dayRef, {'xp': newDayXp});
+      } else {
+        tx.set(dayRef, {'xp': newDayXp});
       }
+      updates['dailyXP'] =
+          (statsData['dailyXP'] as int? ?? 0) + LevelService.xpPerSession;
 
       if (!isMulti && muscleRefs.isNotEmpty) {
         for (final ref in muscleRefs) {


### PR DESCRIPTION
## Summary
- ensure existing XP entries increment when recording a session

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68805a6494508320bbde71330443b467