### PR TITLE
Fix challenge logging by including deviceId

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -237,6 +237,7 @@ class DeviceProvider extends ChangeNotifier {
     for (var set in savedSets) {
       final logDoc = logsCol.doc();
       final data = <String, dynamic>{
+        'deviceId': _device!.uid,
         'userId': userId,
         'exerciseId': _currentExerciseId,
         'sessionId': sessionId,


### PR DESCRIPTION
## Summary
- add deviceId to each workout log to allow challenge checks

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6881ba149fb483209be4c1e33ab15fc5