### PR TITLE
Fix missing debugPrint import

### DIFF
--- a/lib/features/challenges/data/sources/firestore_challenge_source.dart
+++ b/lib/features/challenges/data/sources/firestore_challenge_source.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:async/async.dart';
+import 'package:flutter/foundation.dart';
 import '../../domain/models/challenge.dart';
 import '../../domain/models/badge.dart';
 import '../../domain/models/completed_challenge.dart';


### PR DESCRIPTION
## Summary
- import `flutter/foundation.dart` in `FirestoreChallengeSource` for `debugPrint`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68824659f14c8320b969184e59819d6d