### PR TITLE
chore: update fake_cloud_firestore version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,7 +79,7 @@ dev_dependencies:
   build_runner: ^2.4.6
   json_serializable: ^6.7.0
   flutter_launcher_icons: ^0.14.3
-  fake_cloud_firestore: ^2.5.0
+  fake_cloud_firestore: ^3.1.0
 
 # Dependency overrides to ensure both packages use the git source
 dependency_overrides:


### PR DESCRIPTION
## Summary
- update fake_cloud_firestore to ^3.1.0 to resolve version mismatch with cloud_firestore

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d6c4e3b248320aee38c42921fd6ff