### PR TITLE
Adjust session panel styling

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -153,6 +153,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                         child: Container(
                           decoration: DeviceLevelStyle.widgetDecorationFor(
                             prov.level,
+                            opacity: 0.4,
                           ),
                           padding: const EdgeInsets.all(AppSpacing.sm),
                           child: Column(
@@ -218,6 +219,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                         child: Container(
                           decoration: DeviceLevelStyle.widgetDecorationFor(
                             prov.level,
+                            opacity: 0.4,
                           ),
                           padding: const EdgeInsets.all(AppSpacing.sm),
                           child: Column(

--- a/lib/features/rank/presentation/device_level_style.dart
+++ b/lib/features/rank/presentation/device_level_style.dart
@@ -26,8 +26,16 @@ class DeviceLevelStyle {
     double opacity = 1.0,
     double brightness = -0.6,
   }) {
+    final colors = AppGradients.primary.colors
+        .map((c) => c.withOpacity(opacity))
+        .toList();
+
     return BoxDecoration(
-      gradient: AppGradients.primary,
+      gradient: LinearGradient(
+        begin: AppGradients.primary.begin,
+        end: AppGradients.primary.end,
+        colors: colors,
+      ),
       borderRadius: BorderRadius.circular(AppRadius.card),
     );
   }


### PR DESCRIPTION
## Summary
- make widgetDecorationFor support opacity adjustments
- darken `Letzte Session` and `Neue Session` panels using opacity

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68841eb92f5c8320a9d5fb908a21602a