### PR TITLE
Use detailed muscle heatmap SVG

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -104,7 +104,6 @@ flutter:
     - assets/images/
     - assets/logos/
     - assets/models/
-    - assets/muscle_heatmap_optimized.svg
     - assets/muscle_heatmap.svg
 
 l10n:


### PR DESCRIPTION
## Summary
- drop old `muscle_heatmap_optimized.svg` from pubspec
- keep only the new `assets/muscle_heatmap.svg` asset

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885a5db0628832093f50fc0f4009f15