### PR TITLE
feat(device): add session sets table under feature flag

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -1,0 +1,14 @@
+# Session Sets Table
+
+This page documents the experimental table-based input on the device page.
+
+- **Feature flag**: `ui_sets_table_v1`
+- **Enable locally**: set the flag in `lib/core/feature_flags.dart`.
+
+## QA checklist
+
+- Header displays `SET | PREVIOUS | KGS | REPS | ✓`.
+- `Add Set +` inserts a new row.
+- Previous values show the last session or `—` when none.
+
+Known limitations: controller and advanced interactions are simplified and will be expanded later.

--- a/lib/core/feature_flags.dart
+++ b/lib/core/feature_flags.dart
@@ -1,0 +1,10 @@
+/// Feature flag toggles for the app.
+///
+/// To enable the new session sets table locally, set [uiSetsTableV1] to true.
+/// In production this value should be provided by a remote config service.
+class FeatureFlags {
+  FeatureFlags._();
+
+  /// Flag for new session sets table on the device page.
+  static const bool uiSetsTableV1 = false; // Toggle for testing.
+}

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -17,6 +17,8 @@ import '../widgets/note_button_widget.dart';
 import 'package:tapem/features/rank/presentation/device_level_style.dart';
 import 'package:tapem/features/rank/presentation/widgets/xp_info_button.dart';
 import 'package:tapem/features/feedback/presentation/widgets/feedback_button.dart';
+import 'package:tapem/core/feature_flags.dart';
+import '../widgets/session_sets_table.dart';
 
 class DeviceScreen extends StatefulWidget {
   final String gymId;
@@ -220,25 +222,34 @@ class _DeviceScreenState extends State<DeviceScreen> {
                                 ),
                               ),
                               const SizedBox(height: 8),
-                              for (var entry in prov.sets.asMap().entries)
-                                Padding(
-                                  padding: const EdgeInsets.symmetric(
-                                    vertical: 4,
-                                  ),
-                                  child: _SessionSetRow(
-                                    index: entry.key,
-                                    set: entry.value,
-                                  ),
+                              if (FeatureFlags.uiSetsTableV1) ...[
+                                SizedBox(
+                                  height: 300,
+                                  child: SessionSetsTable(),
                                 ),
-                              TextButton.icon(
-                                onPressed: () {
-                                  prov.addSet();
-                                },
-                                icon: const Icon(Icons.add),
-                                label: const Text('Set hinzufügen'),
-                              ),
-                              const Divider(),
-                              const RestTimerWidget(),
+                                const Divider(),
+                                const RestTimerWidget(),
+                              ] else ...[
+                                for (var entry in prov.sets.asMap().entries)
+                                  Padding(
+                                    padding: const EdgeInsets.symmetric(
+                                      vertical: 4,
+                                    ),
+                                    child: _SessionSetRow(
+                                      index: entry.key,
+                                      set: entry.value,
+                                    ),
+                                  ),
+                                TextButton.icon(
+                                  onPressed: () {
+                                    prov.addSet();
+                                  },
+                                  icon: const Icon(Icons.add),
+                                  label: const Text('Set hinzufügen'),
+                                ),
+                                const Divider(),
+                                const RestTimerWidget(),
+                              ],
                             ],
                           ),
                         ),

--- a/lib/features/device/presentation/widgets/session_sets_table.dart
+++ b/lib/features/device/presentation/widgets/session_sets_table.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../../../core/feature_flags.dart';
+import '../../../../core/providers/device_provider.dart';
+
+/// Table style component for session set input on the device page.
+class SessionSetsTable extends StatelessWidget {
+  const SessionSetsTable({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final prov = context.watch<DeviceProvider>();
+    final previous = prov.lastSessionSets;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _SessionSetsHeader(),
+        const SizedBox(height: 8),
+        Expanded(
+          child: ListView.builder(
+            itemCount: prov.sets.length,
+            itemBuilder: (context, index) {
+              final set = prov.sets[index];
+              final prev = index < previous.length
+                  ? "${previous[index]['weight']} x ${previous[index]['reps']}"
+                  : '—';
+              return _SessionSetRow(
+                index: index,
+                set: set,
+                previous: prev,
+              );
+            },
+          ),
+        ),
+        TextButton(
+          onPressed: prov.addSet,
+          child: const Text('Add Set +'),
+        ),
+      ],
+    );
+  }
+}
+
+class _SessionSetsHeader extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      color: Theme.of(context).colorScheme.surfaceVariant,
+      child: const Row(
+        children: [
+          Expanded(child: Text('SET')),
+          Expanded(child: Text('PREVIOUS')),
+          Expanded(child: Text('KGS')),
+          Expanded(child: Text('REPS')),
+          SizedBox(width: 40, child: Text('✓')),
+        ],
+      ),
+    );
+  }
+}
+
+class _SessionSetRow extends StatelessWidget {
+  final int index;
+  final Map<String, String> set;
+  final String previous;
+
+  const _SessionSetRow({
+    required this.index,
+    required this.set,
+    required this.previous,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final prov = context.read<DeviceProvider>();
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          Expanded(child: Text('${index + 1}')),
+          Expanded(child: Text(previous)),
+          Expanded(
+            child: TextFormField(
+              initialValue: set['weight'],
+              decoration: const InputDecoration(isDense: true),
+              keyboardType: const TextInputType.numberWithOptions(decimal: true),
+              onChanged: (v) => prov.updateSet(index, weight: v),
+            ),
+          ),
+          Expanded(
+            child: TextFormField(
+              initialValue: set['reps'],
+              decoration: const InputDecoration(isDense: true),
+              keyboardType: TextInputType.number,
+              onChanged: (v) => prov.updateSet(index, reps: v),
+            ),
+          ),
+          SizedBox(
+            width: 40,
+            child: Checkbox(
+              value: false,
+              onChanged: (_) {},
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/widgets/session_sets_table_test.dart
+++ b/test/widgets/session_sets_table_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:tapem/core/providers/device_provider.dart';
+import 'package:tapem/features/device/presentation/widgets/session_sets_table.dart';
+import '../test_utils.dart';
+
+void main() {
+  testWidgets('renders header and add row', (tester) async {
+    final prov = DeviceProvider(firestore: makeFirestore());
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: prov,
+        child: const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              height: 400,
+              child: SessionSetsTable(),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('SET'), findsOneWidget);
+    expect(find.text('Add Set +'), findsOneWidget);
+  });
+
+  testWidgets('add set adds a row', (tester) async {
+    final prov = DeviceProvider(firestore: makeFirestore());
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider.value(
+        value: prov,
+        child: const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              height: 400,
+              child: SessionSetsTable(),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Add Set +'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('1'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add experimental session sets table widget with header, rows, and add-set footer
- gate table behind `ui_sets_table_v1` feature flag
- document feature flag and add basic widget tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897ee9ca7988320880e29df589aa196