### PR TITLE
feat(muscle): add granular heatmap screen

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -7,7 +7,7 @@ import 'package:tapem/features/auth/presentation/screens/auth_screen.dart';
 import 'package:tapem/features/device/presentation/screens/device_screen.dart';
 import 'package:tapem/features/device/presentation/screens/exercise_list_screen.dart';
 import 'package:tapem/features/history/presentation/screens/history_screen.dart';
-import 'package:tapem/features/muscle_group/presentation/screens/muscle_group_screen.dart';
+import 'package:tapem/features/muscle_group/presentation/screens/muscle_group_screen_new.dart';
 import 'package:tapem/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart';
 import 'package:tapem/features/home/presentation/screens/home_screen.dart';
 import 'package:tapem/features/admin/presentation/screens/branding_screen.dart';
@@ -95,7 +95,7 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => const ReportScreen());
 
       case muscleGroups:
-        return MaterialPageRoute(builder: (_) => const MuscleGroupScreen());
+        return MaterialPageRoute(builder: (_) => const MuscleGroupScreenNew());
 
       case manageMuscleGroups:
         return MaterialPageRoute(builder: (_) => const MuscleGroupAdminScreen());

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -7,7 +7,7 @@ import 'package:tapem/core/providers/gym_provider.dart';
 import 'package:tapem/core/providers/report_provider.dart';
 import 'package:tapem/features/gym/presentation/screens/gym_screen.dart';
 import 'package:tapem/features/profile/presentation/screens/profile_screen.dart';
-import 'package:tapem/features/muscle_group/presentation/screens/muscle_group_screen.dart';
+import 'package:tapem/features/muscle_group/presentation/screens/muscle_group_screen_new.dart';
 import 'package:tapem/features/report/presentation/screens/report_screen.dart';
 import 'package:tapem/features/admin/presentation/screens/admin_dashboard_screen.dart';
 import 'package:tapem/features/affiliate/presentation/screens/affiliate_screen.dart';
@@ -38,7 +38,7 @@ class _HomeScreenState extends State<HomeScreen> {
       const GymScreen(),
       const ProfileScreen(),
       const ReportScreen(),
-      const MuscleGroupScreen(),
+      const MuscleGroupScreenNew(),
       const AdminDashboardScreen(),
       RankScreen(gymId: gymId, deviceId: deviceId),
       const AffiliateScreen(),

--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../../core/providers/muscle_group_provider.dart';
+import '../../../xp/presentation/widgets/body_heatmap_widget.dart';
+import '../../domain/models/muscle_group.dart';
+
+/// A revised muscle group screen that displays a granular 2D heatmap instead of
+/// the previous rudimentary visualisation. The heatmap colours each muscle
+/// region according to the normalised training count and follows the
+/// mint→turquoise→amber gradient. Hover or tap interactions can be added
+/// later via tooltips.
+class MuscleGroupScreenNew extends StatefulWidget {
+  const MuscleGroupScreenNew({Key? key}) : super(key: key);
+
+  @override
+  State<MuscleGroupScreenNew> createState() => _MuscleGroupScreenNewState();
+}
+
+class _MuscleGroupScreenNewState extends State<MuscleGroupScreenNew> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<MuscleGroupProvider>().loadGroups(context);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final prov = context.watch<MuscleGroupProvider>();
+
+    if (prov.isLoading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    if (prov.error != null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Muskelgruppen')),
+        body: Center(child: Text(prov.error!)),
+      );
+    }
+
+    // Compute intensities: take the maximum count per region and normalise.
+    final Map<MuscleRegion, double> intensities = {};
+    final counts = prov.counts;
+    final groups = prov.groups;
+    final int maxCount = counts.values.isEmpty
+        ? 0
+        : counts.values.reduce((a, b) => a > b ? a : b);
+    if (maxCount > 0) {
+      for (final g in groups) {
+        final count = counts[g.id] ?? 0;
+        final double intensity = count / maxCount;
+        final existing = intensities[g.region];
+        if (existing == null || intensity > existing) {
+          intensities[g.region] = intensity;
+        }
+      }
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Muskelgruppen')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: BodyHeatmapWidget(intensities: intensities),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- integrate granular BodyHeatmapWidget for muscle groups
- wire new MuscleGroupScreenNew into home screen and router

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688583d479188320938432c6b40ed9ca