### PR TITLE
feat(muscle): 2D/3D tabs for heatmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Tap’em ist eine Flutter-App für Fitnessstudios. Sie setzt auf ein modulares K
 - **Dynamisches Branding**: Farbschema, Logos und App-Namen pro Studio konfigurierbar
 - **State Management**: Provider für skalierbare Business-Logik
 - **Visualisierung**: Kalender-Übersicht, Charts (fl_chart), Streak-Badges, Trainingshistorie
+- **Muskel-Heatmap**: Muskelgruppen wahlweise als 2D-Silhouette oder 3D-Modell
 - **Challenges & Badges**: Wöchentliche und monatliche Aufgaben mit XP-Zielen
 - **Offline-Support**: Firestore-Persistence für unterbrechungsfreie Datenerfassung
 - **CI/CD ready**: GitHub Actions für Analyse, Tests und Matrix-Builds von Flavors

--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
@@ -8,6 +8,7 @@ import '../../../../core/providers/muscle_group_provider.dart';
 import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/xp_provider.dart';
 import '../widgets/interactive_svg_muscle_heatmap_widget.dart';
+import '../widgets/mesh_3d_heatmap_widget.dart';
 import '../../domain/models/muscle_group.dart';
 
 /// A revised muscle group screen that displays a granular 2D heatmap instead of
@@ -124,9 +125,26 @@ class _MuscleGroupScreenNewState extends State<MuscleGroupScreenNew> {
       appBar: AppBar(title: const Text('Muskelgruppen')),
       body: Padding(
         padding: const EdgeInsets.all(16),
-        child: InteractiveSvgMuscleHeatmapWidget(
-          colors: colorMap,
-          onRegionTap: showXp,
+        child: DefaultTabController(
+          length: 2,
+          child: Column(
+            children: [
+              const TabBar(
+                tabs: [Tab(text: '2D'), Tab(text: '3D')],
+              ),
+              Expanded(
+                child: TabBarView(
+                  children: [
+                    InteractiveSvgMuscleHeatmapWidget(
+                      colors: colorMap,
+                      onRegionTap: showXp,
+                    ),
+                    Mesh3DHeatmapWidget(muscleColors: colorMap),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- add 3D heatmap widget import
- show TabBar with 2D and 3D views
- update features list in README

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886a1ebb7e48320be8387ca46fe6dca