### PR TITLE
Integrate new dark theme and dashboard widgets

### DIFF
--- a/lib/core/theme/design_tokens.dart
+++ b/lib/core/theme/design_tokens.dart
@@ -1,38 +1,75 @@
 import 'package:flutter/material.dart';
 
-/// Central design tokens for colors, spacing and typography.
+/// New design tokens for the Tap’em dark theme.
+///
+/// This file defines the central colours, spacing values, radii and font sizes
+/// for the refreshed UI.  It is intended to replace or extend the existing
+/// `design_tokens.dart` file.  Colours are based on a high-contrast dark
+/// palette with mint, turquoise and amber accents.  All values follow an
+/// 8-pixel grid for consistency.
 class AppColors {
-  static const background = Color(0xFF121212); // deep anthracite
-  static const surface = Color(0xFF1E1E1E);
-  static const textPrimary = Colors.white;
-  static const textSecondary = Color(0xFFCCCCCC);
-  static const accentBlue = Color(0xFF448AFF);
-  static const accentOrange = Color(0xFFFF7043);
+  /// Main page background (deep anthracite).
+  static const Color background = Color(0xFF121212);
+
+  /// Card and panel background (dark grey).
+  static const Color surface = Color(0xFF1E1E1E);
+
+  /// Primary text colour (white).
+  static const Color textPrimary = Color(0xFFFFFFFF);
+
+  /// Secondary text colour (soft grey).
+  static const Color textSecondary = Color(0xFFB0B0B0);
+
+  /// Primary accent (mint green) used for highlights and progress values.
+  static const Color accentMint = Color(0xFF00E676);
+
+  /// Secondary accent (turquoise) used for medium values and neutral accents.
+  static const Color accentTurquoise = Color(0xFF00BCD4);
+
+  /// Warning accent (amber) used for warnings and low values.
+  static const Color accentAmber = Color(0xFFFFC107);
 }
 
+/// Standard spacing values based on an 8px grid.
 class AppSpacing {
-  static const xs = 8.0;
-  static const sm = 16.0;
-  static const md = 24.0;
+  static const double xs = 8.0;
+  static const double sm = 16.0;
+  static const double md = 24.0;
+  static const double lg = 32.0;
 }
 
+/// Corner radii definitions.
 class AppRadius {
-  static const card = 16.0;
-  static const button = 12.0;
+  static const double card = 16.0;
+  static const double button = 12.0;
 }
 
+/// Typography sizes.  These values may be adjusted to taste but should stay
+/// consistent throughout the app.
 class AppFontSizes {
-  static const headline = 20.0;
-  static const title = 16.0;
-  static const body = 14.0;
+  static const double headline = 24.0;
+  static const double title = 16.0;
+  static const double body = 14.0;
+  static const double kpi = 32.0; // used for large numeric readouts
 }
 
+/// Gradient definitions.
 class AppGradients {
-  static const primary = LinearGradient(
-    colors: [AppColors.accentBlue, AppColors.accentOrange],
+  /// Gradient used for progress rings and charts.  Transitions from mint to
+  /// turquoise to amber.
+  static const LinearGradient progress = LinearGradient(
+    begin: Alignment.topLeft,
+    end: Alignment.bottomRight,
+    colors: [
+      AppColors.accentMint,
+      AppColors.accentTurquoise,
+      AppColors.accentAmber,
+    ],
   );
 }
 
+/// Animation durations.
 class AppDurations {
-  static const short = Duration(milliseconds: 300);
+  static const Duration short = Duration(milliseconds: 250);
+  static const Duration medium = Duration(milliseconds: 400);
 }

--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -3,50 +3,14 @@ import 'package:google_fonts/google_fonts.dart';
 
 import 'design_tokens.dart';
 
-/// Enthält alle Farben und zentrale Theme-Definitionen für die App.
+/// Provides the dark themes for the Tap’em app based on the new design tokens.
+///
+/// The themes defined here build upon `ThemeData.dark()` and override colours
+/// and typography to create high-contrast, minimalistic UIs. Each theme
+/// variant pairs different primary and secondary accents – e.g. mint +
+/// turquoise – while maintaining a consistent base.
 class AppTheme {
-  static const Color primaryBlue  = AppColors.accentBlue;
-  static const Color accentBlue   = AppColors.accentOrange;
-
-  static const Color primaryGreen = Color(0xFF2E7D32);
-  static const Color accentGreen  = Color(0xFF66BB6A);
-
-  static const Color neutralPrimary = Color(0xFF424242);
-  static const Color neutralAccent  = Color(0xFF616161);
-
-  static const Color darkBackground = AppColors.background;
-  static const Color surfaceBlack   = AppColors.surface;
-
-  static const Color onPrimary       = AppColors.textPrimary;
-  static const Color onSurface       = AppColors.textSecondary;
-  static const Color onSurface38     = Colors.white38;
-  static const Color onSurface54     = Colors.white54;
-
-  /// Zentrales Dark-Theme (Blau)
-  static final ThemeData darkTheme = _buildTheme(
-    primary: primaryBlue,
-    secondary: accentBlue,
-  );
-
-  /// Zentrales Dark-Theme (Grün)
-  static final ThemeData greenDarkTheme = _buildTheme(
-    primary: primaryGreen,
-    secondary: accentGreen,
-  );
-
-  /// Neutrales Dark-Theme (Grau) für Auth-Screens
-  static final ThemeData neutralTheme = _buildTheme(
-    primary: neutralPrimary,
-    secondary: neutralAccent,
-  );
-
-  /// Erstellt ein Theme mit beliebigen Farben.
-  static ThemeData customTheme({
-    required Color primary,
-    required Color secondary,
-  }) => _buildTheme(primary: primary, secondary: secondary);
-
-  /// Baut ein ThemeData mit angegebenen Primär- und Sekundärfarben.
+  /// Builds a ThemeData with the given primary and secondary colours.
   static ThemeData _buildTheme({
     required Color primary,
     required Color secondary,
@@ -55,31 +19,67 @@ class AppTheme {
     final scheme = ColorScheme.dark(
       primary: primary,
       secondary: secondary,
-      background: darkBackground,
-      surface: surfaceBlack,
-      onPrimary: onPrimary,
-      onSurface: onSurface,
+      background: AppColors.background,
+      surface: AppColors.surface,
+      onPrimary: AppColors.textPrimary,
+      onSurface: AppColors.textSecondary,
     );
     return base.copyWith(
       colorScheme: scheme,
-      scaffoldBackgroundColor: darkBackground,
-      canvasColor: surfaceBlack,
-      hintColor: onSurface,
-      appBarTheme: AppBarTheme(
-        backgroundColor: surfaceBlack,
-        elevation: 2,
-        iconTheme: IconThemeData(color: onPrimary),
-        titleTextStyle: TextStyle(
-          color: onPrimary,
+      scaffoldBackgroundColor: AppColors.background,
+      canvasColor: AppColors.surface,
+      cardColor: AppColors.surface,
+      hintColor: AppColors.textSecondary,
+      appBarTheme: const AppBarTheme(
+        elevation: 0,
+        backgroundColor: Colors.transparent,
+        centerTitle: true,
+      ),
+      bottomNavigationBarTheme: BottomNavigationBarThemeData(
+        backgroundColor: AppColors.surface,
+        selectedItemColor: secondary,
+        unselectedItemColor: AppColors.textSecondary,
+        showUnselectedLabels: true,
+      ),
+      textTheme: TextTheme(
+        // Large display numbers
+        displayLarge: GoogleFonts.inter(
+          color: AppColors.textPrimary,
+          fontSize: AppFontSizes.kpi,
+          fontWeight: FontWeight.w700,
+        ),
+        titleLarge: GoogleFonts.inter(
+          color: AppColors.textPrimary,
           fontSize: AppFontSizes.headline,
           fontWeight: FontWeight.w600,
         ),
+        titleMedium: GoogleFonts.inter(
+          color: AppColors.textSecondary,
+          fontSize: AppFontSizes.title,
+        ),
+        bodyMedium: GoogleFonts.inter(
+          color: AppColors.textSecondary,
+          fontSize: AppFontSizes.body,
+        ),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: AppColors.surface,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppRadius.button),
+          borderSide: BorderSide(color: AppColors.textSecondary.withOpacity(0.3)),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppRadius.button),
+          borderSide: BorderSide(color: secondary),
+        ),
+        hintStyle: TextStyle(color: AppColors.textSecondary.withOpacity(0.6)),
       ),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
           backgroundColor: secondary,
-          foregroundColor: onPrimary,
-          textStyle: TextStyle(fontWeight: FontWeight.bold),
+          foregroundColor: AppColors.textPrimary,
+          textStyle: const TextStyle(fontWeight: FontWeight.bold),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(AppRadius.button),
           ),
@@ -87,89 +87,31 @@ class AppTheme {
       ),
       outlinedButtonTheme: OutlinedButtonThemeData(
         style: OutlinedButton.styleFrom(
-          foregroundColor: onPrimary,
-          side: BorderSide(color: onSurface54),
+          foregroundColor: secondary,
+          side: BorderSide(color: secondary.withOpacity(0.5)),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(AppRadius.button),
           ),
         ),
       ),
-      textButtonTheme: TextButtonThemeData(
-        style: TextButton.styleFrom(
-          foregroundColor: secondary,
-          textStyle: TextStyle(fontWeight: FontWeight.w600),
-        ),
-      ),
-      floatingActionButtonTheme: FloatingActionButtonThemeData(
-        backgroundColor: secondary,
-        foregroundColor: onPrimary,
-        elevation: 4,
-        sizeConstraints: BoxConstraints.tightFor(width: 48, height: 48),
-      ),
-      inputDecorationTheme: InputDecorationTheme(
-        filled: true,
-        fillColor: surfaceBlack,
-        contentPadding: const EdgeInsets.symmetric(
-          horizontal: AppSpacing.sm,
-          vertical: AppSpacing.xs,
-        ),
-        border: OutlineInputBorder(
-          borderSide: BorderSide(color: onSurface38),
-          borderRadius: BorderRadius.circular(AppRadius.button),
-        ),
-        focusedBorder: OutlineInputBorder(
-          borderSide: BorderSide(color: secondary),
-          borderRadius: BorderRadius.circular(AppRadius.button),
-        ),
-        hintStyle: TextStyle(color: onSurface38),
-        labelStyle: TextStyle(color: onSurface54),
-      ),
-      cardTheme: CardTheme(
-        color: surfaceBlack,
-        elevation: 2,
-        margin: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(AppRadius.card),
-        ),
-      ),
-      bottomNavigationBarTheme: BottomNavigationBarThemeData(
-        backgroundColor: surfaceBlack,
-        selectedItemColor: secondary,
-        unselectedItemColor: onSurface54,
-        showUnselectedLabels: true,
-      ),
-      tabBarTheme: TabBarTheme(
-        indicatorColor: secondary,
-        labelColor: onPrimary,
-        unselectedLabelColor: onSurface54,
-      ),
-      textTheme: TextTheme(
-        titleLarge: GoogleFonts.inter(
-          color: onPrimary,
-          fontSize: AppFontSizes.headline,
-          fontWeight: FontWeight.bold,
-        ),
-        titleMedium: GoogleFonts.inter(
-          color: onSurface,
-          fontSize: AppFontSizes.title,
-        ),
-        bodyMedium: GoogleFonts.inter(
-          color: onSurface,
-          fontSize: AppFontSizes.body,
-        ),
-        labelLarge: GoogleFonts.inter(
-          color: onPrimary,
-          fontSize: AppFontSizes.body,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-      scrollbarTheme: ScrollbarThemeData(
-        thumbColor: MaterialStateProperty.all(secondary.withOpacity(0.7)),
-        radius: const Radius.circular(AppRadius.button),
-        thickness: MaterialStateProperty.all(6),
-      ),
-      dividerColor: onSurface38,
-      dialogBackgroundColor: surfaceBlack,
     );
   }
+
+  /// Builds a custom theme from arbitrary colors.
+  static ThemeData customTheme({
+    required Color primary,
+    required Color secondary,
+  }) => _buildTheme(primary: primary, secondary: secondary);
+
+  /// The default dark theme using mint as primary and turquoise as secondary.
+  static final ThemeData mintDarkTheme = _buildTheme(
+    primary: AppColors.accentMint,
+    secondary: AppColors.accentTurquoise,
+  );
+
+  /// An alternate theme that highlights amber accents (e.g. for warning states).
+  static final ThemeData amberDarkTheme = _buildTheme(
+    primary: AppColors.accentAmber,
+    secondary: AppColors.accentTurquoise,
+  );
 }

--- a/lib/core/theme/theme_loader.dart
+++ b/lib/core/theme/theme_loader.dart
@@ -5,12 +5,12 @@ import 'theme.dart';
 
 /// Lädt dynamisch Themes je nach Gym.
 class ThemeLoader extends ChangeNotifier {
-  ThemeData _currentTheme = AppTheme.darkTheme;
+  ThemeData _currentTheme = AppTheme.mintDarkTheme;
   ThemeData get theme => _currentTheme;
 
-  /// Setzt Standard-Dark-Theme (Blau).
+  /// Setzt das Standard-Dark-Theme.
   void loadDefault() {
-    _currentTheme = AppTheme.darkTheme;
+    _currentTheme = AppTheme.mintDarkTheme;
     notifyListeners();
   }
 

--- a/lib/core/widgets/circular_xp_indicator.dart
+++ b/lib/core/widgets/circular_xp_indicator.dart
@@ -1,0 +1,107 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../theme/design_tokens.dart';
+
+/// Displays a circular XP indicator with animated progress and gradient ring.
+///
+/// Use this widget to visualise the user’s experience points or other
+/// percentage-based metrics. It supports custom size and accepts a value
+/// between 0 and 1. The progress animates smoothly when the value changes.
+class CircularXpIndicator extends StatelessWidget {
+  const CircularXpIndicator({
+    Key? key,
+    required this.progress,
+    this.size = 160,
+    this.label = 'XP',
+  })  : assert(progress >= 0 && progress <= 1),
+        super(key: key);
+
+  /// Progress value between 0.0 and 1.0.
+  final double progress;
+
+  /// Diameter of the ring in logical pixels.
+  final double size;
+
+  /// Label displayed underneath the number (e.g. 'XP').
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return TweenAnimationBuilder<double>(
+      tween: Tween(begin: 0, end: progress),
+      duration: AppDurations.medium,
+      curve: Curves.easeInOut,
+      builder: (context, value, child) {
+        return SizedBox(
+          width: size,
+          height: size,
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              // Background ring
+              SizedBox(
+                width: size,
+                height: size,
+                child: CustomPaint(
+                  painter: _RingPainter(progress: value),
+                ),
+              ),
+              Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    '${(value * 100).round()}%',
+                    style: Theme.of(context).textTheme.displayLarge,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    label,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                ],
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _RingPainter extends CustomPainter {
+  _RingPainter({required this.progress});
+
+  final double progress;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final strokeWidth = size.width * 0.06;
+    final radius = (size.width - strokeWidth) / 2;
+    final centre = Offset(size.width / 2, size.height / 2);
+
+    // Draw background track
+    final backgroundPaint = Paint()
+      ..color = AppColors.surface
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth;
+    canvas.drawCircle(centre, radius, backgroundPaint);
+
+    // Draw progress arc with gradient
+    final rect = Rect.fromCircle(center: centre, radius: radius);
+    final gradient = AppGradients.progress.createShader(rect);
+    final progressPaint = Paint()
+      ..shader = gradient
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round
+      ..strokeWidth = strokeWidth;
+    final sweepAngle = 2 * math.pi * progress;
+    canvas.drawArc(rect, -math.pi / 2, sweepAngle, false, progressPaint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _RingPainter oldDelegate) {
+    return oldDelegate.progress != progress;
+  }
+}

--- a/lib/core/widgets/heatmap_widget.dart
+++ b/lib/core/widgets/heatmap_widget.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+import '../theme/design_tokens.dart';
+
+/// A simple heatmap widget rendering a 2D grid of squares.
+///
+/// The `values` matrix holds intensity values between 0 and 1. Colours are
+/// interpolated between the mint, turquoise and amber accents. When a cell
+/// is tapped, the `onCellTap` callback is invoked with its row and column
+/// indices and value.
+class HeatmapWidget extends StatelessWidget {
+  const HeatmapWidget({
+    Key? key,
+    required this.values,
+    this.cellSize = 24,
+    this.onCellTap,
+  }) : super(key: key);
+
+  /// A 2D list of values between 0 and 1 representing heat intensities.
+  final List<List<double>> values;
+
+  /// Size of each square cell in logical pixels.
+  final double cellSize;
+
+  /// Optional callback when a cell is tapped.
+  final void Function(int row, int col, double value)? onCellTap;
+
+  Color _getColour(double value) {
+    // Map value to gradient: 0→amber, 0.5→turquoise, 1→mint
+    if (value >= 0.66) return AppColors.accentMint;
+    if (value >= 0.33) return AppColors.accentTurquoise;
+    return AppColors.accentAmber;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        for (int i = 0; i < values.length; i++)
+          Row(
+            children: [
+              for (int j = 0; j < values[i].length; j++)
+                GestureDetector(
+                  onTap: onCellTap == null ? null : () => onCellTap!(i, j, values[i][j]),
+                  child: Container(
+                    width: cellSize,
+                    height: cellSize,
+                    margin: const EdgeInsets.all(2),
+                    decoration: BoxDecoration(
+                      color: _getColour(values[i][j]),
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+      ],
+    );
+  }
+}

--- a/lib/core/widgets/horizontal_bar_chart_widget.dart
+++ b/lib/core/widgets/horizontal_bar_chart_widget.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+import '../theme/design_tokens.dart';
+
+/// Displays a horizontal segmented bar chart.
+///
+/// Each entry represents a category (e.g. device usage). The `values`
+/// determine the relative lengths of the segments. Colours are mapped
+/// automatically: high values → mint, medium → turquoise, low → amber.
+class HorizontalBarChart extends StatelessWidget {
+  const HorizontalBarChart({
+    Key? key,
+    required this.data,
+    this.barHeight = 24,
+    this.maxValue,
+  }) : super(key: key);
+
+  /// Map of label to numeric value.
+  final Map<String, double> data;
+
+  /// Height of each bar.
+  final double barHeight;
+
+  /// Optional maximum value used to normalise bar lengths. If null, the
+  /// largest value in `data` will be used.
+  final double? maxValue;
+
+  Color _getColour(double value, double max) {
+    final ratio = value / max;
+    if (ratio > 0.66) return AppColors.accentMint;
+    if (ratio > 0.33) return AppColors.accentTurquoise;
+    return AppColors.accentAmber;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final maxVal = maxValue ?? (data.values.isEmpty ? 1 : data.values.reduce((a, b) => a > b ? a : b));
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: data.entries.map((entry) {
+        final ratio = (entry.value / maxVal).clamp(0.0, 1.0);
+        final colour = _getColour(entry.value, maxVal);
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs / 2),
+          child: Row(
+            children: [
+              SizedBox(
+                width: 80,
+                child: Text(
+                  entry.key,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+              ),
+              Expanded(
+                child: Stack(
+                  children: [
+                    Container(
+                      height: barHeight,
+                      decoration: BoxDecoration(
+                        color: AppColors.surface,
+                        borderRadius: BorderRadius.circular(AppRadius.button),
+                      ),
+                    ),
+                    AnimatedContainer(
+                      duration: AppDurations.short,
+                      height: barHeight,
+                      width: ratio * 1.0,
+                      decoration: BoxDecoration(
+                        color: colour,
+                        borderRadius: BorderRadius.circular(AppRadius.button),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                entry.value.toStringAsFixed(0),
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+            ],
+          ),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/lib/core/widgets/line_chart_widget.dart
+++ b/lib/core/widgets/line_chart_widget.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+
+import '../theme/design_tokens.dart';
+
+/// A reusable line chart widget with gradient stroke and tooltips.
+class TimeSeriesLineChart extends StatelessWidget {
+  const TimeSeriesLineChart({
+    Key? key,
+    required this.points,
+    this.height = 200,
+  }) : super(key: key);
+
+  /// List of data points. The x value is interpreted as an index; if you
+  /// need dates or times, map them to indices outside this widget.
+  final List<double> points;
+
+  /// Chart height in logical pixels.
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: height,
+      child: LineChart(
+        LineChartData(
+          gridData: FlGridData(show: false),
+          titlesData: FlTitlesData(
+            leftTitles: AxisTitles(
+              sideTitles: SideTitles(showTitles: false),
+            ),
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                reservedSize: 24,
+                getTitlesWidget: (value, meta) {
+                  const labels = ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'];
+                  final index = value.toInt();
+                  return Text(
+                    labels[index % labels.length],
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  );
+                },
+                interval: 1,
+              ),
+            ),
+            topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          ),
+          borderData: FlBorderData(show: false),
+          minY: 0,
+          maxY: points.isEmpty ? 0 : (points.reduce((a, b) => a > b ? a : b) * 1.2),
+          lineBarsData: [
+            LineChartBarData(
+              spots: [for (var i = 0; i < points.length; i++) FlSpot(i.toDouble(), points[i])],
+              isCurved: true,
+              color: null,
+              gradient: LinearGradient(
+                colors: [
+                  AppColors.accentTurquoise,
+                  AppColors.accentAmber,
+                ],
+              ),
+              barWidth: 3,
+              dotData: FlDotData(show: true),
+              belowBarData: BarAreaData(
+                show: true,
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    AppColors.accentTurquoise.withOpacity(0.3),
+                    Colors.transparent,
+                  ],
+                ),
+              ),
+            ),
+          ],
+          lineTouchData: LineTouchData(
+            handleBuiltInTouches: true,
+            touchTooltipData: LineTouchTooltipData(
+              tooltipBgColor: AppColors.surface,
+              getTooltipItems: (touchedSpots) {
+                return touchedSpots.map((touchedSpot) {
+                  return LineTooltipItem(
+                    '${touchedSpot.y.toStringAsFixed(1)}',
+                    TextStyle(
+                      color: AppColors.textPrimary,
+                      fontWeight: FontWeight.bold,
+                      fontSize: AppFontSizes.body,
+                    ),
+                  );
+                }).toList();
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/dashboard/presentation/screens/example_dashboard_screen.dart
+++ b/lib/features/dashboard/presentation/screens/example_dashboard_screen.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/widgets/circular_xp_indicator.dart';
+import '../../../core/widgets/line_chart_widget.dart';
+import '../../../core/widgets/horizontal_bar_chart_widget.dart';
+import '../../../core/widgets/heatmap_widget.dart';
+import '../../../core/theme/design_tokens.dart';
+
+/// An example dashboard screen demonstrating the refreshed UI components.
+///
+/// This screen is not wired to real data sources; instead it showcases how
+/// the `CircularXpIndicator`, `TimeSeriesLineChart`, `HorizontalBarChart`
+/// and `HeatmapWidget` can be composed. Use it as a starting point when
+/// integrating the new design into existing features.
+class ExampleDashboardScreen extends StatelessWidget {
+  const ExampleDashboardScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    // Sample data for charts.
+    final lineData = [3.0, 4.5, 2.5, 5.2, 6.0, 4.8, 5.5];
+    final barData = {
+      'Browser': 80.0,
+      'Mail': 50.0,
+      'Terminal': 65.0,
+    };
+    final heatmapData = [
+      [0.1, 0.2, 0.3, 0.4, 0.2],
+      [0.3, 0.6, 0.5, 0.4, 0.3],
+      [0.2, 0.4, 0.8, 0.7, 0.5],
+      [0.1, 0.3, 0.4, 0.2, 0.1],
+    ];
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).maybePop(),
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () {},
+          ),
+        ],
+        title: const Text('Dashboard'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(AppSpacing.sm),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Center(child: CircularXpIndicator(progress: 0.82, label: 'XP')),
+            const SizedBox(height: AppSpacing.md),
+            Card(
+              elevation: 0,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(AppRadius.card),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(AppSpacing.sm),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('Activity', style: Theme.of(context).textTheme.titleLarge),
+                    const SizedBox(height: AppSpacing.sm),
+                    TimeSeriesLineChart(points: lineData),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            Card(
+              elevation: 0,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(AppRadius.card),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(AppSpacing.sm),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('Applications', style: Theme.of(context).textTheme.titleLarge),
+                    const SizedBox(height: AppSpacing.sm),
+                    HorizontalBarChart(data: barData),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            Card(
+              elevation: 0,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(AppRadius.card),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(AppSpacing.sm),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('Heatmap', style: Theme.of(context).textTheme.titleLarge),
+                    const SizedBox(height: AppSpacing.sm),
+                    HeatmapWidget(values: heatmapData),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+          BottomNavigationBarItem(icon: Icon(Icons.leaderboard), label: 'Rank'),
+          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Profile'),
+        ],
+        currentIndex: 0,
+        onTap: (index) {},
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- replace design tokens with updated mint/turquoise/amber palette
- implement new theme with custom colors and default mintDarkTheme
- update theme loader to use mintDarkTheme
- add reusable widgets: circular XP indicator, line chart, horizontal bar chart, heatmap
- provide an example dashboard screen showing the new components

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884088bcddc8320863adbbe7976106f