### PR TITLE
Fix survey CTA placement, show device IDs, prevent multi-device picker repeats

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -36,7 +36,6 @@ class DeviceScreen extends StatefulWidget {
 
 class _DeviceScreenState extends State<DeviceScreen> {
   final _formKey = GlobalKey<FormState>();
-  bool _redirected = false;
 
   @override
   void initState() {
@@ -80,20 +79,6 @@ class _DeviceScreenState extends State<DeviceScreen> {
         appBar: AppBar(title: const Text('Gerät nicht gefunden')),
         body: Center(child: Text('Fehler: ${prov.error ?? "Unbekannt"}')),
       );
-    }
-
-    // **Nur** Multi + initialId==deviceId => ExerciseList
-    if (!_redirected &&
-        prov.device!.isMulti &&
-        widget.exerciseId == widget.deviceId) {
-      _redirected = true;
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        Navigator.of(context).pushReplacementNamed(
-          AppRouter.exerciseList,
-          arguments: {'gymId': widget.gymId, 'deviceId': widget.deviceId},
-        );
-      });
-      return const Scaffold();
     }
 
     // Single-Übung: hier bleiben

--- a/lib/features/gym/presentation/screens/gym_screen.dart
+++ b/lib/features/gym/presentation/screens/gym_screen.dart
@@ -211,14 +211,24 @@ class _GymScreenState extends State<GymScreen> {
                             return DeviceCard(
                               device: d,
                               onTap: () {
-                                final args = {
-                                  'gymId': gymId,
-                                  'deviceId': d.uid,
-                                  'exerciseId': d.uid,
-                                };
-                                Navigator.of(
-                                  context,
-                                ).pushNamed(AppRouter.device, arguments: args);
+                                if (d.isMulti) {
+                                  Navigator.of(context).pushNamed(
+                                    AppRouter.exerciseList,
+                                    arguments: {
+                                      'gymId': gymId,
+                                      'deviceId': d.uid,
+                                    },
+                                  );
+                                } else {
+                                  Navigator.of(context).pushNamed(
+                                    AppRouter.device,
+                                    arguments: {
+                                      'gymId': gymId,
+                                      'deviceId': d.uid,
+                                      'exerciseId': d.uid,
+                                    },
+                                  );
+                                }
                               },
                             );
                           },

--- a/lib/features/gym/presentation/widgets/device_card.dart
+++ b/lib/features/gym/presentation/widgets/device_card.dart
@@ -27,6 +27,7 @@ class _DeviceCardState extends State<DeviceCard> {
     final device = widget.device;
     final initial = device.name.isNotEmpty ? device.name[0].toUpperCase() : '?';
     final subtitle = device.description;
+    final idText = device.id > 0 ? device.id.toString() : '–';
     return Hero(
       tag: 'device-${device.uid}',
       child: AnimatedScale(
@@ -75,6 +76,13 @@ class _DeviceCardState extends State<DeviceCard> {
                       overflow: TextOverflow.ellipsis,
                       style: theme.textTheme.bodyMedium,
                     ),
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    'ID: $idText',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodySmall,
+                  ),
                 ],
               ),
             ),

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -187,25 +187,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
                       ),
                     ),
                     const SizedBox(height: 8),
-                    ElevatedButton(
-                      onPressed: () {
-                        final gymId = context.read<GymProvider>().currentGymId;
-                        final userId =
-                            context.read<AuthProvider>().userId ?? '';
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder:
-                                (_) => SurveyVoteScreen(
-                                  gymId: gymId,
-                                  userId: userId,
-                                ),
-                          ),
-                        );
-                      },
-                      child: const Text('Umfragen'),
-                    ),
-                    const SizedBox(height: 8),
                     Expanded(
                       child: GestureDetector(
                         behavior: HitTestBehavior.opaque,
@@ -218,8 +199,32 @@ class _ProfileScreenState extends State<ProfileScreen> {
                       ),
                     ),
                   ],
-                ),
               ),
+            ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.sm),
+          child: SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: () {
+                final gymId = context.read<GymProvider>().currentGymId;
+                final userId = context.read<AuthProvider>().userId ?? '';
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => SurveyVoteScreen(
+                      gymId: gymId,
+                      userId: userId,
+                    ),
+                  ),
+                );
+              },
+              child: const Text('Umfragen'),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- Anchor profile "Umfragen" CTA at the bottom within a SafeArea
- Display the numeric `id` on each device card
- Open exercise picker directly for multi devices and remove duplicate picker trigger

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6897e154c8e08320bf2e2270efdac704