### PR TITLE
Fix training details load for admins

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -76,8 +76,9 @@ service cloud.firestore {
           // Allow users to read their own logs even if membership data
           // is not yet available. This prevents permission errors when
           // accessing training details shortly after registration.
-          allow read: if isSignedIn() &&
-                       resource.data.userId == request.auth.uid;
+          allow read: if (isSignedIn() &&
+                          resource.data.userId == request.auth.uid) ||
+                       isAdmin(gymId);
           allow update, delete: if false;
         }
 


### PR DESCRIPTION
## Summary
- allow gym admins to view logs of any user

## Testing
- `npx mocha --timeout 120000 firestore-tests/security_rules.test.js` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*
- `npx firebase emulators:exec --only firestore "npx mocha --timeout 120000 firestore-tests/security_rules.test.js"` *(fails: download failed, status 403: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688d1e0008688320bfb1ada753173fd4