### PR TITLE
Add challenge system skeleton

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -15,6 +15,15 @@
         { "fieldPath": "level", "order": "DESCENDING" },
         { "fieldPath": "xp", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "logs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "deviceId", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/functions/index.js
+++ b/functions/index.js
@@ -40,3 +40,83 @@ exports.evaluateChallenges = functions.pubsub
       await doc.ref.delete();
     }
   });
+
+exports.checkChallengesOnLog = functions.firestore
+  .document('gyms/{gymId}/devices/{deviceId}/logs/{logId}')
+  .onCreate(async (snap, context) => {
+    const { gymId, deviceId } = context.params;
+    const data = snap.data();
+    const userId = data.userId;
+    const sessionId = data.sessionId;
+    if (!userId || !sessionId) return null;
+
+    const db = admin.firestore();
+    const existing = await snap.ref.parent
+      .where('sessionId', '==', sessionId)
+      .get();
+    if (existing.size > 1) return null;
+
+    const now = admin.firestore.Timestamp.now();
+    const weeklyRef = db
+      .collection('gyms')
+      .doc(gymId)
+      .collection('weekly')
+      .where('start', '<=', now)
+      .where('end', '>=', now);
+    const monthlyRef = db
+      .collection('gyms')
+      .doc(gymId)
+      .collection('monthly')
+      .where('start', '<=', now)
+      .where('end', '>=', now);
+
+    const [weeklySnap, monthlySnap] = await Promise.all([weeklyRef.get(), monthlyRef.get()]);
+    const challenges = [...weeklySnap.docs, ...monthlySnap.docs];
+
+    for (const doc of challenges) {
+      const ch = doc.data();
+      const devices = ch.deviceIds || [];
+      if (devices.length && !devices.includes(deviceId)) continue;
+
+      const logsSnap = await db
+        .collectionGroup('logs')
+        .where('userId', '==', userId)
+        .where('deviceId', 'in', devices.length ? devices : [deviceId])
+        .where('timestamp', '>=', ch.start)
+        .where('timestamp', '<=', ch.end)
+        .get();
+
+      if (logsSnap.size >= (ch.minSets || 0)) {
+        const badgeRef = db
+          .collection('users')
+          .doc(userId)
+          .collection('badges')
+          .doc(doc.id);
+        await db.runTransaction(async (tx) => {
+          const badgeSnap = await tx.get(badgeRef);
+          if (!badgeSnap.exists) {
+            tx.set(badgeRef, {
+              challengeId: doc.id,
+              awardedAt: admin.firestore.FieldValue.serverTimestamp(),
+            });
+
+            const statsRef = db
+              .collection('gyms')
+              .doc(gymId)
+              .collection('users')
+              .doc(userId)
+              .collection('rank')
+              .doc('stats');
+            const statsSnap = await tx.get(statsRef);
+            const xp = (statsSnap.data()?.challengeXP || 0) + (ch.xpReward || 0);
+            if (statsSnap.exists) {
+              tx.update(statsRef, { challengeXP: xp });
+            } else {
+              tx.set(statsRef, { challengeXP: xp });
+            }
+          }
+        });
+      }
+    }
+    return null;
+  });

--- a/lib/core/providers/challenge_provider.dart
+++ b/lib/core/providers/challenge_provider.dart
@@ -20,9 +20,9 @@ class ChallengeProvider extends ChangeNotifier {
   List<Challenge> get challenges => _challenges;
   List<Badge> get badges => _badges;
 
-  void watchChallenges() {
+  void watchChallenges(String gymId) {
     _chSub?.cancel();
-    _chSub = _repo.watchActiveChallenges().listen((list) {
+    _chSub = _repo.watchActiveChallenges(gymId).listen((list) {
       _challenges = list;
       notifyListeners();
     });

--- a/lib/features/challenges/data/repositories/challenge_repository_impl.dart
+++ b/lib/features/challenges/data/repositories/challenge_repository_impl.dart
@@ -8,8 +8,8 @@ class ChallengeRepositoryImpl implements ChallengeRepository {
   ChallengeRepositoryImpl(this._source);
 
   @override
-  Stream<List<Challenge>> watchActiveChallenges() {
-    return _source.watchActiveChallenges();
+  Stream<List<Challenge>> watchActiveChallenges(String gymId) {
+    return _source.watchActiveChallenges(gymId);
   }
 
   @override

--- a/lib/features/challenges/data/sources/firestore_challenge_source.dart
+++ b/lib/features/challenges/data/sources/firestore_challenge_source.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:async/async.dart';
 import '../../domain/models/challenge.dart';
 import '../../domain/models/badge.dart';
 
@@ -8,15 +9,29 @@ class FirestoreChallengeSource {
   FirestoreChallengeSource({FirebaseFirestore? firestore})
       : _firestore = firestore ?? FirebaseFirestore.instance;
 
-  Stream<List<Challenge>> watchActiveChallenges() {
+  Stream<List<Challenge>> watchActiveChallenges(String gymId) {
     final now = Timestamp.fromDate(DateTime.now());
-    final query = _firestore
-        .collection('challenges')
+    final weekly = _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('weekly')
         .where('start', isLessThanOrEqualTo: now)
-        .where('end', isGreaterThanOrEqualTo: now);
-    return query.snapshots().map((snap) => snap.docs
-        .map((d) => Challenge.fromMap(d.id, d.data()))
-        .toList());
+        .where('end', isGreaterThanOrEqualTo: now)
+        .snapshots()
+        .map((snap) =>
+            snap.docs.map((d) => Challenge.fromMap(d.id, d.data())).toList());
+    final monthly = _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('monthly')
+        .where('start', isLessThanOrEqualTo: now)
+        .where('end', isGreaterThanOrEqualTo: now)
+        .snapshots()
+        .map((snap) =>
+            snap.docs.map((d) => Challenge.fromMap(d.id, d.data())).toList());
+
+    return StreamZip([weekly, monthly])
+        .map((lists) => [...lists[0], ...lists[1]]);
   }
 
   Stream<List<Badge>> watchBadges(String userId) {

--- a/lib/features/challenges/domain/models/challenge.dart
+++ b/lib/features/challenges/domain/models/challenge.dart
@@ -2,46 +2,66 @@ import "package:cloud_firestore/cloud_firestore.dart";
 class Challenge {
   final String id;
   final String title;
+  final String description;
   final DateTime start;
   final DateTime end;
-  final int goalXp;
+  final List<String> deviceIds;
+  final int minSets;
+  final int xpReward;
 
   Challenge({
     required this.id,
     required this.title,
+    this.description = '',
     required this.start,
     required this.end,
-    required this.goalXp,
+    required this.deviceIds,
+    this.minSets = 0,
+    this.xpReward = 0,
   });
 
   Challenge copyWith({
     String? id,
     String? title,
+    String? description,
     DateTime? start,
     DateTime? end,
-    int? goalXp,
+    List<String>? deviceIds,
+    int? minSets,
+    int? xpReward,
   }) {
     return Challenge(
       id: id ?? this.id,
       title: title ?? this.title,
+      description: description ?? this.description,
       start: start ?? this.start,
       end: end ?? this.end,
-      goalXp: goalXp ?? this.goalXp,
+      deviceIds: deviceIds ?? this.deviceIds,
+      minSets: minSets ?? this.minSets,
+      xpReward: xpReward ?? this.xpReward,
     );
   }
 
   factory Challenge.fromMap(String id, Map<String, dynamic> map) => Challenge(
         id: id,
         title: map['title'] as String? ?? '',
+        description: map['description'] as String? ?? '',
         start: (map['start'] as Timestamp?)?.toDate() ?? DateTime.now(),
         end: (map['end'] as Timestamp?)?.toDate() ?? DateTime.now(),
-        goalXp: map['goalXp'] as int? ?? 0,
+        deviceIds: (map['deviceIds'] as List<dynamic>? ?? [])
+            .map((e) => e.toString())
+            .toList(),
+        minSets: map['minSets'] as int? ?? 0,
+        xpReward: map['xpReward'] as int? ?? 0,
       );
 
   Map<String, dynamic> toMap() => {
         'title': title,
+        'description': description,
         'start': Timestamp.fromDate(start),
         'end': Timestamp.fromDate(end),
-        'goalXp': goalXp,
+        'deviceIds': deviceIds,
+        'minSets': minSets,
+        'xpReward': xpReward,
       };
 }

--- a/lib/features/challenges/domain/repositories/challenge_repository.dart
+++ b/lib/features/challenges/domain/repositories/challenge_repository.dart
@@ -2,6 +2,6 @@ import '../models/challenge.dart';
 import '../models/badge.dart';
 
 abstract class ChallengeRepository {
-  Stream<List<Challenge>> watchActiveChallenges();
+  Stream<List<Challenge>> watchActiveChallenges(String gymId);
   Stream<List<Badge>> watchBadges(String userId);
 }

--- a/lib/features/challenges/presentation/screens/challenge_tab.dart
+++ b/lib/features/challenges/presentation/screens/challenge_tab.dart
@@ -1,4 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../../core/providers/auth_provider.dart';
+import '../../../../core/providers/gym_provider.dart';
+import '../widgets/active_challenges_widget.dart';
+import '../widgets/completed_challenges_widget.dart';
+import '../../../../core/providers/challenge_provider.dart';
 
 class ChallengeTab extends StatefulWidget {
   const ChallengeTab({Key? key}) : super(key: key);
@@ -7,46 +13,44 @@ class ChallengeTab extends StatefulWidget {
   State<ChallengeTab> createState() => _ChallengeTabState();
 }
 
-class _ChallengeTabState extends State<ChallengeTab> {
-  String _selection = 'Monthly';
+class _ChallengeTabState extends State<ChallengeTab>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final gymId = context.read<GymProvider>().currentGymId;
+      final userId = context.read<AuthProvider>().userId;
+      if (gymId.isNotEmpty) {
+        context.read<ChallengeProvider>().watchChallenges(gymId);
+      }
+      if (userId != null) {
+        context.read<ChallengeProvider>().watchBadges(userId);
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: Row(
-            children: [
-              Expanded(
-                child: ElevatedButton(
-                  onPressed: () => setState(() => _selection = 'Monthly'),
-                  child: const Text('Monthly'),
-                ),
-              ),
-              const SizedBox(width: 8),
-              Expanded(
-                child: ElevatedButton(
-                  onPressed: () => setState(() => _selection = 'Weekly'),
-                  child: const Text('Weekly'),
-                ),
-              ),
-            ],
-          ),
+        TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'Aktiv'),
+            Tab(text: 'Abgeschlossen'),
+          ],
         ),
         Expanded(
-          child: ListView(
-            children: _selection == 'Weekly'
-                ? const [
-                    ListTile(title: Text('Challenge A')),
-                    ListTile(title: Text('Challenge B')),
-                    ListTile(title: Text('Challenge C')),
-                  ]
-                : const [
-                    ListTile(title: Text('Challenge D')),
-                    ListTile(title: Text('Challenge E')),
-                    ListTile(title: Text('Challenge F')),
-                  ],
+          child: TabBarView(
+            controller: _tabController,
+            children: const [
+              ActiveChallengesWidget(),
+              CompletedChallengesWidget(),
+            ],
           ),
         ),
       ],

--- a/lib/features/challenges/presentation/widgets/active_challenges_widget.dart
+++ b/lib/features/challenges/presentation/widgets/active_challenges_widget.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../../core/providers/challenge_provider.dart';
+
+class ActiveChallengesWidget extends StatelessWidget {
+  const ActiveChallengesWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final challenges = context.watch<ChallengeProvider>().challenges;
+    if (challenges.isEmpty) {
+      return const Center(child: Text('Keine aktiven Challenges'));
+    }
+    return ListView.builder(
+      itemCount: challenges.length,
+      itemBuilder: (_, i) {
+        final c = challenges[i];
+        return ListTile(
+          title: Text(c.title),
+          subtitle: Text(c.description),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/challenges/presentation/widgets/completed_challenges_widget.dart
+++ b/lib/features/challenges/presentation/widgets/completed_challenges_widget.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../../core/providers/challenge_provider.dart';
+
+class CompletedChallengesWidget extends StatelessWidget {
+  const CompletedChallengesWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final badges = context.watch<ChallengeProvider>().badges;
+    if (badges.isEmpty) {
+      return const Center(child: Text('Noch keine Badges'));
+    }
+    return ListView.builder(
+      itemCount: badges.length,
+      itemBuilder: (_, i) {
+        final b = badges[i];
+        return ListTile(
+          title: Text(b.challengeId),
+          subtitle: Text('${b.awardedAt.toLocal()}'),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- expand `Challenge` model with device restrictions and rewards
- adapt challenge repository and provider to select by gym
- fetch active challenges from new weekly/monthly subcollections
- display active challenges and earned badges
- add function `checkChallengesOnLog` to award challenge XP
- provide Firestore index for querying logs

## Testing
- `flutter analyze` *(fails: command not found)*
- `npm test --prefix firestore-tests` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68816d4078348320a59fbe4a0893e876