### PR TITLE
Fix missing XpPeriod imports

### DIFF
--- a/lib/features/xp/presentation/screens/day_xp_screen.dart
+++ b/lib/features/xp/presentation/screens/day_xp_screen.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/xp_provider.dart';
+import '../widgets/xp_time_series_chart.dart';
 import 'leaderboard_screen.dart';
 
 class DayXpScreen extends StatefulWidget {

--- a/lib/features/xp/presentation/screens/xp_overview_screen.dart
+++ b/lib/features/xp/presentation/screens/xp_overview_screen.dart
@@ -7,6 +7,7 @@ import '../../../../core/providers/xp_provider.dart';
 import '../../../../core/providers/muscle_group_provider.dart';
 import '../../../muscle_group/domain/models/muscle_group.dart';
 import '../widgets/xp_gauge.dart';
+import '../widgets/xp_time_series_chart.dart';
 // Graph and heatmap widgets were removed in the simplified design
 import 'leaderboard_screen.dart';
 


### PR DESCRIPTION
## Summary
- fix analysis errors by importing `xp_time_series_chart.dart`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688577f3a0048320b751918fbedcccd8