### PR TITLE
Fix user profile update rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -42,7 +42,7 @@ service cloud.firestore {
     // ----- User documents -----
     // Only the authenticated user may read/write their user profile
     match /users/{userId} {
-      allow read, write: if isOwner(userId);
+      allow create, read, update: if isOwner(userId);
     }
 
     // Allow access to any nested collections under the user document


### PR DESCRIPTION
## Summary
- allow update on `/users/{userId}` for the authenticated user

## Testing
- `npx mocha firestore-tests/security_rules.test.js` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_688d09b8b8dc8320a46e8b5c053493bb