### PR TITLE
Security rules v1: harden Firestore and add Storage rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: flutter test --coverage
 
   rules_test:
-    name: Firestore Security Rules Tests
+    name: Firestore & Storage Rules Tests
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -81,12 +81,19 @@ jobs:
       - name: Install JS dependencies
         run: npm ci
 
-      - name: Run Firestore security-rules tests
+      - name: Run rules tests
         run: |
           firebase emulators:exec \
-            --only firestore \
+            --only firestore,storage \
             --project tap-em \
-            "npx mocha --timeout 120000 firestore-tests/security_rules.test.js"
+            "npm run rules-test" | tee rules-test.log
+
+      - name: Upload emulator logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rules-test-log
+          path: rules-test.log
 
   build:
     name: Build Debug APK

--- a/docs/security_rules_v1.md
+++ b/docs/security_rules_v1.md
@@ -1,0 +1,36 @@
+# Security Rules v1
+
+## Trust boundary
+Client applications are untrusted. All critical checks are enforced via Firestore
+and Storage rules. Server-side processes (e.g. admin tooling) operate with
+privileged credentials.
+
+## Firestore
+- **Cross-gym isolation:** access to `/gyms/{gymId}/**` requires membership in
+  the targeted gym. Device reads no longer allow generic signed-in access.
+- **Membership lifecycle:** documents under `/gyms/{gymId}/users/{userId}` can
+  only be created, updated or deleted by gym admins. Members may read membership
+  data for their gym but cannot join or change roles themselves.
+- **Training plans:** read and write access requires membership in the gym and
+  either admin privileges or `createdBy == uid`.
+- **Feedback:** members may create feedback; only admins can read or modify
+  entries.
+- **Leaderboard:** writes require `userId` to match the path. TODO: move writes
+  to Cloud Functions.
+- **Gym documents:** considered public. Public fields are `name`, `code`, and
+  `logoUrl`.
+- Global fallback denies all other access.
+
+## Cloud Storage
+- Path structure: `feedback/{gymId}/{userId}/{file}`. Gym ID and owner UID are
+  encoded in the path to allow rule evaluation.
+- Authenticated access only. Reads and writes are restricted to the owner or an
+  admin of the corresponding gym.
+- Only images (`image/*`) up to 5 MB are accepted. Directory listing is
+  disabled.
+- Download tokens are not exposed; files are accessed only in authenticated
+  contexts.
+
+## Known TODOs
+- Leaderboard writes should move to server-side functions.
+- Project-wide App Check enforcement to be enabled separately.

--- a/firebase.json
+++ b/firebase.json
@@ -3,9 +3,15 @@
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
   },
+  "storage": {
+    "rules": "storage.rules"
+  },
   "emulators": {
     "firestore": {
       "port": 8080
+    },
+    "storage": {
+      "port": 9199
     },
     "ui": {
       "enabled": true

--- a/firestore.rules
+++ b/firestore.rules
@@ -32,7 +32,9 @@ service cloud.firestore {
       return inGym(gymId) && request.resource.data.userId == request.auth.uid;
     }
     function resourceOwnerOrAdmin(gymId) {
-      return (isSignedIn() && resource.data.userId == request.auth.uid) || isAdmin(gymId);
+      // v1 hardening: ensure read access requires gym membership (logs_owner_cross_gym)
+      return (inGym(gymId) && resource.data.userId == request.auth.uid) ||
+             isAdmin(gymId);
     }
 
 
@@ -79,24 +81,21 @@ service cloud.firestore {
     // ----- Gyms -----
     match /gyms/{gymId} {
       // Gym documents are readable for everyone to validate gym codes.
-      // Write access remains restricted to admins.
-      // Allow unauthenticated users to verify gym codes during registration
+      // Public fields: name, code, logoUrl
+      // v1 hardening: document contains no sensitive fields (gym_document_public)
       allow read: if true;
       allow write: if isAdmin(gymId);
 
       // ---- Devices collection ----
       match /devices/{deviceId} {
-        // Allow any authenticated user to read device information so that
-        // training details can be displayed even before membership data exists.
-        allow read: if inGym(gymId) || isSignedIn();
+        // v1 hardening: block cross-gym reads (device_cross_gym)
+        allow read: if inGym(gymId);
         allow write: if isAdmin(gymId);
 
         // Logs are appended by the owning user only. They are immutable.
         match /logs/{logId} {
           allow create: if requestOwnerInGym(gymId);
-          // Allow users to read their own logs even if membership data
-          // is not yet available. This prevents permission errors when
-          // accessing training details shortly after registration.
+          // v1 hardening: owner must belong to gym (logs_owner_cross_gym)
           allow read: if resourceOwnerOrAdmin(gymId);
           allow update, delete: if false;
         }
@@ -108,13 +107,15 @@ service cloud.firestore {
 
         // Leaderboard entries are updated per user.
         match /leaderboard/{userId}/{doc=**} {
-          allow read, write: if ownerOrAdmin(gymId, userId);
+          // v1 hardening: enforce userId match; TODO server-side writes (leaderboard_owner_only)
+          allow read, write: if ownerOrAdmin(gymId, userId) &&
+                             request.resource.data.userId == userId;
         }
 
         // Custom exercises per user
         match /exercises/{exerciseId} {
           allow read: if isAdmin(gymId) ||
-                       (isSignedIn() &&
+                       (inGym(gymId) &&
                         (request.auth.uid == resource.data.userId || isPublicExercise()));
           allow write: if inGym(gymId) &&
                           (request.auth.uid == request.resource.data.userId ||
@@ -138,6 +139,7 @@ service cloud.firestore {
 
       // ---- Feedback ----
       match /feedback/{entryId} {
+        // v1 hardening: limit feedback reads to admins (feedback_access)
         allow create: if inGym(gymId) &&
           request.resource.data.userId == request.auth.uid;
         allow read, update, delete: if isAdmin(gymId);
@@ -145,10 +147,12 @@ service cloud.firestore {
 
       // ---- Training plans ----
       match /trainingPlans/{planId}/{subdoc=**} {
-        allow read, write:
-          if isAdmin(gymId) ||
-             request.auth.uid == request.resource.data.createdBy ||
-             request.auth.uid == resource.data.createdBy;
+        // v1 hardening: require gym membership and creator/admin (training_plan_scoping)
+        allow read, write: if inGym(gymId) && (
+          isAdmin(gymId) ||
+          request.auth.uid == request.resource.data.createdBy ||
+          request.auth.uid == resource.data.createdBy
+        );
       }
 
       // ---- Muscle groups ----
@@ -166,11 +170,9 @@ service cloud.firestore {
       // ---- Users subcollection ----
       // Users are referenced under their gym as well
       match /users/{userId} {
-        // Allow initial creation for the authenticated user even before
-        // membership exists. Further reads/writes require gym membership or
-        // admin role.
-        allow create: if isOwner(userId);
-        allow read, update, delete: if ownerOrAdmin(gymId, userId);
+        // v1 hardening: membership lifecycle admin-only (membership_admin_only)
+        allow read: if inGym(gymId);
+        allow create, update, delete: if isAdmin(gymId);
       }
       match /users/{userId}/{doc=**} {
         allow read, write: if ownerOrAdmin(gymId, userId);

--- a/lib/features/auth/data/sources/firestore_auth_source.dart
+++ b/lib/features/auth/data/sources/firestore_auth_source.dart
@@ -52,13 +52,8 @@ class FirestoreAuthSource {
     );
     await _firestore.collection('users').doc(uid).set(dto.toJson());
 
-    // Nutzer zusätzlich unterhalb des Gyms referenzieren
-    await _firestore
-        .collection('gyms')
-        .doc(gym.id)
-        .collection('users')
-        .doc(uid)
-        .set({'role': 'member', 'createdAt': Timestamp.fromDate(now)});
+    // v1 hardening: membership creation is admin-only (membership_admin_only)
+    // Admins must add the user to a gym via server-side process.
 
     return dto;
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "set-admin": "node scripts/setAdmin.js"
+    "set-admin": "node scripts/setAdmin.js",
+    "rules-test": "mocha --timeout 120000 firestore-tests/security_rules.test.js"
   },
   "repository": {
     "type": "git",

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,36 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+    function inGym(gymId) {
+      return isSignedIn() && (
+        request.auth.token.gymId == gymId ||
+        exists(/databases/(default)/documents/gyms/$(gymId)/users/$(request.auth.uid))
+      );
+    }
+    function isAdmin(gymId) {
+      return inGym(gymId) && (
+        request.auth.token.role == 'admin' ||
+        get(/databases/(default)/documents/gyms/$(gymId)/users/$(request.auth.uid)).data.role == 'admin'
+      );
+    }
+    function ownerOrAdmin(gymId, userId) {
+      return (request.auth.uid == userId && inGym(gymId)) || isAdmin(gymId);
+    }
+
+    match /feedback/{gymId}/{userId}/{fileId} {
+      // v1 hardening: feedback images owner/admin only (storage_feedback_owner)
+      allow read: if ownerOrAdmin(gymId, userId);
+      allow write: if ownerOrAdmin(gymId, userId) &&
+                   request.resource.contentType.matches('image/.*') &&
+                   request.resource.size < 5 * 1024 * 1024; // v1 hardening: image & size check (storage_feedback_mime)
+      allow list: if false;
+    }
+
+    match /{path=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Harden Firestore rules to block cross-gym device reads, enforce admin-only membership lifecycle, and scope training plans to gym and creator/admin.
- Introduce Cloud Storage rules for feedback images and wire rules tests into CI with log artifacts.
- Remove client-side membership self-join and document the security policy.

## Testing
- `dart format lib/features/auth/data/sources/firestore_auth_source.dart` *(command not found)*
- `npx firebase emulators:exec --only firestore,storage --project tap-em "npm run rules-test"` *(download failed: status 403)*

## Follow-up
- Enable App Check enforcement.
- Migrate leaderboard writes to Cloud Functions.


------
https://chatgpt.com/codex/tasks/task_e_6896d7e627048320bade96f681cffb06