### PR TITLE
Add muscle group name labels

### DIFF
--- a/lib/features/device/presentation/screens/exercise_list_screen.dart
+++ b/lib/features/device/presentation/screens/exercise_list_screen.dart
@@ -5,6 +5,7 @@ import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/core/providers/exercise_provider.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
+import '../widgets/muscle_group_card.dart';
 
 class ExerciseListScreen extends StatefulWidget {
   final String gymId;
@@ -90,27 +91,16 @@ class _ExerciseListScreenState extends State<ExerciseListScreen> {
                                 runSpacing: 4,
                                 children: [
                                   for (final g in groups)
-                                    FilterChip(
-                                      label: Text(g.name),
+                                    MuscleGroupCard(
+                                      label: g.name,
                                       selected: _selectedGroups.contains(g.id),
-                                      selectedColor: _selectedGroups.contains(g.id)
-                                          ? (_selectedGroups.indexOf(g.id) == 0
-                                              ? Theme.of(context)
-                                                  .colorScheme
-                                                  .primary
-                                              : Theme.of(context)
-                                                  .colorScheme
-                                                  .secondary)
-                                          : null,
-                                      checkmarkColor:
-                                          Theme.of(context).colorScheme.onPrimary,
-                                      onSelected: (v) => setSt(() {
-                                        if (v) {
-                                          if (!_selectedGroups.contains(g.id)) {
-                                            _selectedGroups.add(g.id);
-                                          }
-                                        } else {
+                                      isPrimary: _selectedGroups.contains(g.id) &&
+                                          _selectedGroups.indexOf(g.id) == 0,
+                                      onTap: () => setSt(() {
+                                        if (_selectedGroups.contains(g.id)) {
                                           _selectedGroups.remove(g.id);
+                                        } else {
+                                          _selectedGroups.add(g.id);
                                         }
                                       }),
                                     ),

--- a/lib/features/device/presentation/widgets/muscle_group_card.dart
+++ b/lib/features/device/presentation/widgets/muscle_group_card.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+class MuscleGroupCard extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final bool isPrimary;
+  final VoidCallback onTap;
+
+  const MuscleGroupCard({
+    super.key,
+    required this.label,
+    required this.selected,
+    required this.isPrimary,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final background = selected
+        ? (isPrimary ? scheme.primary : scheme.secondary)
+        : scheme.surfaceVariant;
+    final textColor = selected ? scheme.onPrimary : scheme.onSurface;
+
+    return Material(
+      color: background,
+      borderRadius: BorderRadius.circular(4),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(4),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          child: Text(
+            label,
+            style: TextStyle(color: textColor),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add new `MuscleGroupCard` widget to display muscle groups with clear labels
- use `MuscleGroupCard` in exercise creation dialog so selected groups show names

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68842da6e3988320925877406b410b6d