### PR TITLE
Fix challenge completion logic

### DIFF
--- a/lib/core/providers/challenge_provider.dart
+++ b/lib/core/providers/challenge_provider.dart
@@ -63,6 +63,14 @@ class ChallengeProvider extends ChangeNotifier {
     });
   }
 
+  Future<void> checkChallenges(
+    String gymId,
+    String userId,
+    String deviceId,
+  ) {
+    return _repo.checkChallenges(gymId, userId, deviceId);
+  }
+
   @override
   void dispose() {
     _chSub?.cancel();

--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -14,6 +14,7 @@ import 'package:tapem/features/rank/domain/models/level_info.dart';
 import 'package:tapem/features/rank/domain/services/level_service.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/xp_provider.dart';
+import 'package:tapem/core/providers/challenge_provider.dart';
 
 class DeviceProvider extends ChangeNotifier {
   final GetDevicesForGym _getDevicesForGym;
@@ -237,6 +238,7 @@ class DeviceProvider extends ChangeNotifier {
     for (var set in savedSets) {
       final logDoc = logsCol.doc();
       final data = <String, dynamic>{
+        'deviceId': _device!.uid,
         'userId': userId,
         'exerciseId': _currentExerciseId,
         'sessionId': sessionId,
@@ -280,6 +282,13 @@ class DeviceProvider extends ChangeNotifier {
         primaryMuscleGroupIds: _device!.primaryMuscleGroups,
       );
       debugPrint('✅ addSessionXp completed');
+
+      // Challenges prüfen
+      await Provider.of<ChallengeProvider>(context, listen: false).checkChallenges(
+        gymId,
+        userId,
+        _device!.uid,
+      );
     } catch (e, st) {
       debugPrintStack(label: '_updateXp', stackTrace: st);
     }

--- a/lib/features/admin/presentation/screens/challenge_admin_screen.dart
+++ b/lib/features/admin/presentation/screens/challenge_admin_screen.dart
@@ -89,11 +89,8 @@ class _ChallengeAdminScreenState extends State<ChallengeAdminScreen> {
       _error = null;
     });
 
-    final colName = _type == 'weekly' ? 'weekly' : 'monthly';
-    final col = FirebaseFirestore.instance
-        .collection('gyms')
-        .doc(gymId)
-        .collection(colName);
+    final colName = _type == 'weekly' ? 'challenges/weekly' : 'challenges/monthly';
+    final col = FirebaseFirestore.instance.collection('gyms/$gymId/$colName');
     try {
       print('Creating challenge in gym $gymId/$colName: $data');
       final docRef = await col.add(data);

--- a/lib/features/challenges/data/repositories/challenge_repository_impl.dart
+++ b/lib/features/challenges/data/repositories/challenge_repository_impl.dart
@@ -23,4 +23,14 @@ class ChallengeRepositoryImpl implements ChallengeRepository {
       String gymId, String userId) {
     return _source.watchCompletedChallenges(gymId, userId);
   }
+
+  @override
+  Future<void> checkChallenges(
+      String gymId, String userId, String deviceId) {
+    return _source.checkChallenges(
+      gymId: gymId,
+      userId: userId,
+      deviceId: deviceId,
+    );
+  }
 }

--- a/lib/features/challenges/data/sources/firestore_challenge_source.dart
+++ b/lib/features/challenges/data/sources/firestore_challenge_source.dart
@@ -13,18 +13,14 @@ class FirestoreChallengeSource {
   Stream<List<Challenge>> watchActiveChallenges(String gymId) {
     final now = Timestamp.fromDate(DateTime.now());
     final weekly = _firestore
-        .collection('gyms')
-        .doc(gymId)
-        .collection('weekly')
+        .collection('gyms/$gymId/challenges/weekly')
         .where('start', isLessThanOrEqualTo: now)
         .where('end', isGreaterThanOrEqualTo: now)
         .snapshots()
         .map((snap) =>
             snap.docs.map((d) => Challenge.fromMap(d.id, d.data())).toList());
     final monthly = _firestore
-        .collection('gyms')
-        .doc(gymId)
-        .collection('monthly')
+        .collection('gyms/$gymId/challenges/monthly')
         .where('start', isLessThanOrEqualTo: now)
         .where('end', isGreaterThanOrEqualTo: now)
         .snapshots()
@@ -47,13 +43,89 @@ class FirestoreChallengeSource {
   Stream<List<CompletedChallenge>> watchCompletedChallenges(
       String gymId, String userId) {
     final col = _firestore
-        .collection('gyms')
-        .doc(gymId)
-        .collection('completedChallenges')
-        .where('userId', isEqualTo: userId)
+        .collection('gyms/$gymId/users/$userId/completedChallenges')
         .orderBy('completedAt', descending: true);
     return col.snapshots().map((snap) => snap.docs
         .map((d) => CompletedChallenge.fromMap(d.id, d.data()))
         .toList());
+  }
+
+  Future<void> checkChallenges({
+    required String gymId,
+    required String userId,
+    required String deviceId,
+  }) async {
+    final now = Timestamp.fromDate(DateTime.now());
+    final weeklySnap = await _firestore
+        .collection('gyms/$gymId/challenges/weekly')
+        .where('start', isLessThanOrEqualTo: now)
+        .where('end', isGreaterThanOrEqualTo: now)
+        .get();
+    final monthlySnap = await _firestore
+        .collection('gyms/$gymId/challenges/monthly')
+        .where('start', isLessThanOrEqualTo: now)
+        .where('end', isGreaterThanOrEqualTo: now)
+        .get();
+
+    final challenges = [
+      ...weeklySnap.docs.map((d) => Challenge.fromMap(d.id, d.data())),
+      ...monthlySnap.docs.map((d) => Challenge.fromMap(d.id, d.data())),
+    ];
+
+    for (final ch in challenges) {
+      if (ch.deviceIds.isNotEmpty && !ch.deviceIds.contains(deviceId)) {
+        continue;
+      }
+      final deviceIds = ch.deviceIds.isEmpty ? [deviceId] : ch.deviceIds;
+      final logsSnap = await _firestore
+          .collectionGroup('logs')
+          .where('userId', isEqualTo: userId)
+          .where('deviceId', whereIn: deviceIds)
+          .where('timestamp', isGreaterThanOrEqualTo: ch.start)
+          .where('timestamp', isLessThanOrEqualTo: ch.end)
+          .get();
+
+      if (logsSnap.size >= ch.minSets) {
+        final completedRef = _firestore
+            .collection('gyms/$gymId/users/$userId/completedChallenges')
+            .doc(ch.id);
+        await _firestore.runTransaction((tx) async {
+          final completedSnap = await tx.get(completedRef);
+          if (!completedSnap.exists) {
+            tx.set(completedRef, {
+              'challengeId': ch.id,
+              'userId': userId,
+              'title': ch.title,
+              'completedAt': FieldValue.serverTimestamp(),
+              'xpReward': ch.xpReward,
+            });
+            final badgeRef = _firestore
+                .collection('users')
+                .doc(userId)
+                .collection('badges')
+                .doc(ch.id);
+            final statsRef = _firestore
+                .collection('gyms')
+                .doc(gymId)
+                .collection('users')
+                .doc(userId)
+                .collection('rank')
+                .doc('stats');
+            final statsSnap = await tx.get(statsRef);
+            final xp = (statsSnap.data()?['challengeXP'] as int? ?? 0) + ch.xpReward;
+            if (statsSnap.exists) {
+              tx.update(statsRef, {'challengeXP': xp});
+            } else {
+              tx.set(statsRef, {'challengeXP': xp});
+            }
+            tx.set(badgeRef, {
+              'challengeId': ch.id,
+              'userId': userId,
+              'awardedAt': FieldValue.serverTimestamp(),
+            });
+          }
+        });
+      }
+    }
   }
 }

--- a/lib/features/challenges/domain/repositories/challenge_repository.dart
+++ b/lib/features/challenges/domain/repositories/challenge_repository.dart
@@ -9,4 +9,10 @@ abstract class ChallengeRepository {
     String gymId,
     String userId,
   );
+
+  Future<void> checkChallenges(
+    String gymId,
+    String userId,
+    String deviceId,
+  );
 }


### PR DESCRIPTION
## Summary
- handle challenges in `/gyms/<gym>/challenges/...` collections
- store completed documents under `/gyms/<gym>/users/<user>/completedChallenges`
- create badge documents when completing a challenge

## Testing
- `git log -1 --stat`
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881ba149fb483209be4c1e33ab15fc5