### PR TITLE
Add Firebase-mocked provider tests and coverage workflow

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -1,0 +1,34 @@
+name: Test and Coverage
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Run tests with coverage
+        run: flutter test --coverage
+      - name: Install lcov
+        run: sudo apt-get update && sudo apt-get install -y lcov bc
+      - name: Check coverage threshold
+        run: |
+          total=$(lcov --summary coverage/lcov.info | grep lines | awk '{print $2}' | sed 's/%//')
+          echo "Coverage: $total%"
+          if (( $(echo "$total < 30" | bc -l) )); then
+            echo "Coverage below 30%"
+            exit 1
+          fi
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/

--- a/lib/core/providers/branding_provider.dart
+++ b/lib/core/providers/branding_provider.dart
@@ -2,11 +2,23 @@ import 'package:flutter/foundation.dart';
 import 'package:tapem/features/gym/data/sources/firestore_gym_source.dart';
 import 'package:tapem/features/gym/domain/models/branding.dart';
 
+typedef LogFn = void Function(String message, [StackTrace? stack]);
+
+void _defaultLog(String message, [StackTrace? stack]) {
+  if (stack != null) {
+    debugPrintStack(label: message, stackTrace: stack);
+  } else {
+    debugPrint(message);
+  }
+}
+
 class BrandingProvider extends ChangeNotifier {
   final FirestoreGymSource _source;
+  final LogFn _log;
 
-  BrandingProvider({FirestoreGymSource? source})
-    : _source = source ?? FirestoreGymSource();
+  BrandingProvider({FirestoreGymSource? source, LogFn? log})
+    : _source = source ?? FirestoreGymSource(),
+      _log = log ?? _defaultLog;
 
   Branding? _branding;
   bool _isLoading = false;
@@ -22,9 +34,9 @@ class BrandingProvider extends ChangeNotifier {
     notifyListeners();
     try {
       _branding = await _source.getBranding(gymId);
-    } catch (e) {
+    } catch (e, st) {
       _error = 'Fehler beim Laden: ${e.toString()}';
-      debugPrint('BrandingProvider.loadBranding error: $e');
+      _log('BrandingProvider.loadBranding error: $e', st);
       _branding = null;
     } finally {
       _isLoading = false;

--- a/lib/features/feedback/feedback_provider.dart
+++ b/lib/features/feedback/feedback_provider.dart
@@ -1,12 +1,25 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
 
+typedef LogFn = void Function(String message, [StackTrace? stack]);
+
+void _defaultLog(String message, [StackTrace? stack]) {
+  if (stack != null) {
+    debugPrintStack(label: message, stackTrace: stack);
+  } else {
+    debugPrint(message);
+  }
+}
+
 import 'models/feedback_entry.dart';
 
 class FeedbackProvider extends ChangeNotifier {
   final FirebaseFirestore _firestore;
-  FeedbackProvider({FirebaseFirestore? firestore})
-    : _firestore = firestore ?? FirebaseFirestore.instance;
+  final LogFn _log;
+
+  FeedbackProvider({FirebaseFirestore? firestore, LogFn? log})
+    : _firestore = firestore ?? FirebaseFirestore.instance,
+      _log = log ?? _defaultLog;
 
   bool _loading = false;
   String? _error;
@@ -39,7 +52,7 @@ class FeedbackProvider extends ChangeNotifier {
           snap.docs.map((d) => FeedbackEntry.fromMap(d.id, d.data(), gymId)),
         );
     } catch (e, st) {
-      debugPrintStack(label: 'FeedbackProvider.loadFeedback', stackTrace: st);
+      _log('FeedbackProvider.loadFeedback error: $e', st);
       _error = e.toString();
     } finally {
       _loading = false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,6 +80,7 @@ dev_dependencies:
   json_serializable: ^6.7.0
   flutter_launcher_icons: ^0.14.3
   fake_cloud_firestore: ^3.1.0
+  firebase_core_mocks: ^1.3.0
 
 # Dependency overrides to ensure both packages use the git source
 dependency_overrides:

--- a/test/firebase_test_utils.dart
+++ b/test/firebase_test_utils.dart
@@ -1,0 +1,7 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_core_mocks/firebase_core_mocks.dart';
+
+Future<void> setupFirebaseMocks() async {
+  setupFirebaseCoreMocks();
+  await Firebase.initializeApp();
+}

--- a/test/providers/branding_provider_test.dart
+++ b/test/providers/branding_provider_test.dart
@@ -3,6 +3,7 @@ import 'package:tapem/core/providers/branding_provider.dart';
 import 'package:tapem/features/gym/data/sources/firestore_gym_source.dart';
 import 'package:tapem/features/gym/domain/models/branding.dart';
 import 'package:tapem/features/gym/domain/models/gym_config.dart';
+import '../firebase_test_utils.dart';
 
 class FakeGymSource implements FirestoreGymSource {
   FakeGymSource({this.branding, this.throwError});
@@ -25,10 +26,17 @@ class FakeGymSource implements FirestoreGymSource {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  setUpAll(() async {
+    await setupFirebaseMocks();
+  });
+
   group('BrandingProvider', () {
     test('loads branding successfully', () async {
       final source = FakeGymSource(branding: Branding(logoUrl: 'x'));
-      final provider = BrandingProvider(source: source);
+      final provider = BrandingProvider(
+        source: source,
+        log: (_, [__]) {},
+      );
       await provider.loadBranding('g1');
       expect(provider.branding?.logoUrl, 'x');
       expect(provider.error, isNull);
@@ -36,14 +44,20 @@ void main() {
 
     test('handles missing document', () async {
       final source = FakeGymSource(branding: null);
-      final provider = BrandingProvider(source: source);
+      final provider = BrandingProvider(
+        source: source,
+        log: (_, [__]) {},
+      );
       await provider.loadBranding('g1');
       expect(provider.branding, isNull);
     });
 
     test('handles exceptions', () async {
       final source = FakeGymSource(throwError: true);
-      final provider = BrandingProvider(source: source);
+      final provider = BrandingProvider(
+        source: source,
+        log: (_, [__]) {},
+      );
       await provider.loadBranding('g1');
       expect(provider.branding, isNull);
       expect(provider.error, isNotNull);

--- a/test/providers/device_provider_test.dart
+++ b/test/providers/device_provider_test.dart
@@ -14,6 +14,7 @@ import 'package:tapem/features/challenges/domain/models/challenge.dart';
 import 'package:tapem/features/challenges/domain/models/badge.dart';
 import 'package:tapem/features/challenges/domain/models/completed_challenge.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../firebase_test_utils.dart';
 
 class FakeDeviceRepository implements DeviceRepository {
   FakeDeviceRepository(this.devices);
@@ -78,6 +79,10 @@ class FakeChallengeRepository implements ChallengeRepository {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  setUpAll(() async {
+    await setupFirebaseMocks();
+  });
+
   group('DeviceProvider', () {
     test('loadDevice sets device and last session', () async {
       final firestore = FakeFirebaseFirestore();
@@ -127,6 +132,7 @@ void main() {
       final provider = DeviceProvider(
         getDevicesForGym: GetDevicesForGym(FakeDeviceRepository([device])),
         firestore: firestore,
+        log: (_, [__]) {},
       );
 
       await provider.loadDevice(
@@ -153,6 +159,7 @@ void main() {
       final provider = DeviceProvider(
         getDevicesForGym: GetDevicesForGym(FakeDeviceRepository([device])),
         firestore: firestore,
+        log: (_, [__]) {},
       );
       await provider.loadDevice(
         gymId: 'g1',

--- a/test/providers/feedback_provider_test.dart
+++ b/test/providers/feedback_provider_test.dart
@@ -2,14 +2,22 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:tapem/features/feedback/feedback_provider.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../firebase_test_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  setUpAll(() async {
+    await setupFirebaseMocks();
+  });
+
   group('FeedbackProvider', () {
     test('submitFeedback creates document', () async {
       final firestore = FakeFirebaseFirestore();
-      final provider = FeedbackProvider(firestore: firestore);
+      final provider = FeedbackProvider(
+        firestore: firestore,
+        log: (_, [__]) {},
+      );
       await provider.submitFeedback(
         gymId: 'g1',
         deviceId: 'd1',
@@ -37,7 +45,10 @@ void main() {
             'createdAt': Timestamp.now(),
             'isDone': false,
           });
-      final provider = FeedbackProvider(firestore: firestore);
+      final provider = FeedbackProvider(
+        firestore: firestore,
+        log: (_, [__]) {},
+      );
       await provider.loadFeedback('g1');
       expect(provider.entries.length, 1);
     });
@@ -55,7 +66,10 @@ void main() {
             'createdAt': Timestamp.now(),
             'isDone': false,
           });
-      final provider = FeedbackProvider(firestore: firestore);
+      final provider = FeedbackProvider(
+        firestore: firestore,
+        log: (_, [__]) {},
+      );
       await provider.loadFeedback('g1');
       await provider.markDone(gymId: 'g1', entryId: doc.id);
       final updated = await doc.get();

--- a/test/providers/survey_provider_test.dart
+++ b/test/providers/survey_provider_test.dart
@@ -2,9 +2,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:tapem/features/survey/survey_provider.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../firebase_test_utils.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await setupFirebaseMocks();
+  });
 
   group('SurveyProvider', () {
     test('createSurvey adds document', () async {

--- a/test/widgets/report_screen_test.dart
+++ b/test/widgets/report_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:tapem/features/report/domain/usecases/get_device_usage_stats.dar
 import 'package:tapem/features/report/domain/usecases/get_all_log_timestamps.dart';
 import 'package:tapem/features/report/domain/repositories/report_repository.dart';
 import 'package:tapem/features/report/presentation/widgets/device_usage_chart.dart';
+import '../firebase_test_utils.dart';
 
 class FakeReportRepository implements ReportRepository {
   FakeReportRepository({this.usage = const {}, this.times = const []});
@@ -22,6 +23,10 @@ class FakeReportRepository implements ReportRepository {
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await setupFirebaseMocks();
+  });
 
   testWidgets('ReportScreenNew shows chart with fallback data', (tester) async {
     final repo = FakeReportRepository();


### PR DESCRIPTION
## Summary
- refactor providers to allow logger injection, enabling silenced tests
- add shared Firebase mock setup and extend provider tests
- introduce coverage-enforcing GitHub Actions workflow

## Testing
- `flutter pub get` *(fails: command not found)*
- `git clone https://github.com/flutter/flutter.git /workspace/flutter` *(fails: CONNECT tunnel failed)*


------
https://chatgpt.com/codex/tasks/task_e_688ffe1f08008320b8f5db50f68682db