### PR TITLE
Fix daily XP awarded once per day

### DIFF
--- a/lib/features/xp/data/sources/firestore_xp_source.dart
+++ b/lib/features/xp/data/sources/firestore_xp_source.dart
@@ -63,8 +63,10 @@ class FirestoreXpSource {
       } else {
         tx.set(dayRef, {'xp': newDayXp});
       }
-      updates['dailyXP'] =
-          (statsData['dailyXP'] as int? ?? 0) + LevelService.xpPerSession;
+      if (currentDayXp == 0) {
+        updates['dailyXP'] =
+            (statsData['dailyXP'] as int? ?? 0) + LevelService.xpPerSession;
+      }
 
       if (!isMulti && muscleRefs.isNotEmpty) {
         for (var i = 0; i < muscleRefs.length; i++) {


### PR DESCRIPTION
## Summary
- ensure dailyXP only increases on a user's first session each day

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6880f834dad88320983a7ee91a43a41c