### PR TITLE
Add front/back toggle for muscle heatmap

### DIFF
--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
@@ -24,6 +24,7 @@ class MuscleGroupScreenNew extends StatefulWidget {
 }
 
 class _MuscleGroupScreenNewState extends State<MuscleGroupScreenNew> {
+  bool showFront = true;
   @override
   void initState() {
     super.initState();
@@ -132,12 +133,41 @@ class _MuscleGroupScreenNewState extends State<MuscleGroupScreenNew> {
               const TabBar(
                 tabs: [Tab(text: '2D'), Tab(text: '3D')],
               ),
+              const SizedBox(height: 8),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  TextButton(
+                    onPressed: () => setState(() => showFront = true),
+                    child: Text(
+                      'Front',
+                      style: TextStyle(
+                        color: showFront ? Colors.green : Colors.grey,
+                      ),
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: () => setState(() => showFront = false),
+                    child: Text(
+                      'Back',
+                      style: TextStyle(
+                        color: !showFront ? Colors.green : Colors.grey,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
               Expanded(
                 child: TabBarView(
                   children: [
-                    InteractiveSvgMuscleHeatmapWidget(
-                      colors: colorMap,
-                      onRegionTap: showXp,
+                    Center(
+                      child: InteractiveSvgMuscleHeatmapWidget(
+                        colors: colorMap,
+                        assetPath: showFront
+                            ? 'assets/body_front.svg'
+                            : 'assets/body_back.svg',
+                        onRegionTap: showXp,
+                      ),
                     ),
                     Mesh3DHeatmapWidget(muscleColors: colorMap),
                   ],


### PR DESCRIPTION
## Summary
- implement `showFront` toggle in muscle group screen
- center the heatmap and swap SVG depending on toggle state

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6886be7fa93883208c9f7eebd5b94ff9