### PR TITLE
Fix training details permission

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -64,7 +64,9 @@ service cloud.firestore {
 
       // ---- Devices collection ----
       match /devices/{deviceId} {
-        allow read: if inGym(gymId);
+        // Allow any authenticated user to read device information so that
+        // training details can be displayed even before membership data exists.
+        allow read: if inGym(gymId) || isSignedIn();
         allow write: if isAdmin(gymId);
 
         // Logs are appended by the owning user only. They are immutable.

--- a/lib/core/providers/training_details_provider.dart
+++ b/lib/core/providers/training_details_provider.dart
@@ -26,14 +26,17 @@ class TrainingDetailsProvider extends ChangeNotifier {
     required String userId,
     required DateTime date,
   }) async {
+    debugPrint('📆 loadSessions user=$userId date=$date');
     _isLoading = true;
     _error = null;
     notifyListeners();
 
     try {
       _sessions = await _getSessions.execute(userId: userId, date: date);
+      debugPrint('✅ loaded ${_sessions.length} sessions');
     } catch (e) {
       _error = e.toString();
+      debugPrint('❌ loadSessions error: $e');
     } finally {
       _isLoading = false;
       notifyListeners();


### PR DESCRIPTION
## Summary
- allow signed-in users to read device docs
- add debug output when loading sessions

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d185631488320b3804fd1a188701f