### PR TITLE
Fix XP source generics and initState timing

### DIFF
--- a/lib/features/xp/data/sources/firestore_xp_source.dart
+++ b/lib/features/xp/data/sources/firestore_xp_source.dart
@@ -28,7 +28,8 @@ class FirestoreXpSource {
     final dayRef = userRef.collection('trainingDayXP').doc(dateStr);
     final muscleRefs = primaryMuscleGroupIds
         .map((id) => userRef.collection('muscleGroupXP').doc(id))
-        .toList();
+        .toList()
+        .cast<DocumentReference<Map<String, dynamic>>>();
     final statsRef = _firestore
         .collection('gyms')
         .doc(gymId)
@@ -44,7 +45,7 @@ class FirestoreXpSource {
       final statsSnap = await tx.get(statsRef);
 
       // Preload muscle snapshots if required.
-      final muscleSnaps = <DocumentSnapshot>[];
+      final muscleSnaps = <DocumentSnapshot<Map<String, dynamic>>>[];
       if (!isMulti && muscleRefs.isNotEmpty) {
         for (final ref in muscleRefs) {
           muscleSnaps.add(await tx.get(ref));

--- a/lib/features/xp/presentation/screens/xp_overview_screen.dart
+++ b/lib/features/xp/presentation/screens/xp_overview_screen.dart
@@ -25,7 +25,9 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
       debugPrint('👀 overview watchDayXp/watchMuscleXp userId=$uid');
       xpProv.watchDayXp(uid, DateTime.now());
       xpProv.watchMuscleXp(uid);
-      muscleProv.loadGroups(context);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        muscleProv.loadGroups(context);
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- correctly type Firestore snapshots in `FirestoreXpSource`
- load muscle groups after first frame in `XpOverviewScreen`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6880618460a08320a5be1c4cb9e60209