### PR TITLE
refactor: inject firestore consistently

### DIFF
--- a/lib/features/history/data/sources/firestore_history_source.dart
+++ b/lib/features/history/data/sources/firestore_history_source.dart
@@ -7,8 +7,8 @@ import '../dtos/workout_log_dto.dart';
 class FirestoreHistorySource {
   final FirebaseFirestore _firestore;
 
-  FirestoreHistorySource([FirebaseFirestore? instance])
-    : _firestore = instance ?? FirebaseFirestore.instance;
+  FirestoreHistorySource({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
 
   Future<List<WorkoutLogDto>> getLogs({
     required String gymId,

--- a/lib/features/muscle_group/data/sources/firestore_muscle_group_source.dart
+++ b/lib/features/muscle_group/data/sources/firestore_muscle_group_source.dart
@@ -6,8 +6,8 @@ import '../../domain/models/muscle_group.dart';
 class FirestoreMuscleGroupSource {
   final FirebaseFirestore _firestore;
 
-  FirestoreMuscleGroupSource([FirebaseFirestore? firestore])
-    : _firestore = firestore ?? FirebaseFirestore.instance;
+  FirestoreMuscleGroupSource({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
 
   CollectionReference<Map<String, dynamic>> _col(String gymId) {
     return _firestore.collection('gyms').doc(gymId).collection('muscleGroups');


### PR DESCRIPTION
## Summary
- refactor FirestoreHistorySource to use a named `firestore` parameter
- refactor FirestoreMuscleGroupSource to use a named `firestore` parameter

## Testing
- `dart analyze` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68981889b3e88320aea0fdf6f687e2be