### PR TITLE
Fix challenge debug and index instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ Weitere Details zum State-Management stehen in [docs/provider_structure.md](docs
    flutter pub get
    ```
 
+4. **Firestore Indexes deployen**
+   Damit komplexe Abfragen funktionieren (z.B. für Challenges), müssen die in
+   `firestore.indexes.json` definierten Indexe in dein Firebase-Projekt übertragen
+   werden:
+   ```bash
+   firebase deploy --only firestore:indexes
+   ```
+
 ---
 
 ## Flavors

--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -290,6 +290,7 @@ class DeviceProvider extends ChangeNotifier {
         _device!.uid,
       );
     } catch (e, st) {
+      debugPrint('⚠️ _updateXp error: $e');
       debugPrintStack(label: '_updateXp', stackTrace: st);
     }
 

--- a/lib/features/challenges/data/sources/firestore_challenge_source.dart
+++ b/lib/features/challenges/data/sources/firestore_challenge_source.dart
@@ -103,25 +103,36 @@ class FirestoreChallengeSource {
         continue;
       }
       debugPrint('➡️ check challenge ${ch.id} devices=${ch.deviceIds}');
-      final deviceIds = ch.deviceIds.isEmpty ? [deviceId] : ch.deviceIds;
 
-      // Firestore erlaubt maximal 10 IDs pro whereIn-Query.
-      final chunks = <List<String>>[];
-      for (var i = 0; i < deviceIds.length; i += 10) {
-        chunks.add(
-            deviceIds.sublist(i, i + 10 > deviceIds.length ? deviceIds.length : i + 10));
-      }
+      try {
 
       var logCount = 0;
-      for (final ids in chunks) {
+      if (ch.deviceIds.isEmpty) {
         final snap = await _firestore
             .collectionGroup('logs')
             .where('userId', isEqualTo: userId)
-            .where('deviceId', whereIn: ids)
             .where('timestamp', isGreaterThanOrEqualTo: ch.start)
             .where('timestamp', isLessThanOrEqualTo: ch.end)
             .get();
-        logCount += snap.size;
+        logCount = snap.size;
+      } else {
+        // Firestore erlaubt maximal 10 IDs pro whereIn-Query.
+        final chunks = <List<String>>[];
+        for (var i = 0; i < ch.deviceIds.length; i += 10) {
+          chunks.add(ch.deviceIds.sublist(
+              i, i + 10 > ch.deviceIds.length ? ch.deviceIds.length : i + 10));
+        }
+
+        for (final ids in chunks) {
+          final snap = await _firestore
+              .collectionGroup('logs')
+              .where('userId', isEqualTo: userId)
+              .where('deviceId', whereIn: ids)
+              .where('timestamp', isGreaterThanOrEqualTo: ch.start)
+              .where('timestamp', isLessThanOrEqualTo: ch.end)
+              .get();
+          logCount += snap.size;
+        }
       }
       debugPrint(
           '📊 logs $logCount / required ${ch.minSets} for challenge ${ch.id}');
@@ -183,6 +194,9 @@ class FirestoreChallengeSource {
                 '🏁 challenge ${ch.id} completed -> +${ch.xpReward} XP (daily=$dailyXp)');
           }
         });
+      }
+      } on FirebaseException catch (e) {
+        debugPrint('🔥 error checking challenge ${ch.id}: ${e.message}');
       }
     }
   }


### PR DESCRIPTION
## Summary
- print the caught error in `DeviceProvider` so we see Firestore issues
- wrap challenge queries in a try/catch to log Firebase exceptions
- document deploying Firestore indexes

## Testing
- `npm test` *(fails: `Error: no test specified`)*
- `npx mocha firestore-tests/security_rules.test.js` *(failed to run: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68825acf94588320980b44d4938bff04