### PR TITLE
Fix XP header to read dailyXP from stats

### DIFF
--- a/lib/core/providers/xp_provider.dart
+++ b/lib/core/providers/xp_provider.dart
@@ -18,11 +18,14 @@ class XpProvider extends ChangeNotifier {
   final Map<String, int> _deviceXp = {};
   StreamSubscription<Map<String, int>>? _dayListSub;
   final Map<String, StreamSubscription<int>> _deviceSubs = {};
+  int _statsDailyXp = 0;
+  StreamSubscription<int>? _statsDailySub;
 
   Map<String, int> get muscleXp => _muscleXp;
   int get dayXp => _dayXp;
   Map<String, int> get dayListXp => _dayListXp;
   Map<String, int> get deviceXp => _deviceXp;
+  int get statsDailyXp => _statsDailyXp;
 
   Future<void> addSessionXp({
     required String gymId,
@@ -93,9 +96,21 @@ class XpProvider extends ChangeNotifier {
           .listen((xp) {
             _deviceXp[id] = xp;
             debugPrint('🔄 provider device $id xp=$xp');
-            notifyListeners();
-          });
+          notifyListeners();
+        });
     }
+  }
+
+  void watchStatsDailyXp(String gymId, String userId) {
+    debugPrint('👀 provider watchStatsDailyXp gymId=$gymId userId=$userId');
+    _statsDailySub?.cancel();
+    _statsDailySub = _repo
+        .watchStatsDailyXp(gymId: gymId, userId: userId)
+        .listen((xp) {
+      _statsDailyXp = xp;
+      debugPrint('🔄 provider statsDailyXp=$xp');
+      notifyListeners();
+    });
   }
 
   @override
@@ -103,6 +118,7 @@ class XpProvider extends ChangeNotifier {
     _daySub?.cancel();
     _muscleSub?.cancel();
     _dayListSub?.cancel();
+    _statsDailySub?.cancel();
     for (final sub in _deviceSubs.values) {
       sub.cancel();
     }

--- a/lib/features/challenges/data/sources/firestore_challenge_source.dart
+++ b/lib/features/challenges/data/sources/firestore_challenge_source.dart
@@ -204,9 +204,11 @@ class FirestoreChallengeSource {
               }
 
               final data = statsSnap.data() ?? {};
+              final previousDaily = data['dailyXP'] as int? ?? 0;
               final challengeXp =
                   (data['challengeXP'] as int? ?? 0) + ch.xpReward;
-              final dailyXp = (data['dailyXP'] as int? ?? 0) + ch.xpReward;
+              final dailyXp = previousDaily + ch.xpReward;
+              debugPrint('📊 dailyXP $previousDaily -> $dailyXp');
 
               if (statsSnap.exists) {
                 tx.update(statsRef, {
@@ -219,6 +221,7 @@ class FirestoreChallengeSource {
                   'dailyXP': dailyXp,
                 });
               }
+              debugPrint('✅ dailyXP set to $dailyXp');
 
               debugPrint(
                 '🏁 challenge ${ch.id} completed -> +${ch.xpReward} XP (daily=$dailyXp)',

--- a/lib/features/xp/data/repositories/xp_repository_impl.dart
+++ b/lib/features/xp/data/repositories/xp_repository_impl.dart
@@ -59,4 +59,12 @@ class XpRepositoryImpl implements XpRepository {
       userId: userId,
     );
   }
+
+  @override
+  Stream<int> watchStatsDailyXp({
+    required String gymId,
+    required String userId,
+  }) {
+    return _source.watchStatsDailyXp(gymId: gymId, userId: userId);
+  }
 }

--- a/lib/features/xp/data/sources/firestore_xp_source.dart
+++ b/lib/features/xp/data/sources/firestore_xp_source.dart
@@ -191,4 +191,23 @@ class FirestoreXpSource {
       return xp;
     });
   }
+
+  Stream<int> watchStatsDailyXp({
+    required String gymId,
+    required String userId,
+  }) {
+    final doc = _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('users')
+        .doc(userId)
+        .collection('rank')
+        .doc('stats');
+    debugPrint('👀 watchStatsDailyXp gymId=$gymId userId=$userId');
+    return doc.snapshots().map((snap) {
+      final xp = (snap.data()?['dailyXP'] as int?) ?? 0;
+      debugPrint('📥 stats dailyXP snapshot $xp');
+      return xp;
+    });
+  }
 }

--- a/lib/features/xp/domain/xp_repository.dart
+++ b/lib/features/xp/domain/xp_repository.dart
@@ -26,4 +26,9 @@ abstract class XpRepository {
     required String deviceId,
     required String userId,
   });
+
+  Stream<int> watchStatsDailyXp({
+    required String gymId,
+    required String userId,
+  });
 }

--- a/lib/features/xp/presentation/screens/day_xp_screen.dart
+++ b/lib/features/xp/presentation/screens/day_xp_screen.dart
@@ -25,6 +25,7 @@ class _DayXpScreenState extends State<DayXpScreen> {
     final uid = auth.userId;
     if (uid != null) {
       xpProv.watchTrainingDays(uid);
+      xpProv.watchStatsDailyXp(auth.gymCode ?? '', uid);
       _listenLeaderboard(auth.gymCode ?? '');
     }
   }
@@ -74,7 +75,7 @@ class _DayXpScreenState extends State<DayXpScreen> {
     final xpProv = context.watch<XpProvider>();
     final entries = xpProv.dayListXp.entries.toList()
       ..sort((a, b) => b.key.compareTo(a.key));
-    final totalXp = xpProv.dayListXp.values.fold<int>(0, (a, b) => a + b);
+    final totalXp = xpProv.statsDailyXp;
 
     final auth = context.watch<AuthProvider>();
     return Scaffold(


### PR DESCRIPTION
## Summary
- stream stats.dailyXP for experience page
- expose provider API for stats daily XP
- show header XP from new stream
- log dailyXP updates during challenge award

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6882ba8a9bb083209f37e4df971a0296