### PR TITLE
Add Firestore debug logging

### DIFF
--- a/lib/features/training_details/data/repositories/session_repository_impl.dart
+++ b/lib/features/training_details/data/repositories/session_repository_impl.dart
@@ -14,6 +14,7 @@ class SessionRepositoryImpl implements SessionRepository {
     required DateTime date,
   }) async {
     final dtos = await _source.getSessionsForDate(userId: userId, date: date);
+    debugPrint('📥 SessionRepositoryImpl: processing ${dtos.length} log dtos');
 
     // 1) Gruppieren
     final Map<String, List<SessionDto>> grouped = {};
@@ -31,16 +32,20 @@ class SessionRepositoryImpl implements SessionRepository {
 
       // Referenz aufs Device-Dokument:
       final deviceRef = first.reference.parent.parent!;
+      debugPrint('📥 SessionRepositoryImpl: read device ${deviceRef.path}');
       final deviceSnap = await deviceRef.get();
       final data = deviceSnap.data()!;
 
       var deviceName = (data['name'] as String?) ?? first.deviceId;
       final deviceDescription = (data['description'] as String?) ?? '';
       final isMulti = (data['isMulti'] as bool?) ?? false;
+      debugPrint(
+        '📥 SessionRepositoryImpl: deviceName=$deviceName isMulti=$isMulti');
 
       if (isMulti && first.exerciseId.isNotEmpty) {
-        final exSnap =
-            await deviceRef.collection('exercises').doc(first.exerciseId).get();
+        final exRef = deviceRef.collection('exercises').doc(first.exerciseId);
+        debugPrint('📥 SessionRepositoryImpl: read exercise ${exRef.path}');
+        final exSnap = await exRef.get();
         if (exSnap.exists) {
           final exName = (exSnap.data()?["name"] as String?) ?? '';
           if (exName.isNotEmpty) deviceName = exName;

--- a/lib/features/training_details/data/sources/firestore_session_source.dart
+++ b/lib/features/training_details/data/sources/firestore_session_source.dart
@@ -17,6 +17,10 @@ class FirestoreSessionSource {
         .add(const Duration(days: 1))
         .subtract(const Duration(milliseconds: 1));
 
+    debugPrint(
+      '📥 FirestoreSessionSource: query logs user=$userId start=$start end=$end',
+    );
+
     final snap =
         await _firestore
             .collectionGroup('logs')
@@ -27,6 +31,8 @@ class FirestoreSessionSource {
             )
             .where('timestamp', isLessThanOrEqualTo: Timestamp.fromDate(end))
             .get();
+
+    debugPrint('📥 FirestoreSessionSource: fetched ${snap.docs.length} log docs');
 
     return snap.docs.map((doc) => SessionDto.fromFirestore(doc)).toList();
   }


### PR DESCRIPTION
## Summary
- enhance FirestoreSessionSource with debug logs for queries
- add debug logging in SessionRepositoryImpl for device and exercise lookups

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d2ecf3a9883209db2a7a5c8302bb9