### PR TITLE
Update muscle heatmap assets

### DIFF
--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
@@ -8,6 +8,27 @@ import '../widgets/svg_muscle_heatmap_widget.dart';
 import '../widgets/mesh_3d_heatmap_widget.dart';
 import '../../domain/models/muscle_group.dart';
 
+const Map<String, List<String>> muscleCategoryMap = {
+  'chest': ['pectoral'],
+  'back': ['latissimus_dorsi', 'lower_back', 'rhomboids'],
+  'arms': ['biceps', 'triceps', 'forearm'],
+  'legs': [
+    'quadriceps',
+    'hamstrings',
+    'adductors',
+    'abductors',
+    'calves',
+    'feet'
+  ],
+  'core': ['abs'],
+  'shoulders': [
+    'anterior_deltoid',
+    'lateral_deltoid',
+    'posterior_deltoid',
+    'trapezius'
+  ],
+};
+
 class MuscleGroupScreen extends StatefulWidget {
   const MuscleGroupScreen({Key? key}) : super(key: key);
 

--- a/lib/features/muscle_group/presentation/widgets/interactive_svg_muscle_heatmap_widget.dart
+++ b/lib/features/muscle_group/presentation/widgets/interactive_svg_muscle_heatmap_widget.dart
@@ -13,7 +13,7 @@ class InteractiveSvgMuscleHeatmapWidget extends StatelessWidget {
     Key? key,
     required this.colors,
     this.onRegionTap,
-    this.assetPath = 'assets/muscle_heatmap.svg',
+    this.assetPath = 'assets/body_front.svg',
   }) : super(key: key);
 
   // Normalised bounding boxes for each region (based on the 200x408 viewBox).

--- a/lib/features/muscle_group/presentation/widgets/svg_muscle_heatmap_widget.dart
+++ b/lib/features/muscle_group/presentation/widgets/svg_muscle_heatmap_widget.dart
@@ -18,7 +18,7 @@ class SvgMuscleHeatmapWidget extends StatelessWidget {
   const SvgMuscleHeatmapWidget({
     Key? key,
     required this.colors,
-    this.assetPath = 'assets/muscle_heatmap.svg',
+    this.assetPath = 'assets/body_front.svg',
   }) : super(key: key);
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -107,6 +107,8 @@ flutter:
     - assets/models/
     - assets/models/body.gltf
     - assets/muscle_heatmap.svg
+    - assets/body_front.svg
+    - assets/body_back.svg
 
 l10n:
   arb-dir: lib/l10n


### PR DESCRIPTION
## Beschreibung
- neue SVGs `body_front.svg` und `body_back.svg` registriert
- Default‐Pfad der 2D‐Heatmap auf `body_front.svg` umgestellt
- Mapping von XP/Device-Kategorien zu SVG-Regionen ergänzt

## Typ der Änderung
- [x] feat: neues Feature

## Checkliste
- [ ] flutter analyze läuft fehlerfrei
- [ ] flutter test ist erfolgreich
- [x] Keine sensiblen Daten in Commits

------
https://chatgpt.com/codex/tasks/task_e_6886b81f30208320931f71b3c2b022e9