### PR TITLE
test(providers): add baseline provider and widget tests

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,6 +79,7 @@ dev_dependencies:
   build_runner: ^2.4.6
   json_serializable: ^6.7.0
   flutter_launcher_icons: ^0.14.3
+  fake_cloud_firestore: ^2.5.0
 
 # Dependency overrides to ensure both packages use the git source
 dependency_overrides:

--- a/test/providers/branding_provider_test.dart
+++ b/test/providers/branding_provider_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/core/providers/branding_provider.dart';
+import 'package:tapem/features/gym/data/sources/firestore_gym_source.dart';
+import 'package:tapem/features/gym/domain/models/branding.dart';
+
+class FakeGymSource extends FirestoreGymSource {
+  FakeGymSource({this.branding, this.throwError});
+  final Branding? branding;
+  final bool? throwError;
+  @override
+  Future<Branding?> getBranding(String gymId) async {
+    if (throwError == true) throw Exception('fail');
+    return branding;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('BrandingProvider', () {
+    test('loads branding successfully', () async {
+      final source = FakeGymSource(branding: Branding(logoUrl: 'x'));
+      final provider = BrandingProvider(source: source);
+      await provider.loadBranding('g1');
+      expect(provider.branding?.logoUrl, 'x');
+      expect(provider.error, isNull);
+    });
+
+    test('handles missing document', () async {
+      final source = FakeGymSource(branding: null);
+      final provider = BrandingProvider(source: source);
+      await provider.loadBranding('g1');
+      expect(provider.branding, isNull);
+    });
+
+    test('handles exceptions', () async {
+      final source = FakeGymSource(throwError: true);
+      final provider = BrandingProvider(source: source);
+      await provider.loadBranding('g1');
+      expect(provider.branding, isNull);
+      expect(provider.error, isNotNull);
+    });
+  });
+}

--- a/test/providers/device_provider_test.dart
+++ b/test/providers/device_provider_test.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/device_provider.dart';
+import 'package:tapem/core/providers/xp_provider.dart';
+import 'package:tapem/core/providers/challenge_provider.dart';
+import 'package:tapem/features/device/domain/models/device.dart';
+import 'package:tapem/features/device/domain/repositories/device_repository.dart';
+import 'package:tapem/features/device/domain/usecases/get_devices_for_gym.dart';
+import 'package:tapem/features/xp/domain/xp_repository.dart';
+import 'package:tapem/features/challenges/domain/repositories/challenge_repository.dart';
+import 'package:tapem/features/challenges/domain/models/challenge.dart';
+import 'package:tapem/features/challenges/domain/models/badge.dart';
+import 'package:tapem/features/challenges/domain/models/completed_challenge.dart';
+
+class FakeDeviceRepository implements DeviceRepository {
+  FakeDeviceRepository(this.devices);
+  final List<Device> devices;
+  @override
+  Future<List<Device>> getDevicesForGym(String gymId) async => devices;
+  @override
+  Future<void> createDevice(String gymId, Device device) => throw UnimplementedError();
+  @override
+  Future<Device?> getDeviceByNfcCode(String gymId, String nfcCode) => throw UnimplementedError();
+  @override
+  Future<void> deleteDevice(String gymId, String deviceId) => throw UnimplementedError();
+  @override
+  Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) => throw UnimplementedError();
+  @override
+  Future<void> setMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) => throw UnimplementedError();
+}
+
+class FakeXpRepository implements XpRepository {
+  int calls = 0;
+  @override
+  Future<void> addSessionXp({
+    required String gymId,
+    required String userId,
+    required String deviceId,
+    required String sessionId,
+    required bool showInLeaderboard,
+    required bool isMulti,
+    required List<String> primaryMuscleGroupIds,
+  }) async {
+    calls++;
+  }
+
+  @override
+  Stream<int> watchDayXp({required String userId, required DateTime date}) => const Stream.empty();
+  @override
+  Stream<Map<String, int>> watchMuscleXp({required String gymId, required String userId}) => const Stream.empty();
+  @override
+  Stream<Map<String, int>> watchTrainingDaysXp(String userId) => const Stream.empty();
+  @override
+  Stream<int> watchDeviceXp({required String gymId, required String deviceId, required String userId}) => const Stream.empty();
+  @override
+  Stream<int> watchStatsDailyXp({required String gymId, required String userId}) => const Stream.empty();
+}
+
+class FakeChallengeRepository implements ChallengeRepository {
+  int calls = 0;
+  @override
+  Future<void> checkChallenges(String gymId, String userId, String deviceId) async {
+    calls++;
+  }
+
+  @override
+  Stream<List<Challenge>> watchActiveChallenges(String gymId) => const Stream.empty();
+  @override
+  Stream<List<Badge>> watchBadges(String userId) => const Stream.empty();
+  @override
+  Stream<List<CompletedChallenge>> watchCompletedChallenges(String gymId, String userId) => const Stream.empty();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('DeviceProvider', () {
+    test('loadDevice sets device and last session', () async {
+      final firestore = FakeFirebaseFirestore();
+      final logsCol = firestore
+          .collection('gyms')
+          .doc('g1')
+          .collection('devices')
+          .doc('d1')
+          .collection('logs');
+      final ts1 = Timestamp.fromDate(DateTime(2024, 1, 1));
+      final ts2 = Timestamp.fromDate(DateTime(2024, 1, 1, 1));
+      await logsCol.add({
+        'deviceId': 'd1',
+        'userId': 'u1',
+        'exerciseId': 'ex1',
+        'sessionId': 's1',
+        'timestamp': ts1,
+        'weight': 50.0,
+        'reps': 10,
+        'note': 'n',
+      });
+      await logsCol.add({
+        'deviceId': 'd1',
+        'userId': 'u1',
+        'exerciseId': 'ex1',
+        'sessionId': 's1',
+        'timestamp': ts2,
+        'weight': 60.0,
+        'reps': 8,
+        'note': 'n',
+      });
+      await firestore
+          .collection('gyms')
+          .doc('g1')
+          .collection('devices')
+          .doc('d1')
+          .collection('leaderboard')
+          .doc('u1')
+          .set({'xp': 10, 'level': 2});
+
+      final device = Device(
+        uid: 'd1',
+        id: 1,
+        name: 'Device',
+        primaryMuscleGroups: const ['m1'],
+      );
+      final provider = DeviceProvider(
+        getDevicesForGym: GetDevicesForGym(FakeDeviceRepository([device])),
+        firestore: firestore,
+      );
+
+      await provider.loadDevice(
+        gymId: 'g1',
+        deviceId: 'd1',
+        exerciseId: 'ex1',
+        userId: 'u1',
+      );
+
+      expect(provider.device?.uid, 'd1');
+      expect(provider.lastSessionSets.length, 2);
+    });
+
+    testWidgets('saveWorkoutSession writes log and adds XP', (tester) async {
+      final firestore = FakeFirebaseFirestore();
+      final device = Device(
+        uid: 'd1',
+        id: 1,
+        name: 'Device',
+        primaryMuscleGroups: const ['m1'],
+      );
+      final xpRepo = FakeXpRepository();
+      final chRepo = FakeChallengeRepository();
+      final provider = DeviceProvider(
+        getDevicesForGym: GetDevicesForGym(FakeDeviceRepository([device])),
+        firestore: firestore,
+      );
+      await provider.loadDevice(
+        gymId: 'g1',
+        deviceId: 'd1',
+        exerciseId: 'ex1',
+        userId: 'u1',
+      );
+      provider.updateSet(0, weight: '70', reps: '6');
+      provider.setNote('test');
+
+      final xpProvider = XpProvider(repo: xpRepo);
+      final challengeProvider = ChallengeProvider(repo: chRepo);
+
+      await tester.pumpWidget(
+        MultiProvider(
+          providers: [
+            ChangeNotifierProvider<XpProvider>.value(value: xpProvider),
+            ChangeNotifierProvider<ChallengeProvider>.value(value: challengeProvider),
+            ChangeNotifierProvider<DeviceProvider>.value(value: provider),
+          ],
+          child: const MaterialApp(home: Scaffold(body: SizedBox())),
+        ),
+      );
+
+      final ctx = tester.element(find.byType(SizedBox));
+      await provider.saveWorkoutSession(
+        context: ctx,
+        gymId: 'g1',
+        userId: 'u1',
+        showInLeaderboard: false,
+      );
+
+      final logs = await firestore
+          .collection('gyms')
+          .doc('g1')
+          .collection('devices')
+          .doc('d1')
+          .collection('logs')
+          .get();
+      expect(logs.docs.length, 1);
+      expect(xpRepo.calls, 1);
+      expect(chRepo.calls, 1);
+    });
+  });
+}
+

--- a/test/providers/feedback_provider_test.dart
+++ b/test/providers/feedback_provider_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:tapem/features/feedback/feedback_provider.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('FeedbackProvider', () {
+    test('submitFeedback creates document', () async {
+      final firestore = FakeFirebaseFirestore();
+      final provider = FeedbackProvider(firestore: firestore);
+      await provider.submitFeedback(
+        gymId: 'g1',
+        deviceId: 'd1',
+        userId: 'u1',
+        text: 'hi',
+      );
+      final snap = await firestore
+          .collection('gyms')
+          .doc('g1')
+          .collection('feedback')
+          .get();
+      expect(snap.docs.length, 1);
+    });
+
+    test('loadFeedback reads entries', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore
+          .collection('gyms')
+          .doc('g1')
+          .collection('feedback')
+          .add({
+            'deviceId': 'd1',
+            'userId': 'u1',
+            'text': 'hi',
+            'createdAt': Timestamp.now(),
+            'isDone': false,
+          });
+      final provider = FeedbackProvider(firestore: firestore);
+      await provider.loadFeedback('g1');
+      expect(provider.entries.length, 1);
+    });
+
+    test('markDone updates entry', () async {
+      final firestore = FakeFirebaseFirestore();
+      final doc = await firestore
+          .collection('gyms')
+          .doc('g1')
+          .collection('feedback')
+          .add({
+            'deviceId': 'd1',
+            'userId': 'u1',
+            'text': 'hi',
+            'createdAt': Timestamp.now(),
+            'isDone': false,
+          });
+      final provider = FeedbackProvider(firestore: firestore);
+      await provider.loadFeedback('g1');
+      await provider.markDone(gymId: 'g1', entryId: doc.id);
+      final updated = await doc.get();
+      expect(updated.data()?['isDone'], true);
+      expect(provider.doneEntries.length, 1);
+    });
+  });
+}

--- a/test/providers/survey_provider_test.dart
+++ b/test/providers/survey_provider_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:tapem/features/survey/survey_provider.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SurveyProvider', () {
+    test('createSurvey adds document', () async {
+      final firestore = FakeFirebaseFirestore();
+      final provider = SurveyProvider(firestore: firestore);
+      await provider.createSurvey(
+        gymId: 'g1',
+        title: 'Test',
+        options: const ['A', 'B'],
+      );
+      final snap = await firestore
+          .collection('gyms')
+          .doc('g1')
+          .collection('surveys')
+          .get();
+      expect(snap.docs.length, 1);
+    });
+
+    test('submitAnswer stores response', () async {
+      final firestore = FakeFirebaseFirestore();
+      final provider = SurveyProvider(firestore: firestore);
+      final surveyRef = await firestore
+          .collection('gyms')
+          .doc('g1')
+          .collection('surveys')
+          .add({
+            'title': 'T',
+            'options': ['A', 'B'],
+            'status': 'open',
+            'createdAt': Timestamp.now(),
+          });
+      await provider.submitAnswer(
+        gymId: 'g1',
+        surveyId: surveyRef.id,
+        userId: 'u1',
+        selectedOption: 'A',
+      );
+      final snap = await surveyRef.collection('answers').get();
+      expect(snap.docs.length, 1);
+    });
+
+    test('getResults counts votes', () async {
+      final firestore = FakeFirebaseFirestore();
+      final provider = SurveyProvider(firestore: firestore);
+      final surveyRef = await firestore
+          .collection('gyms')
+          .doc('g1')
+          .collection('surveys')
+          .add({
+            'title': 'T',
+            'options': ['A', 'B'],
+            'status': 'open',
+            'createdAt': Timestamp.now(),
+          });
+      await surveyRef.collection('answers').add({
+        'surveyId': surveyRef.id,
+        'userId': 'u1',
+        'selectedOption': 'A',
+        'timestamp': Timestamp.now(),
+      });
+      await surveyRef.collection('answers').add({
+        'surveyId': surveyRef.id,
+        'userId': 'u2',
+        'selectedOption': 'B',
+        'timestamp': Timestamp.now(),
+      });
+      await surveyRef.collection('answers').add({
+        'surveyId': surveyRef.id,
+        'userId': 'u3',
+        'selectedOption': 'A',
+        'timestamp': Timestamp.now(),
+      });
+      final results = await provider.getResults(
+        gymId: 'g1',
+        surveyId: surveyRef.id,
+        options: const ['A', 'B'],
+      );
+      expect(results['A'], 2);
+      expect(results['B'], 1);
+    });
+  });
+}

--- a/test/widgets/report_screen_test.dart
+++ b/test/widgets/report_screen_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:tapem/features/report/presentation/screens/report_screen_new.dart';
+import 'package:tapem/core/providers/report_provider.dart';
+import 'package:tapem/core/providers/feedback_provider.dart';
+import 'package:tapem/features/report/domain/usecases/get_device_usage_stats.dart';
+import 'package:tapem/features/report/domain/usecases/get_all_log_timestamps.dart';
+import 'package:tapem/features/report/domain/repositories/report_repository.dart';
+import 'package:tapem/features/report/presentation/widgets/device_usage_chart.dart';
+
+class FakeReportRepository implements ReportRepository {
+  FakeReportRepository({this.usage = const {}, this.times = const []});
+  final Map<String, int> usage;
+  final List<DateTime> times;
+  @override
+  Future<Map<String, int>> fetchUsageCountPerMachine(String gymId) async => usage;
+  @override
+  Future<List<DateTime>> fetchAllLogTimestamps(String gymId) async => times;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('ReportScreenNew shows chart with fallback data', (tester) async {
+    final repo = FakeReportRepository();
+    final reportProvider = ReportProvider(
+      getUsageStats: GetDeviceUsageStats(repo),
+      getLogTimestamps: GetAllLogTimestamps(repo),
+    );
+    final feedbackProvider = FeedbackProvider(firestore: FakeFirebaseFirestore());
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<ReportProvider>.value(value: reportProvider),
+          ChangeNotifierProvider<FeedbackProvider>.value(value: feedbackProvider),
+        ],
+        child: const MaterialApp(home: ReportScreenNew(gymId: 'g1')),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.byType(DeviceUsageChart), findsOneWidget);
+    final chart = tester.widget<DeviceUsageChart>(find.byType(DeviceUsageChart));
+    expect(chart.usageData.isNotEmpty, true);
+  });
+}


### PR DESCRIPTION
## Summary
- add fake_cloud_firestore for Firestore mocking
- write unit tests for DeviceProvider, SurveyProvider, FeedbackProvider, BrandingProvider
- add smoke test ensuring ReportScreenNew shows DeviceUsageChart with fallback data

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d69ba9dd48320a5f723b77bde1b64