### PR TITLE
Fix survey status and update session overview

### DIFF
--- a/lib/features/survey/presentation/widgets/create_survey_sheet.dart
+++ b/lib/features/survey/presentation/widgets/create_survey_sheet.dart
@@ -40,12 +40,26 @@ class _CreateSurveySheetState extends State<CreateSurveySheet> {
 
   Future<void> _save() async {
     final title = _titleController.text.trim();
-    if (title.isEmpty || _options.length < 2) return;
+    if (title.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Titel eingeben')),
+      );
+      return;
+    }
+    if (_options.length < 2) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Mindestens zwei Optionen angeben')),
+      );
+      return;
+    }
     await context.read<SurveyProvider>().createSurvey(
-          gymId: widget.gymId,
-          title: title,
-          options: List<String>.from(_options),
-        );
+      gymId: widget.gymId,
+      title: title,
+      options: List<String>.from(_options),
+    );
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Umfrage gespeichert')),
+    );
     if (mounted) Navigator.of(context).pop();
   }
 

--- a/lib/features/survey/survey.dart
+++ b/lib/features/survey/survey.dart
@@ -29,7 +29,7 @@ class Survey {
       id: id,
       title: data['title'] as String? ?? '',
       options: List<String>.from(data['options'] as List<dynamic>? ?? []),
-      open: data['status'] == 'offen',
+      open: data['status'] == 'offen' || data['status'] == 'open',
       createdAt: createdAt,
     );
   }

--- a/lib/features/survey/survey_provider.dart
+++ b/lib/features/survey/survey_provider.dart
@@ -22,7 +22,7 @@ class SurveyProvider extends ChangeNotifier {
         .collection('gyms')
         .doc(gymId)
         .collection('surveys')
-        .where('status', isEqualTo: 'offen')
+        .where('status', isEqualTo: 'open')
         .orderBy('createdAt', descending: true)
         .snapshots()
         .map((snap) =>
@@ -60,8 +60,8 @@ class SurveyProvider extends ChangeNotifier {
     final doc = {
       'title': title,
       'options': options,
-      'status': 'offen',
-      'createdAt': DateTime.now(),
+      'status': 'open',
+      'createdAt': FieldValue.serverTimestamp(),
     };
     await _firestore
         .collection('gyms')

--- a/lib/features/training_details/presentation/screens/training_details_screen.dart
+++ b/lib/features/training_details/presentation/screens/training_details_screen.dart
@@ -7,6 +7,7 @@ import 'package:intl/intl.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/core/providers/training_details_provider.dart';
 import 'package:tapem/features/training_details/domain/models/session.dart';
+import '../widgets/day_sessions_overview.dart';
 
 class TrainingDetailsScreen extends StatelessWidget {
   final DateTime date;
@@ -49,15 +50,12 @@ class TrainingDetailsScreen extends StatelessWidget {
           final sessions = prov.sessions;
           return Scaffold(
             appBar: _AppBar(titleDate: date),
-            body: sessions.isEmpty
-                ? const Center(child: Text('Keine Trainingseinheiten'))
-                : ListView.builder(
-                    padding: const EdgeInsets.all(16),
-                    itemCount: sessions.length,
-                    itemBuilder: (_, i) => _SessionTile(
-                      session: sessions[i],
-                    ),
-                  ),
+            body: Padding(
+              padding: const EdgeInsets.all(16),
+              child: sessions.isEmpty
+                  ? const Center(child: Text('Keine Trainingseinheiten'))
+                  : DaySessionsOverview(sessions: sessions),
+            ),
           );
         },
       ),
@@ -83,54 +81,4 @@ class _AppBar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
-}
-
-/// Single session tile: deviceName (bold) + description underneath + all sets + optional note
-class _SessionTile extends StatelessWidget {
-  final Session session;
-  const _SessionTile({required this.session});
-
-  @override
-  Widget build(BuildContext context) {
-    return Card(
-      margin: const EdgeInsets.symmetric(vertical: 8),
-      child: ExpansionTile(
-        title: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Device name in bold
-            Text(
-              session.deviceName,
-              style: const TextStyle(fontWeight: FontWeight.bold),
-            ),
-            // Device description, if available
-            if (session.deviceDescription.isNotEmpty)
-              Text(session.deviceDescription),
-          ],
-        ),
-        // If you want the timestamp back, uncomment:
-        // subtitle: Text(
-        //   DateFormat.Hm(
-        //     Localizations.localeOf(context).toString(),
-        //   ).format(session.timestamp),
-        // ),
-        children: [
-          // One ListTile per set
-          ...session.sets.map(
-            (s) => ListTile(
-              title: Text('${s.weight} kg × ${s.reps} Wdh.'),
-            ),
-          ),
-          // Optional note
-          if (session.note.isNotEmpty) ...[
-            const Divider(),
-            Padding(
-              padding: const EdgeInsets.all(12),
-              child: Text('Notiz: ${session.note}'),
-            ),
-          ],
-        ],
-      ),
-    );
-  }
 }

--- a/lib/features/training_details/presentation/widgets/day_sessions_overview.dart
+++ b/lib/features/training_details/presentation/widgets/day_sessions_overview.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import '../../domain/models/session.dart';
+
+class DaySessionsOverview extends StatelessWidget {
+  final List<Session> sessions;
+  const DaySessionsOverview({Key? key, required this.sessions}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final int columns = (sessions.length <= 2)
+        ? sessions.length
+        : (sessions.length <= 4 ? 2 : 3);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final double cardWidth =
+            (constraints.maxWidth - (columns - 1) * 12) / columns;
+        return Wrap(
+          spacing: 12,
+          runSpacing: 12,
+          children: sessions.map((session) {
+            return SizedBox(
+              width: cardWidth,
+              child: _buildCard(context, session),
+            );
+          }).toList(),
+        );
+      },
+    );
+  }
+
+  Widget _buildCard(BuildContext context, Session session) {
+    return Card(
+      color: const Color(0xFF1E1E1E),
+      elevation: 4,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              session.deviceName,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            for (final set in session.sets)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 2.0),
+                child: Row(
+                  children: [
+                    const Icon(Icons.fitness_center,
+                        color: Color(0xFF00E676), size: 16),
+                    const SizedBox(width: 4),
+                    Text(
+                      '${set.weight.toStringAsFixed(1)} kg',
+                      style:
+                          const TextStyle(color: Colors.white70, fontSize: 14),
+                    ),
+                    const SizedBox(width: 8),
+                    const Icon(Icons.repeat,
+                        color: Color(0xFF00BCD4), size: 16),
+                    const SizedBox(width: 4),
+                    Text(
+                      '${set.reps} Wdh',
+                      style:
+                          const TextStyle(color: Colors.white70, fontSize: 14),
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- fix server timestamp and status in `SurveyProvider`
- recognize both `open` and `offen` in `Survey`
- improve survey creation dialog with validation and SnackBars
- replace session expansion lists with new card grid overview

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887fa320c648320ab263375af485045