### PR TITLE
Fix Firestore rule for exercises

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -93,10 +93,13 @@ service cloud.firestore {
 
         // Custom exercises per user
         match /exercises/{exerciseId} {
-          allow read, write: if inGym(gymId) &&
-            (request.auth.uid == request.resource.data.userId ||
-             request.auth.uid == resource.data.userId) ||
-            isAdmin(gymId);
+          allow read: if (isSignedIn() &&
+                        request.auth.uid == resource.data.userId) ||
+                       isAdmin(gymId);
+          allow write: if inGym(gymId) &&
+                          (request.auth.uid == request.resource.data.userId ||
+                           request.auth.uid == resource.data.userId) ||
+                        isAdmin(gymId);
         }
       }
 


### PR DESCRIPTION
## Summary
- adjust rules so signed-in users can read their own custom exercises without gym membership

## Testing
- `npx mocha firestore-tests/security_rules.test.js` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_688d1a714af88320a2544d3d2cc99141