### PR TITLE
Grant log read access for authenticated users

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -35,6 +35,7 @@ service cloud.firestore {
       return (isSignedIn() && resource.data.userId == request.auth.uid) || isAdmin(gymId);
     }
 
+
     // Exercise is shared globally (no userId field or empty)
     function isPublicExercise() {
       return !("userId" in resource.data) || resource.data.userId == null || resource.data.userId == "";
@@ -53,6 +54,11 @@ service cloud.firestore {
     function isGymDocument(gymId) {
       return resource.__name__ ==
              "/databases/" + database + "/documents/gyms/" + gymId;
+    }
+
+    // Allow users to read their own log documents across all gyms.
+    match /{path=**}/logs/{logId} {
+      allow read: if isSignedIn() && resource.data.userId == request.auth.uid;
     }
 
     // ----- User documents -----


### PR DESCRIPTION
## Summary
- update Firestore rules to allow authenticated users to read their own `logs` documents when using a collection group query

## Testing
- `npx mocha firestore-tests/security_rules.test.js --reporter spec` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_688d326afe248320a3230fe009a148b1