### PR TITLE
Add survey system and update report features

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -24,6 +24,8 @@ import 'package:tapem/features/admin/presentation/screens/challenge_admin_screen
 import 'package:tapem/features/xp/presentation/screens/day_xp_screen.dart';
 import 'package:tapem/features/xp/presentation/screens/device_xp_screen.dart';
 import 'package:tapem/features/feedback/presentation/screens/feedback_overview_screen.dart';
+import 'package:tapem/features/survey/presentation/screens/survey_overview_screen.dart';
+import 'package:tapem/features/survey/presentation/screens/survey_vote_screen.dart';
 
 class AppRouter {
   static const splash = '/';
@@ -51,6 +53,8 @@ class AppRouter {
   static const challenges = '/challenges';
   static const manageChallenges = '/manage_challenges';
   static const feedbackOverview = '/feedback_overview';
+  static const surveyOverview = '/survey_overview';
+  static const surveyVote = '/survey_vote';
 
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
     switch (settings.name) {
@@ -158,6 +162,21 @@ class AppRouter {
         final gymId = settings.arguments as String? ?? '';
         return MaterialPageRoute(
           builder: (_) => FeedbackOverviewScreen(gymId: gymId),
+        );
+
+      case surveyOverview:
+        final gymId = settings.arguments as String? ?? '';
+        return MaterialPageRoute(
+          builder: (_) => SurveyOverviewScreen(gymId: gymId),
+        );
+
+      case surveyVote:
+        final args = settings.arguments as Map<String, String>? ?? const {};
+        return MaterialPageRoute(
+          builder: (_) => SurveyVoteScreen(
+            gymId: args['gymId'] ?? '',
+            userId: args['userId'] ?? '',
+          ),
         );
 
       default:

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -5,11 +5,13 @@ import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/app_provider.dart' as app;
 import 'package:tapem/core/providers/profile_provider.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/core/providers/gym_provider.dart';
 import 'package:tapem/features/nfc/widgets/nfc_scan_button.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import '../widgets/calendar.dart';
 import '../widgets/calendar_popup.dart';
+import '../../survey/presentation/screens/survey_vote_screen.dart';
 
 class ProfileScreen extends StatefulWidget {
   const ProfileScreen({Key? key}) : super(key: key);
@@ -181,6 +183,23 @@ class _ProfileScreenState extends State<ProfileScreen> {
                         fontWeight: FontWeight.bold,
                         fontSize: 16,
                       ),
+                    ),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: () {
+                        final gymId =
+                            context.read<GymProvider>().currentGymId;
+                        final userId =
+                            context.read<AuthProvider>().userId ?? '';
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) =>
+                                SurveyVoteScreen(gymId: gymId, userId: userId),
+                          ),
+                        );
+                      },
+                      child: const Text('Umfragen'),
                     ),
                     const SizedBox(height: 8),
                     Expanded(

--- a/lib/features/report/presentation/screens/report_screen_new.dart
+++ b/lib/features/report/presentation/screens/report_screen_new.dart
@@ -4,6 +4,10 @@ import 'package:provider/provider.dart';
 import '../widgets/device_usage_chart.dart';
 import '../../../feedback/presentation/screens/feedback_overview_screen.dart';
 import '../../../feedback/feedback_provider.dart';
+import '../../../survey/presentation/screens/survey_overview_screen.dart';
+import '../../../survey/survey_provider.dart';
+import '../../../survey/survey.dart';
+import '../../../../core/providers/report_provider.dart';
 
 class ReportScreenNew extends StatelessWidget {
   final String gymId;
@@ -12,7 +16,8 @@ class ReportScreenNew extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Map<String, int> usageData = _exampleUsageData(context);
+    final usageData = context.watch<ReportProvider>().usageCounts;
+    final data = usageData.isEmpty ? _exampleUsageData(context) : usageData;
     final feedbackProvider = context.watch<FeedbackProvider>();
     if (!feedbackProvider.isLoading &&
         feedbackProvider.entries.isEmpty) {
@@ -31,7 +36,7 @@ class ReportScreenNew extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            DeviceUsageChart(usageData: usageData),
+            DeviceUsageChart(usageData: data),
             const SizedBox(height: 24),
             Card(
               elevation: 2,
@@ -50,6 +55,35 @@ class ReportScreenNew extends StatelessWidget {
                     ),
                   );
                 },
+              ),
+            ),
+            const SizedBox(height: 16),
+            Card(
+              elevation: 2,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ListTile(
+                    leading: const Icon(Icons.add_circle_outline),
+                    title: const Text('Umfrage erstellen'),
+                    onTap: () => _showCreateSurveyDialog(context),
+                  ),
+                  const Divider(height: 1),
+                  ListTile(
+                    leading: const Icon(Icons.poll),
+                    title: const Text('Umfragen ansehen'),
+                    trailing: const Icon(Icons.chevron_right),
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) =>
+                              SurveyOverviewScreen(gymId: gymId),
+                        ),
+                      );
+                    },
+                  ),
+                ],
               ),
             ),
           ],
@@ -77,5 +111,81 @@ class ReportScreenNew extends StatelessWidget {
       'Gerät O': 10,
       'Gerät P': 5,
     };
+  }
+
+  void _showCreateSurveyDialog(BuildContext context) {
+    final titleController = TextEditingController();
+    final optionController = TextEditingController();
+    final options = <String>[];
+
+    showDialog(
+      context: context,
+      builder: (_) {
+        return AlertDialog(
+          title: const Text('Neue Umfrage'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: titleController,
+                decoration: const InputDecoration(labelText: 'Titel'),
+              ),
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: optionController,
+                      decoration:
+                          const InputDecoration(labelText: 'Option hinzufügen'),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.add),
+                    onPressed: () {
+                      final txt = optionController.text.trim();
+                      if (txt.isNotEmpty) {
+                        options.add(txt);
+                        optionController.clear();
+                        (context as Element).markNeedsBuild();
+                      }
+                    },
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              SizedBox(
+                height: 100,
+                child: ListView(
+                  children: options
+                      .map((e) => ListTile(title: Text(e)))
+                      .toList(),
+                ),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Abbrechen'),
+            ),
+            ElevatedButton(
+              onPressed: () async {
+                final title = titleController.text.trim();
+                if (title.isNotEmpty && options.length >= 2) {
+                  await context.read<SurveyProvider>().createSurvey(
+                        gymId: gymId,
+                        title: title,
+                        options: options,
+                      );
+                  Navigator.pop(context);
+                }
+              },
+              child: const Text('Speichern'),
+            ),
+          ],
+        );
+      },
+    );
   }
 }

--- a/lib/features/survey/presentation/screens/survey_detail_screen.dart
+++ b/lib/features/survey/presentation/screens/survey_detail_screen.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../survey.dart';
+import '../../survey_provider.dart';
+
+class SurveyDetailScreen extends StatefulWidget {
+  final String gymId;
+  final Survey survey;
+  const SurveyDetailScreen({Key? key, required this.gymId, required this.survey})
+      : super(key: key);
+
+  @override
+  State<SurveyDetailScreen> createState() => _SurveyDetailScreenState();
+}
+
+class _SurveyDetailScreenState extends State<SurveyDetailScreen> {
+  late Future<Map<String, int>> _resultsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _resultsFuture = context.read<SurveyProvider>().getResults(
+          gymId: widget.gymId,
+          surveyId: widget.survey.id,
+          options: widget.survey.options,
+        );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.survey.title)),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Ergebnisse',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 16),
+            Expanded(
+              child: FutureBuilder<Map<String, int>>(
+                future: _resultsFuture,
+                builder: (context, snapshot) {
+                  if (!snapshot.hasData) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+                  final results = snapshot.data!;
+                  final total = results.values.fold<int>(0, (s, v) => s + v);
+                  return ListView(
+                    children: results.keys.map((option) {
+                      final count = results[option] ?? 0;
+                      final percent = total == 0 ? 0 : count / total;
+                      return Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 8.0),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(option,
+                                style: const TextStyle(fontSize: 16)),
+                            const SizedBox(height: 4),
+                            LinearProgressIndicator(
+                              value: percent,
+                              minHeight: 8,
+                              backgroundColor: Colors.grey.shade700,
+                              valueColor: AlwaysStoppedAnimation<Color>(
+                                percent < 0.6
+                                    ? const Color(0xFF00E676)
+                                    : percent < 0.9
+                                        ? const Color(0xFF00BCD4)
+                                        : const Color(0xFFFFC107),
+                              ),
+                            ),
+                            const SizedBox(height: 2),
+                            Text('$count Stimmen (${(percent * 100).toStringAsFixed(1)}%)'),
+                          ],
+                        ),
+                      );
+                    }).toList(),
+                  );
+                },
+              ),
+            ),
+            const SizedBox(height: 16),
+            if (widget.survey.open)
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  icon: const Icon(Icons.close),
+                  label: const Text('Umfrage abschließen'),
+                  onPressed: () async {
+                    await context.read<SurveyProvider>().closeSurvey(
+                          gymId: widget.gymId,
+                          surveyId: widget.survey.id,
+                        );
+                    Navigator.pop(context);
+                  },
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/survey/presentation/screens/survey_overview_screen.dart
+++ b/lib/features/survey/presentation/screens/survey_overview_screen.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../../survey_provider.dart';
+import '../../survey.dart';
+import 'survey_detail_screen.dart';
+
+class SurveyOverviewScreen extends StatefulWidget {
+  final String gymId;
+  const SurveyOverviewScreen({Key? key, required this.gymId}) : super(key: key);
+
+  @override
+  State<SurveyOverviewScreen> createState() => _SurveyOverviewScreenState();
+}
+
+class _SurveyOverviewScreenState extends State<SurveyOverviewScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<SurveyProvider>().listen(widget.gymId);
+    });
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    context.read<SurveyProvider>().cancel();
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final surveyProv = context.watch<SurveyProvider>();
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Umfragen'),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'Offen'),
+            Tab(text: 'Abgeschlossen'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          _buildList(context, surveyProv.openSurveys, open: true),
+          _buildList(context, surveyProv.closedSurveys, open: false),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildList(BuildContext context, List<Survey> surveys, {required bool open}) {
+    if (surveys.isEmpty) {
+      return const Center(child: Text('Keine Umfragen'));
+    }
+    return ListView.builder(
+      itemCount: surveys.length,
+      itemBuilder: (_, index) {
+        final survey = surveys[index];
+        return ListTile(
+          title: Text(survey.title),
+          subtitle: Text(DateFormat.yMd().add_Hm().format(survey.createdAt)),
+          trailing: open ? const Icon(Icons.arrow_forward_ios) : null,
+          onTap: open
+              ? () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => SurveyDetailScreen(
+                          gymId: widget.gymId, survey: survey),
+                    ),
+                  );
+                }
+              : null,
+        );
+      },
+    );
+  }
+}

--- a/lib/features/survey/presentation/screens/survey_vote_screen.dart
+++ b/lib/features/survey/presentation/screens/survey_vote_screen.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../survey_provider.dart';
+import '../../survey.dart';
+
+class SurveyVoteScreen extends StatefulWidget {
+  final String gymId;
+  final String userId;
+  const SurveyVoteScreen({Key? key, required this.gymId, required this.userId})
+      : super(key: key);
+
+  @override
+  State<SurveyVoteScreen> createState() => _SurveyVoteScreenState();
+}
+
+class _SurveyVoteScreenState extends State<SurveyVoteScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<SurveyProvider>().listen(widget.gymId);
+    });
+  }
+
+  @override
+  void dispose() {
+    context.read<SurveyProvider>().cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final prov = context.watch<SurveyProvider>();
+    final surveys = prov.openSurveys;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Umfragen')),
+      body: surveys.isEmpty
+          ? const Center(child: Text('Keine offenen Umfragen'))
+          : ListView.builder(
+              itemCount: surveys.length,
+              itemBuilder: (_, index) {
+                final s = surveys[index];
+                return ListTile(
+                  title: Text(s.title),
+                  trailing: const Icon(Icons.arrow_forward_ios),
+                  onTap: () => Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => _SurveyVoteDetailScreen(
+                        gymId: widget.gymId,
+                        survey: s,
+                        userId: widget.userId,
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+    );
+  }
+}
+
+class _SurveyVoteDetailScreen extends StatefulWidget {
+  final String gymId;
+  final Survey survey;
+  final String userId;
+  const _SurveyVoteDetailScreen({
+    Key? key,
+    required this.gymId,
+    required this.survey,
+    required this.userId,
+  }) : super(key: key);
+
+  @override
+  State<_SurveyVoteDetailScreen> createState() => _SurveyVoteDetailScreenState();
+}
+
+class _SurveyVoteDetailScreenState extends State<_SurveyVoteDetailScreen> {
+  String? _selectedOption;
+  bool _submitted = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.survey.title)),
+      body: _submitted
+          ? const Center(child: Text('Danke für deine Teilnahme!'))
+          : Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('Bitte wähle eine Option:',
+                      style: TextStyle(fontSize: 16)),
+                  const SizedBox(height: 16),
+                  Expanded(
+                    child: ListView(
+                      children: widget.survey.options.map((opt) {
+                        return RadioListTile<String>(
+                          title: Text(opt),
+                          value: opt,
+                          groupValue: _selectedOption,
+                          onChanged: (value) {
+                            setState(() {
+                              _selectedOption = value;
+                            });
+                          },
+                        );
+                      }).toList(),
+                    ),
+                  ),
+                  ElevatedButton(
+                    onPressed: _selectedOption == null
+                        ? null
+                        : () async {
+                            await context.read<SurveyProvider>().submitAnswer(
+                                  gymId: widget.gymId,
+                                  surveyId: widget.survey.id,
+                                  userId: widget.userId,
+                                  selectedOption: _selectedOption!,
+                                );
+                            setState(() {
+                              _submitted = true;
+                            });
+                          },
+                    child: const Text('Absenden'),
+                  ),
+                ],
+              ),
+            ),
+    );
+  }
+}

--- a/lib/features/survey/survey.dart
+++ b/lib/features/survey/survey.dart
@@ -1,0 +1,89 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class Survey {
+  final String id;
+  final String title;
+  final List<String> options;
+  final bool open;
+  final DateTime createdAt;
+
+  Survey({
+    required this.id,
+    required this.title,
+    required this.options,
+    required this.open,
+    required this.createdAt,
+  });
+
+  factory Survey.fromMap(String id, Map<String, dynamic> data) {
+    final created = data['createdAt'];
+    DateTime createdAt;
+    if (created is Timestamp) {
+      createdAt = created.toDate();
+    } else if (created is DateTime) {
+      createdAt = created;
+    } else {
+      createdAt = DateTime.now();
+    }
+    return Survey(
+      id: id,
+      title: data['title'] as String? ?? '',
+      options: List<String>.from(data['options'] as List<dynamic>? ?? []),
+      open: data['status'] == 'offen',
+      createdAt: createdAt,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'title': title,
+      'options': options,
+      'status': open ? 'offen' : 'abgeschlossen',
+      'createdAt': createdAt,
+    };
+  }
+}
+
+class SurveyAnswer {
+  final String id;
+  final String surveyId;
+  final String userId;
+  final String selectedOption;
+  final DateTime timestamp;
+
+  SurveyAnswer({
+    required this.id,
+    required this.surveyId,
+    required this.userId,
+    required this.selectedOption,
+    required this.timestamp,
+  });
+
+  factory SurveyAnswer.fromMap(String id, Map<String, dynamic> data) {
+    final ts = data['timestamp'];
+    DateTime time;
+    if (ts is Timestamp) {
+      time = ts.toDate();
+    } else if (ts is DateTime) {
+      time = ts;
+    } else {
+      time = DateTime.now();
+    }
+    return SurveyAnswer(
+      id: id,
+      surveyId: data['surveyId'] as String? ?? '',
+      userId: data['userId'] as String? ?? '',
+      selectedOption: data['selectedOption'] as String? ?? '',
+      timestamp: time,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'surveyId': surveyId,
+      'userId': userId,
+      'selectedOption': selectedOption,
+      'timestamp': timestamp,
+    };
+  }
+}

--- a/lib/features/survey/survey_provider.dart
+++ b/lib/features/survey/survey_provider.dart
@@ -1,0 +1,130 @@
+import 'dart:async';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+import 'survey.dart';
+
+class SurveyProvider extends ChangeNotifier {
+  final FirebaseFirestore _firestore;
+  StreamSubscription<List<Survey>>? _openSub;
+  StreamSubscription<List<Survey>>? _closedSub;
+
+  List<Survey> openSurveys = [];
+  List<Survey> closedSurveys = [];
+
+  SurveyProvider({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  void listen(String gymId) {
+    _openSub?.cancel();
+    _closedSub?.cancel();
+
+    _openSub = _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('surveys')
+        .where('status', isEqualTo: 'offen')
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map((snap) =>
+            snap.docs.map((d) => Survey.fromMap(d.id, d.data())).toList())
+        .listen((surveys) {
+      openSurveys = surveys;
+      notifyListeners();
+    });
+
+    _closedSub = _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('surveys')
+        .where('status', isEqualTo: 'abgeschlossen')
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map((snap) =>
+            snap.docs.map((d) => Survey.fromMap(d.id, d.data())).toList())
+        .listen((surveys) {
+      closedSurveys = surveys;
+      notifyListeners();
+    });
+  }
+
+  void cancel() {
+    _openSub?.cancel();
+    _closedSub?.cancel();
+  }
+
+  Future<void> createSurvey({
+    required String gymId,
+    required String title,
+    required List<String> options,
+  }) async {
+    final doc = {
+      'title': title,
+      'options': options,
+      'status': 'offen',
+      'createdAt': DateTime.now(),
+    };
+    await _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('surveys')
+        .add(doc);
+  }
+
+  Future<void> closeSurvey({required String gymId, required String surveyId}) async {
+    await _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('surveys')
+        .doc(surveyId)
+        .update({'status': 'abgeschlossen'});
+  }
+
+  Future<void> submitAnswer({
+    required String gymId,
+    required String surveyId,
+    required String userId,
+    required String selectedOption,
+  }) async {
+    await _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('surveys')
+        .doc(surveyId)
+        .collection('answers')
+        .add({
+      'surveyId': surveyId,
+      'userId': userId,
+      'selectedOption': selectedOption,
+      'timestamp': DateTime.now(),
+    });
+  }
+
+  Future<Map<String, int>> getResults({
+    required String gymId,
+    required String surveyId,
+    required List<String> options,
+  }) async {
+    final snap = await _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('surveys')
+        .doc(surveyId)
+        .collection('answers')
+        .get();
+    final Map<String, int> counts = {for (final o in options) o: 0};
+    for (final doc in snap.docs) {
+      final data = doc.data();
+      final opt = data['selectedOption'] as String?;
+      if (opt != null && counts.containsKey(opt)) {
+        counts[opt] = counts[opt]! + 1;
+      }
+    }
+    return counts;
+  }
+
+  @override
+  void dispose() {
+    cancel();
+    super.dispose();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -34,6 +34,7 @@ import 'package:tapem/core/providers/training_plan_provider.dart';
 import 'package:tapem/core/providers/branding_provider.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/features/feedback/feedback_provider.dart';
+import 'package:tapem/features/survey/survey_provider.dart';
 
 import 'features/nfc/data/nfc_service.dart';
 import 'features/nfc/domain/usecases/read_nfc_code.dart';
@@ -198,6 +199,7 @@ class AppEntry extends StatelessWidget {
                 getLogTimestamps: logsUC,
               ),
         ),
+        ChangeNotifierProvider(create: (_) => SurveyProvider()),
         ChangeNotifierProvider(create: (_) => FeedbackProvider()),
         ChangeNotifierProvider(create: (_) => RankProvider()),
         ChangeNotifierProvider(create: (_) => ChallengeProvider()),


### PR DESCRIPTION
## Summary
- integrate survey feature with models, provider, and screens
- hook survey provider into app
- extend report screen with device usage chart and survey actions
- add survey vote entry on profile screen
- route to survey screens via AppRouter

## Testing
- `dart` or `flutter` commands were unavailable in the environment, so no analyzer or tests were run

------
https://chatgpt.com/codex/tasks/task_e_688797165c9c83209ae1414d24bde55d