### PR TITLE
Add challenge completion workflow

### DIFF
--- a/lib/features/admin/presentation/screens/challenge_admin_screen.dart
+++ b/lib/features/admin/presentation/screens/challenge_admin_screen.dart
@@ -93,7 +93,9 @@ class _ChallengeAdminScreenState extends State<ChallengeAdminScreen> {
     final col = FirebaseFirestore.instance
         .collection('gyms')
         .doc(gymId)
-        .collection(colName);
+        .collection('challenges')
+        .doc(colName)
+        .collection('items');
     try {
       print('Creating challenge in gym $gymId/$colName: $data');
       final docRef = await col.add(data);


### PR DESCRIPTION
## Summary
- read active challenges from `challenges/{type}/items`
- store completed challenges per user
- award badges when finishing a challenge
- adjust admin screen paths
- update Cloud Function logic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68821fd9627083208756d425be66d768