### PR TITLE
Fix minSets reading and add challenge logs

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -96,6 +96,7 @@ exports.checkChallengesOnLog = functions.firestore
         console.log(`➡️ challenge ${doc.id} skipped for device ${deviceId}`);
         continue;
       }
+      console.log(`🔍 checking challenge ${doc.id}, minSets=${ch.minSets || 0}`);
 
       let logCount = 0;
       if (devices.length === 0) {

--- a/lib/features/challenges/data/sources/firestore_challenge_source.dart
+++ b/lib/features/challenges/data/sources/firestore_challenge_source.dart
@@ -114,11 +114,12 @@ class FirestoreChallengeSource {
 
     debugPrint('🎯 evaluating ${challenges.length} challenges');
 
-    for (final ch in challenges) {
-      if (ch.deviceIds.isNotEmpty && !ch.deviceIds.contains(deviceId)) {
-        continue;
-      }
+      for (final ch in challenges) {
+        if (ch.deviceIds.isNotEmpty && !ch.deviceIds.contains(deviceId)) {
+          continue;
+        }
       debugPrint('➡️ check challenge ${ch.id} devices=${ch.deviceIds}');
+      debugPrint('🔍 required sets for ${ch.id}: ${ch.minSets}');
       try {
         var logCount = 0;
         if (ch.deviceIds.isEmpty) {
@@ -157,6 +158,7 @@ class FirestoreChallengeSource {
         debugPrint(
           '📊 logs $logCount / required ${ch.minSets} for challenge ${ch.id}',
         );
+        debugPrint('📈 progress ${logCount}/${ch.minSets} for ${ch.id}');
 
         if (logCount >= ch.minSets) {
           final completedRef = _firestore

--- a/lib/features/challenges/domain/models/challenge.dart
+++ b/lib/features/challenges/domain/models/challenge.dart
@@ -51,8 +51,8 @@ class Challenge {
         deviceIds: (map['deviceIds'] as List<dynamic>? ?? [])
             .map((e) => e.toString())
             .toList(),
-        minSets: map['minSets'] as int? ?? 0,
-        xpReward: map['xpReward'] as int? ?? 0,
+        minSets: _parseInt(map['minSets']),
+        xpReward: _parseInt(map['xpReward']),
       );
 
   Map<String, dynamic> toMap() => {
@@ -64,4 +64,11 @@ class Challenge {
         'minSets': minSets,
         'xpReward': xpReward,
       };
+}
+
+int _parseInt(dynamic value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  if (value is String) return int.tryParse(value) ?? 0;
+  return 0;
 }


### PR DESCRIPTION
## Summary
- fix challenge model to parse numbers reliably
- add debug logs around challenge checks in Flutter
- log required sets in cloud function

## Testing
- `npm test` *(fails: Error: no test specified)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882c687a54083209c22f325a326bc76