### PR TITLE
Add survey creation bottom sheet

### DIFF
--- a/lib/features/report/presentation/screens/report_screen_new.dart
+++ b/lib/features/report/presentation/screens/report_screen_new.dart
@@ -7,6 +7,7 @@ import '../../../feedback/feedback_provider.dart';
 import '../../../survey/presentation/screens/survey_overview_screen.dart';
 import '../../../survey/survey_provider.dart';
 import '../../../survey/survey.dart';
+import '../../../survey/presentation/widgets/create_survey_sheet.dart';
 import '../../../../core/providers/report_provider.dart';
 
 class ReportScreenNew extends StatelessWidget {
@@ -114,84 +115,10 @@ class ReportScreenNew extends StatelessWidget {
   }
 
   void _showCreateSurveyDialog(BuildContext context) {
-    final titleController = TextEditingController();
-    final optionController = TextEditingController();
-    final options = <String>[];
-
-    showDialog(
+    showModalBottomSheet(
       context: context,
-      builder: (_) {
-        return StatefulBuilder(
-          builder: (context, setState) {
-            return AlertDialog(
-              title: const Text('Neue Umfrage'),
-              content: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  TextField(
-                    controller: titleController,
-                    decoration: const InputDecoration(labelText: 'Titel'),
-                  ),
-                  const SizedBox(height: 8),
-                  Row(
-                    children: [
-                      Expanded(
-                        child: TextField(
-                          controller: optionController,
-                          decoration: const InputDecoration(
-                              labelText: 'Option hinzufügen'),
-                        ),
-                      ),
-                      IconButton(
-                        icon: const Icon(Icons.add),
-                        onPressed: () {
-                          final txt = optionController.text.trim();
-                          if (txt.isNotEmpty) {
-                            setState(() {
-                              options.add(txt);
-                            });
-                            optionController.clear();
-                          }
-                        },
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 8),
-                  SizedBox(
-                    height: 100,
-                    width: double.maxFinite,
-                    child: ListView(
-                      shrinkWrap: true,
-                      children:
-                          options.map((e) => ListTile(title: Text(e))).toList(),
-                    ),
-                  ),
-                ],
-              ),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.pop(context),
-                  child: const Text('Abbrechen'),
-                ),
-                ElevatedButton(
-                  onPressed: () async {
-                    final title = titleController.text.trim();
-                    if (title.isNotEmpty && options.length >= 2) {
-                      await context.read<SurveyProvider>().createSurvey(
-                            gymId: gymId,
-                            title: title,
-                            options: options,
-                          );
-                      Navigator.pop(context);
-                    }
-                  },
-                  child: const Text('Speichern'),
-                ),
-              ],
-            );
-          },
-        );
-      },
+      isScrollControlled: true,
+      builder: (_) => CreateSurveySheet(gymId: gymId),
     );
   }
 }

--- a/lib/features/survey/presentation/widgets/create_survey_sheet.dart
+++ b/lib/features/survey/presentation/widgets/create_survey_sheet.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../survey_provider.dart';
+
+class CreateSurveySheet extends StatefulWidget {
+  final String gymId;
+  const CreateSurveySheet({Key? key, required this.gymId}) : super(key: key);
+
+  @override
+  State<CreateSurveySheet> createState() => _CreateSurveySheetState();
+}
+
+class _CreateSurveySheetState extends State<CreateSurveySheet> {
+  final TextEditingController _titleController = TextEditingController();
+  final TextEditingController _optionController = TextEditingController();
+  final List<String> _options = [];
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _optionController.dispose();
+    super.dispose();
+  }
+
+  void _addOption() {
+    final txt = _optionController.text.trim();
+    if (txt.isEmpty) return;
+    setState(() {
+      _options.add(txt);
+    });
+    _optionController.clear();
+  }
+
+  void _removeOption(String option) {
+    setState(() {
+      _options.remove(option);
+    });
+  }
+
+  Future<void> _save() async {
+    final title = _titleController.text.trim();
+    if (title.isEmpty || _options.length < 2) return;
+    await context.read<SurveyProvider>().createSurvey(
+          gymId: widget.gymId,
+          title: title,
+          options: List<String>.from(_options),
+        );
+    if (mounted) Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bottom = MediaQuery.of(context).viewInsets.bottom;
+    return Padding(
+      padding: EdgeInsets.only(bottom: bottom, left: 16, right: 16, top: 16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Text(
+            'Neue Umfrage',
+            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _titleController,
+            decoration: const InputDecoration(labelText: 'Titel'),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _optionController,
+                  decoration: const InputDecoration(labelText: 'Option'),
+                  onSubmitted: (_) => _addOption(),
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.add),
+                onPressed: _addOption,
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          if (_options.isNotEmpty)
+            Wrap(
+              spacing: 8,
+              runSpacing: 4,
+              children: _options
+                  .map(
+                    (o) => Chip(
+                      label: Text(o),
+                      onDeleted: () => _removeOption(o),
+                    ),
+                  )
+                  .toList(),
+            ),
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: _save,
+            child: const Text('Speichern'),
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- improve survey creation by using a bottom sheet
- allow adding/removing options using chips
- keep Firestore integration via `SurveyProvider`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887f055a68083208c0d01f4e3d89765