### PR TITLE
fix: crash when leaving survey screen

### DIFF
--- a/lib/features/survey/presentation/screens/survey_overview_screen.dart
+++ b/lib/features/survey/presentation/screens/survey_overview_screen.dart
@@ -17,19 +17,21 @@ class SurveyOverviewScreen extends StatefulWidget {
 class _SurveyOverviewScreenState extends State<SurveyOverviewScreen>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
+  late SurveyProvider _surveyProvider;
 
   @override
   void initState() {
     super.initState();
+    _surveyProvider = context.read<SurveyProvider>();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      context.read<SurveyProvider>().listen(widget.gymId);
+      _surveyProvider.listen(widget.gymId);
     });
     _tabController = TabController(length: 2, vsync: this);
   }
 
   @override
   void dispose() {
-    context.read<SurveyProvider>().cancel();
+    _surveyProvider.cancel();
     _tabController.dispose();
     super.dispose();
   }


### PR DESCRIPTION
## Summary
- avoid Provider lookup in dispose of `SurveyOverviewScreen`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887e8493ad883208b657c3292b17736