### PR TITLE
Update README on removed FilePicker dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,10 @@ Vor dem Start müssen die passenden `.env`-Dateien vorhanden sein.
 
 ## Häufige Probleme
 
-Falls es nach dem Entfernen oder Hinzufügen von Abhängigkeiten zu "Target of URI doesn't exist" Fehlern kommt, hilft meist ein erneutes Ausführen von:
-
-```bash
-flutter pub get
-```
-
-Damit aktualisiert Flutter die verwendeten Pakete.
+- Falls es nach dem Entfernen oder Hinzufügen von Abhängigkeiten zu "Target of URI doesn't exist" Fehlern kommt, hilft meist ein erneutes Ausführen von
+  `flutter pub get`. Damit aktualisiert Flutter die verwendeten Pakete.
+- Die App verwendet keinen `file_picker` mehr. Logo-Upload und Plan-Import
+  erfordern daher das manuelle Einfügen der Daten.
 
 ---
 


### PR DESCRIPTION
## Summary
- document that FilePicker is no longer used

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68830bac08dc83209fe54361fecf6569