### PR TITLE
Reuse existing Firebase app on hot restart

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -16,3 +16,8 @@ This page documents the experimental table-based input on the device page.
 Expected behaviour: Hot reload or restart does not crash; toggling the flag in Remote Config switches the UI live once `fetchAndActivate` or a config update occurs.
 
 Known limitations: controller and advanced interactions are simplified and will be expanded later.
+
+## Hot-Restart-sicherer Bootstrap
+
+Bei einem Hot-Restart wird nur der Dart-VM-State neu gestartet, die native Firebase-App lebt weiter. Dadurch kam es vorher zum Fehler `[core/duplicate-app]`.
+Der Bootstrap prüft jetzt beim Start, ob bereits eine Firebase-App existiert und verwendet sie wieder. Nur wenn keine App vorhanden ist, wird eine neue initialisiert.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -77,14 +77,26 @@ Future<void> main() async {
   // Load .env
   await dotenv.load(fileName: '.env.dev').catchError((_) {});
 
-  final app = await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
-  FirebaseFirestore.instance.settings = const Settings(
+  final FirebaseApp app;
+  if (Firebase.apps.isNotEmpty) {
+    if (kDebugMode) {
+      debugPrint('Using existing Firebase app');
+    }
+    app = Firebase.app();
+  } else {
+    app = await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+    if (kDebugMode) {
+      debugPrint('Initialized Firebase app');
+    }
+  }
+
+  FirebaseFirestore.instanceFor(app: app).settings = const Settings(
     persistenceEnabled: true,
   );
 
-  fb_auth.FirebaseAuth.instance.setSettings(
+  fb_auth.FirebaseAuth.instanceFor(app: app).setSettings(
     appVerificationDisabledForTesting: true,
   );
 


### PR DESCRIPTION
## Summary
- make Firebase bootstrap idempotent and log whether an app was reused or initialized
- use app-scoped instances for Firestore, Auth and FeatureFlags
- document hot-restart-safe bootstrap

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

## Checklist
- [ ] Hot reload and hot restart on Android & iOS → no exceptions
- [ ] FeatureFlags change (via --dart-define or Remote Config toggle) → UI switches without crash

------
https://chatgpt.com/codex/tasks/task_e_689808eee3608320b3283b465d49318d