### PR TITLE
Fix import and naming errors in MuscleGroup screens

### DIFF
--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../../../../core/providers/muscle_group_provider.dart';
 import '../widgets/svg_muscle_heatmap_widget.dart';
+import '../../domain/models/muscle_group.dart';
 
 class MuscleGroupScreen extends StatefulWidget {
   const MuscleGroupScreen({Key? key}) : super(key: key);
@@ -58,7 +59,7 @@ class _MuscleGroupScreenState extends State<MuscleGroupScreen> {
             }
           }
 
-          Color _gradient(double value) {
+          Color gradient(double value) {
             const muted = Color(0xFF555555);
             const mint = Color(0xFF00E676);
             const turquoise = Color(0xFF00BCD4);
@@ -78,19 +79,19 @@ class _MuscleGroupScreenState extends State<MuscleGroupScreen> {
 
           final colors = <String, Color>{
             'head': const Color(0xFF555555),
-            'chest': _gradient(intensities[MuscleRegion.chest] ?? 0),
-            'core': _gradient(intensities[MuscleRegion.core] ?? 0),
-            'pelvis': _gradient(intensities[MuscleRegion.core] ?? 0),
-            'upper_arm_left': _gradient(intensities[MuscleRegion.arms] ?? 0),
-            'upper_arm_right': _gradient(intensities[MuscleRegion.arms] ?? 0),
-            'forearm_left': _gradient(intensities[MuscleRegion.arms] ?? 0),
-            'forearm_right': _gradient(intensities[MuscleRegion.arms] ?? 0),
-            'thigh_left': _gradient(intensities[MuscleRegion.legs] ?? 0),
-            'thigh_right': _gradient(intensities[MuscleRegion.legs] ?? 0),
-            'calf_left': _gradient(intensities[MuscleRegion.legs] ?? 0),
-            'calf_right': _gradient(intensities[MuscleRegion.legs] ?? 0),
-            'foot_left': _gradient(intensities[MuscleRegion.legs] ?? 0),
-            'foot_right': _gradient(intensities[MuscleRegion.legs] ?? 0),
+            'chest': gradient(intensities[MuscleRegion.chest] ?? 0),
+            'core': gradient(intensities[MuscleRegion.core] ?? 0),
+            'pelvis': gradient(intensities[MuscleRegion.core] ?? 0),
+            'upper_arm_left': gradient(intensities[MuscleRegion.arms] ?? 0),
+            'upper_arm_right': gradient(intensities[MuscleRegion.arms] ?? 0),
+            'forearm_left': gradient(intensities[MuscleRegion.arms] ?? 0),
+            'forearm_right': gradient(intensities[MuscleRegion.arms] ?? 0),
+            'thigh_left': gradient(intensities[MuscleRegion.legs] ?? 0),
+            'thigh_right': gradient(intensities[MuscleRegion.legs] ?? 0),
+            'calf_left': gradient(intensities[MuscleRegion.legs] ?? 0),
+            'calf_right': gradient(intensities[MuscleRegion.legs] ?? 0),
+            'foot_left': gradient(intensities[MuscleRegion.legs] ?? 0),
+            'foot_right': gradient(intensities[MuscleRegion.legs] ?? 0),
           };
 
           return SvgMuscleHeatmapWidget(

--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
@@ -60,7 +60,7 @@ class _MuscleGroupScreenNewState extends State<MuscleGroupScreenNew> {
       }
     }
 
-    Color _gradient(double value) {
+    Color gradient(double value) {
       const muted = Color(0xFF555555);
       const mint = Color(0xFF00E676);
       const turquoise = Color(0xFF00BCD4);
@@ -80,19 +80,19 @@ class _MuscleGroupScreenNewState extends State<MuscleGroupScreenNew> {
 
     final colors = <String, Color>{
       'head': const Color(0xFF555555),
-      'chest': _gradient(intensities[MuscleRegion.chest] ?? 0),
-      'core': _gradient(intensities[MuscleRegion.core] ?? 0),
-      'pelvis': _gradient(intensities[MuscleRegion.core] ?? 0),
-      'upper_arm_left': _gradient(intensities[MuscleRegion.arms] ?? 0),
-      'upper_arm_right': _gradient(intensities[MuscleRegion.arms] ?? 0),
-      'forearm_left': _gradient(intensities[MuscleRegion.arms] ?? 0),
-      'forearm_right': _gradient(intensities[MuscleRegion.arms] ?? 0),
-      'thigh_left': _gradient(intensities[MuscleRegion.legs] ?? 0),
-      'thigh_right': _gradient(intensities[MuscleRegion.legs] ?? 0),
-      'calf_left': _gradient(intensities[MuscleRegion.legs] ?? 0),
-      'calf_right': _gradient(intensities[MuscleRegion.legs] ?? 0),
-      'foot_left': _gradient(intensities[MuscleRegion.legs] ?? 0),
-      'foot_right': _gradient(intensities[MuscleRegion.legs] ?? 0),
+      'chest': gradient(intensities[MuscleRegion.chest] ?? 0),
+      'core': gradient(intensities[MuscleRegion.core] ?? 0),
+      'pelvis': gradient(intensities[MuscleRegion.core] ?? 0),
+      'upper_arm_left': gradient(intensities[MuscleRegion.arms] ?? 0),
+      'upper_arm_right': gradient(intensities[MuscleRegion.arms] ?? 0),
+      'forearm_left': gradient(intensities[MuscleRegion.arms] ?? 0),
+      'forearm_right': gradient(intensities[MuscleRegion.arms] ?? 0),
+      'thigh_left': gradient(intensities[MuscleRegion.legs] ?? 0),
+      'thigh_right': gradient(intensities[MuscleRegion.legs] ?? 0),
+      'calf_left': gradient(intensities[MuscleRegion.legs] ?? 0),
+      'calf_right': gradient(intensities[MuscleRegion.legs] ?? 0),
+      'foot_left': gradient(intensities[MuscleRegion.legs] ?? 0),
+      'foot_right': gradient(intensities[MuscleRegion.legs] ?? 0),
     };
 
     return Scaffold(


### PR DESCRIPTION
## Summary
- import `MuscleGroup` model in `muscle_group_screen.dart`
- rename local `_gradient` functions to `gradient`

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6885914dbe348320a4b9c7a875fee2a8