### PR TITLE
Add dev Firestore rules and Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-.PHONY: ios android push ios-dev ios-emu R
+.PHONY: ios android push ios-dev ios-emu R rules rules-dev
 
 # Gerätedefinitionen
 iOS_DEV_ID   := 00008030-001E59420191802E
 IOS_EMU_ID   := 47B92242-AE5E-489D-9EA0-199C9CAE3003
 ANDROID_ID   := 519e8f06
 TMUX_SESSION := flutter
+FIREBASE_CONFIG ?= firebase.json
 
 # Standard-Targets
 ios:
@@ -60,4 +61,7 @@ ios-wireless:
 
 # Deploy firestore.rules
 rules:
-	firebase deploy --only firestore:rules
+        npx firebase deploy --only firestore:rules -c $(FIREBASE_CONFIG)
+
+rules-dev:
+        $(MAKE) rules FIREBASE_CONFIG=firebase.dev.json

--- a/firebase.dev.json
+++ b/firebase.dev.json
@@ -1,0 +1,15 @@
+{
+  "firestore": {
+    "rules": "firestore-dev.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": true
+    },
+    "singleProjectMode": true
+  }
+}

--- a/firestore-dev.rules
+++ b/firestore-dev.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if true;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add permissive `firestore-dev.rules` for local development
- provide `firebase.dev.json` to deploy the dev rules
- update `Makefile` with configurable rules deployment and a `rules-dev` helper

## Testing
- `npx mocha firestore-tests/security_rules.test.js` *(fails: ECONNREFUSED to Firestore emulator)*

------
https://chatgpt.com/codex/tasks/task_e_688d42e330f08320a2eae707b195ac5e