### PR TITLE
Fix log access rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -71,7 +71,10 @@ service cloud.firestore {
         match /logs/{logId} {
           allow create: if inGym(gymId) &&
                          request.resource.data.userId == request.auth.uid;
-          allow read: if inGym(gymId) &&
+          // Allow users to read their own logs even if membership data
+          // is not yet available. This prevents permission errors when
+          // accessing training details shortly after registration.
+          allow read: if isSignedIn() &&
                        resource.data.userId == request.auth.uid;
           allow update, delete: if false;
         }


### PR DESCRIPTION
## Summary
- allow reading training logs without requiring gym membership

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_688d15af2b948320bddf40c401b53a57