### PR TITLE
Add interactive muscle heatmap

### DIFF
--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
@@ -2,9 +2,12 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:collection/collection.dart';
 
 import '../../../../core/providers/muscle_group_provider.dart';
-import '../widgets/svg_muscle_heatmap_widget.dart';
+import '../../../../core/providers/auth_provider.dart';
+import '../../../../core/providers/xp_provider.dart';
+import '../widgets/interactive_svg_muscle_heatmap_widget.dart';
 import '../../domain/models/muscle_group.dart';
 
 /// A revised muscle group screen that displays a granular 2D heatmap instead of
@@ -24,7 +27,15 @@ class _MuscleGroupScreenNewState extends State<MuscleGroupScreenNew> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      context.read<MuscleGroupProvider>().loadGroups(context);
+      final muscleProv = context.read<MuscleGroupProvider>();
+      final auth = context.read<AuthProvider>();
+      final xpProv = context.read<XpProvider>();
+      muscleProv.loadGroups(context);
+      final uid = auth.userId;
+      final gym = auth.gymCode;
+      if (uid != null && gym != null) {
+        xpProv.watchMuscleXp(gym, uid);
+      }
     });
   }
 
@@ -44,16 +55,25 @@ class _MuscleGroupScreenNewState extends State<MuscleGroupScreenNew> {
       );
     }
 
-    // Sum all logged counts per region.
-    final Map<MuscleRegion, double> regionXp = {};
-    final counts = prov.counts;
+    final xpProv = context.watch<XpProvider>();
+
+    // Map XP data from the provider to the corresponding muscle regions.
+    final Map<MuscleRegion, int> regionXp = {};
     final groups = prov.groups;
-    for (final g in groups) {
-      final count = counts[g.id] ?? 0;
-      regionXp[g.region] = (regionXp[g.region] ?? 0) + count.toDouble();
+    for (final entry in xpProv.muscleXp.entries) {
+      MuscleRegion? region;
+      final grp = groups.firstWhereOrNull((g) => g.id == entry.key);
+      if (grp != null) {
+        region = grp.region;
+      } else {
+        region = MuscleRegion.values.firstWhereOrNull((r) => r.name == entry.key);
+      }
+      if (region != null) {
+        regionXp[region] = (regionXp[region] ?? 0) + entry.value;
+      }
     }
 
-    final xpMap = <String, double>{
+    final xpMap = <String, int>{
       'head': 0,
       'chest': regionXp[MuscleRegion.chest] ?? 0,
       'core': regionXp[MuscleRegion.core] ?? 0,
@@ -70,7 +90,7 @@ class _MuscleGroupScreenNewState extends State<MuscleGroupScreenNew> {
       'foot_right': regionXp[MuscleRegion.legs] ?? 0,
     };
 
-    final values = xpMap.values;
+    final values = xpMap.values.map((e) => e.toDouble());
     final minXp = values.isNotEmpty ? values.reduce(math.min) : 0.0;
     final maxXp = values.isNotEmpty ? values.reduce(math.max) : 0.0;
     const mintColor = Color(0xFF00E676);
@@ -83,12 +103,30 @@ class _MuscleGroupScreenNewState extends State<MuscleGroupScreenNew> {
       colorMap[id] = Color.lerp(mintColor, amberColor, t)!;
     });
 
+    void showXp(String regionId) {
+      final xp = xpMap[regionId] ?? 0;
+      showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: Text(regionId.replaceAll('_', ' ')),
+          content: Text('$xp XP'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(title: const Text('Muskelgruppen')),
       body: Padding(
         padding: const EdgeInsets.all(16),
-        child: SvgMuscleHeatmapWidget(
+        child: InteractiveSvgMuscleHeatmapWidget(
           colors: colorMap,
+          onRegionTap: showXp,
         ),
       ),
     );

--- a/lib/features/muscle_group/presentation/widgets/interactive_svg_muscle_heatmap_widget.dart
+++ b/lib/features/muscle_group/presentation/widgets/interactive_svg_muscle_heatmap_widget.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+import 'svg_muscle_heatmap_widget.dart';
+
+/// Displays the muscle heatmap and adds translucent hit regions so that each
+/// muscle group can be tapped individually.
+class InteractiveSvgMuscleHeatmapWidget extends StatelessWidget {
+  final Map<String, Color> colors;
+  final void Function(String id)? onRegionTap;
+  final String assetPath;
+
+  const InteractiveSvgMuscleHeatmapWidget({
+    Key? key,
+    required this.colors,
+    this.onRegionTap,
+    this.assetPath = 'assets/muscle_heatmap.svg',
+  }) : super(key: key);
+
+  // Normalised bounding boxes for each region (based on the 200x408 viewBox).
+  static const Map<String, Rect> _bounds = {
+    'head': Rect.fromLTWH(72, 12, 56, 56),
+    'chest': Rect.fromLTWH(40, 70, 120, 50),
+    'upper_arm_left': Rect.fromLTWH(20, 90, 15, 90),
+    'upper_arm_right': Rect.fromLTWH(165, 90, 15, 90),
+    'forearm_left': Rect.fromLTWH(20, 180, 10, 120),
+    'forearm_right': Rect.fromLTWH(170, 180, 10, 120),
+    'core': Rect.fromLTWH(60, 120, 80, 80),
+    'pelvis': Rect.fromLTWH(60, 200, 80, 40),
+    'thigh_left': Rect.fromLTWH(60, 240, 25, 140),
+    'thigh_right': Rect.fromLTWH(115, 240, 25, 140),
+    'calf_left': Rect.fromLTWH(60, 380, 15, 20),
+    'calf_right': Rect.fromLTWH(125, 380, 15, 20),
+    'foot_left': Rect.fromLTWH(58, 400, 24, 8),
+    'foot_right': Rect.fromLTWH(118, 400, 24, 8),
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(builder: (context, constraints) {
+      final scaleX = constraints.maxWidth / 200;
+      // The SVG height is fixed to 400 while the viewBox height is 408.
+      const scaleY = 400 / 408;
+
+      return Stack(
+        children: [
+          SvgMuscleHeatmapWidget(colors: colors, assetPath: assetPath),
+          for (final entry in _bounds.entries)
+            Positioned(
+              left: entry.value.left * scaleX,
+              top: entry.value.top * scaleY,
+              width: entry.value.width * scaleX,
+              height: entry.value.height * scaleY,
+              child: GestureDetector(
+                behavior: HitTestBehavior.translucent,
+                onTap: () => onRegionTap?.call(entry.key),
+              ),
+            ),
+        ],
+      );
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add `InteractiveSvgMuscleHeatmapWidget` to detect taps on muscle regions
- watch XP data and show a popup with XP when tapping the heatmap

## Testing
- `dart format lib/features/muscle_group/presentation/widgets/interactive_svg_muscle_heatmap_widget.dart lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart` *(fails: `dart: command not found`)*
- `flutter --version` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6885aa514a8083208ef95a91f3895bae