### PR TITLE
Fix username dialog logging

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -42,7 +42,10 @@ service cloud.firestore {
     // ----- User documents -----
     // Only the authenticated user may read/write their user profile
     match /users/{userId} {
-      allow create, read, update: if isOwner(userId);
+      allow create: if isOwner(userId);
+      allow read: if isOwner(userId);
+      // Permit username updates right after registration
+      allow update: if isOwner(userId);
     }
 
     // Allow access to any nested collections under the user document

--- a/lib/features/auth/presentation/widgets/username_dialog.dart
+++ b/lib/features/auth/presentation/widgets/username_dialog.dart
@@ -34,9 +34,12 @@ Future<void> showUsernameDialog(BuildContext context) async {
                       if (name.isEmpty) return;
                       final success = await auth.setUsername(name);
                       if (success) {
+                        debugPrint('Username "$name" successfully saved');
                         // ignore: use_build_context_synchronously
                         Navigator.pop(ctx);
                       } else {
+                        debugPrint('Failed to set username "$name": '
+                            '${auth.error ?? 'unknown error'}');
                         setState(() => error = auth.error ?? loc.usernameTaken);
                       }
                     },


### PR DESCRIPTION
## Summary
- print success/failure messages in username dialog
- split user rules for clarity

## Testing
- `npm ci`
- `npx mocha --timeout 120000 firestore-tests/security_rules.test.js` *(fails: connect ECONNREFUSED)*
- `flutter test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d0d17f3988320a7c81106522cb421