### PR TITLE
feat(xp): add debug logging

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -265,6 +265,7 @@ class DeviceProvider extends ChangeNotifier {
 
     // XP-System aktualisieren
     try {
+      debugPrint('➡️ call addSessionXp session=$sessionId device=${_device!.uid}');
       await Provider.of<XpProvider>(context, listen: false).addSessionXp(
         gymId: gymId,
         userId: userId,
@@ -274,6 +275,7 @@ class DeviceProvider extends ChangeNotifier {
         isMulti: _device!.isMulti,
         primaryMuscleGroupIds: _device!.primaryMuscleGroups,
       );
+      debugPrint('✅ addSessionXp completed');
     } catch (e, st) {
       debugPrintStack(label: '_updateXp', stackTrace: st);
     }

--- a/lib/core/providers/xp_provider.dart
+++ b/lib/core/providers/xp_provider.dart
@@ -33,6 +33,7 @@ class XpProvider extends ChangeNotifier {
     required bool isMulti,
     required List<String> primaryMuscleGroupIds,
   }) {
+    debugPrint('🆕 addSessionXp gymId=$gymId userId=$userId deviceId=$deviceId sessionId=$sessionId');
     return _repo.addSessionXp(
       gymId: gymId,
       userId: userId,
@@ -45,30 +46,37 @@ class XpProvider extends ChangeNotifier {
   }
 
   void watchDayXp(String userId, DateTime date) {
+    debugPrint('👀 provider watchDayXp userId=$userId date=$date');
     _daySub?.cancel();
     _daySub = _repo.watchDayXp(userId: userId, date: date).listen((value) {
       _dayXp = value;
+      debugPrint('🔄 provider dayXp=$value');
       notifyListeners();
     });
   }
 
   void watchMuscleXp(String userId) {
+    debugPrint('👀 provider watchMuscleXp userId=$userId');
     _muscleSub?.cancel();
     _muscleSub = _repo.watchMuscleXp(userId).listen((map) {
       _muscleXp = map;
+      debugPrint('🔄 provider muscleXp=${map.length} entries');
       notifyListeners();
     });
   }
 
   void watchTrainingDays(String userId) {
+    debugPrint('👀 provider watchTrainingDays userId=$userId');
     _dayListSub?.cancel();
     _dayListSub = _repo.watchTrainingDaysXp(userId).listen((map) {
       _dayListXp = map;
+      debugPrint('🔄 provider dayListXp=${map.length} days');
       notifyListeners();
     });
   }
 
   void watchDeviceXp(String gymId, String userId, List<String> deviceIds) {
+    debugPrint('👀 provider watchDeviceXp userId=$userId devices=$deviceIds');
     for (final id in _deviceSubs.keys.toList()) {
       if (!deviceIds.contains(id)) {
         _deviceSubs[id]?.cancel();
@@ -82,6 +90,7 @@ class XpProvider extends ChangeNotifier {
           .watchDeviceXp(gymId: gymId, deviceId: id, userId: userId)
           .listen((xp) {
             _deviceXp[id] = xp;
+            debugPrint('🔄 provider device $id xp=$xp');
             notifyListeners();
           });
     }

--- a/lib/features/xp/presentation/screens/day_xp_screen.dart
+++ b/lib/features/xp/presentation/screens/day_xp_screen.dart
@@ -32,12 +32,14 @@ class _DayXpScreenState extends State<DayXpScreen> {
   void _listenLeaderboard(String gymId) {
     if (gymId.isEmpty) return;
     final fs = FirebaseFirestore.instance;
+    debugPrint('👀 listen leaderboard gymId=$gymId');
     _lbSub = fs
         .collection('gyms')
         .doc(gymId)
         .collection('users')
         .snapshots()
         .listen((snap) async {
+      debugPrint('📥 leaderboard snapshot users=${snap.docs.length}');
       final List<Map<String, dynamic>> data = [];
       for (final doc in snap.docs) {
         final uid = doc.id;
@@ -56,6 +58,7 @@ class _DayXpScreenState extends State<DayXpScreen> {
         data.add({'userId': uid, 'username': username, 'xp': xp});
       }
       data.sort((a, b) => (b['xp'] as int).compareTo(a['xp'] as int));
+      debugPrint('🏆 leaderboard entries=${data.length}');
       setState(() => _lbEntries = data);
     });
   }

--- a/lib/features/xp/presentation/screens/xp_overview_screen.dart
+++ b/lib/features/xp/presentation/screens/xp_overview_screen.dart
@@ -22,6 +22,7 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
     final muscleProv = context.read<MuscleGroupProvider>();
     final uid = auth.userId;
     if (uid != null) {
+      debugPrint('👀 overview watchDayXp/watchMuscleXp userId=$uid');
       xpProv.watchDayXp(uid, DateTime.now());
       xpProv.watchMuscleXp(uid);
       muscleProv.loadGroups(context);


### PR DESCRIPTION
## Summary
- add detailed debug output around XP additions and watchers
- show leaderboard logs to inspect XP values

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68805c60080c8320b9da682f366548b9