### PR TITLE
refactor: centralize Firebase bootstrap and inject instances

### DIFF
--- a/lib/core/providers/auth_provider.dart
+++ b/lib/core/providers/auth_provider.dart
@@ -28,16 +28,16 @@ class AuthProvider extends ChangeNotifier {
   String? _error;
   String? _selectedGymCode;
 
-  AuthProvider({AuthRepositoryImpl? repo, fb_auth.FirebaseAuth? auth})
-    : _loginUC = LoginUseCase(repo, auth),
-      _registerUC = RegisterUseCase(repo, auth),
-      _logoutUC = LogoutUseCase(repo),
-      _currentUC = GetCurrentUserUseCase(repo),
-      _setUsernameUC = SetUsernameUseCase(repo),
-      _setShowInLbUC = SetShowInLeaderboardUseCase(repo),
-      _checkUsernameUC = CheckUsernameAvailable(repo),
-      _resetPasswordUC = ResetPasswordUseCase(repo),
-      _auth = auth ?? fb_auth.FirebaseAuth.instance {
+  AuthProvider({required AuthRepositoryImpl repo, required fb_auth.FirebaseAuth auth})
+      : _loginUC = LoginUseCase(repo, auth),
+        _registerUC = RegisterUseCase(repo, auth),
+        _logoutUC = LogoutUseCase(repo),
+        _currentUC = GetCurrentUserUseCase(repo),
+        _setUsernameUC = SetUsernameUseCase(repo),
+        _setShowInLbUC = SetShowInLeaderboardUseCase(repo),
+        _checkUsernameUC = CheckUsernameAvailable(repo),
+        _resetPasswordUC = ResetPasswordUseCase(repo),
+        _auth = auth {
     _loadCurrentUser();
   }
 

--- a/lib/core/providers/challenge_provider.dart
+++ b/lib/core/providers/challenge_provider.dart
@@ -16,8 +16,7 @@ class ChallengeProvider extends ChangeNotifier {
   StreamSubscription? _badgeSub;
   StreamSubscription? _completedSub;
 
-  ChallengeProvider({ChallengeRepository? repo})
-    : _repo = repo ?? ChallengeRepositoryImpl(FirestoreChallengeSource());
+  ChallengeProvider({required ChallengeRepository repo}) : _repo = repo;
 
   List<Challenge> get challenges => _challenges;
   List<CompletedChallenge> get completed => _completed;

--- a/lib/core/providers/history_provider.dart
+++ b/lib/core/providers/history_provider.dart
@@ -11,10 +11,8 @@ import 'package:tapem/features/history/domain/models/workout_log.dart';
 class HistoryProvider extends ChangeNotifier {
   final GetHistoryForDevice _getHistory;
 
-  HistoryProvider({GetHistoryForDevice? getHistory})
-    : _getHistory =
-          getHistory ??
-          GetHistoryForDevice(HistoryRepositoryImpl(FirestoreHistorySource()));
+  HistoryProvider({required GetHistoryForDevice getHistory})
+      : _getHistory = getHistory;
 
   bool _isLoading = false;
   String? _error;

--- a/lib/core/providers/muscle_group_provider.dart
+++ b/lib/core/providers/muscle_group_provider.dart
@@ -27,40 +27,18 @@ class MuscleGroupProvider extends ChangeNotifier {
   final SetDeviceMuscleGroupsUseCase _setDeviceGroups;
 
   MuscleGroupProvider({
-    GetMuscleGroupsForGym? getGroups,
-    SaveMuscleGroup? saveGroup,
-    DeleteMuscleGroup? deleteGroup,
-    GetHistoryForDevice? getHistory,
-    UpdateDeviceMuscleGroupsUseCase? updateDeviceGroups,
-    SetDeviceMuscleGroupsUseCase? setDeviceGroups,
-  }) : _getGroups =
-           getGroups ??
-           GetMuscleGroupsForGym(
-             MuscleGroupRepositoryImpl(FirestoreMuscleGroupSource()),
-           ),
-       _saveGroup =
-           saveGroup ??
-           SaveMuscleGroup(
-             MuscleGroupRepositoryImpl(FirestoreMuscleGroupSource()),
-           ),
-       _deleteGroup =
-           deleteGroup ??
-           DeleteMuscleGroup(
-             MuscleGroupRepositoryImpl(FirestoreMuscleGroupSource()),
-           ),
-       _getHistory =
-           getHistory ??
-           GetHistoryForDevice(HistoryRepositoryImpl(FirestoreHistorySource())),
-       _updateDeviceGroups =
-           updateDeviceGroups ??
-           UpdateDeviceMuscleGroupsUseCase(
-             DeviceRepositoryImpl(FirestoreDeviceSource()),
-           ),
-       _setDeviceGroups =
-           setDeviceGroups ??
-           SetDeviceMuscleGroupsUseCase(
-             DeviceRepositoryImpl(FirestoreDeviceSource()),
-           );
+    required GetMuscleGroupsForGym getGroups,
+    required SaveMuscleGroup saveGroup,
+    required DeleteMuscleGroup deleteGroup,
+    required GetHistoryForDevice getHistory,
+    required UpdateDeviceMuscleGroupsUseCase updateDeviceGroups,
+    required SetDeviceMuscleGroupsUseCase setDeviceGroups,
+  })  : _getGroups = getGroups,
+        _saveGroup = saveGroup,
+        _deleteGroup = deleteGroup,
+        _getHistory = getHistory,
+        _updateDeviceGroups = updateDeviceGroups,
+        _setDeviceGroups = setDeviceGroups;
 
   bool _isLoading = false;
   String? _error;

--- a/lib/core/providers/profile_provider.dart
+++ b/lib/core/providers/profile_provider.dart
@@ -11,10 +11,8 @@ import 'package:tapem/features/history/domain/usecases/get_history_for_device.da
 class ProfileProvider extends ChangeNotifier {
   final GetHistoryForDevice _getHistory;
 
-  ProfileProvider({GetHistoryForDevice? getHistory})
-    : _getHistory =
-          getHistory ??
-          GetHistoryForDevice(HistoryRepositoryImpl(FirestoreHistorySource()));
+  ProfileProvider({required GetHistoryForDevice getHistory})
+      : _getHistory = getHistory;
 
   bool _isLoading = false;
   String? _error;

--- a/lib/core/providers/rank_provider.dart
+++ b/lib/core/providers/rank_provider.dart
@@ -9,8 +9,7 @@ class RankProvider extends ChangeNotifier {
   List<Map<String, dynamic>> _deviceEntries = [];
   StreamSubscription? _deviceSub;
 
-  RankProvider({RankRepository? repository})
-    : _repository = repository ?? RankRepositoryImpl(FirestoreRankSource());
+  RankProvider({required RankRepository repository}) : _repository = repository;
 
   List<Map<String, dynamic>> get deviceEntries => _deviceEntries;
 

--- a/lib/core/providers/training_details_provider.dart
+++ b/lib/core/providers/training_details_provider.dart
@@ -16,11 +16,8 @@ class TrainingDetailsProvider extends ChangeNotifier {
   String? get error => _error;
   List<Session> get sessions => List.unmodifiable(_sessions);
 
-  TrainingDetailsProvider({GetSessionsForDate? getSessions})
-      : _getSessions = getSessions ??
-            GetSessionsForDate(
-              SessionRepositoryImpl(FirestoreSessionSource()),
-            );
+  TrainingDetailsProvider({required GetSessionsForDate getSessions})
+      : _getSessions = getSessions;
 
   /// Lädt alle Sessions für [userId] am [date].
   Future<void> loadSessions({

--- a/lib/core/providers/training_plan_provider.dart
+++ b/lib/core/providers/training_plan_provider.dart
@@ -19,9 +19,8 @@ class TrainingPlanProvider extends ChangeNotifier {
   bool isSaving = false;
   String? error;
 
-  TrainingPlanProvider({TrainingPlanRepository? repo})
-    : _repo =
-          repo ?? TrainingPlanRepositoryImpl(FirestoreTrainingPlanSource()) {
+  TrainingPlanProvider({required TrainingPlanRepository repo})
+      : _repo = repo {
     _loadActivePlanId();
   }
 

--- a/lib/core/providers/xp_provider.dart
+++ b/lib/core/providers/xp_provider.dart
@@ -7,8 +7,7 @@ import 'package:tapem/features/xp/data/repositories/xp_repository_impl.dart';
 
 class XpProvider extends ChangeNotifier {
   final XpRepository _repo;
-  XpProvider({XpRepository? repo})
-    : _repo = repo ?? XpRepositoryImpl(FirestoreXpSource());
+  XpProvider({required XpRepository repo}) : _repo = repo;
 
   Map<String, int> _muscleXp = {};
   int _dayXp = 0;

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -8,8 +8,7 @@ import 'package:tapem/features/auth/domain/repositories/auth_repository.dart';
 class AuthRepositoryImpl implements AuthRepository {
   final FirestoreAuthSource _source;
 
-  AuthRepositoryImpl([FirestoreAuthSource? src])
-    : _source = src ?? FirestoreAuthSource();
+  AuthRepositoryImpl(this._source);
 
   @override
   Future<UserData> login(String email, String password) async {

--- a/lib/features/auth/data/sources/firestore_auth_source.dart
+++ b/lib/features/auth/data/sources/firestore_auth_source.dart
@@ -7,9 +7,9 @@ class FirestoreAuthSource {
   final FirebaseAuth _auth;
   final FirebaseFirestore _firestore;
 
-  FirestoreAuthSource({FirebaseAuth? auth, FirebaseFirestore? firestore})
-    : _auth = auth ?? FirebaseAuth.instance,
-      _firestore = firestore ?? FirebaseFirestore.instance;
+  FirestoreAuthSource({required FirebaseAuth auth, required FirebaseFirestore firestore})
+      : _auth = auth,
+        _firestore = firestore;
 
   Future<UserDataDto> login(String email, String password) async {
     final cred = await _auth.signInWithEmailAndPassword(
@@ -34,7 +34,7 @@ class FirestoreAuthSource {
     final uid = cred.user!.uid;
 
     // Gym anhand des Codes suchen und dessen ID speichern
-    final gymSrc = FirestoreGymSource();
+    final gymSrc = FirestoreGymSource(firestore: _firestore);
     final gym = await gymSrc.getGymByCode(initialGymCode);
     if (gym == null) throw Exception('Gym code not found');
 

--- a/lib/features/auth/domain/usecases/check_username_available.dart
+++ b/lib/features/auth/domain/usecases/check_username_available.dart
@@ -3,8 +3,7 @@ import '../../data/repositories/auth_repository_impl.dart';
 
 class CheckUsernameAvailable {
   final AuthRepository _repo;
-  CheckUsernameAvailable([AuthRepository? repo])
-    : _repo = repo ?? AuthRepositoryImpl();
+  CheckUsernameAvailable(AuthRepository repo) : _repo = repo;
 
   Future<bool> execute(String username) {
     return _repo.isUsernameAvailable(username);

--- a/lib/features/auth/domain/usecases/get_current_user.dart
+++ b/lib/features/auth/domain/usecases/get_current_user.dart
@@ -3,8 +3,7 @@ import '../models/user_data.dart';
 
 class GetCurrentUserUseCase {
   final AuthRepositoryImpl _repo;
-  GetCurrentUserUseCase([AuthRepositoryImpl? repo])
-    : _repo = repo ?? AuthRepositoryImpl();
+  GetCurrentUserUseCase(this._repo);
 
   Future<UserData?> execute() => _repo.getCurrentUser();
 }

--- a/lib/features/auth/domain/usecases/login.dart
+++ b/lib/features/auth/domain/usecases/login.dart
@@ -10,9 +10,9 @@ import '../repositories/auth_repository.dart';
 class LoginUseCase {
   final AuthRepository _repo;
   final fb_auth.FirebaseAuth _auth;
-  LoginUseCase([AuthRepository? repo, fb_auth.FirebaseAuth? auth])
-      : _repo = repo ?? AuthRepositoryImpl(),
-        _auth = auth ?? fb_auth.FirebaseAuth.instance;
+  LoginUseCase(AuthRepository repo, fb_auth.FirebaseAuth auth)
+      : _repo = repo,
+        _auth = auth;
 
   Future<UserData> execute(String email, String password) async {
     // 1) Authentifizieren und UserData aus Firestore holen

--- a/lib/features/auth/domain/usecases/logout.dart
+++ b/lib/features/auth/domain/usecases/logout.dart
@@ -2,8 +2,7 @@ import '../../data/repositories/auth_repository_impl.dart';
 
 class LogoutUseCase {
   final AuthRepositoryImpl _repo;
-  LogoutUseCase([AuthRepositoryImpl? repo])
-    : _repo = repo ?? AuthRepositoryImpl();
+  LogoutUseCase(AuthRepositoryImpl repo) : _repo = repo;
 
   Future<void> execute() => _repo.logout();
 }

--- a/lib/features/auth/domain/usecases/register.dart
+++ b/lib/features/auth/domain/usecases/register.dart
@@ -10,9 +10,9 @@ import '../repositories/auth_repository.dart';
 class RegisterUseCase {
   final AuthRepository _repo;
   final fb_auth.FirebaseAuth _auth;
-  RegisterUseCase([AuthRepository? repo, fb_auth.FirebaseAuth? auth])
-      : _repo = repo ?? AuthRepositoryImpl(),
-        _auth = auth ?? fb_auth.FirebaseAuth.instance;
+  RegisterUseCase(AuthRepository repo, fb_auth.FirebaseAuth auth)
+      : _repo = repo,
+        _auth = auth;
 
   Future<UserData> execute(String email, String password, String gymId) async {
     // 1) Nutzerkonto anlegen und UserData in Firestore speichern

--- a/lib/features/auth/domain/usecases/reset_password.dart
+++ b/lib/features/auth/domain/usecases/reset_password.dart
@@ -3,8 +3,7 @@ import '../repositories/auth_repository.dart';
 
 class ResetPasswordUseCase {
   final AuthRepository _repo;
-  ResetPasswordUseCase([AuthRepository? repo])
-    : _repo = repo ?? AuthRepositoryImpl();
+  ResetPasswordUseCase(AuthRepository repo) : _repo = repo;
 
   Future<void> execute(String email) => _repo.sendPasswordResetEmail(email);
 }

--- a/lib/features/auth/domain/usecases/set_show_in_leaderboard.dart
+++ b/lib/features/auth/domain/usecases/set_show_in_leaderboard.dart
@@ -3,8 +3,7 @@ import '../../data/repositories/auth_repository_impl.dart';
 
 class SetShowInLeaderboardUseCase {
   final AuthRepository _repo;
-  SetShowInLeaderboardUseCase([AuthRepository? repo])
-    : _repo = repo ?? AuthRepositoryImpl();
+  SetShowInLeaderboardUseCase(AuthRepository repo) : _repo = repo;
 
   Future<void> execute(String userId, bool value) {
     return _repo.setShowInLeaderboard(userId, value);

--- a/lib/features/auth/domain/usecases/set_username.dart
+++ b/lib/features/auth/domain/usecases/set_username.dart
@@ -3,8 +3,7 @@ import '../../data/repositories/auth_repository_impl.dart';
 
 class SetUsernameUseCase {
   final AuthRepository _repo;
-  SetUsernameUseCase([AuthRepository? repo])
-    : _repo = repo ?? AuthRepositoryImpl();
+  SetUsernameUseCase(AuthRepository repo) : _repo = repo;
 
   Future<void> execute(String userId, String username) {
     return _repo.setUsername(userId, username);

--- a/lib/features/auth/presentation/widgets/registration_form.dart
+++ b/lib/features/auth/presentation/widgets/registration_form.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
@@ -41,7 +42,9 @@ class _RegistrationFormState extends State<RegistrationForm> {
     _formKey.currentState!.save();
     setState(() => _gymError = null);
 
-    final validator = ValidateGymCode(GymRepositoryImpl(FirestoreGymSource()));
+    final fs = context.read<FirebaseFirestore>();
+    final validator =
+        ValidateGymCode(GymRepositoryImpl(FirestoreGymSource(firestore: fs)));
 
     try {
       await validator.execute(_gymCode);

--- a/lib/features/challenges/data/sources/firestore_challenge_source.dart
+++ b/lib/features/challenges/data/sources/firestore_challenge_source.dart
@@ -8,8 +8,8 @@ import '../../domain/models/completed_challenge.dart';
 class FirestoreChallengeSource {
   final FirebaseFirestore _firestore;
 
-  FirestoreChallengeSource({FirebaseFirestore? firestore})
-    : _firestore = firestore ?? FirebaseFirestore.instance;
+  FirestoreChallengeSource({required FirebaseFirestore firestore})
+      : _firestore = firestore;
 
   Stream<List<Challenge>> watchActiveChallenges(String gymId) {
     final now = Timestamp.fromDate(DateTime.now());

--- a/lib/features/device/data/sources/firestore_device_source.dart
+++ b/lib/features/device/data/sources/firestore_device_source.dart
@@ -7,8 +7,8 @@ import '../dtos/device_dto.dart';
 class FirestoreDeviceSource {
   final FirebaseFirestore _firestore;
 
-  FirestoreDeviceSource({FirebaseFirestore? firestore})
-      : _firestore = firestore ?? FirebaseFirestore.instance;
+  FirestoreDeviceSource({required FirebaseFirestore firestore})
+      : _firestore = firestore;
 
   Future<List<DeviceDto>> getDevicesForGym(String gymId) async {
     final snap =

--- a/lib/features/device/data/sources/firestore_exercise_source.dart
+++ b/lib/features/device/data/sources/firestore_exercise_source.dart
@@ -5,8 +5,8 @@ import '../../domain/models/exercise.dart';
 class FirestoreExerciseSource {
   final FirebaseFirestore _firestore;
 
-  FirestoreExerciseSource({FirebaseFirestore? firestore})
-      : _firestore = firestore ?? FirebaseFirestore.instance;
+  FirestoreExerciseSource({required FirebaseFirestore firestore})
+      : _firestore = firestore;
 
   CollectionReference _col(String gymId, String deviceId) => _firestore
       .collection('gyms')

--- a/lib/features/gym/data/sources/firestore_gym_source.dart
+++ b/lib/features/gym/data/sources/firestore_gym_source.dart
@@ -6,8 +6,8 @@ import '../../domain/models/branding.dart';
 class FirestoreGymSource {
   final FirebaseFirestore _firestore;
 
-  FirestoreGymSource({FirebaseFirestore? firestore})
-      : _firestore = firestore ?? FirebaseFirestore.instance;
+  FirestoreGymSource({required FirebaseFirestore firestore})
+      : _firestore = firestore;
 
   /// Sucht in 'gyms' nach dem Dokument mit Feld 'code' == [code].
   Future<GymConfig?> getGymByCode(String code) async {

--- a/lib/features/history/data/sources/firestore_history_source.dart
+++ b/lib/features/history/data/sources/firestore_history_source.dart
@@ -7,8 +7,8 @@ import '../dtos/workout_log_dto.dart';
 class FirestoreHistorySource {
   final FirebaseFirestore _firestore;
 
-  FirestoreHistorySource({FirebaseFirestore? firestore})
-      : _firestore = firestore ?? FirebaseFirestore.instance;
+  FirestoreHistorySource({required FirebaseFirestore firestore})
+      : _firestore = firestore;
 
   Future<List<WorkoutLogDto>> getLogs({
     required String gymId,

--- a/lib/features/muscle_group/data/sources/firestore_muscle_group_source.dart
+++ b/lib/features/muscle_group/data/sources/firestore_muscle_group_source.dart
@@ -6,8 +6,8 @@ import '../../domain/models/muscle_group.dart';
 class FirestoreMuscleGroupSource {
   final FirebaseFirestore _firestore;
 
-  FirestoreMuscleGroupSource({FirebaseFirestore? firestore})
-      : _firestore = firestore ?? FirebaseFirestore.instance;
+  FirestoreMuscleGroupSource({required FirebaseFirestore firestore})
+      : _firestore = firestore;
 
   CollectionReference<Map<String, dynamic>> _col(String gymId) {
     return _firestore.collection('gyms').doc(gymId).collection('muscleGroups');

--- a/lib/features/rank/data/sources/firestore_rank_source.dart
+++ b/lib/features/rank/data/sources/firestore_rank_source.dart
@@ -7,8 +7,8 @@ import '../../domain/services/level_service.dart';
 class FirestoreRankSource {
   final FirebaseFirestore _firestore;
 
-  FirestoreRankSource({FirebaseFirestore? firestore})
-    : _firestore = firestore ?? FirebaseFirestore.instance;
+  FirestoreRankSource({required FirebaseFirestore firestore})
+      : _firestore = firestore;
 
   Future<void> addXp({
     required String gymId,

--- a/lib/features/report/data/repositories/report_repository_impl.dart
+++ b/lib/features/report/data/repositories/report_repository_impl.dart
@@ -6,8 +6,7 @@ import 'package:tapem/features/report/domain/repositories/report_repository.dart
 
 class ReportRepositoryImpl implements ReportRepository {
   final FirestoreReportSource _source;
-  ReportRepositoryImpl([FirestoreReportSource? source])
-    : _source = source ?? FirestoreReportSource();
+  ReportRepositoryImpl(this._source);
 
   @override
   Future<Map<String, int>> fetchUsageCountPerMachine(String gymId) async {

--- a/lib/features/report/data/sources/firestore_report_source.dart
+++ b/lib/features/report/data/sources/firestore_report_source.dart
@@ -4,8 +4,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 class FirestoreReportSource {
   final FirebaseFirestore _fs;
-  FirestoreReportSource([FirebaseFirestore? fs])
-    : _fs = fs ?? FirebaseFirestore.instance;
+  FirestoreReportSource(this._fs);
 
   /// Alle Geräte des Gyms laden
   Future<List<DocumentSnapshot<Map<String, dynamic>>>> fetchDevices(

--- a/lib/features/training_details/data/sources/firestore_session_source.dart
+++ b/lib/features/training_details/data/sources/firestore_session_source.dart
@@ -6,8 +6,8 @@ import '../dtos/session_dto.dart';
 class FirestoreSessionSource {
   final FirebaseFirestore _firestore;
 
-  FirestoreSessionSource({FirebaseFirestore? firestore})
-    : _firestore = firestore ?? FirebaseFirestore.instance;
+  FirestoreSessionSource({required FirebaseFirestore firestore})
+      : _firestore = firestore;
 
   Future<List<SessionDto>> getSessionsForDate({
     required String userId,

--- a/lib/features/training_plan/data/sources/firestore_training_plan_source.dart
+++ b/lib/features/training_plan/data/sources/firestore_training_plan_source.dart
@@ -9,8 +9,8 @@ import '../../domain/models/exercise_entry.dart';
 class FirestoreTrainingPlanSource {
   final FirebaseFirestore _firestore;
 
-  FirestoreTrainingPlanSource({FirebaseFirestore? firestore})
-    : _firestore = firestore ?? FirebaseFirestore.instance;
+  FirestoreTrainingPlanSource({required FirebaseFirestore firestore})
+      : _firestore = firestore;
 
   CollectionReference<Map<String, dynamic>> _plansCol(String gymId) =>
       _firestore.collection('gyms').doc(gymId).collection('trainingPlans');

--- a/lib/features/xp/data/sources/firestore_xp_source.dart
+++ b/lib/features/xp/data/sources/firestore_xp_source.dart
@@ -7,9 +7,9 @@ class FirestoreXpSource {
   final FirebaseFirestore _firestore;
   final FirestoreRankSource _rankSource;
 
-  FirestoreXpSource({FirebaseFirestore? firestore})
-    : _firestore = firestore ?? FirebaseFirestore.instance,
-      _rankSource = FirestoreRankSource(firestore: firestore);
+  FirestoreXpSource({required FirebaseFirestore firestore})
+      : _firestore = firestore,
+        _rankSource = FirestoreRankSource(firestore: firestore);
 
   Future<void> addSessionXp({
     required String gymId,


### PR DESCRIPTION
## Summary
- centralize Firebase app bootstrap and log init status deterministically
- inject FirebaseAuth/Firestore into providers and sources instead of global singletons
- fix registration form to validate gym codes with injected Firestore instance

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68981fa06b2c8320845d793f5cda4e92