### PR TITLE
Fix user membership creation

### DIFF
--- a/firestore-tests/security_rules.test.js
+++ b/firestore-tests/security_rules.test.js
@@ -52,4 +52,28 @@ describe('Firestore Security Rules', function() {
 
     await assertFails(badRef.set({ foo: 'bar' }));
   });
+
+  it('erlaubt Anlage der eigenen Mitgliedschaft', async () => {
+    const authCtx = testEnv.authenticatedContext('newUser', {});
+    const db = authCtx.firestore();
+    const ref = db
+      .collection('gyms')
+      .doc('gymA')
+      .collection('users')
+      .doc('newUser');
+
+    await assertSucceeds(ref.set({ role: 'member' }));
+  });
+
+  it('blockt Anlage der Mitgliedschaft für fremden Nutzer', async () => {
+    const authCtx = testEnv.authenticatedContext('hacker', {});
+    const db = authCtx.firestore();
+    const ref = db
+      .collection('gyms')
+      .doc('gymA')
+      .collection('users')
+      .doc('otherUser');
+
+    await assertFails(ref.set({ role: 'member' }));
+  });
 });

--- a/firestore.rules
+++ b/firestore.rules
@@ -134,7 +134,11 @@ service cloud.firestore {
       // ---- Users subcollection ----
       // Users are referenced under their gym as well
       match /users/{userId} {
-        allow read, write: if isOwnerInGym(gymId, userId) || isAdmin(gymId);
+        // Allow initial creation for the authenticated user even before
+        // membership exists. Further reads/writes require gym membership or
+        // admin role.
+        allow create: if isOwner(userId);
+        allow read, update, delete: if isOwnerInGym(gymId, userId) || isAdmin(gymId);
       }
       match /users/{userId}/{doc=**} {
         allow read, write: if isOwnerInGym(gymId, userId) || isAdmin(gymId);


### PR DESCRIPTION
## Summary
- allow initial creation of gym membership for new users in `firestore.rules`
- extend security rule tests for membership creation scenarios

## Testing
- `flutter test` *(fails: command not found)*
- `npx mocha firestore-tests/security_rules.test.js` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_688d06f82ae48320b16a63ea32ff7850