### PR TITLE
Fix debugPrint errors

### DIFF
--- a/lib/features/training_details/data/repositories/session_repository_impl.dart
+++ b/lib/features/training_details/data/repositories/session_repository_impl.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
 import 'package:tapem/features/training_details/data/dtos/session_dto.dart';
 import 'package:tapem/features/training_details/data/sources/firestore_session_source.dart';
 import 'package:tapem/features/training_details/domain/models/session.dart';

--- a/lib/features/training_details/data/sources/firestore_session_source.dart
+++ b/lib/features/training_details/data/sources/firestore_session_source.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
 import '../dtos/session_dto.dart';
 
 /// Liest alle Log‐Einträge (collectionGroup "logs") für ein Datum aus.


### PR DESCRIPTION
## Summary
- import flutter's foundation library for debugPrint

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `npx mocha --timeout 120000 firestore-tests/security_rules.test.js` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_688d308baca48320a9a41ef54749b36b