### PR TITLE
feat(device): show names on muscle group cards

### DIFF
--- a/lib/features/device/presentation/screens/exercise_list_screen.dart
+++ b/lib/features/device/presentation/screens/exercise_list_screen.dart
@@ -5,6 +5,7 @@ import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/core/providers/exercise_provider.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
+import '../widgets/muscle_group_card.dart';
 
 class ExerciseListScreen extends StatefulWidget {
   final String gymId;
@@ -90,29 +91,16 @@ class _ExerciseListScreenState extends State<ExerciseListScreen> {
                                 runSpacing: 4,
                                 children: [
                                   for (final g in groups)
-                                    FilterChip(
-                                      label: Text(
-                                        g.name,
-                                        style: TextStyle(
-                                          color: _selectedGroups.contains(g.id)
-                                              ? Theme.of(context).colorScheme.onPrimary
-                                              : null,
-                                        ),
-                                      ),
-                                      showCheckmark: false,
+                                    MuscleGroupCard(
+                                      name: g.name,
                                       selected: _selectedGroups.contains(g.id),
-                                      selectedColor: _selectedGroups.contains(g.id)
-                                          ? (_selectedGroups.indexOf(g.id) == 0
-                                              ? Theme.of(context).colorScheme.primary
-                                              : Theme.of(context).colorScheme.secondary)
-                                          : null,
-                                      onSelected: (v) => setSt(() {
-                                        if (v) {
-                                          if (!_selectedGroups.contains(g.id)) {
-                                            _selectedGroups.add(g.id);
-                                          }
-                                        } else {
+                                      primary: _selectedGroups.contains(g.id) &&
+                                          _selectedGroups.indexOf(g.id) == 0,
+                                      onTap: () => setSt(() {
+                                        if (_selectedGroups.contains(g.id)) {
                                           _selectedGroups.remove(g.id);
+                                        } else {
+                                          _selectedGroups.add(g.id);
                                         }
                                       }),
                                     ),

--- a/lib/features/device/presentation/widgets/muscle_group_card.dart
+++ b/lib/features/device/presentation/widgets/muscle_group_card.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+class MuscleGroupCard extends StatelessWidget {
+  final String name;
+  final bool selected;
+  final bool primary;
+  final VoidCallback onTap;
+
+  const MuscleGroupCard({
+    Key? key,
+    required this.name,
+    required this.selected,
+    required this.primary,
+    required this.onTap,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final Color bgColor = selected
+        ? (primary
+            ? theme.colorScheme.primary
+            : theme.colorScheme.secondary)
+        : theme.colorScheme.surface;
+    final Color textColor = selected
+        ? theme.colorScheme.onPrimary
+        : theme.colorScheme.onSurface;
+
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: bgColor,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(
+          name,
+          style: TextStyle(color: textColor),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `MuscleGroupCard` widget for selecting muscle groups with a visible name
- show these cards instead of `FilterChip` in `ExerciseListScreen`

## Testing
- `dart` was not available so formatting/tests could not be executed

------
https://chatgpt.com/codex/tasks/task_e_68844c515f548320bfc79abf5804bb79