### PR TITLE
Fix gym code lookup

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -33,6 +33,12 @@ service cloud.firestore {
       return inGym(gymId) && request.auth.uid == userId;
     }
 
+    // check if the request targets only the gym document itself
+    function isGymDocument(gymId) {
+      return resource.__name__ ==
+             "/databases/" + database + "/documents/gyms/" + gymId;
+    }
+
     // ----- User documents -----
     // Only the authenticated user may read/write their user profile and
     // any nested collections (trainingDayXP, muscleGroupXP, badges, ...)
@@ -42,8 +48,9 @@ service cloud.firestore {
 
     // ----- Gyms -----
     match /gyms/{gymId} {
-      // Admins can modify gym documents. All users in the gym can read.
-      allow read: if inGym(gymId);
+      // Gym documents are readable for everyone to validate gym codes.
+      // Write access remains restricted to admins.
+      allow read: if inGym(gymId) || isGymDocument(gymId);
       allow write: if isAdmin(gymId);
 
       // ---- Devices collection ----


### PR DESCRIPTION
## Summary
- allow reading a gym document without authentication for code verification

## Testing
- `npx firebase emulators:exec --only firestore --project tap-em "npx mocha --timeout 120000 firestore-tests/security_rules.test.js"` *(fails: download failed, status 403: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688cf1de18d48320b2878d19a84335c4