### PR TITLE
feat(ui): dynamic muscle heatmap

### DIFF
--- a/assets/muscle_heatmap.svg
+++ b/assets/muscle_heatmap.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Optimised SVG silhouette for the muscle heatmap. This graphic consists of
+  multiple path elements, each with its own id corresponding to a muscle
+  region. You can recolour each region programmatically via the
+  SvgMuscleHeatmapWidget by matching the ids. The design loosely
+  approximates the proportions of the mock-up while keeping the vectors
+  simple enough to edit.
+-->
+<svg viewBox="0 0 200 400" xmlns="http://www.w3.org/2000/svg" stroke="none">
+  <!-- Head -->
+  <circle id="head" cx="100" cy="40" r="28" fill="#00BCD4" />
+
+  <!-- Shoulders and chest (upper torso) -->
+  <path id="chest" fill="#00BCD4" d="M40 70 C 55 50, 145 50, 160 70 L160 120 L40 120 Z" />
+
+  <!-- Upper arms (left and right) -->
+  <path id="upper_arm_left" fill="#00E676" d="M20 90 L35 90 C40 120, 40 150, 35 180 L20 180 Z" />
+  <path id="upper_arm_right" fill="#00E676" d="M180 90 L165 90 C160 120, 160 150, 165 180 L180 180 Z" />
+
+  <!-- Forearms (left and right) -->
+  <path id="forearm_left" fill="#00E676" d="M20 180 L30 180 C35 220, 35 260, 30 300 L20 300 Z" />
+  <path id="forearm_right" fill="#00E676" d="M180 180 L170 180 C165 220, 165 260, 170 300 L180 300 Z" />
+
+  <!-- Core / abs -->
+  <path id="core" fill="#00BCD4" d="M60 120 L140 120 L140 200 L60 200 Z" />
+
+  <!-- Pelvis/hip -->
+  <path id="pelvis" fill="#00BCD4" d="M70 200 L130 200 L140 240 L60 240 Z" />
+
+  <!-- Thighs (left and right) -->
+  <path id="thigh_left" fill="#FFC107" d="M60 240 L85 240 C90 300, 90 350, 80 380 L60 380 Z" />
+  <path id="thigh_right" fill="#FFC107" d="M140 240 L115 240 C110 300, 110 350, 120 380 L140 380 Z" />
+
+  <!-- Calves (left and right) -->
+  <path id="calf_left" fill="#FFC107" d="M65 380 L75 380 C78 390, 78 400, 70 400 L60 400 Z" />
+  <path id="calf_right" fill="#FFC107" d="M135 380 L125 380 C122 390, 122 400, 130 400 L140 400 Z" />
+
+  <!-- Feet (left and right) -->
+  <path id="foot_left" fill="#00BCD4" d="M58 400 L82 400 L82 408 L58 408 Z" />
+  <path id="foot_right" fill="#00BCD4" d="M142 400 L118 400 L118 408 L142 408 Z" />
+</svg>

--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
@@ -44,59 +44,31 @@ class _MuscleGroupScreenState extends State<MuscleGroupScreen> {
         child: Builder(builder: (context) {
           final counts = prov.counts;
           final groups = prov.groups;
-          final intensities = <MuscleRegion, double>{};
-          final maxCount = counts.values.isEmpty
-              ? 0
-              : counts.values.reduce((a, b) => a > b ? a : b);
-          if (maxCount > 0) {
-            for (final g in groups) {
-              final count = counts[g.id] ?? 0;
-              final intensity = count / maxCount;
-              final existing = intensities[g.region];
-              if (existing == null || intensity > existing) {
-                intensities[g.region] = intensity;
-              }
-            }
+          final regionXp = <MuscleRegion, double>{};
+          for (final g in groups) {
+            final count = counts[g.id] ?? 0;
+            regionXp[g.region] = (regionXp[g.region] ?? 0) + count.toDouble();
           }
 
-          Color gradient(double value) {
-            const muted = Color(0xFF555555);
-            const mint = Color(0xFF00E676);
-            const turquoise = Color(0xFF00BCD4);
-            const amber = Color(0xFFFFC107);
-            if (value <= 0.0) return muted;
-            if (value <= 0.5) {
-              final t = value / 0.5;
-              return Color.lerp(muted, mint, t)!;
-            } else if (value <= 0.8) {
-              final t = (value - 0.5) / 0.3;
-              return Color.lerp(mint, turquoise, t)!;
-            } else {
-              final t = (value - 0.8) / 0.2;
-              return Color.lerp(turquoise, amber, t.clamp(0.0, 1.0))!;
-            }
-          }
-
-          final colors = <String, Color>{
-            'head': const Color(0xFF555555),
-            'chest': gradient(intensities[MuscleRegion.chest] ?? 0),
-            'core': gradient(intensities[MuscleRegion.core] ?? 0),
-            'pelvis': gradient(intensities[MuscleRegion.core] ?? 0),
-            'upper_arm_left': gradient(intensities[MuscleRegion.arms] ?? 0),
-            'upper_arm_right': gradient(intensities[MuscleRegion.arms] ?? 0),
-            'forearm_left': gradient(intensities[MuscleRegion.arms] ?? 0),
-            'forearm_right': gradient(intensities[MuscleRegion.arms] ?? 0),
-            'thigh_left': gradient(intensities[MuscleRegion.legs] ?? 0),
-            'thigh_right': gradient(intensities[MuscleRegion.legs] ?? 0),
-            'calf_left': gradient(intensities[MuscleRegion.legs] ?? 0),
-            'calf_right': gradient(intensities[MuscleRegion.legs] ?? 0),
-            'foot_left': gradient(intensities[MuscleRegion.legs] ?? 0),
-            'foot_right': gradient(intensities[MuscleRegion.legs] ?? 0),
+          final xpMap = <String, double>{
+            'head': 0,
+            'chest': regionXp[MuscleRegion.chest] ?? 0,
+            'core': regionXp[MuscleRegion.core] ?? 0,
+            'pelvis': regionXp[MuscleRegion.core] ?? 0,
+            'upper_arm_left': regionXp[MuscleRegion.arms] ?? 0,
+            'upper_arm_right': regionXp[MuscleRegion.arms] ?? 0,
+            'forearm_left': regionXp[MuscleRegion.arms] ?? 0,
+            'forearm_right': regionXp[MuscleRegion.arms] ?? 0,
+            'thigh_left': regionXp[MuscleRegion.legs] ?? 0,
+            'thigh_right': regionXp[MuscleRegion.legs] ?? 0,
+            'calf_left': regionXp[MuscleRegion.legs] ?? 0,
+            'calf_right': regionXp[MuscleRegion.legs] ?? 0,
+            'foot_left': regionXp[MuscleRegion.legs] ?? 0,
+            'foot_right': regionXp[MuscleRegion.legs] ?? 0,
           };
 
           return SvgMuscleHeatmapWidget(
-            colors: colors,
-            assetPath: 'assets/muscle_heatmap_optimized.svg',
+            xpMap: xpMap,
           );
         }),
       ),

--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
@@ -42,57 +42,30 @@ class _MuscleGroupScreenNewState extends State<MuscleGroupScreenNew> {
       );
     }
 
-    // Compute intensities: take the maximum count per region and normalise.
-    final Map<MuscleRegion, double> intensities = {};
+    // Sum all logged counts per region.
+    final Map<MuscleRegion, double> regionXp = {};
     final counts = prov.counts;
     final groups = prov.groups;
-    final int maxCount = counts.values.isEmpty
-        ? 0
-        : counts.values.reduce((a, b) => a > b ? a : b);
-    if (maxCount > 0) {
-      for (final g in groups) {
-        final count = counts[g.id] ?? 0;
-        final double intensity = count / maxCount;
-        final existing = intensities[g.region];
-        if (existing == null || intensity > existing) {
-          intensities[g.region] = intensity;
-        }
-      }
+    for (final g in groups) {
+      final count = counts[g.id] ?? 0;
+      regionXp[g.region] = (regionXp[g.region] ?? 0) + count.toDouble();
     }
 
-    Color gradient(double value) {
-      const muted = Color(0xFF555555);
-      const mint = Color(0xFF00E676);
-      const turquoise = Color(0xFF00BCD4);
-      const amber = Color(0xFFFFC107);
-      if (value <= 0.0) return muted;
-      if (value <= 0.5) {
-        final t = value / 0.5;
-        return Color.lerp(muted, mint, t)!;
-      } else if (value <= 0.8) {
-        final t = (value - 0.5) / 0.3;
-        return Color.lerp(mint, turquoise, t)!;
-      } else {
-        final t = (value - 0.8) / 0.2;
-        return Color.lerp(turquoise, amber, t.clamp(0.0, 1.0))!;
-      }
-    }
-
-    final colors = <String, Color>{
-      'head': const Color(0xFF555555),
-      'chest': gradient(intensities[MuscleRegion.chest] ?? 0),
-      'core': gradient(intensities[MuscleRegion.core] ?? 0),
-      'pelvis': gradient(intensities[MuscleRegion.core] ?? 0),
-      'upper_arm_left': gradient(intensities[MuscleRegion.arms] ?? 0),
-      'upper_arm_right': gradient(intensities[MuscleRegion.arms] ?? 0),
-      'forearm_left': gradient(intensities[MuscleRegion.arms] ?? 0),
-      'forearm_right': gradient(intensities[MuscleRegion.arms] ?? 0),
-      'thigh_left': gradient(intensities[MuscleRegion.legs] ?? 0),
-      'thigh_right': gradient(intensities[MuscleRegion.legs] ?? 0),
-      'calf_left': gradient(intensities[MuscleRegion.legs] ?? 0),
-      'calf_right': gradient(intensities[MuscleRegion.legs] ?? 0),
-      'foot_left': gradient(intensities[MuscleRegion.legs] ?? 0),
-      'foot_right': gradient(intensities[MuscleRegion.legs] ?? 0),
+    final xpMap = <String, double>{
+      'head': 0,
+      'chest': regionXp[MuscleRegion.chest] ?? 0,
+      'core': regionXp[MuscleRegion.core] ?? 0,
+      'pelvis': regionXp[MuscleRegion.core] ?? 0,
+      'upper_arm_left': regionXp[MuscleRegion.arms] ?? 0,
+      'upper_arm_right': regionXp[MuscleRegion.arms] ?? 0,
+      'forearm_left': regionXp[MuscleRegion.arms] ?? 0,
+      'forearm_right': regionXp[MuscleRegion.arms] ?? 0,
+      'thigh_left': regionXp[MuscleRegion.legs] ?? 0,
+      'thigh_right': regionXp[MuscleRegion.legs] ?? 0,
+      'calf_left': regionXp[MuscleRegion.legs] ?? 0,
+      'calf_right': regionXp[MuscleRegion.legs] ?? 0,
+      'foot_left': regionXp[MuscleRegion.legs] ?? 0,
+      'foot_right': regionXp[MuscleRegion.legs] ?? 0,
     };
 
     return Scaffold(
@@ -100,8 +73,7 @@ class _MuscleGroupScreenNewState extends State<MuscleGroupScreenNew> {
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: SvgMuscleHeatmapWidget(
-          colors: colors,
-          assetPath: 'assets/muscle_heatmap_optimized.svg',
+          xpMap: xpMap,
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -105,6 +105,7 @@ flutter:
     - assets/logos/
     - assets/models/
     - assets/muscle_heatmap_optimized.svg
+    - assets/muscle_heatmap.svg
 
 l10n:
   arb-dir: lib/l10n


### PR DESCRIPTION
## Summary
- compute XP-based colours inside `SvgMuscleHeatmapWidget`
- load `assets/muscle_heatmap.svg` and display centred
- use XP maps in muscle group screens
- add new asset to pubspec

## Testing
- `dart format` *(fails: command not found)*
- `flutter format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885978e92e083208427bad64d948435