### PR TITLE
Implement leaderboard button and simplify XP pages

### DIFF
--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
@@ -44,8 +44,6 @@ class _MuscleGroupScreenState extends State<MuscleGroupScreen> {
         child: Column(
           children: const [
             AdvancedBodyHeatmap(),
-            SizedBox(height: 16),
-            BodyHeatmap3D(),
           ],
         ),
       ),

--- a/lib/features/xp/presentation/screens/day_xp_screen.dart
+++ b/lib/features/xp/presentation/screens/day_xp_screen.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/xp_provider.dart';
+import 'leaderboard_screen.dart';
 
 class DayXpScreen extends StatefulWidget {
   const DayXpScreen({Key? key}) : super(key: key);
@@ -16,6 +17,43 @@ class DayXpScreen extends StatefulWidget {
 class _DayXpScreenState extends State<DayXpScreen> {
   StreamSubscription? _lbSub;
   List<Map<String, dynamic>> _lbEntries = [];
+
+  void _openLeaderboard() {
+    final auth = context.read<AuthProvider>();
+    final gymId = auth.gymCode ?? '';
+    Future<List<LeaderboardEntry>> fetchEntries(XpPeriod period) async {
+      if (gymId.isEmpty) return [];
+      final fs = FirebaseFirestore.instance;
+      final snap = await fs.collection('gyms').doc(gymId).collection('users').get();
+      final List<LeaderboardEntry> data = [];
+      for (final doc in snap.docs) {
+        final uid = doc.id;
+        final userDoc = await fs.collection('users').doc(uid).get();
+        if (!(userDoc.data()?['showInLeaderboard'] as bool? ?? true)) continue;
+        final username = userDoc.data()?['username'] as String? ?? uid;
+        final statsDoc = await fs
+            .collection('gyms')
+            .doc(gymId)
+            .collection('users')
+            .doc(uid)
+            .collection('rank')
+            .doc('stats')
+            .get();
+        final xp = statsDoc.data()?['dailyXP'] as int? ?? 0;
+        data.add(LeaderboardEntry(userId: uid, username: username, xp: xp));
+      }
+      return data;
+    }
+
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => LeaderboardScreen(
+          title: 'Rangliste',
+          fetchEntries: fetchEntries,
+        ),
+      ),
+    );
+  }
 
   @override
   void initState() {
@@ -73,13 +111,20 @@ class _DayXpScreenState extends State<DayXpScreen> {
   @override
   Widget build(BuildContext context) {
     final xpProv = context.watch<XpProvider>();
-    final entries = xpProv.dayListXp.entries.toList()
-      ..sort((a, b) => b.key.compareTo(a.key));
     final totalXp = xpProv.statsDailyXp;
 
     final auth = context.watch<AuthProvider>();
     return Scaffold(
-      appBar: AppBar(title: const Text('Erfahrung')),
+      appBar: AppBar(
+        title: const Text('Erfahrung'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.leaderboard),
+            tooltip: 'Rangliste',
+            onPressed: _openLeaderboard,
+          ),
+        ],
+      ),
       body: ListView(
         children: [
           ListTile(
@@ -94,13 +139,6 @@ class _DayXpScreenState extends State<DayXpScreen> {
                   trailing: Text('${e.value['xp']} XP'),
                 ),
               ),
-          const Divider(),
-          ...entries.map(
-            (e) => ListTile(
-              title: Text(e.key),
-              trailing: Text('${e.value} XP'),
-            ),
-          ),
         ],
       ),
     );

--- a/lib/features/xp/presentation/screens/xp_overview_screen.dart
+++ b/lib/features/xp/presentation/screens/xp_overview_screen.dart
@@ -7,8 +7,7 @@ import '../../../../core/providers/xp_provider.dart';
 import '../../../../core/providers/muscle_group_provider.dart';
 import '../../../muscle_group/domain/models/muscle_group.dart';
 import '../widgets/xp_gauge.dart';
-import '../widgets/xp_time_series_chart.dart';
-import '../widgets/body_heatmap_widget.dart';
+// Graph and heatmap widgets were removed in the simplified design
 import 'leaderboard_screen.dart';
 
 /// A revamped XP overview screen that combines gauges, charts and a heatmap.
@@ -66,27 +65,7 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
       }
     }
 
-    // Build intensities for the heatmap: normalise values to 0–1.
-    double maxRegionXp = regionXp.values.isEmpty
-        ? 0.0
-        : regionXp.values.reduce((a, b) => a > b ? a : b).toDouble();
-    final Map<MuscleRegion, double> intensities = {};
-    regionXp.forEach((region, xp) {
-      final intensity = maxRegionXp > 0 ? xp / maxRegionXp : 0.0;
-      intensities[region] = intensity;
-    });
-
-    // Build time series data: convert xpProv.dayListXp (Map<String,int>) to
-    // Map<DateTime,int>.
-    final Map<DateTime, int> timeData = {};
-    xpProv.dayListXp.forEach((day, xp) {
-      // Assume keys are ISO date strings (yyyy-MM-dd). If parsing fails,
-      // ignore the entry.
-      try {
-        final date = DateTime.parse(day);
-        timeData[date] = xp as int;
-      } catch (_) {}
-    });
+    // No time series or heatmap calculation needed in the simplified design.
 
     void openLeaderboard(MuscleRegion region) {
       // Fetch entries callback: aggregate XP per user for this region.
@@ -141,11 +120,6 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
               ],
             ),
             const SizedBox(height: 16),
-            XpTimeSeriesChart(data: timeData, period: _period),
-            const SizedBox(height: 24),
-            // Heatmap
-            BodyHeatmapWidget(intensities: intensities),
-            const SizedBox(height: 24),
             const Text(
               'Muskelgruppen',
               style: TextStyle(
@@ -168,6 +142,20 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
                     size: 100,
                   onTap: () => openLeaderboard(region),
                   ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            DataTable(
+              columns: const [
+                DataColumn(label: Text('Muskelgruppe')),
+                DataColumn(label: Text('XP')),
+              ],
+              rows: [
+                for (final region in MuscleRegion.values)
+                  DataRow(cells: [
+                    DataCell(Text(region.name)),
+                    DataCell(Text('${regionXp[region] ?? 0}')),
+                  ]),
               ],
             ),
           ],


### PR DESCRIPTION
## Summary
- remove heatmap and graph on XP overview
- show a table of XP per muscle
- drop 3D heatmap from Muscle Groups page
- add leaderboard button on daily XP screen
- hide daily XP list

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688576d0035c83208b48395506a37307