### PR TITLE
Enable username queries

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -43,7 +43,8 @@ service cloud.firestore {
     // Only the authenticated user may read/write their user profile
     match /users/{userId} {
       allow create: if isOwner(userId);
-      allow read: if isOwner(userId);
+      // Allow signed-in users to read usernames for availability checks
+      allow read: if isSignedIn();
       // Permit username updates right after registration
       allow update: if isOwner(userId);
     }


### PR DESCRIPTION
## Summary
- allow any signed-in user to read user documents so username availability checks succeed

## Testing
- `npx mocha firestore-tests/security_rules.test.js --reporter spec` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_688d100c9edc8320b76d5d1ff1d05a40