### PR TITLE
refactor(providers): inject firestore and simplify firebase setup

### DIFF
--- a/lib/features/device/data/sources/firestore_device_source.dart
+++ b/lib/features/device/data/sources/firestore_device_source.dart
@@ -5,7 +5,10 @@ import '../../domain/models/device.dart';
 import '../dtos/device_dto.dart';
 
 class FirestoreDeviceSource {
-  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final FirebaseFirestore _firestore;
+
+  FirestoreDeviceSource({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
 
   Future<List<DeviceDto>> getDevicesForGym(String gymId) async {
     final snap =

--- a/lib/features/device/data/sources/firestore_exercise_source.dart
+++ b/lib/features/device/data/sources/firestore_exercise_source.dart
@@ -3,7 +3,10 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../domain/models/exercise.dart';
 
 class FirestoreExerciseSource {
-  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final FirebaseFirestore _firestore;
+
+  FirestoreExerciseSource({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
 
   CollectionReference _col(String gymId, String deviceId) => _firestore
       .collection('gyms')

--- a/lib/features/gym/data/sources/firestore_gym_source.dart
+++ b/lib/features/gym/data/sources/firestore_gym_source.dart
@@ -4,7 +4,10 @@ import '../../domain/models/gym_config.dart';
 import '../../domain/models/branding.dart';
 
 class FirestoreGymSource {
-  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final FirebaseFirestore _firestore;
+
+  FirestoreGymSource({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
 
   /// Sucht in 'gyms' nach dem Dokument mit Feld 'code' == [code].
   Future<GymConfig?> getGymByCode(String code) async {

--- a/lib/features/survey/survey_provider.dart
+++ b/lib/features/survey/survey_provider.dart
@@ -3,16 +3,33 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
 import 'survey.dart';
 
+typedef LogFn = void Function(String message, [StackTrace? stack]);
+
+void _defaultLog(String message, [StackTrace? stack]) {
+  if (stack != null) {
+    debugPrintStack(label: message, stackTrace: stack);
+  } else {
+    debugPrint(message);
+  }
+}
+
 class SurveyProvider extends ChangeNotifier {
   final FirebaseFirestore _firestore;
+  final LogFn _log;
   StreamSubscription<List<Survey>>? _openSub;
   StreamSubscription<List<Survey>>? _closedSub;
 
   List<Survey> openSurveys = [];
   List<Survey> closedSurveys = [];
+  String? _error;
+  bool _isLoading = false;
 
-  SurveyProvider({FirebaseFirestore? firestore})
-    : _firestore = firestore ?? FirebaseFirestore.instance;
+  String? get error => _error;
+  bool get isLoading => _isLoading;
+
+  SurveyProvider({FirebaseFirestore? firestore, LogFn? log})
+      : _firestore = firestore ?? FirebaseFirestore.instance,
+        _log = log ?? _defaultLog;
 
   void listen(String gymId) {
     _openSub?.cancel();
@@ -61,29 +78,41 @@ class SurveyProvider extends ChangeNotifier {
     required String title,
     required List<String> options,
   }) async {
-    final doc = {
-      'title': title,
-      'options': options,
-      'status': 'open',
-      'createdAt': FieldValue.serverTimestamp(),
-    };
-    await _firestore
-        .collection('gyms')
-        .doc(gymId)
-        .collection('surveys')
-        .add(doc);
+    _error = null;
+    try {
+      final doc = {
+        'title': title,
+        'options': options,
+        'status': 'open',
+        'createdAt': FieldValue.serverTimestamp(),
+      };
+      await _firestore
+          .collection('gyms')
+          .doc(gymId)
+          .collection('surveys')
+          .add(doc);
+    } catch (e, st) {
+      _log('SurveyProvider.createSurvey error: $e', st);
+      _error = e.toString();
+    }
   }
 
   Future<void> closeSurvey({
     required String gymId,
     required String surveyId,
   }) async {
-    await _firestore
-        .collection('gyms')
-        .doc(gymId)
-        .collection('surveys')
-        .doc(surveyId)
-        .update({'status': 'abgeschlossen'});
+    _error = null;
+    try {
+      await _firestore
+          .collection('gyms')
+          .doc(gymId)
+          .collection('surveys')
+          .doc(surveyId)
+          .update({'status': 'abgeschlossen'});
+    } catch (e, st) {
+      _log('SurveyProvider.closeSurvey error: $e', st);
+      _error = e.toString();
+    }
   }
 
   Future<void> submitAnswer({
@@ -92,18 +121,24 @@ class SurveyProvider extends ChangeNotifier {
     required String userId,
     required String selectedOption,
   }) async {
-    await _firestore
-        .collection('gyms')
-        .doc(gymId)
-        .collection('surveys')
-        .doc(surveyId)
-        .collection('answers')
-        .add({
-          'surveyId': surveyId,
-          'userId': userId,
-          'selectedOption': selectedOption,
-          'timestamp': DateTime.now(),
-        });
+    _error = null;
+    try {
+      await _firestore
+          .collection('gyms')
+          .doc(gymId)
+          .collection('surveys')
+          .doc(surveyId)
+          .collection('answers')
+          .add({
+            'surveyId': surveyId,
+            'userId': userId,
+            'selectedOption': selectedOption,
+            'timestamp': DateTime.now(),
+          });
+    } catch (e, st) {
+      _log('SurveyProvider.submitAnswer error: $e', st);
+      _error = e.toString();
+    }
   }
 
   Future<Map<String, int>> getResults({
@@ -111,23 +146,29 @@ class SurveyProvider extends ChangeNotifier {
     required String surveyId,
     required List<String> options,
   }) async {
-    final snap =
-        await _firestore
-            .collection('gyms')
-            .doc(gymId)
-            .collection('surveys')
-            .doc(surveyId)
-            .collection('answers')
-            .get();
-    final Map<String, int> counts = {for (final o in options) o: 0};
-    for (final doc in snap.docs) {
-      final data = doc.data();
-      final opt = data['selectedOption'] as String?;
-      if (opt != null && counts.containsKey(opt)) {
-        counts[opt] = counts[opt]! + 1;
+    _error = null;
+    try {
+      final snap = await _firestore
+          .collection('gyms')
+          .doc(gymId)
+          .collection('surveys')
+          .doc(surveyId)
+          .collection('answers')
+          .get();
+      final Map<String, int> counts = {for (final o in options) o: 0};
+      for (final doc in snap.docs) {
+        final data = doc.data();
+        final opt = data['selectedOption'] as String?;
+        if (opt != null && counts.containsKey(opt)) {
+          counts[opt] = counts[opt]! + 1;
+        }
       }
+      return counts;
+    } catch (e, st) {
+      _log('SurveyProvider.getResults error: $e', st);
+      _error = e.toString();
+      return {};
     }
-    return counts;
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,7 +80,6 @@ dev_dependencies:
   json_serializable: ^6.7.0
   flutter_launcher_icons: ^0.14.3
   fake_cloud_firestore: ^3.1.0
-  firebase_core_mocks: ^1.3.0
 
 # Dependency overrides to ensure both packages use the git source
 dependency_overrides:

--- a/test/firebase_test_utils.dart
+++ b/test/firebase_test_utils.dart
@@ -1,7 +1,14 @@
 import 'package:firebase_core/firebase_core.dart';
-import 'package:firebase_core_mocks/firebase_core_mocks.dart';
 
-Future<void> setupFirebaseMocks() async {
-  setupFirebaseCoreMocks();
-  await Firebase.initializeApp();
+Future<void> setupFirebase() async {
+  if (Firebase.apps.isEmpty) {
+    await Firebase.initializeApp(
+      options: const FirebaseOptions(
+        apiKey: 'test',
+        appId: 'test',
+        messagingSenderId: 'test',
+        projectId: 'test',
+      ),
+    );
+  }
 }

--- a/test/providers/branding_provider_test.dart
+++ b/test/providers/branding_provider_test.dart
@@ -27,7 +27,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() async {
-    await setupFirebaseMocks();
+    await setupFirebase();
   });
 
   group('BrandingProvider', () {

--- a/test/providers/device_provider_test.dart
+++ b/test/providers/device_provider_test.dart
@@ -80,7 +80,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() async {
-    await setupFirebaseMocks();
+    await setupFirebase();
   });
 
   group('DeviceProvider', () {

--- a/test/providers/feedback_provider_test.dart
+++ b/test/providers/feedback_provider_test.dart
@@ -8,7 +8,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() async {
-    await setupFirebaseMocks();
+    await setupFirebase();
   });
 
   group('FeedbackProvider', () {

--- a/test/providers/survey_provider_test.dart
+++ b/test/providers/survey_provider_test.dart
@@ -8,13 +8,16 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() async {
-    await setupFirebaseMocks();
+    await setupFirebase();
   });
 
   group('SurveyProvider', () {
     test('createSurvey adds document', () async {
       final firestore = FakeFirebaseFirestore();
-      final provider = SurveyProvider(firestore: firestore);
+      final provider = SurveyProvider(
+        firestore: firestore,
+        log: (_, [__]) {},
+      );
       await provider.createSurvey(
         gymId: 'g1',
         title: 'Test',
@@ -30,7 +33,10 @@ void main() {
 
     test('submitAnswer stores response', () async {
       final firestore = FakeFirebaseFirestore();
-      final provider = SurveyProvider(firestore: firestore);
+      final provider = SurveyProvider(
+        firestore: firestore,
+        log: (_, [__]) {},
+      );
       final surveyRef = await firestore
           .collection('gyms')
           .doc('g1')
@@ -53,7 +59,10 @@ void main() {
 
     test('getResults counts votes', () async {
       final firestore = FakeFirebaseFirestore();
-      final provider = SurveyProvider(firestore: firestore);
+      final provider = SurveyProvider(
+        firestore: firestore,
+        log: (_, [__]) {},
+      );
       final surveyRef = await firestore
           .collection('gyms')
           .doc('g1')

--- a/test/widgets/report_screen_test.dart
+++ b/test/widgets/report_screen_test.dart
@@ -25,7 +25,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() async {
-    await setupFirebaseMocks();
+    await setupFirebase();
   });
 
   testWidgets('ReportScreenNew shows chart with fallback data', (tester) async {
@@ -34,7 +34,10 @@ void main() {
       getUsageStats: GetDeviceUsageStats(repo),
       getLogTimestamps: GetAllLogTimestamps(repo),
     );
-    final feedbackProvider = FeedbackProvider(firestore: FakeFirebaseFirestore());
+    final feedbackProvider = FeedbackProvider(
+      firestore: FakeFirebaseFirestore(),
+      log: (_, [__]) {},
+    );
 
     await tester.pumpWidget(
       MultiProvider(


### PR DESCRIPTION
## Summary
- remove firebase_core_mocks and configure fake_cloud_firestore for tests
- inject FirebaseFirestore into providers and sources with improved error handling
- update tests to use fake Cloud Firestore and initialize Firebase with dummy options

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test --coverage` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689001dd554483209a985465195c2a31