### PR TITLE
Add active/completed challenge tabs

### DIFF
--- a/lib/features/challenges/data/repositories/challenge_repository_impl.dart
+++ b/lib/features/challenges/data/repositories/challenge_repository_impl.dart
@@ -2,6 +2,7 @@ import '../../domain/repositories/challenge_repository.dart';
 import '../sources/firestore_challenge_source.dart';
 import '../../domain/models/challenge.dart';
 import '../../domain/models/badge.dart';
+import '../../domain/models/completed_challenge.dart';
 
 class ChallengeRepositoryImpl implements ChallengeRepository {
   final FirestoreChallengeSource _source;
@@ -15,5 +16,11 @@ class ChallengeRepositoryImpl implements ChallengeRepository {
   @override
   Stream<List<Badge>> watchBadges(String userId) {
     return _source.watchBadges(userId);
+  }
+
+  @override
+  Stream<List<CompletedChallenge>> watchCompletedChallenges(
+      String gymId, String userId) {
+    return _source.watchCompletedChallenges(gymId, userId);
   }
 }

--- a/lib/features/challenges/data/sources/firestore_challenge_source.dart
+++ b/lib/features/challenges/data/sources/firestore_challenge_source.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:async/async.dart';
 import '../../domain/models/challenge.dart';
 import '../../domain/models/badge.dart';
+import '../../domain/models/completed_challenge.dart';
 
 class FirestoreChallengeSource {
   final FirebaseFirestore _firestore;
@@ -41,5 +42,18 @@ class FirestoreChallengeSource {
         .snapshots()
         .map((snap) =>
             snap.docs.map((d) => Badge.fromMap(d.id, d.data())).toList());
+  }
+
+  Stream<List<CompletedChallenge>> watchCompletedChallenges(
+      String gymId, String userId) {
+    final col = _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('completedChallenges')
+        .where('userId', isEqualTo: userId)
+        .orderBy('completedAt', descending: true);
+    return col.snapshots().map((snap) => snap.docs
+        .map((d) => CompletedChallenge.fromMap(d.id, d.data()))
+        .toList());
   }
 }

--- a/lib/features/challenges/domain/models/completed_challenge.dart
+++ b/lib/features/challenges/domain/models/completed_challenge.dart
@@ -1,0 +1,24 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class CompletedChallenge {
+  final String id;
+  final String title;
+  final DateTime completedAt;
+
+  CompletedChallenge({
+    required this.id,
+    required this.title,
+    required this.completedAt,
+  });
+
+  factory CompletedChallenge.fromMap(String id, Map<String, dynamic> map) => CompletedChallenge(
+        id: id,
+        title: map['title'] as String? ?? '',
+        completedAt: (map['completedAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
+      );
+
+  Map<String, dynamic> toMap() => {
+        'title': title,
+        'completedAt': Timestamp.fromDate(completedAt),
+      };
+}

--- a/lib/features/challenges/domain/repositories/challenge_repository.dart
+++ b/lib/features/challenges/domain/repositories/challenge_repository.dart
@@ -1,7 +1,12 @@
 import '../models/challenge.dart';
 import '../models/badge.dart';
+import '../models/completed_challenge.dart';
 
 abstract class ChallengeRepository {
   Stream<List<Challenge>> watchActiveChallenges(String gymId);
   Stream<List<Badge>> watchBadges(String userId);
+  Stream<List<CompletedChallenge>> watchCompletedChallenges(
+    String gymId,
+    String userId,
+  );
 }

--- a/lib/features/challenges/presentation/screens/challenge_tab.dart
+++ b/lib/features/challenges/presentation/screens/challenge_tab.dart
@@ -24,8 +24,8 @@ class _ChallengeTabState extends State<ChallengeTab>
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final gymId = context.read<GymProvider>().currentGymId;
       final userId = context.read<AuthProvider>().userId;
-      if (gymId.isNotEmpty) {
-        context.read<ChallengeProvider>().watchChallenges(gymId);
+      if (gymId.isNotEmpty && userId != null) {
+        context.read<ChallengeProvider>().watchChallenges(gymId, userId);
       }
       if (userId != null) {
         context.read<ChallengeProvider>().watchBadges(userId);

--- a/lib/features/challenges/presentation/widgets/active_challenges_widget.dart
+++ b/lib/features/challenges/presentation/widgets/active_challenges_widget.dart
@@ -15,9 +15,36 @@ class ActiveChallengesWidget extends StatelessWidget {
       itemCount: challenges.length,
       itemBuilder: (_, i) {
         final c = challenges[i];
-        return ListTile(
-          title: Text(c.title),
-          subtitle: Text(c.description),
+        return Card(
+          margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          child: ListTile(
+            title: Text(c.title),
+            onTap: () {
+              showDialog(
+                context: context,
+                builder: (_) => AlertDialog(
+                  title: Text(c.title),
+                  content: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(c.description),
+                      const SizedBox(height: 8),
+                      Text('XP: ${c.xpReward}'),
+                      const SizedBox(height: 8),
+                      Text('Geräte: ${c.deviceIds.join(', ')}'),
+                    ],
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(context),
+                      child: const Text('Schließen'),
+                    )
+                  ],
+                ),
+              );
+            },
+          ),
         );
       },
     );

--- a/lib/features/challenges/presentation/widgets/completed_challenges_widget.dart
+++ b/lib/features/challenges/presentation/widgets/completed_challenges_widget.dart
@@ -7,17 +7,17 @@ class CompletedChallengesWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final badges = context.watch<ChallengeProvider>().badges;
-    if (badges.isEmpty) {
-      return const Center(child: Text('Noch keine Badges'));
+    final completed = context.watch<ChallengeProvider>().completed;
+    if (completed.isEmpty) {
+      return const Center(child: Text('Keine abgeschlossenen Challenges'));
     }
     return ListView.builder(
-      itemCount: badges.length,
+      itemCount: completed.length,
       itemBuilder: (_, i) {
-        final b = badges[i];
+        final c = completed[i];
         return ListTile(
-          title: Text(b.challengeId),
-          subtitle: Text('${b.awardedAt.toLocal()}'),
+          title: Text(c.title),
+          subtitle: Text('${c.completedAt.toLocal()}'),
         );
       },
     );


### PR DESCRIPTION
## Summary
- add `CompletedChallenge` model
- extend challenge repository for completed challenges
- watch active and completed challenges in `ChallengeProvider`
- connect to provider in `ChallengeTab`
- show challenge detail dialog and completed list

## Testing
- `npm --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68817d8ee49c8320ade01740c818a9af