### PR TITLE
Remove file_picker dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ Vor dem Start müssen die passenden `.env`-Dateien vorhanden sein.
 
 ---
 
+## Häufige Probleme
+
+Falls es nach dem Entfernen oder Hinzufügen von Abhängigkeiten zu "Target of URI doesn't exist" Fehlern kommt, hilft meist ein erneutes Ausführen von:
+
+```bash
+flutter pub get
+```
+
+Damit aktualisiert Flutter die verwendeten Pakete.
+
+---
+
 ## Lizenz
 
 Siehe [LICENSE](LICENSE).

--- a/lib/features/admin/presentation/screens/branding_screen.dart
+++ b/lib/features/admin/presentation/screens/branding_screen.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cloud_functions/cloud_functions.dart';
@@ -25,21 +24,7 @@ class _BrandingScreenState extends State<BrandingScreen> {
   final _hexReg = RegExp(r'^[0-9a-fA-F]{6}\$');
 
   Future<void> _pickLogo() async {
-    final result = await FilePicker.platform.pickFiles(
-      type: FileType.image,
-      withData: true,
-    );
-    if (result == null) return;
-    final bytes = result.files.single.bytes;
-    if (bytes == null) return;
-    if (bytes.length > 500 * 1024) {
-      setState(() => _error = 'Bild zu groß (max 500KB)');
-      return;
-    }
-    setState(() {
-      _logoBytes = bytes;
-      _error = null;
-    });
+    setState(() => _error = 'Dateiauswahl nicht verfügbar');
   }
 
   Future<void> _save() async {

--- a/lib/features/training_plan/presentation/screens/import_plan_screen.dart
+++ b/lib/features/training_plan/presentation/screens/import_plan_screen.dart
@@ -1,9 +1,5 @@
-import 'dart:convert';
-
 import 'package:csv/csv.dart';
 import 'package:flutter/material.dart';
-import 'package:file_picker/file_picker.dart';
-import 'dart:io';
 import 'package:provider/provider.dart';
 
 import '../../../../core/providers/auth_provider.dart';
@@ -28,19 +24,10 @@ class _ImportPlanScreenState extends State<ImportPlanScreen> {
   final _csvCtr = TextEditingController();
 
   Future<void> _pickFile() async {
-    final result = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: ['csv'],
-    );
-    if (result != null) {
-      final file = result.files.single;
-      String content = '';
-      if (file.bytes != null) {
-        content = utf8.decode(file.bytes!);
-      } else if (file.path != null) {
-        content = await File(file.path!).readAsString();
-      }
-      setState(() => _csvCtr.text = content);
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Dateiauswahl nicht verfügbar')),
+      );
     }
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -321,14 +321,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
-  file_picker:
-    dependency: "direct main"
-    description:
-      name: file_picker
-      sha256: "1bbf65dd997458a08b531042ec3794112a6c39c07c37ff22113d2e7e4f81d4e4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.2.1"
   firebase_auth:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,6 @@ dependencies:
   csv: ^6.0.0
   googleapis: ^14.0.0     # Nur falls du wirklich die Sheets-API nutzt
   # google_sign_in: ^6.2.1
-  file_picker: ^6.1.1
   async: ^2.11.0
 
   # Firebase


### PR DESCRIPTION
## Summary
- remove file_picker package from `pubspec.yaml`
- delete plugin references in lockfile
- drop FilePicker imports and replace the selection logic with a placeholder
- document how to fix stale dependency errors in README

## Testing
- `npm test --silent` *(fails: Error: no test specified)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688306f003dc8320b4d76291fbf4e7b1