### PR TITLE
fix: avoid firebase init in branding tests

### DIFF
--- a/test/providers/branding_provider_test.dart
+++ b/test/providers/branding_provider_test.dart
@@ -2,11 +2,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tapem/core/providers/branding_provider.dart';
 import 'package:tapem/features/gym/data/sources/firestore_gym_source.dart';
 import 'package:tapem/features/gym/domain/models/branding.dart';
+import 'package:tapem/features/gym/domain/models/gym_config.dart';
 
-class FakeGymSource extends FirestoreGymSource {
+class FakeGymSource implements FirestoreGymSource {
   FakeGymSource({this.branding, this.throwError});
   final Branding? branding;
   final bool? throwError;
+
+  @override
+  Future<GymConfig?> getGymByCode(String code) async => null;
+
+  @override
+  Future<GymConfig?> getGymById(String id) async => null;
+
   @override
   Future<Branding?> getBranding(String gymId) async {
     if (throwError == true) throw Exception('fail');


### PR DESCRIPTION
## Summary
- avoid unnecessary Firebase initialization in branding provider tests by replacing inheritance with a simple interface implementation

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ff852f08c8320840af8c738179b2c