### PR TITLE
Allow public read for gyms

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -50,7 +50,8 @@ service cloud.firestore {
     match /gyms/{gymId} {
       // Gym documents are readable for everyone to validate gym codes.
       // Write access remains restricted to admins.
-      allow read: if inGym(gymId) || isGymDocument(gymId);
+      // Allow unauthenticated users to verify gym codes during registration
+      allow read: if true;
       allow write: if isAdmin(gymId);
 
       // ---- Devices collection ----


### PR DESCRIPTION
## Summary
- adjust Firestore rule so anyone can read `gyms` docs

## Testing
- `npx mocha firestore-tests/security_rules.test.js --timeout 120000` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cf55cb34883209530eec0268e9c4a