### PR TITLE
Fix analyze errors

### DIFF
--- a/lib/core/theme/design_tokens.dart
+++ b/lib/core/theme/design_tokens.dart
@@ -66,6 +66,16 @@ class AppGradients {
       AppColors.accentAmber,
     ],
   );
+
+  /// Primary gradient used for buttons and icons.
+  static const LinearGradient primary = LinearGradient(
+    begin: Alignment.topLeft,
+    end: Alignment.bottomRight,
+    colors: [
+      AppColors.accentMint,
+      AppColors.accentTurquoise,
+    ],
+  );
 }
 
 /// Animation durations.

--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -114,4 +114,10 @@ class AppTheme {
     primary: AppColors.accentAmber,
     secondary: AppColors.accentTurquoise,
   );
+
+  /// A neutral dark theme without strong branding accents.
+  static final ThemeData neutralTheme = _buildTheme(
+    primary: AppColors.accentTurquoise,
+    secondary: AppColors.accentTurquoise,
+  );
 }

--- a/lib/core/widgets/line_chart_widget.dart
+++ b/lib/core/widgets/line_chart_widget.dart
@@ -83,7 +83,7 @@ class TimeSeriesLineChart extends StatelessWidget {
               getTooltipItems: (touchedSpots) {
                 return touchedSpots.map((touchedSpot) {
                   return LineTooltipItem(
-                    '${touchedSpot.y.toStringAsFixed(1)}',
+                    touchedSpot.y.toStringAsFixed(1),
                     TextStyle(
                       color: AppColors.textPrimary,
                       fontWeight: FontWeight.bold,

--- a/lib/features/dashboard/presentation/screens/example_dashboard_screen.dart
+++ b/lib/features/dashboard/presentation/screens/example_dashboard_screen.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 
-import '../../../core/widgets/circular_xp_indicator.dart';
-import '../../../core/widgets/line_chart_widget.dart';
-import '../../../core/widgets/horizontal_bar_chart_widget.dart';
-import '../../../core/widgets/heatmap_widget.dart';
-import '../../../core/theme/design_tokens.dart';
+import 'package:tapem/core/widgets/circular_xp_indicator.dart';
+import 'package:tapem/core/widgets/line_chart_widget.dart';
+import 'package:tapem/core/widgets/horizontal_bar_chart_widget.dart';
+import 'package:tapem/core/widgets/heatmap_widget.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
 
 /// An example dashboard screen demonstrating the refreshed UI components.
 ///


### PR DESCRIPTION
## Summary
- add primary gradient
- add neutral theme
- align imports for example dashboard
- update tooltip naming

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688409d2823c8320b648c1a580755f23