### PR TITLE
Apply dark mode tokens and gradient styling

### DIFF
--- a/lib/core/theme/design_tokens.dart
+++ b/lib/core/theme/design_tokens.dart
@@ -20,3 +20,19 @@ class AppRadius {
   static const card = 16.0;
   static const button = 12.0;
 }
+
+class AppFontSizes {
+  static const headline = 20.0;
+  static const title = 16.0;
+  static const body = 14.0;
+}
+
+class AppGradients {
+  static const primary = LinearGradient(
+    colors: [AppColors.accentBlue, AppColors.accentOrange],
+  );
+}
+
+class AppDurations {
+  static const short = Duration(milliseconds: 300);
+}

--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -71,7 +71,7 @@ class AppTheme {
         iconTheme: IconThemeData(color: onPrimary),
         titleTextStyle: TextStyle(
           color: onPrimary,
-          fontSize: 20,
+          fontSize: AppFontSizes.headline,
           fontWeight: FontWeight.w600,
         ),
       ),
@@ -81,7 +81,7 @@ class AppTheme {
           foregroundColor: onPrimary,
           textStyle: TextStyle(fontWeight: FontWeight.bold),
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: BorderRadius.circular(AppRadius.button),
           ),
         ),
       ),
@@ -90,7 +90,7 @@ class AppTheme {
           foregroundColor: onPrimary,
           side: BorderSide(color: onSurface54),
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
+            borderRadius: BorderRadius.circular(AppRadius.button),
           ),
         ),
       ),
@@ -109,14 +109,17 @@ class AppTheme {
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
         fillColor: surfaceBlack,
-        contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.sm,
+          vertical: AppSpacing.xs,
+        ),
         border: OutlineInputBorder(
           borderSide: BorderSide(color: onSurface38),
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(AppRadius.button),
         ),
         focusedBorder: OutlineInputBorder(
           borderSide: BorderSide(color: secondary),
-          borderRadius: BorderRadius.circular(8),
+          borderRadius: BorderRadius.circular(AppRadius.button),
         ),
         hintStyle: TextStyle(color: onSurface38),
         labelStyle: TextStyle(color: onSurface54),
@@ -124,9 +127,9 @@ class AppTheme {
       cardTheme: CardTheme(
         color: surfaceBlack,
         elevation: 2,
-        margin: EdgeInsets.symmetric(vertical: 8),
+        margin: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
         shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
+          borderRadius: BorderRadius.circular(AppRadius.card),
         ),
       ),
       bottomNavigationBarTheme: BottomNavigationBarThemeData(
@@ -143,26 +146,26 @@ class AppTheme {
       textTheme: TextTheme(
         titleLarge: GoogleFonts.inter(
           color: onPrimary,
-          fontSize: 20,
+          fontSize: AppFontSizes.headline,
           fontWeight: FontWeight.bold,
         ),
         titleMedium: GoogleFonts.inter(
           color: onSurface,
-          fontSize: 16,
+          fontSize: AppFontSizes.title,
         ),
         bodyMedium: GoogleFonts.inter(
           color: onSurface,
-          fontSize: 14,
+          fontSize: AppFontSizes.body,
         ),
         labelLarge: GoogleFonts.inter(
           color: onPrimary,
-          fontSize: 14,
+          fontSize: AppFontSizes.body,
           fontWeight: FontWeight.w600,
         ),
       ),
       scrollbarTheme: ScrollbarThemeData(
         thumbColor: MaterialStateProperty.all(secondary.withOpacity(0.7)),
-        radius: Radius.circular(8),
+        radius: const Radius.circular(AppRadius.button),
         thickness: MaterialStateProperty.all(6),
       ),
       dividerColor: onSurface38,

--- a/lib/core/widgets/gradient_button.dart
+++ b/lib/core/widgets/gradient_button.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import '../theme/design_tokens.dart';
+
+class GradientButton extends StatelessWidget {
+  final VoidCallback? onPressed;
+  final Widget child;
+
+  const GradientButton({super.key, required this.onPressed, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        gradient: AppGradients.primary,
+        borderRadius: BorderRadius.circular(AppRadius.button),
+      ),
+      child: ElevatedButton(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: Colors.transparent,
+          shadowColor: Colors.transparent,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppRadius.button),
+          ),
+        ),
+        onPressed: onPressed,
+        child: child,
+      ),
+    );
+  }
+}
+

--- a/lib/features/admin/presentation/screens/admin_dashboard_screen.dart
+++ b/lib/features/admin/presentation/screens/admin_dashboard_screen.dart
@@ -13,6 +13,7 @@ import 'package:tapem/features/device/domain/usecases/create_device_usecase.dart
 import 'package:tapem/features/device/domain/usecases/get_devices_for_gym.dart';
 import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
 
 class AdminDashboardScreen extends StatefulWidget {
   const AdminDashboardScreen({Key? key}) : super(key: key);
@@ -112,8 +113,13 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen> {
                 ],
               ),
               const SizedBox(height: 8),
-              Text('Device ID: $newId',
-                  style: const TextStyle(fontSize: 12, color: Colors.grey)),
+              Text(
+                'Device ID: $newId',
+                style: TextStyle(
+                  fontSize: AppFontSizes.body,
+                  color: Theme.of(context).colorScheme.onSurface,
+                ),
+              ),
             ],
           ),
           actions: [

--- a/lib/features/admin/presentation/screens/branding_screen.dart
+++ b/lib/features/admin/presentation/screens/branding_screen.dart
@@ -101,7 +101,10 @@ class _BrandingScreenState extends State<BrandingScreen> {
             ),
             if (_error != null) ...[
               const SizedBox(height: 8),
-              Text(_error!, style: const TextStyle(color: Colors.red)),
+              Text(
+                _error!,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
             ],
             const Spacer(),
             ElevatedButton(

--- a/lib/features/admin/presentation/screens/challenge_admin_screen.dart
+++ b/lib/features/admin/presentation/screens/challenge_admin_screen.dart
@@ -197,7 +197,10 @@ class _ChallengeAdminScreenState extends State<ChallengeAdminScreen> {
             ),
             if (_error != null) ...[
               const SizedBox(height: 8),
-              Text(_error!, style: const TextStyle(color: Colors.red)),
+              Text(
+                _error!,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
             ],
             const SizedBox(height: 16),
             ElevatedButton(

--- a/lib/features/auth/presentation/screens/auth_screen.dart
+++ b/lib/features/auth/presentation/screens/auth_screen.dart
@@ -58,7 +58,7 @@ class _AuthScreenState extends State<AuthScreen>
             ),
             if (authProv.isLoading)
               Container(
-                color: Colors.black45,
+                color: Theme.of(context).colorScheme.surface.withOpacity(0.7),
                 child: const Center(child: CircularProgressIndicator()),
               ),
           ],

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
+import 'package:tapem/core/widgets/gradient_button.dart';
 
 import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
@@ -96,7 +97,13 @@ class _DeviceScreenState extends State<DeviceScreen> {
     // Single-Übung: hier bleiben
     return Scaffold(
       appBar: AppBar(
-        title: Text(prov.device!.name),
+        title: Hero(
+          tag: 'device-${prov.device!.uid}',
+          child: Material(
+            type: MaterialType.transparency,
+            child: Text(prov.device!.name),
+          ),
+        ),
         centerTitle: true,
         actions: [
           if (!prov.device!.isMulti)
@@ -130,7 +137,9 @@ class _DeviceScreenState extends State<DeviceScreen> {
                     if (prov.device!.description.isNotEmpty) ...[
                       Text(
                         prov.device!.description,
-                        style: const TextStyle(color: Colors.black54),
+                        style: TextStyle(
+                          color: Theme.of(context).colorScheme.onSurface,
+                        ),
                       ),
                       const SizedBox(height: 16),
                     ],
@@ -355,7 +364,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                 ),
                 const SizedBox(width: 12),
                 Expanded(
-                  child: ElevatedButton(
+                  child: GradientButton(
                     onPressed: () async {
                       if (_formKey.currentState!.validate()) {
                         try {

--- a/lib/features/gym/presentation/widgets/device_card.dart
+++ b/lib/features/gym/presentation/widgets/device_card.dart
@@ -16,18 +16,20 @@ class DeviceCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = context.theme;
-    return Card(
-      elevation: 4,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(AppRadius.card),
-      ),
-      child: InkWell(
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpacing.sm),
-          child: Row(
-            children: [
-              Text('${device.id}', style: theme.textTheme.labelLarge),
+    return Hero(
+      tag: 'device-${device.uid}',
+      child: Card(
+        elevation: 4,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadius.card),
+        ),
+        child: InkWell(
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.sm),
+            child: Row(
+              children: [
+                Text('${device.id}', style: theme.textTheme.labelLarge),
               const SizedBox(width: AppSpacing.sm),
               Expanded(
                 child: Column(
@@ -42,6 +44,7 @@ class DeviceCard extends StatelessWidget {
               const Icon(Icons.chevron_right),
             ],
           ),
+        ),
         ),
       ),
     );

--- a/lib/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart
@@ -70,10 +70,11 @@ class _MuscleGroupAdminScreenState extends State<MuscleGroupAdminScreen> {
                         selected: selectedRegions.contains(r),
                         selectedColor: selectedRegions.contains(r)
                             ? (selectedRegions.indexOf(r) == 0
-                                ? Colors.blue
-                                : Colors.yellow)
+                                ? Theme.of(context).colorScheme.primary
+                                : Theme.of(context).colorScheme.secondary)
                             : null,
-                        checkmarkColor: Colors.white,
+                        checkmarkColor:
+                            Theme.of(context).colorScheme.onPrimary,
                         onSelected: (v) => setSt(() {
                           if (v) {
                             if (!selectedRegions.contains(r)) {
@@ -176,10 +177,11 @@ class _MuscleGroupAdminScreenState extends State<MuscleGroupAdminScreen> {
                     selected: selectedRegions.contains(r),
                     selectedColor: selectedRegions.contains(r)
                         ? (selectedRegions.indexOf(r) == 0
-                            ? Colors.blue
-                            : Colors.yellow)
+                            ? Theme.of(context).colorScheme.primary
+                            : Theme.of(context).colorScheme.secondary)
                         : null,
-                    checkmarkColor: Colors.white,
+                    checkmarkColor:
+                        Theme.of(context).colorScheme.onPrimary,
                     onSelected: (v) => setSt(() {
                       if (v) {
                         if (!selectedRegions.contains(r)) {
@@ -293,13 +295,18 @@ return Scaffold(
                           for (final g in primary)
                             Chip(
                               label: Text(g.region.name),
-                              backgroundColor: Colors.blue,
-                              labelStyle: const TextStyle(color: Colors.white),
+                              backgroundColor:
+                                  Theme.of(context).colorScheme.primary,
+                              labelStyle: TextStyle(
+                                color:
+                                    Theme.of(context).colorScheme.onPrimary,
+                              ),
                             ),
                           for (final g in secondary)
                             Chip(
                               label: Text(g.region.name),
-                              backgroundColor: Colors.yellow,
+                              backgroundColor:
+                                  Theme.of(context).colorScheme.secondary,
                             ),
                         ],
                       ),

--- a/lib/features/training_plan/presentation/screens/plan_editor_screen.dart
+++ b/lib/features/training_plan/presentation/screens/plan_editor_screen.dart
@@ -329,7 +329,9 @@ class _DayView extends StatelessWidget {
         final exIndex = index - 1;
         return Dismissible(
           key: ValueKey('${day.date}-$exIndex'),
-          background: Container(color: Colors.red),
+          background: Container(
+            color: Theme.of(context).colorScheme.error,
+          ),
           onDismissed: (_) =>
               prov.removeExercise(weekNumber, day.date, exIndex),
           child: _PlanEntryEditor(


### PR DESCRIPTION
## Summary
- introduce design token classes for fonts, gradients and durations
- refresh theme setup to use tokens for sizes and spacing
- add `GradientButton` widget for neon accent buttons
- wrap device cards in hero animations and show hero title in device screen
- use theme colors for admin screens and plan editor
- minor UI tweaks to match dark style

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6882e94c37708320b020acc39110f3fc