### PR TITLE
Fix branding screen regex

### DIFF
--- a/lib/features/admin/presentation/screens/branding_screen.dart
+++ b/lib/features/admin/presentation/screens/branding_screen.dart
@@ -21,7 +21,8 @@ class _BrandingScreenState extends State<BrandingScreen> {
   bool _loading = false;
   String? _error;
 
-  final _hexReg = RegExp(r'^[0-9a-fA-F]{6}\$');
+  // Expect exactly six hexadecimal characters.
+  final _hexReg = RegExp(r'^[0-9a-fA-F]{6}$');
 
   // File selection via file_picker was removed to avoid an additional
   // dependency. Show a hint instead so the user can provide the logo data


### PR DESCRIPTION
## Summary
- correct hex color validation regex in BrandingScreen

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68830d6c26508320b3a44613eecfedf1