### PR TITLE
fix: resolve analyze errors in tests

### DIFF
--- a/test/providers/device_provider_test.dart
+++ b/test/providers/device_provider_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide Badge;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:provider/provider.dart';
@@ -13,6 +13,7 @@ import 'package:tapem/features/challenges/domain/repositories/challenge_reposito
 import 'package:tapem/features/challenges/domain/models/challenge.dart';
 import 'package:tapem/features/challenges/domain/models/badge.dart';
 import 'package:tapem/features/challenges/domain/models/completed_challenge.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class FakeDeviceRepository implements DeviceRepository {
   FakeDeviceRepository(this.devices);
@@ -68,7 +69,8 @@ class FakeChallengeRepository implements ChallengeRepository {
   @override
   Stream<List<Challenge>> watchActiveChallenges(String gymId) => const Stream.empty();
   @override
-  Stream<List<Badge>> watchBadges(String userId) => const Stream.empty();
+  Stream<List<Badge>> watchBadges(String userId) =>
+      const Stream<List<Badge>>.empty();
   @override
   Stream<List<CompletedChallenge>> watchCompletedChallenges(String gymId, String userId) => const Stream.empty();
 }

--- a/test/widgets/report_screen_test.dart
+++ b/test/widgets/report_screen_test.dart
@@ -4,7 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:tapem/features/report/presentation/screens/report_screen_new.dart';
 import 'package:tapem/core/providers/report_provider.dart';
-import 'package:tapem/core/providers/feedback_provider.dart';
+import 'package:tapem/features/feedback/feedback_provider.dart';
 import 'package:tapem/features/report/domain/usecases/get_device_usage_stats.dart';
 import 'package:tapem/features/report/domain/usecases/get_all_log_timestamps.dart';
 import 'package:tapem/features/report/domain/repositories/report_repository.dart';


### PR DESCRIPTION
## Summary
- hide Flutter `Badge` and correct return type in device provider test
- import missing Cloud Firestore Timestamp in device provider test
- use correct FeedbackProvider import in report screen test

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d6e241e2c83209f1302556bdb7dbc