### PR TITLE
Fix analyze errors: remove deprecated tooltip parameter

### DIFF
--- a/lib/core/widgets/line_chart_widget.dart
+++ b/lib/core/widgets/line_chart_widget.dart
@@ -79,7 +79,6 @@ class TimeSeriesLineChart extends StatelessWidget {
           lineTouchData: LineTouchData(
             handleBuiltInTouches: true,
             touchTooltipData: LineTouchTooltipData(
-              tooltipBgColor: AppColors.surface,
               getTooltipItems: (touchedSpots) {
                 return touchedSpots.map((touchedSpot) {
                   return LineTooltipItem(

--- a/lib/features/xp/presentation/screens/xp_overview_screen.dart
+++ b/lib/features/xp/presentation/screens/xp_overview_screen.dart
@@ -89,7 +89,6 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
     });
 
     void openLeaderboard(MuscleRegion region) {
-      final auth = context.read<AuthProvider>();
       // Fetch entries callback: aggregate XP per user for this region.
       Future<List<LeaderboardEntry>> fetchEntries(XpPeriod period) async {
         // This is a placeholder implementation. In a real app you would

--- a/lib/features/xp/presentation/widgets/xp_time_series_chart.dart
+++ b/lib/features/xp/presentation/widgets/xp_time_series_chart.dart
@@ -89,7 +89,6 @@ class XpTimeSeriesChart extends StatelessWidget {
           lineTouchData: LineTouchData(
             handleBuiltInTouches: true,
             touchTooltipData: LineTouchTooltipData(
-              tooltipBgColor: Colors.black54,
               getTooltipItems: (touchedSpots) {
                 return touchedSpots.map((spot) {
                   final idx = spot.x.toInt();


### PR DESCRIPTION
## Summary
- remove obsolete `tooltipBgColor` parameter
- drop unused `auth` variable

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68856cdc5d1483209c703f7feb8e3492