### PR TITLE
Add basic 3D heatmap view

### DIFF
--- a/assets/models/body.gltf
+++ b/assets/models/body.gltf
@@ -1,0 +1,38 @@
+{
+  "asset": { "version": "2.0", "generator": "Minimal GlTF stub" },
+  "scenes": [{ "nodes": [0] }],
+  "nodes": [{ "mesh": 0, "name": "BodyRoot" }],
+  "meshes": [
+    {
+      "primitives": [{
+        "attributes": { "POSITION": 0, "NORMAL": 1 },
+        "indices": 2,
+        "material": 0
+      }],
+      "name": "full_body"
+    }
+  ],
+  "materials": [
+    {
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [1.0, 0.0, 0.0, 1.0],
+        "metallicFactor": 0.0,
+        "roughnessFactor": 1.0
+      },
+      "name": "body_mat"
+    }
+  ],
+  "buffers": [
+    { "uri": "data:application/octet-stream;base64,AAAAAA==", "byteLength": 36 }
+  ],
+  "bufferViews": [
+    { "buffer": 0, "byteOffset": 0,  "byteLength": 12, "target": 34962 },
+    { "buffer": 0, "byteOffset": 12, "byteLength": 12, "target": 34962 },
+    { "buffer": 0, "byteOffset": 24, "byteLength": 12, "target": 34963 }
+  ],
+  "accessors": [
+    { "bufferView": 0, "componentType": 5126, "count": 1, "type": "VEC3" },
+    { "bufferView": 1, "componentType": 5126, "count": 1, "type": "VEC3" },
+    { "bufferView": 2, "componentType": 5123, "count": 3, "type": "SCALAR" }
+  ]
+}

--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 
 import '../../../../core/providers/muscle_group_provider.dart';
 import '../widgets/svg_muscle_heatmap_widget.dart';
+import '../widgets/mesh_3d_heatmap_widget.dart';
 import '../../domain/models/muscle_group.dart';
 
 class MuscleGroupScreen extends StatefulWidget {
@@ -82,8 +83,23 @@ class _MuscleGroupScreenState extends State<MuscleGroupScreen> {
             colorMap[id] = Color.lerp(mintColor, amberColor, t)!;
           });
 
-          return SvgMuscleHeatmapWidget(
-            colors: colorMap,
+          return DefaultTabController(
+            length: 2,
+            child: Column(
+              children: [
+                const TabBar(
+                  tabs: [Tab(text: '2D'), Tab(text: '3D')],
+                ),
+                Expanded(
+                  child: TabBarView(
+                    children: [
+                      SvgMuscleHeatmapWidget(colors: colorMap),
+                      Mesh3DHeatmapWidget(muscleColors: colorMap),
+                    ],
+                  ),
+                ),
+              ],
+            ),
           );
         }),
       ),

--- a/lib/features/muscle_group/presentation/widgets/mesh_3d_heatmap_widget.dart
+++ b/lib/features/muscle_group/presentation/widgets/mesh_3d_heatmap_widget.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:model_viewer_plus/model_viewer_plus.dart';
+
+/// Displays a 3D body model and applies colours to its materials based on
+/// [muscleColors]. The material names should match the keys of the map.
+class Mesh3DHeatmapWidget extends StatefulWidget {
+  final Map<String, Color> muscleColors;
+  final String assetPath;
+
+  const Mesh3DHeatmapWidget({
+    Key? key,
+    required this.muscleColors,
+    this.assetPath = 'assets/models/body.gltf',
+  }) : super(key: key);
+
+  @override
+  State<Mesh3DHeatmapWidget> createState() => _Mesh3DHeatmapWidgetState();
+}
+
+class _Mesh3DHeatmapWidgetState extends State<Mesh3DHeatmapWidget> {
+  late final ModelViewerController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = ModelViewerController();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ModelViewer(
+      src: widget.assetPath,
+      ar: false,
+      autoRotate: false,
+      cameraControls: true,
+      onModelLoaded: () {
+        for (final entry in widget.muscleColors.entries) {
+          _controller.setColor(entry.key, entry.value);
+        }
+      },
+      controller: _controller,
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   vector_math: ^2.1.4
   flutter_colorpicker: ^1.0.3
   flutter_svg: ^1.1.6
+  model_viewer_plus: ^1.0.7
 
   # Weitere Helfer
   flutter_dotenv: ^5.0.2
@@ -104,6 +105,7 @@ flutter:
     - assets/images/
     - assets/logos/
     - assets/models/
+    - assets/models/body.gltf
     - assets/muscle_heatmap.svg
 
 l10n:


### PR DESCRIPTION
## Summary
- include `model_viewer_plus` dependency and add body.gltf asset
- add stub model file
- implement `Mesh3DHeatmapWidget`
- show heatmap in 2D and 3D tabs

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68869defb138832095163531efa6ee88