### PR TITLE
Fix registration Firestore permission

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -40,8 +40,12 @@ service cloud.firestore {
     }
 
     // ----- User documents -----
-    // Only the authenticated user may read/write their user profile and
-    // any nested collections (trainingDayXP, muscleGroupXP, badges, ...)
+    // Only the authenticated user may read/write their user profile
+    match /users/{userId} {
+      allow read, write: if isOwner(userId);
+    }
+
+    // Allow access to any nested collections under the user document
     match /users/{userId}/{document=**} {
       allow read, write: if isOwner(userId);
     }
@@ -128,6 +132,10 @@ service cloud.firestore {
       }
 
       // ---- Users subcollection ----
+      // Users are referenced under their gym as well
+      match /users/{userId} {
+        allow read, write: if isOwnerInGym(gymId, userId) || isAdmin(gymId);
+      }
       match /users/{userId}/{doc=**} {
         allow read, write: if isOwnerInGym(gymId, userId) || isAdmin(gymId);
       }


### PR DESCRIPTION
## Summary
- add rule to allow users to create their own document
- ensure gym user references are also writable

## Testing
- `npx mocha firestore-tests/security_rules.test.js` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_688cf81f6b64832092bf94d8a80a5213