### PR TITLE
Fix iOS build error from file_picker

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
   googleapis: ^14.0.0     # Nur falls du wirklich die Sheets-API nutzt
   # google_sign_in: ^6.2.1
   file_picker: ^6.2.1
+  # Add explicit linux plugin for file_picker to prevent build errors on iOS
+  file_picker_linux: ^3.0.0
   async: ^2.11.0
 
   # Firebase


### PR DESCRIPTION
## Summary
- add `file_picker_linux` plugin to avoid missing default plugin error when building for iOS

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6882f98af80083208eea0d9e4b2c39b8