### PR TITLE
Fix gym screen blur and layout

### DIFF
--- a/lib/features/gym/presentation/screens/gym_screen.dart
+++ b/lib/features/gym/presentation/screens/gym_screen.dart
@@ -147,11 +147,7 @@ class _GymScreenState extends State<GymScreen> {
                   pinned: true,
                   title: Text(loc.gymTitle),
                   backgroundColor:
-                      Theme.of(context).colorScheme.surface.withOpacity(0.7),
-                  flexibleSpace: BackdropFilter(
-                    filter: ImageFilter.blur(sigmaX: 4, sigmaY: 4),
-                    child: const SizedBox.expand(),
-                  ),
+                      Theme.of(context).colorScheme.surface.withOpacity(0.9),
                 ),
                 SliverPersistentHeader(
                   pinned: true,
@@ -266,10 +262,10 @@ class _SearchHeaderDelegate extends SliverPersistentHeaderDelegate {
   });
 
   @override
-  double get maxExtent => 112;
+  double get maxExtent => 128;
 
   @override
-  double get minExtent => 112;
+  double get minExtent => 128;
 
   @override
   Widget build(


### PR DESCRIPTION
## Summary
- remove blur filter from gym screen's app bar to prevent blurry look
- increase `_SearchHeaderDelegate` height to avoid bottom overflow errors

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884143e78408320b95a156cbbeabc57