### PR TITLE
fix(branding): reduce error logging noise

### DIFF
--- a/lib/core/providers/branding_provider.dart
+++ b/lib/core/providers/branding_provider.dart
@@ -22,9 +22,9 @@ class BrandingProvider extends ChangeNotifier {
     notifyListeners();
     try {
       _branding = await _source.getBranding(gymId);
-    } catch (e, st) {
+    } catch (e) {
       _error = 'Fehler beim Laden: ${e.toString()}';
-      debugPrintStack(label: 'BrandingProvider.loadBranding', stackTrace: st);
+      debugPrint('BrandingProvider.loadBranding error: $e');
       _branding = null;
     } finally {
       _isLoading = false;


### PR DESCRIPTION
## Summary
- avoid emitting stack trace when branding load fails

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ffb58753483209c235e4ac9f80c4a