### PR TITLE
fix: overflow in sessions overview

### DIFF
--- a/lib/features/training_details/presentation/widgets/day_sessions_overview.dart
+++ b/lib/features/training_details/presentation/widgets/day_sessions_overview.dart
@@ -7,9 +7,9 @@ class DaySessionsOverview extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final int columns = (sessions.length <= 2)
-        ? sessions.length
-        : (sessions.length <= 4 ? 2 : 3);
+    // Limit to a maximum of two columns to avoid layout overflow on small screens
+    final int columns =
+        sessions.length <= 2 ? sessions.length : 2;
     return LayoutBuilder(
       builder: (context, constraints) {
         final double cardWidth =


### PR DESCRIPTION
## Beschreibung
Begrenzt die Anzahl der angezeigten Spalten in `DaySessionsOverview` auf maximal zwei, um Überläufe bei vielen Sessions zu verhindern.

## Typ der Änderung
- [x] fix: Bugfix

## Checkliste
- [ ] flutter analyze läuft fehlerfrei
- [ ] flutter test ist erfolgreich
- [ ] Keine sensiblen Daten in Commits

------
https://chatgpt.com/codex/tasks/task_e_688802389d1c83209738abcd23dca607