### PR TITLE
feat(gym): redesign gym screen

### DIFF
--- a/lib/features/gym/presentation/screens/gym_screen.dart
+++ b/lib/features/gym/presentation/screens/gym_screen.dart
@@ -1,14 +1,22 @@
 // lib/features/gym/presentation/screens/gym_screen.dart
 
+import 'dart:async';
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:collection/collection.dart';
+import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+import 'package:flutter_sticky_header/flutter_sticky_header.dart';
 
 import 'package:tapem/app_router.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/core/providers/gym_provider.dart';
-import 'package:tapem/features/gym/presentation/widgets/device_card.dart';
+import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
+import '../widgets/device_card.dart';
 
 class GymScreen extends StatefulWidget {
   const GymScreen({Key? key}) : super(key: key);
@@ -18,114 +26,306 @@ class GymScreen extends StatefulWidget {
 }
 
 class _GymScreenState extends State<GymScreen> {
-  String _searchQuery = '';
+  final TextEditingController _searchCtr = TextEditingController();
+  final ScrollController _scrollCtr = ScrollController();
+  final Map<String, GlobalKey> _headerKeys = {};
+  Timer? _debounce;
+  String _query = '';
+  final Set<String> _groupFilter = {};
+  bool _single = true;
+  bool _multi = true;
 
   @override
   void initState() {
     super.initState();
+    _searchCtr.addListener(_onQueryChanged);
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      final authProv = context.read<AuthProvider>();
-      final gymProv = context.read<GymProvider>();
-      final gymCode = authProv.gymCode;
-      if (gymCode != null && gymCode.isNotEmpty) {
-        gymProv.loadGymData(gymCode);
+      final auth = context.read<AuthProvider>();
+      final gym = context.read<GymProvider>();
+      final groups = context.read<MuscleGroupProvider>();
+      final code = auth.gymCode;
+      if (code != null && code.isNotEmpty) {
+        gym.loadGymData(code);
+        groups.loadGroups(context);
       }
     });
   }
 
   @override
+  void dispose() {
+    _debounce?.cancel();
+    _searchCtr.dispose();
+    _scrollCtr.dispose();
+    super.dispose();
+  }
+
+  void _onQueryChanged() {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 300), () {
+      setState(() => _query = _searchCtr.text);
+    });
+  }
+
+  List<Device> _applyFilters(List<Device> devices) {
+    var res = devices.where((d) {
+      final q = _query.toLowerCase();
+      final matches = d.name.toLowerCase().contains(q) ||
+          d.description.toLowerCase().contains(q);
+      return matches;
+    }).toList();
+    if (_groupFilter.isNotEmpty) {
+      res = res
+          .where((d) => d.muscleGroups.any((g) => _groupFilter.contains(g)))
+          .toList();
+    }
+    if (_single && !_multi) {
+      res = res.where((d) => !d.isMulti).toList();
+    } else if (_multi && !_single) {
+      res = res.where((d) => d.isMulti).toList();
+    }
+    return res;
+  }
+
+  Map<String, List<Device>> _groupByLetter(List<Device> devices) {
+    final groups = groupBy(devices, (Device d) =>
+        d.name.isNotEmpty ? d.name[0].toUpperCase() : '#');
+    final sortedKeys = groups.keys.toList()..sort();
+    return {for (final k in sortedKeys) k: groups[k]!};
+  }
+
+  int _crossAxisCount(BuildContext context) {
+    final w = MediaQuery.of(context).size.width;
+    if (w >= 900) return 3;
+    if (w >= 600) return 2;
+    return 1;
+  }
+
+  void _jumpToLetter(String letter) {
+    final key = _headerKeys[letter];
+    if (key != null && key.currentContext != null) {
+      Scrollable.ensureVisible(
+        key.currentContext!,
+        duration: AppDurations.short,
+      );
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
-    final authProv = context.read<AuthProvider>();
+    final auth = context.read<AuthProvider>();
     final gymProv = context.watch<GymProvider>();
-    final gymCode = authProv.gymCode!;
-
-    final appBar = AppBar(title: Text(loc.gymTitle));
+    final groupProv = context.watch<MuscleGroupProvider>();
+    final gymId = auth.gymCode ?? '';
 
     if (gymProv.isLoading) {
-      return Scaffold(
-        appBar: appBar,
-        body: const Center(child: CircularProgressIndicator()),
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
       );
     }
     if (gymProv.error != null) {
       return Scaffold(
-        appBar: appBar,
+        appBar: AppBar(title: Text(loc.gymTitle)),
         body: Center(child: Text('${loc.errorPrefix}: ${gymProv.error}')),
       );
     }
 
-    final devices = gymProv.devices;
-    if (devices.isEmpty) {
-      return Scaffold(
-        appBar: appBar,
-        body: Center(child: Text(loc.gymNoDevices)),
-      );
-    }
-
-    // Filtert Geräte nach Name und Beschreibung
-    final filteredDevices =
-        devices.where((device) {
-          final q = _searchQuery.toLowerCase();
-          return device.name.toLowerCase().contains(q) ||
-              device.description.toLowerCase().contains(q);
-        }).toList();
+    final devices = _applyFilters(gymProv.devices);
+    final grouped = _groupByLetter(devices);
+    final letters = grouped.keys.toList();
 
     return Scaffold(
-      appBar: appBar,
-      body: Column(
+      body: Stack(
         children: [
-          // Suchleiste mit hartkodiertem Hinweis-Text
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: TextField(
-              onChanged: (value) => setState(() => _searchQuery = value),
-              decoration: InputDecoration(
-                hintText: 'Geräte nach Name oder Beschreibung durchsuchen',
-                prefixIcon: const Icon(Icons.search),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(8),
+          RefreshIndicator(
+            onRefresh: () async => gymProv.loadGymData(gymId),
+            child: CustomScrollView(
+              controller: _scrollCtr,
+              slivers: [
+                SliverAppBar(
+                  pinned: true,
+                  title: Text(loc.gymTitle),
+                  backgroundColor:
+                      Theme.of(context).colorScheme.surface.withOpacity(0.7),
+                  flexibleSpace: const BackdropFilter(
+                    filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+                    child: SizedBox.expand(),
+                  ),
                 ),
-              ),
+                SliverPersistentHeader(
+                  pinned: true,
+                  delegate: _SearchHeaderDelegate(
+                    controller: _searchCtr,
+                    groups: groupProv.groups
+                        .map((g) => g.region.name)
+                        .toSet()
+                        .toList(),
+                    selectedGroups: _groupFilter,
+                    showSingle: _single,
+                    showMulti: _multi,
+                    onGroupToggle: (g) => setState(() {
+                      if (_groupFilter.contains(g)) {
+                        _groupFilter.remove(g);
+                      } else {
+                        _groupFilter.add(g);
+                      }
+                    }),
+                    onToggleSingle: (v) => setState(() => _single = v),
+                    onToggleMulti: (v) => setState(() => _multi = v),
+                  ),
+                ),
+                if (devices.isEmpty)
+                  SliverFillRemaining(
+                    child: Center(child: Text(loc.gymNoDevices)),
+                  )
+                else
+                  for (final entry in grouped.entries)
+                    SliverStickyHeader(
+                      header: Container(
+                        key: _headerKeys.putIfAbsent(
+                            entry.key, () => GlobalKey()),
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 16, vertical: 8),
+                        color: Theme.of(context).colorScheme.surface,
+                        child: Text(entry.key,
+                            style: Theme.of(context).textTheme.titleLarge),
+                      ),
+                      sliver: SliverPadding(
+                        padding: const EdgeInsets.all(8),
+                        sliver: SliverMasonryGrid.count(
+                          crossAxisCount: _crossAxisCount(context),
+                          mainAxisSpacing: 8,
+                          crossAxisSpacing: 8,
+                          childCount: entry.value.length,
+                          itemBuilder: (c, i) {
+                            final d = entry.value[i];
+                            return DeviceCard(
+                              device: d,
+                              onTap: () {
+                                final args = {
+                                  'gymId': gymId,
+                                  'deviceId': d.uid,
+                                  'exerciseId': d.uid,
+                                };
+                                Navigator.of(context)
+                                    .pushNamed(AppRouter.device, arguments: args);
+                              },
+                            );
+                          },
+                        ),
+                      ),
+                    ),
+              ],
             ),
           ),
-
-          // Liste oder Hinweis, wenn keine Treffer
-          Expanded(
-            child:
-                filteredDevices.isEmpty
-                    ? const Center(
-                      child: Text('Keine passenden Geräte gefunden'),
-                    )
-                    : ListView.separated(
-                      padding: const EdgeInsets.symmetric(
-                        vertical: 8,
-                        horizontal: 16,
-                      ),
-                      itemCount: filteredDevices.length,
-                      separatorBuilder: (_, __) => const SizedBox(height: 12),
-                      itemBuilder: (ctx, i) {
-                        final device = filteredDevices[i];
-                        return DeviceCard(
-                          device: device,
-                          onTap: () {
-                            final args = {
-                              'gymId': gymCode,
-                              'deviceId': device.uid,
-                              // Bei Single-Geräten entspricht exerciseId der deviceId
-                              'exerciseId':
-                                  device.isMulti ? device.uid : device.uid,
-                            };
-                            Navigator.of(
-                              ctx,
-                            ).pushNamed(AppRouter.device, arguments: args);
-                          },
-                        );
-                      },
+          Positioned(
+            right: 4,
+            top: 100,
+            bottom: 100,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                for (final l in letters)
+                  GestureDetector(
+                    onTap: () => _jumpToLetter(l),
+                    child: Padding(
+                      padding: const EdgeInsets.all(2),
+                      child: Text(l,
+                          style: Theme.of(context).textTheme.labelLarge),
                     ),
+                  ),
+              ],
+            ),
           ),
         ],
       ),
     );
   }
 }
+
+class _SearchHeaderDelegate extends SliverPersistentHeaderDelegate {
+  final TextEditingController controller;
+  final List<String> groups;
+  final Set<String> selectedGroups;
+  final bool showSingle;
+  final bool showMulti;
+  final ValueChanged<String> onGroupToggle;
+  final ValueChanged<bool> onToggleSingle;
+  final ValueChanged<bool> onToggleMulti;
+
+  _SearchHeaderDelegate({
+    required this.controller,
+    required this.groups,
+    required this.selectedGroups,
+    required this.showSingle,
+    required this.showMulti,
+    required this.onGroupToggle,
+    required this.onToggleSingle,
+    required this.onToggleMulti,
+  });
+
+  @override
+  double get maxExtent => 112;
+
+  @override
+  double get minExtent => 112;
+
+  @override
+  Widget build(
+      BuildContext context, double shrinkOffset, bool overlapsContent) {
+    return Container(
+      color: Theme.of(context).scaffoldBackgroundColor.withOpacity(0.9),
+      padding: const EdgeInsets.all(8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextField(
+            controller: controller,
+            decoration: InputDecoration(
+              hintText: 'Search devices',
+              prefixIcon: const Icon(Icons.search),
+            ),
+          ),
+          const SizedBox(height: 8),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: [
+                FilterChip(
+                  label: const Text('Single'),
+                  selected: showSingle,
+                  onSelected: onToggleSingle,
+                ),
+                const SizedBox(width: 4),
+                FilterChip(
+                  label: const Text('Multi'),
+                  selected: showMulti,
+                  onSelected: onToggleMulti,
+                ),
+                const SizedBox(width: 4),
+                for (final g in groups)
+                  Padding(
+                    padding: const EdgeInsets.only(right: 4),
+                    child: FilterChip(
+                      label: Text(g),
+                      selected: selectedGroups.contains(g),
+                      onSelected: (_) => onGroupToggle(g),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  bool shouldRebuild(covariant _SearchHeaderDelegate oldDelegate) {
+    return oldDelegate.groups != groups ||
+        oldDelegate.selectedGroups != selectedGroups ||
+        oldDelegate.showSingle != showSingle ||
+        oldDelegate.showMulti != showMulti;
+  }
+}
+

--- a/lib/features/gym/presentation/widgets/device_card.dart
+++ b/lib/features/gym/presentation/widgets/device_card.dart
@@ -1,10 +1,11 @@
 // lib/features/gym/presentation/widgets/device_card.dart
+import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/core/utils/context_extensions.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 
-class DeviceCard extends StatelessWidget {
+class DeviceCard extends StatefulWidget {
   final Device device;
   final VoidCallback? onTap;
   const DeviceCard({
@@ -14,39 +15,76 @@ class DeviceCard extends StatelessWidget {
   }) : super(key: key);
 
   @override
+  State<DeviceCard> createState() => _DeviceCardState();
+}
+
+class _DeviceCardState extends State<DeviceCard> {
+  double _scale = 1;
+
+  void _onTapDown(TapDownDetails d) => setState(() => _scale = 0.97);
+  void _onTapEnd([_]) => setState(() => _scale = 1);
+
+  @override
   Widget build(BuildContext context) {
     final theme = context.theme;
+    final device = widget.device;
+    final initial = device.name.isNotEmpty ? device.name[0].toUpperCase() : '?';
+    final subtitle = device.description;
     return Hero(
       tag: 'device-${device.uid}',
-      child: Card(
-        elevation: 4,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(AppRadius.card),
-        ),
-        child: InkWell(
-          onTap: onTap,
-          child: Padding(
-            padding: const EdgeInsets.all(AppSpacing.sm),
-            child: Row(
-              children: [
-                Text('${device.id}', style: theme.textTheme.labelLarge),
-              const SizedBox(width: AppSpacing.sm),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(device.name, style: theme.textTheme.titleMedium),
-                    if (device.description.isNotEmpty)
-                      Text(device.description, style: theme.textTheme.bodyMedium),
-                  ],
-                ),
-              ),
-              const Icon(Icons.chevron_right),
-            ],
+      child: AnimatedScale(
+        duration: AppDurations.short,
+        scale: _scale,
+        child: Card(
+          elevation: 4,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppRadius.card),
           ),
-        ),
+          child: InkWell(
+            borderRadius: BorderRadius.circular(AppRadius.card),
+            onTap: widget.onTap,
+            onTapDown: _onTapDown,
+            onTapCancel: _onTapEnd,
+            onTapUp: _onTapEnd,
+            child: Padding(
+              padding: const EdgeInsets.all(AppSpacing.sm),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    height: 56,
+                    width: 56,
+                    decoration: const BoxDecoration(
+                      shape: BoxShape.circle,
+                      gradient: AppGradients.primary,
+                    ),
+                    alignment: Alignment.center,
+                    child: Text(
+                      initial,
+                      style: theme.textTheme.titleLarge,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    device.name,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  if (subtitle.isNotEmpty)
+                    Text(
+                      subtitle,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                ],
+              ),
+            ),
+          ),
         ),
       ),
     );
   }
 }
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
   cupertino_icons: ^1.0.8
   cached_network_image: ^3.4.1
   flutter_staggered_grid_view: ^0.7.0
+  flutter_sticky_header: ^0.6.5
+  scrollable_positioned_list: ^0.3.5
   google_fonts: ^6.1.0
 
   # Lokalisierung


### PR DESCRIPTION
## Summary
- show grid of devices grouped alphabetically
- add search with debounce and filter chips
- add sticky headers and side index
- add gradient device cards with scale animation
- include flutter_sticky_header and scrollable_positioned_list dependencies

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6882f1228a8c8320ac2cfb0bbbf07997