### PR TITLE
Fix XP overview reading from stats

### DIFF
--- a/lib/core/providers/xp_provider.dart
+++ b/lib/core/providers/xp_provider.dart
@@ -55,10 +55,10 @@ class XpProvider extends ChangeNotifier {
     });
   }
 
-  void watchMuscleXp(String userId) {
-    debugPrint('👀 provider watchMuscleXp userId=$userId');
+  void watchMuscleXp(String gymId, String userId) {
+    debugPrint('👀 provider watchMuscleXp userId=$userId gymId=$gymId');
     _muscleSub?.cancel();
-    _muscleSub = _repo.watchMuscleXp(userId).listen((map) {
+    _muscleSub = _repo.watchMuscleXp(gymId: gymId, userId: userId).listen((map) {
       _muscleXp = map;
       debugPrint('🔄 provider muscleXp=${map.length} entries');
       notifyListeners();

--- a/lib/features/xp/data/repositories/xp_repository_impl.dart
+++ b/lib/features/xp/data/repositories/xp_repository_impl.dart
@@ -35,8 +35,11 @@ class XpRepositoryImpl implements XpRepository {
   }
 
   @override
-  Stream<Map<String, int>> watchMuscleXp(String userId) {
-    return _source.watchMuscleXp(userId);
+  Stream<Map<String, int>> watchMuscleXp({
+    required String gymId,
+    required String userId,
+  }) {
+    return _source.watchMuscleXp(gymId: gymId, userId: userId);
   }
 
   @override

--- a/lib/features/xp/data/sources/firestore_xp_source.dart
+++ b/lib/features/xp/data/sources/firestore_xp_source.dart
@@ -127,13 +127,27 @@ class FirestoreXpSource {
     });
   }
 
-  Stream<Map<String, int>> watchMuscleXp(String userId) {
-    final col = _firestore.collection('users').doc(userId).collection('muscleGroupXP');
-    debugPrint('👀 watchMuscleXp userId=$userId');
-    return col.snapshots().map((snap) {
+  Stream<Map<String, int>> watchMuscleXp({
+    required String gymId,
+    required String userId,
+  }) {
+    final doc = _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('users')
+        .doc(userId)
+        .collection('rank')
+        .doc('stats');
+    debugPrint('👀 watchMuscleXp userId=$userId gymId=$gymId');
+    return doc.snapshots().map((snap) {
+      final data = snap.data() ?? {};
       final map = <String, int>{};
-      for (final doc in snap.docs) {
-        map[doc.id] = (doc.data()['xp'] as int? ?? 0);
+      for (final entry in data.entries) {
+        final key = entry.key;
+        if (key.endsWith('XP') && key != 'dailyXP') {
+          final group = key.substring(0, key.length - 2);
+          map[group] = (entry.value as int? ?? 0);
+        }
       }
       debugPrint('📥 muscleXp snapshot ${map.length} entries');
       return map;

--- a/lib/features/xp/domain/xp_repository.dart
+++ b/lib/features/xp/domain/xp_repository.dart
@@ -14,7 +14,10 @@ abstract class XpRepository {
     required DateTime date,
   });
 
-  Stream<Map<String, int>> watchMuscleXp(String userId);
+  Stream<Map<String, int>> watchMuscleXp({
+    required String gymId,
+    required String userId,
+  });
 
   Stream<Map<String, int>> watchTrainingDaysXp(String userId);
 

--- a/lib/features/xp/presentation/screens/xp_overview_screen.dart
+++ b/lib/features/xp/presentation/screens/xp_overview_screen.dart
@@ -21,10 +21,11 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
     final xpProv = context.read<XpProvider>();
     final muscleProv = context.read<MuscleGroupProvider>();
     final uid = auth.userId;
-    if (uid != null) {
+    final gymId = auth.gymCode;
+    if (uid != null && gymId != null) {
       debugPrint('👀 overview watchDayXp/watchMuscleXp userId=$uid');
       xpProv.watchDayXp(uid, DateTime.now());
-      xpProv.watchMuscleXp(uid);
+      xpProv.watchMuscleXp(gymId, uid);
       WidgetsBinding.instance.addPostFrameCallback((_) {
         muscleProv.loadGroups(context);
       });


### PR DESCRIPTION
## Summary
- wire `watchMuscleXp` through gym stats
- update provider and screen to supply gym id
- adjust repository methods accordingly

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e511d01483209eefe6c0b93e8380