### PR TITLE
Increase provider and usecase test coverage

### DIFF
--- a/test/providers/challenge_provider_additional_test.dart
+++ b/test/providers/challenge_provider_additional_test.dart
@@ -1,0 +1,101 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/core/providers/challenge_provider.dart';
+import 'package:tapem/features/challenges/domain/models/challenge.dart';
+import 'package:tapem/features/challenges/domain/models/completed_challenge.dart';
+import 'package:tapem/features/challenges/domain/models/badge.dart';
+import 'package:tapem/features/challenges/domain/repositories/challenge_repository.dart';
+
+class FakeChallengeRepository implements ChallengeRepository {
+  final activeCtrl = StreamController<List<Challenge>>.broadcast();
+  final completedCtrl = StreamController<List<CompletedChallenge>>.broadcast();
+  final badgeCtrl = StreamController<List<Badge>>.broadcast();
+  int checkCalls = 0;
+
+  @override
+  Stream<List<Challenge>> watchActiveChallenges(String gymId) =>
+      activeCtrl.stream;
+
+  @override
+  Stream<List<CompletedChallenge>> watchCompletedChallenges(
+    String gymId,
+    String userId,
+  ) =>
+      completedCtrl.stream;
+
+  @override
+  Stream<List<Badge>> watchBadges(String userId) => badgeCtrl.stream;
+
+  @override
+  Future<void> checkChallenges(String gymId, String userId, String deviceId) async {
+    checkCalls++;
+  }
+
+  void dispose() {
+    activeCtrl.close();
+    completedCtrl.close();
+    badgeCtrl.close();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ChallengeProvider', () {
+    test('watchChallenges filters completed', () async {
+      final repo = FakeChallengeRepository();
+      final provider = ChallengeProvider(repo: repo);
+      provider.watchChallenges('g1', 'u1');
+      repo.activeCtrl.add([
+        Challenge(
+          id: 'c1',
+          title: 'A',
+          start: DateTime(2024),
+          end: DateTime(2024),
+          deviceIds: const [],
+        ),
+        Challenge(
+          id: 'c2',
+          title: 'B',
+          start: DateTime(2024),
+          end: DateTime(2024),
+          deviceIds: const [],
+        ),
+      ]);
+      repo.completedCtrl.add([
+        CompletedChallenge(id: 'c1', title: 'A', completedAt: DateTime(2024))
+      ]);
+      await Future.delayed(const Duration(milliseconds: 10));
+      expect(provider.challenges.map((c) => c.id), ['c2']);
+      provider.dispose();
+      repo.dispose();
+    });
+
+    test('watchBadges updates list', () async {
+      final repo = FakeChallengeRepository();
+      final provider = ChallengeProvider(repo: repo);
+      provider.watchBadges('u1');
+      repo.badgeCtrl.add([
+        Badge(
+          id: 'b1',
+          challengeId: 'c1',
+          userId: 'u1',
+          awardedAt: DateTime(2024),
+        ),
+      ]);
+      await Future.delayed(const Duration(milliseconds: 10));
+      expect(provider.badges.length, 1);
+      provider.dispose();
+      repo.dispose();
+    });
+
+    test('checkChallenges delegates to repository', () async {
+      final repo = FakeChallengeRepository();
+      final provider = ChallengeProvider(repo: repo);
+      await provider.checkChallenges('g1', 'u1', 'd1');
+      expect(repo.checkCalls, 1);
+      repo.dispose();
+    });
+  });
+}

--- a/test/providers/rank_provider_test.dart
+++ b/test/providers/rank_provider_test.dart
@@ -1,0 +1,53 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/core/providers/rank_provider.dart';
+import 'package:tapem/features/rank/domain/rank_repository.dart';
+
+class FakeRankRepository implements RankRepository {
+  final deviceCtrl = StreamController<List<Map<String, dynamic>>>.broadcast();
+  int addCalls = 0;
+
+  @override
+  Stream<List<Map<String, dynamic>>> watchLeaderboard(
+    String gymId,
+    String deviceId,
+  ) =>
+      deviceCtrl.stream;
+
+  @override
+  Future<void> addXp(String gymId, String userId, String deviceId,
+      String sessionId, bool showInLeaderboard) async {
+    addCalls++;
+  }
+
+  void dispose() {
+    deviceCtrl.close();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('RankProvider', () {
+    test('watchDevice updates entries', () async {
+      final repo = FakeRankRepository();
+      final provider = RankProvider(repository: repo);
+      provider.watchDevice('g1', 'd1');
+      repo.deviceCtrl.add([
+        {'userId': 'u1', 'xp': 10}
+      ]);
+      await Future.delayed(const Duration(milliseconds: 10));
+      expect(provider.deviceEntries.length, 1);
+      repo.dispose();
+    });
+
+    test('addXp delegates to repository', () async {
+      final repo = FakeRankRepository();
+      final provider = RankProvider(repository: repo);
+      await provider.addXp('g1', 'u1', 'd1', 's1', true);
+      expect(repo.addCalls, 1);
+      repo.dispose();
+    });
+  });
+}

--- a/test/providers/xp_provider_test.dart
+++ b/test/providers/xp_provider_test.dart
@@ -1,0 +1,121 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/core/providers/xp_provider.dart';
+import 'package:tapem/features/xp/domain/xp_repository.dart';
+
+class FakeXpRepository implements XpRepository {
+  final dayCtrl = StreamController<int>.broadcast();
+  final muscleCtrl = StreamController<Map<String, int>>.broadcast();
+  final deviceCtrls = <String, StreamController<int>>{};
+  int addCalls = 0;
+
+  @override
+  Future<void> addSessionXp({
+    required String gymId,
+    required String userId,
+    required String deviceId,
+    required String sessionId,
+    required bool showInLeaderboard,
+    required bool isMulti,
+    required List<String> primaryMuscleGroupIds,
+  }) async {
+    addCalls++;
+  }
+
+  @override
+  Stream<int> watchDayXp({required String userId, required DateTime date}) =>
+      dayCtrl.stream;
+
+  @override
+  Stream<Map<String, int>> watchMuscleXp({
+    required String gymId,
+    required String userId,
+  }) =>
+      muscleCtrl.stream;
+
+  @override
+  Stream<Map<String, int>> watchTrainingDaysXp(String userId) =>
+      const Stream.empty();
+
+  @override
+  Stream<int> watchDeviceXp({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+  }) =>
+      deviceCtrls
+          .putIfAbsent(deviceId, () => StreamController<int>.broadcast())
+          .stream;
+
+  @override
+  Stream<int> watchStatsDailyXp({
+    required String gymId,
+    required String userId,
+  }) =>
+      const Stream.empty();
+
+  void dispose() {
+    dayCtrl.close();
+    muscleCtrl.close();
+    for (final c in deviceCtrls.values) {
+      c.close();
+    }
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('XpProvider', () {
+    test('addSessionXp delegates to repository', () async {
+      final repo = FakeXpRepository();
+      final provider = XpProvider(repo: repo);
+      await provider.addSessionXp(
+        gymId: 'g1',
+        userId: 'u1',
+        deviceId: 'd1',
+        sessionId: 's1',
+        showInLeaderboard: false,
+        isMulti: false,
+        primaryMuscleGroupIds: const [],
+      );
+      expect(repo.addCalls, 1);
+      repo.dispose();
+    });
+
+    test('watchDayXp updates dayXp', () async {
+      final repo = FakeXpRepository();
+      final provider = XpProvider(repo: repo);
+      provider.watchDayXp('u1', DateTime(2024, 1, 1));
+      repo.dayCtrl.add(15);
+      await Future.delayed(const Duration(milliseconds: 10));
+      expect(provider.dayXp, 15);
+      provider.dispose();
+      repo.dispose();
+    });
+
+    test('watchMuscleXp updates muscleXp', () async {
+      final repo = FakeXpRepository();
+      final provider = XpProvider(repo: repo);
+      provider.watchMuscleXp('g1', 'u1');
+      repo.muscleCtrl.add({'m1': 5});
+      await Future.delayed(const Duration(milliseconds: 10));
+      expect(provider.muscleXp, {'m1': 5});
+      provider.dispose();
+      repo.dispose();
+    });
+
+    test('watchDeviceXp tracks multiple devices', () async {
+      final repo = FakeXpRepository();
+      final provider = XpProvider(repo: repo);
+      provider.watchDeviceXp('g1', 'u1', ['d1', 'd2']);
+      repo.deviceCtrls['d1']!.add(7);
+      repo.deviceCtrls['d2']!.add(3);
+      await Future.delayed(const Duration(milliseconds: 10));
+      expect(provider.deviceXp, {'d1': 7, 'd2': 3});
+      provider.dispose();
+      repo.dispose();
+    });
+  });
+}

--- a/test/usecases/report_usecases_test.dart
+++ b/test/usecases/report_usecases_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/features/report/domain/usecases/get_device_usage_stats.dart';
+import 'package:tapem/features/report/domain/usecases/get_all_log_timestamps.dart';
+import 'package:tapem/features/report/domain/repositories/report_repository.dart';
+
+class FakeReportRepository implements ReportRepository {
+  int usageCalls = 0;
+  int timeCalls = 0;
+
+  @override
+  Future<Map<String, int>> fetchUsageCountPerMachine(String gymId) async {
+    usageCalls++;
+    return {'d1': 1};
+  }
+
+  @override
+  Future<List<DateTime>> fetchAllLogTimestamps(String gymId) async {
+    timeCalls++;
+    return [DateTime(2024)];
+  }
+}
+
+void main() {
+  group('Report usecases', () {
+    test('GetDeviceUsageStats delegates to repository', () async {
+      final repo = FakeReportRepository();
+      final usecase = GetDeviceUsageStats(repo);
+      final result = await usecase.execute('g1');
+      expect(result, {'d1': 1});
+      expect(repo.usageCalls, 1);
+    });
+
+    test('GetAllLogTimestamps delegates to repository', () async {
+      final repo = FakeReportRepository();
+      final usecase = GetAllLogTimestamps(repo);
+      final result = await usecase.execute('g1');
+      expect(result.length, 1);
+      expect(repo.timeCalls, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add tests for XpProvider stream updates and addSessionXp delegation
- cover RankProvider leaderboard watching and XP addition
- test ChallengeProvider active/completed filtering and badge watching
- ensure report usecases delegate to repository

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6890b502345883208a041c5011c97570