### PR TITLE
Fix ChallengeTab init and dependencies

### DIFF
--- a/lib/features/challenges/presentation/screens/challenge_tab.dart
+++ b/lib/features/challenges/presentation/screens/challenge_tab.dart
@@ -21,16 +21,17 @@ class _ChallengeTabState extends State<ChallengeTab>
   void initState() {
     super.initState();
     _tabController = TabController(length: 2, vsync: this);
-      final gymId = context.read<GymProvider>().currentGymId;
-      final userId = context.read<AuthProvider>().userId;
-      print("ChallengeTab init with gym: $gymId, user: $userId");
-      if (gymId.isNotEmpty && userId != null) {
-        context.read<ChallengeProvider>().watchChallenges(gymId, userId);
-      }
-      if (userId != null) {
-        context.read<ChallengeProvider>().watchBadges(userId);
-      }
-    });
+
+    final gymId = context.read<GymProvider>().currentGymId;
+    final userId = context.read<AuthProvider>().userId;
+    print('ChallengeTab init with gym: $gymId, user: $userId');
+
+    if (gymId.isNotEmpty && userId != null) {
+      context.read<ChallengeProvider>().watchChallenges(gymId, userId);
+    }
+    if (userId != null) {
+      context.read<ChallengeProvider>().watchBadges(userId);
+    }
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   googleapis: ^14.0.0     # Nur falls du wirklich die Sheets-API nutzt
   # google_sign_in: ^6.2.1
   file_picker: ^6.2.1
+  async: ^2.11.0
 
   # Firebase
   firebase_auth: ^5.5.3


### PR DESCRIPTION
## Summary
- fix `ChallengeTab`'s `initState` method so the class compiles
- add the missing `async` package dependency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688193e0d2dc832083ca33d851861526