### PR TITLE
Implement challenge completion on session

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -154,11 +154,19 @@ exports.checkChallengesOnLog = functions.firestore
               .collection('rank')
               .doc('stats');
             const statsSnap = await tx.get(statsRef);
-            const xp = (statsSnap.data()?.challengeXP || 0) + (ch.xpReward || 0);
+            const data = statsSnap.data() || {};
+            const challengeXp = (data.challengeXP || 0) + (ch.xpReward || 0);
+            const dailyXp = (data.dailyXP || 0) + (ch.xpReward || 0);
             if (statsSnap.exists) {
-              tx.update(statsRef, { challengeXP: xp });
+              tx.update(statsRef, {
+                challengeXP: challengeXp,
+                dailyXP: dailyXp,
+              });
             } else {
-              tx.set(statsRef, { challengeXP: xp });
+              tx.set(statsRef, {
+                challengeXP: challengeXp,
+                dailyXP: dailyXp,
+              });
             }
             console.log(
               `🏁 challenge ${doc.id} completed by ${userId}, +${ch.xpReward || 0} XP`


### PR DESCRIPTION
## Summary
- log challenge evaluation in FirestoreChallengeSource
- update dailyXP and challengeXP when a challenge gets completed
- extend Cloud Function to also update dailyXP

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6882387c6cc8832099a81028dd19b3df