### PR TITLE
Integrate new XP overview widgets

### DIFF
--- a/lib/features/xp/presentation/screens/leaderboard_screen.dart
+++ b/lib/features/xp/presentation/screens/leaderboard_screen.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import '../widgets/xp_time_series_chart.dart';
+
+/// A simple model representing a single leaderboard entry. This can be
+/// expanded later to include avatar URLs, rank icons and badges.
+class LeaderboardEntry {
+  final String userId;
+  final String username;
+  final int xp;
+
+  LeaderboardEntry({required this.userId, required this.username, required this.xp});
+}
+
+/// A configurable leaderboard screen modelled after e-sport ranking pages.
+///
+/// [fetchEntries] is a callback that returns a future list of entries for the
+/// given period. Only users with `showInLeaderboard` set to true should be
+/// returned by the callback.
+class LeaderboardScreen extends StatefulWidget {
+  final String title;
+  final Future<List<LeaderboardEntry>> Function(XpPeriod period) fetchEntries;
+
+  const LeaderboardScreen({Key? key, required this.title, required this.fetchEntries}) : super(key: key);
+
+  @override
+  State<LeaderboardScreen> createState() => _LeaderboardScreenState();
+}
+
+class _LeaderboardScreenState extends State<LeaderboardScreen> {
+  XpPeriod _period = XpPeriod.last7Days;
+  List<LeaderboardEntry>? _entries;
+  bool _loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadEntries();
+  }
+
+  Future<void> _loadEntries() async {
+    setState(() {
+      _loading = true;
+    });
+    final data = await widget.fetchEntries(_period);
+    data.sort((a, b) => b.xp.compareTo(a.xp));
+    setState(() {
+      _entries = data;
+      _loading = false;
+    });
+  }
+
+  void _onPeriodChanged(XpPeriod? value) {
+    if (value != null && value != _period) {
+      setState(() {
+        _period = value;
+      });
+      _loadEntries();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title),
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+            child: Row(
+              children: [
+                const Text('Zeitraum:', style: TextStyle(color: Colors.white70)),
+                const SizedBox(width: 8),
+                DropdownButton<XpPeriod>(
+                  value: _period,
+                  dropdownColor: const Color(0xFF1E1E1E),
+                  style: const TextStyle(color: Colors.white),
+                  underline: const SizedBox.shrink(),
+                  items: const [
+                    DropdownMenuItem(value: XpPeriod.last7Days, child: Text('7 Tage')),
+                    DropdownMenuItem(value: XpPeriod.last30Days, child: Text('30 Tage')),
+                    DropdownMenuItem(value: XpPeriod.total, child: Text('Gesamt')),
+                  ],
+                  onChanged: _onPeriodChanged,
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: _loading
+                ? const Center(child: CircularProgressIndicator())
+                : _entries == null
+                    ? const SizedBox.shrink()
+                    : ListView.builder(
+                        itemCount: _entries!.length,
+                        itemBuilder: (context, index) {
+                          final entry = _entries![index];
+                          final maxXp = _entries!.first.xp;
+                          final fraction = maxXp > 0 ? entry.xp / maxXp : 0.0;
+                          return ListTile(
+                            contentPadding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                            leading: CircleAvatar(
+                              backgroundColor: Colors.grey.shade700,
+                              child: Text('${index + 1}', style: const TextStyle(color: Colors.white)),
+                            ),
+                            title: Text(
+                              entry.username.isNotEmpty ? entry.username : entry.userId,
+                              style: const TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w500),
+                            ),
+                            subtitle: Padding(
+                              padding: const EdgeInsets.only(top: 4.0),
+                              child: LinearProgressIndicator(
+                                value: fraction.clamp(0.0, 1.0),
+                                minHeight: 6,
+                                valueColor: AlwaysStoppedAnimation<Color>(
+                                  Color.lerp(const Color(0xFF00E676), const Color(0xFFFFC107), fraction)!,
+                                ),
+                                backgroundColor: Colors.grey.shade800,
+                              ),
+                            ),
+                            trailing: Text(
+                              '${entry.xp} XP',
+                              style: const TextStyle(color: Colors.white, fontSize: 14),
+                            ),
+                          );
+                        },
+                      ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/xp/presentation/screens/xp_overview_screen.dart
+++ b/lib/features/xp/presentation/screens/xp_overview_screen.dart
@@ -1,11 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:collection/collection.dart';
+
 import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/xp_provider.dart';
 import '../../../../core/providers/muscle_group_provider.dart';
-import '../../../muscle_group/domain/models/muscle_group.dart';
+import '../../domain/models/muscle_group.dart';
+import '../widgets/xp_gauge.dart';
+import '../widgets/xp_time_series_chart.dart';
+import '../widgets/body_heatmap_widget.dart';
+import 'leaderboard_screen.dart';
 
+/// A revamped XP overview screen that combines gauges, charts and a heatmap.
+///
+/// Users can see their progress for each muscle region, inspect their XP
+/// evolution over time and open a dedicated leaderboard for each region via
+/// the included button. The interface uses the dark theme and mint/turquoise
+/// colours defined in the style guide.
 class XpOverviewScreen extends StatefulWidget {
   const XpOverviewScreen({Key? key}) : super(key: key);
 
@@ -14,6 +25,8 @@ class XpOverviewScreen extends StatefulWidget {
 }
 
 class _XpOverviewScreenState extends State<XpOverviewScreen> {
+  XpPeriod _period = XpPeriod.last7Days;
+
   @override
   void initState() {
     super.initState();
@@ -23,7 +36,6 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
     final uid = auth.userId;
     final gymId = auth.gymCode;
     if (uid != null && gymId != null) {
-      debugPrint('👀 overview watchDayXp/watchMuscleXp userId=$uid');
       xpProv.watchDayXp(uid, DateTime.now());
       xpProv.watchMuscleXp(gymId, uid);
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -37,43 +49,131 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
     final xpProv = context.watch<XpProvider>();
     final muscleProv = context.watch<MuscleGroupProvider>();
 
-    final regionXp = <MuscleRegion, int>{};
+    // Map region→total XP by summing all muscle group entries and mapping to
+    // their region via MuscleGroupProvider.
+    final Map<MuscleRegion, int> regionXp = {};
     for (final entry in xpProv.muscleXp.entries) {
-      debugPrint('📊 xpEntry ${entry.key} -> ${entry.value}');
       MuscleRegion? region;
-      final group =
-          muscleProv.groups.firstWhereOrNull((g) => g.id == entry.key);
+      final group = muscleProv.groups.firstWhereOrNull((g) => g.id == entry.key);
       if (group != null) {
         region = group.region;
-        debugPrint('↪ matched group ${group.name} (${group.id}) '
-            '-> region ${region.name}');
       } else {
-        region = MuscleRegion.values
-            .firstWhereOrNull((r) => r.name == entry.key);
-        if (region != null) {
-          debugPrint('↪ interpreted key ${entry.key} as region ${region.name}');
-        } else {
-          debugPrint('⚠️ could not map key ${entry.key} to a region');
-        }
+        // Fallback: try to interpret the key as a region name.
+        region = MuscleRegion.values.firstWhereOrNull((r) => r.name == entry.key);
       }
-
       if (region != null) {
-        regionXp[region] = (regionXp[region] ?? 0) + entry.value;
+        regionXp[region] = (regionXp[region] ?? 0) + entry.value as int;
       }
     }
 
-    debugPrint('💡 regionXp map: $regionXp');
+    // Build intensities for the heatmap: normalise values to 0–1.
+    double maxRegionXp = regionXp.values.isEmpty
+        ? 0.0
+        : regionXp.values.reduce((a, b) => a > b ? a : b).toDouble();
+    final Map<MuscleRegion, double> intensities = {};
+    regionXp.forEach((region, xp) {
+      final intensity = maxRegionXp > 0 ? xp / maxRegionXp : 0.0;
+      intensities[region] = intensity;
+    });
+
+    // Build time series data: convert xpProv.dayListXp (Map<String,int>) to
+    // Map<DateTime,int>.
+    final Map<DateTime, int> timeData = {};
+    xpProv.dayListXp.forEach((day, xp) {
+      // Assume keys are ISO date strings (yyyy-MM-dd). If parsing fails,
+      // ignore the entry.
+      try {
+        final date = DateTime.parse(day);
+        timeData[date] = xp as int;
+      } catch (_) {}
+    });
+
+    void _openLeaderboard(MuscleRegion region) {
+      final auth = context.read<AuthProvider>();
+      final gymId = auth.gymCode ?? '';
+      // Fetch entries callback: aggregate XP per user for this region.
+      Future<List<LeaderboardEntry>> fetchEntries(XpPeriod period) async {
+        // This is a placeholder implementation. In a real app you would
+        // delegate to a repository or cloud function that aggregates XP
+        // per user for the selected muscle region and period.
+        // For now, return an empty list.
+        return [];
+      }
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => LeaderboardScreen(
+            title: 'Rangliste: ${region.name}',
+            fetchEntries: fetchEntries,
+          ),
+        ),
+      );
+    }
 
     return Scaffold(
-      appBar: AppBar(title: const Text('XP Muskelgruppen')),
-      body: ListView(
-        children: [
-          for (final region in MuscleRegion.values)
-            ListTile(
-              title: Text(region.name),
-              trailing: Text('${regionXp[region] ?? 0} XP'),
+      backgroundColor: const Color(0xFF121212),
+      appBar: AppBar(
+        title: const Text('XP Übersicht'),
+        backgroundColor: const Color(0xFF121212),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Time period selector and chart.
+            Row(
+              children: [
+                const Text(
+                  'Zeitraum:',
+                  style: TextStyle(color: Colors.white70, fontSize: 14),
+                ),
+                const SizedBox(width: 8),
+                DropdownButton<XpPeriod>(
+                  value: _period,
+                  dropdownColor: const Color(0xFF1E1E1E),
+                  style: const TextStyle(color: Colors.white),
+                  underline: const SizedBox.shrink(),
+                  items: const [
+                    DropdownMenuItem(value: XpPeriod.last7Days, child: Text('7 Tage')),
+                    DropdownMenuItem(value: XpPeriod.last30Days, child: Text('30 Tage')),
+                    DropdownMenuItem(value: XpPeriod.total, child: Text('Gesamt')),
+                  ],
+                  onChanged: (value) => setState(() => _period = value ?? _period),
+                ),
+              ],
             ),
-        ],
+            const SizedBox(height: 16),
+            XpTimeSeriesChart(data: timeData, period: _period),
+            const SizedBox(height: 24),
+            // Heatmap
+            BodyHeatmapWidget(intensities: intensities),
+            const SizedBox(height: 24),
+            const Text(
+              'Muskelgruppen',
+              style: TextStyle(
+                color: Colors.white70,
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            // Wrap gauges for each region.
+            Wrap(
+              spacing: 16,
+              runSpacing: 16,
+              children: [
+                for (final region in MuscleRegion.values)
+                  XpGauge(
+                    currentXp: regionXp[region] ?? 0,
+                    level: ((regionXp[region] ?? 0) / 1000).floor(),
+                    label: region.name,
+                    size: 100,
+                    onTap: () => _openLeaderboard(region),
+                  ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/xp/presentation/widgets/body_heatmap_widget.dart
+++ b/lib/features/xp/presentation/widgets/body_heatmap_widget.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
+import 'package:tapem/features/muscle_group/presentation/widgets/muscle_paths.dart';
+
+/// A custom painter that draws a two–dimensional human silhouette and colours
+/// each muscle region based on provided intensity values. The colours follow
+/// the mint→turquoise→amber gradient specified in the design guide. Regions
+/// with no XP are rendered in a muted grey tone.
+class _HeatmapPainter extends CustomPainter {
+  final Map<MuscleRegion, double> intensities;
+  _HeatmapPainter(this.intensities);
+
+  // Base shape of the body (head, torso and limbs) in a muted grey.
+  static const _baseColor = Color(0xFF2A2A2A);
+  static const _mutedColor = Color(0xFF555555);
+
+  // Gradient colours for low→medium→high intensity.
+  static const _mint = Color(0xFF00E676);
+  static const _turquoise = Color(0xFF00BCD4);
+  static const _amber = Color(0xFFFFC107);
+
+  Color _color(double value) {
+    if (value <= 0.0) return _mutedColor;
+    if (value <= 0.5) {
+      final t = value / 0.5;
+      return Color.lerp(_mutedColor, _mint, t)!;
+    } else if (value <= 0.8) {
+      final t = (value - 0.5) / 0.3;
+      return Color.lerp(_mint, _turquoise, t)!;
+    } else {
+      final t = (value - 0.8) / 0.2;
+      return Color.lerp(_turquoise, _amber, t.clamp(0.0, 1.0))!;
+    }
+  }
+
+  Path _mirror(Path path, double width) {
+    final matrix = Matrix4.identity()
+      ..scale(-1.0, 1.0)
+      ..translate(width, 0.0);
+    return path.transform(matrix.storage);
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final fill = Paint()..style = PaintingStyle.fill;
+    final stroke = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.5
+      ..color = Colors.black.withOpacity(0.5);
+
+    final w = size.width;
+    final h = size.height;
+
+    // Draw base silhouette
+    final body = Path()
+      ..addOval(Rect.fromCircle(center: Offset(w * 0.5, h * 0.07), radius: h * 0.07))
+      ..addRRect(RRect.fromRectAndRadius(
+          Rect.fromLTWH(w * 0.38, h * 0.14, w * 0.24, h * 0.4),
+          Radius.circular(w * 0.05)))
+      ..addRect(Rect.fromLTWH(w * 0.18, h * 0.18, w * 0.12, h * 0.5))
+      ..addRect(Rect.fromLTWH(w * 0.70, h * 0.18, w * 0.12, h * 0.5))
+      ..addRect(Rect.fromLTWH(w * 0.45, h * 0.54, w * 0.10, h * 0.4))
+      ..addRect(Rect.fromLTWH(w * 0.55, h * 0.54, w * 0.10, h * 0.4));
+    fill.color = _baseColor;
+    canvas.drawPath(body, fill);
+
+    void drawRegion(Path path, MuscleRegion region) {
+      final intensity = intensities[region] ?? 0.0;
+      fill.color = _color(intensity);
+      canvas.drawPath(path, fill);
+      canvas.drawPath(path, stroke);
+    }
+
+    // Shoulders (deltoid)
+    final leftShoulder = MusclePaths.deltoidPath(size);
+    final rightShoulder = _mirror(leftShoulder, w);
+    drawRegion(leftShoulder, MuscleRegion.shoulders);
+    drawRegion(rightShoulder, MuscleRegion.shoulders);
+
+    // Chest
+    drawRegion(MusclePaths.pectoralisPath(size), MuscleRegion.chest);
+
+    // Biceps
+    final leftBiceps = MusclePaths.bicepsPath(size);
+    final rightBiceps = _mirror(leftBiceps, w);
+    drawRegion(leftBiceps, MuscleRegion.arms);
+    drawRegion(rightBiceps, MuscleRegion.arms);
+
+    // Forearms
+    final leftForearm = MusclePaths.forearmFlexorsPath(size);
+    final rightForearm = _mirror(leftForearm, w);
+    drawRegion(leftForearm, MuscleRegion.arms);
+    drawRegion(rightForearm, MuscleRegion.arms);
+
+    // Obliques
+    final leftOblique = MusclePaths.obliquesPath(size);
+    final rightOblique = _mirror(leftOblique, w);
+    drawRegion(leftOblique, MuscleRegion.core);
+    drawRegion(rightOblique, MuscleRegion.core);
+
+    // Abs
+    drawRegion(MusclePaths.rectusAbdominisPath(size), MuscleRegion.core);
+
+    // Quadriceps
+    drawRegion(MusclePaths.quadricepsPath(size), MuscleRegion.legs);
+
+    // Vastus medialis (inner knee)
+    final leftVastus = MusclePaths.vastusMedialisPath(size);
+    final rightVastus = _mirror(leftVastus, w);
+    drawRegion(leftVastus, MuscleRegion.legs);
+    drawRegion(rightVastus, MuscleRegion.legs);
+
+    // Tibialis anterior (shin)
+    drawRegion(MusclePaths.tibialisAnteriorPath(size), MuscleRegion.legs);
+
+    // Calves
+    final leftCalf = MusclePaths.gastrocnemiusPath(size);
+    final rightCalf = _mirror(leftCalf, w);
+    drawRegion(leftCalf, MuscleRegion.legs);
+    drawRegion(rightCalf, MuscleRegion.legs);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => true;
+}
+
+/// A widget that wraps [_HeatmapPainter] and exposes a simple API: pass
+/// normalised intensities for each muscle region and the widget draws
+/// a colourised silhouette. The widget has a fixed height but stretches
+/// horizontally to fill its parent.
+class BodyHeatmapWidget extends StatelessWidget {
+  /// A map containing normalised intensity values (0.0–1.0) for each
+  /// [MuscleRegion]. Keys missing from this map are treated as 0.0.
+  final Map<MuscleRegion, double> intensities;
+
+  const BodyHeatmapWidget({Key? key, required this.intensities}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: _HeatmapPainter(intensities),
+      child: const SizedBox(
+        width: double.infinity,
+        height: 350,
+      ),
+    );
+  }
+}

--- a/lib/features/xp/presentation/widgets/xp_gauge.dart
+++ b/lib/features/xp/presentation/widgets/xp_gauge.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+
+/// A circular XP gauge that animates from 0 to the provided XP value.
+///
+/// One full revolution (360°) corresponds to 1000 XP and therefore one level.
+/// The gauge changes colour depending on how close the user is to the next
+/// level: mint for low progress, turquoise for medium progress and amber for
+/// high progress. A central label shows the current level, total XP and an
+/// optional description (e.g. muscle name or device name).
+class XpGauge extends StatelessWidget {
+  /// The current XP value for this gauge.
+  final int currentXp;
+
+  /// The current level of the user. A level is reached every 1000 XP.
+  final int level;
+
+  /// A label displayed underneath the XP value (e.g. muscle group or day).
+  final String label;
+
+  /// The diameter of the gauge in logical pixels.
+  final double size;
+
+  /// Optional callback triggered when the gauge is tapped. Can be used to
+  /// navigate to a detail or leaderboard page.
+  final VoidCallback? onTap;
+
+  const XpGauge({
+    Key? key,
+    required this.currentXp,
+    required this.level,
+    required this.label,
+    this.size = 120.0,
+    this.onTap,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    // Calculate the fractional progress towards the next level.
+    final double progress = (currentXp % 1000) / 1000.0;
+
+    // Helper to determine the colour at the current progress.
+    Color _progressColor(double value) {
+      // Mint green (#00E676) for the first 60%.
+      const mint = Color(0xFF00E676);
+      // Turquoise (#00BCD4) in the middle segment.
+      const turquoise = Color(0xFF00BCD4);
+      // Amber (#FFC107) when approaching the next level.
+      const amber = Color(0xFFFFC107);
+
+      if (value <= 0.6) {
+        return mint;
+      } else if (value <= 0.9) {
+        final t = (value - 0.6) / 0.3;
+        return Color.lerp(mint, turquoise, t)!;
+      } else {
+        final t = (value - 0.9) / 0.1;
+        return Color.lerp(turquoise, amber, t)!;
+      }
+    }
+
+    return GestureDetector(
+      onTap: onTap,
+      child: SizedBox(
+        width: size,
+        height: size,
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            // The circular progress bar.
+            SizedBox(
+              width: size,
+              height: size,
+              child: CircularProgressIndicator(
+                value: progress.clamp(0.0, 1.0),
+                strokeWidth: size * 0.08,
+                valueColor: AlwaysStoppedAnimation<Color>(
+                  _progressColor(progress),
+                ),
+                backgroundColor: const Color(0xFF3A3A3A),
+              ),
+            ),
+            // The label text in the centre of the gauge.
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'Lv. $level',
+                  style: TextStyle(
+                    fontSize: size * 0.22,
+                    fontWeight: FontWeight.w600,
+                    color: Colors.white,
+                  ),
+                ),
+                Text(
+                  '$currentXp XP',
+                  style: TextStyle(
+                    fontSize: size * 0.14,
+                    color: Colors.grey.shade400,
+                  ),
+                ),
+                Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: size * 0.12,
+                    color: Colors.grey.shade500,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/xp/presentation/widgets/xp_time_series_chart.dart
+++ b/lib/features/xp/presentation/widgets/xp_time_series_chart.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+
+/// Defines the selectable time periods for the XP time series chart.
+enum XpPeriod {
+  last7Days,
+  last30Days,
+  total,
+}
+
+/// A line chart that visualises the XP progression over time.
+///
+/// It takes a map of DateTime keys to integer XP values and draws a smooth
+/// line with dots at each point. The chart automatically sorts the input
+/// data by date. A tooltip appears when hovering or tapping on a point,
+/// showing the date and XP value. Colours follow the mint→turquoise→amber
+/// gradient defined in the design guidelines.
+class XpTimeSeriesChart extends StatelessWidget {
+  /// Mapping of dates to XP values. Only the dates relevant for the current
+  /// period will be displayed.
+  final Map<DateTime, int> data;
+
+  /// The selected time period for the chart. Determines how many points are
+  /// shown and how the x-axis labels are formatted.
+  final XpPeriod period;
+
+  const XpTimeSeriesChart({
+    Key? key,
+    required this.data,
+    required this.period,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    // Prepare a sorted list of entries for the selected period.
+    final now = DateTime.now();
+    DateTime? cutoff;
+    switch (period) {
+      case XpPeriod.last7Days:
+        cutoff = now.subtract(const Duration(days: 6));
+        break;
+      case XpPeriod.last30Days:
+        cutoff = now.subtract(const Duration(days: 29));
+        break;
+      case XpPeriod.total:
+        cutoff = null;
+        break;
+    }
+    final entries = data.entries
+        .where((e) => cutoff == null || !e.key.isBefore(cutoff!))
+        .toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+
+    final spots = <FlSpot>[];
+    for (int i = 0; i < entries.length; i++) {
+      final date = entries[i].key;
+      final xp = entries[i].value;
+      spots.add(FlSpot(i.toDouble(), xp.toDouble()));
+    }
+
+    // Determine axis labels.
+    String getFormattedLabel(int index) {
+      if (index < 0 || index >= entries.length) return '';
+      final date = entries[index].key;
+      if (period == XpPeriod.last7Days) {
+        return '${date.day}.${date.month}';
+      } else if (period == XpPeriod.last30Days) {
+        return '${date.day}.${date.month}';
+      } else {
+        return '${date.month}/${date.year % 100}';
+      }
+    }
+
+    // Colour of the line: start with mint and end with amber.
+    const mint = Color(0xFF00E676);
+    const turquoise = Color(0xFF00BCD4);
+    const amber = Color(0xFFFFC107);
+    final gradientColors = [mint, turquoise, amber];
+
+    return SizedBox(
+      height: 200,
+      child: LineChart(
+        LineChartData(
+          minX: 0,
+          maxX: spots.isNotEmpty ? (spots.length - 1).toDouble() : 0,
+          minY: 0,
+          maxY: spots.isNotEmpty
+              ? (spots.map((e) => e.y).reduce((a, b) => a > b ? a : b) * 1.2)
+              : 1000,
+          lineTouchData: LineTouchData(
+            handleBuiltInTouches: true,
+            touchTooltipData: LineTouchTooltipData(
+              tooltipBgColor: Colors.black54,
+              getTooltipItems: (touchedSpots) {
+                return touchedSpots.map((spot) {
+                  final idx = spot.x.toInt();
+                  final date = entries[idx].key;
+                  final xp = entries[idx].value;
+                  return LineTooltipItem(
+                    '${date.day}.${date.month}.${date.year}\n$xp XP',
+                    const TextStyle(color: Colors.white),
+                  );
+                }).toList();
+              },
+            ),
+          ),
+          gridData: FlGridData(show: true, horizontalInterval: 500),
+          titlesData: FlTitlesData(
+            leftTitles: AxisTitles(
+              sideTitles: SideTitles(
+                reservedSize: 40,
+                showTitles: true,
+                interval: 500,
+                getTitlesWidget: (value, meta) {
+                  return Text(
+                    value.toInt().toString(),
+                    style: const TextStyle(color: Colors.white70, fontSize: 10),
+                  );
+                },
+              ),
+            ),
+            bottomTitles: AxisTitles(
+              sideTitles: SideTitles(
+                showTitles: true,
+                interval: 1,
+                getTitlesWidget: (value, meta) {
+                  return Text(
+                    getFormattedLabel(value.toInt()),
+                    style: const TextStyle(color: Colors.white70, fontSize: 10),
+                  );
+                },
+              ),
+            ),
+            topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+            rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          ),
+          borderData: FlBorderData(show: false),
+          lineBarsData: [
+            LineChartBarData(
+              spots: spots,
+              isCurved: true,
+              barWidth: 3,
+              dotData: FlDotData(show: true),
+              gradient: LinearGradient(colors: gradientColors),
+              belowBarData: BarAreaData(show: false),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add gamification widgets: XP gauge, time series chart and heatmap
- add leaderboard screen for ranking views
- replace old XP overview with the new design using gauges and charts

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6885676fea94832095dec349e1a79672