### PR TITLE
feat: refactor device session sets

### DIFF
--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/device_provider.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/features/rank/presentation/device_level_style.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
+class SetCard extends StatefulWidget {
+  final int index;
+  final Map<String, String> set;
+  final Map<String, String>? previous;
+
+  const SetCard({super.key, required this.index, required this.set, this.previous});
+
+  @override
+  State<SetCard> createState() => _SetCardState();
+}
+
+class _SetCardState extends State<SetCard> {
+  bool _showExtras = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final prov = context.watch<DeviceProvider>();
+    final loc = AppLocalizations.of(context)!;
+    final done = widget.set['done'] == 'true';
+
+    final decoration = DeviceLevelStyle.widgetDecorationFor(
+      prov.level,
+      opacity: 0.6,
+    );
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeOut,
+      decoration: decoration.copyWith(
+        color: done ? Colors.green.withOpacity(0.1) : null,
+        boxShadow: const [
+          BoxShadow(blurRadius: 6, color: Colors.black12, offset: Offset(0, 2)),
+        ],
+      ),
+      padding: const EdgeInsets.all(AppSpacing.sm),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              CircleAvatar(
+                radius: 12,
+                backgroundColor: Theme.of(context).colorScheme.surfaceVariant,
+                child: Text('${widget.index + 1}'),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (widget.previous != null)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 4),
+                        child: Text(
+                          'Previous: ${widget.previous!['weight']} × ${widget.previous!['reps']}',
+                          style: Theme.of(context)
+                              .textTheme
+                              .bodySmall
+                              ?.copyWith(color: Colors.grey),
+                        ),
+                      ),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: TextFormField(
+                            readOnly: done,
+                            initialValue: widget.set['weight'],
+                            decoration: const InputDecoration(
+                              labelText: 'kg',
+                              isDense: true,
+                            ),
+                            keyboardType: const TextInputType.numberWithOptions(
+                              decimal: true,
+                            ),
+                            inputFormatters: [
+                              FilteringTextInputFormatter.allow(
+                                  RegExp(r'[0-9.,]')),
+                            ],
+                            validator: (v) {
+                              if (v == null || v.isEmpty) return loc.kgRequired;
+                              if (double.tryParse(v.replaceAll(',', '.')) ==
+                                  null) {
+                                return loc.numberInvalid;
+                              }
+                              return null;
+                            },
+                            onChanged: (v) =>
+                                prov.updateSet(widget.index, weight: v),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: TextFormField(
+                            readOnly: done,
+                            initialValue: widget.set['reps'],
+                            decoration: const InputDecoration(
+                              labelText: 'x',
+                              isDense: true,
+                            ),
+                            keyboardType: TextInputType.number,
+                            inputFormatters: [
+                              FilteringTextInputFormatter.digitsOnly,
+                            ],
+                            validator: (v) {
+                              if (v == null || v.isEmpty) return loc.repsRequired;
+                              if (int.tryParse(v) == null) {
+                                return loc.intRequired;
+                              }
+                              return null;
+                            },
+                            onChanged: (v) => prov.updateSet(widget.index, reps: v),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        IconButton(
+                          onPressed: () {
+                            final form = Form.of(context);
+                            if (form != null && !form.validate()) {
+                              HapticFeedback.lightImpact();
+                              return;
+                            }
+                            prov.toggleSetDone(widget.index);
+                          },
+                          icon: Icon(
+                            done
+                                ? Icons.check_circle
+                                : Icons.check_circle_outline,
+                            color: done ? Colors.green : null,
+                          ),
+                          tooltip: done
+                              ? loc.setReopenTooltip
+                              : loc.setCompleteTooltip,
+                        ),
+                        IconButton(
+                          onPressed: () => setState(() {
+                            _showExtras = !_showExtras;
+                          }),
+                          icon: Icon(_showExtras
+                              ? Icons.expand_less
+                              : Icons.more_horiz),
+                          tooltip: 'More',
+                        ),
+                      ],
+                    ),
+                    if (_showExtras)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 8),
+                        child: Row(
+                          children: [
+                            Expanded(
+                              child: TextFormField(
+                                readOnly: done,
+                                initialValue: widget.set['rir'],
+                                decoration: const InputDecoration(
+                                  labelText: 'RIR',
+                                  isDense: true,
+                                ),
+                                keyboardType: TextInputType.number,
+                                inputFormatters: [
+                                  FilteringTextInputFormatter.digitsOnly,
+                                ],
+                                onChanged: (v) =>
+                                    prov.updateSet(widget.index, rir: v),
+                              ),
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              flex: 2,
+                              child: TextFormField(
+                                readOnly: done,
+                                initialValue: widget.set['note'],
+                                decoration: InputDecoration(
+                                  labelText: loc.noteFieldLabel,
+                                  isDense: true,
+                                ),
+                                onChanged: (v) =>
+                                    prov.updateSet(widget.index, note: v),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/feedback/presentation/widgets/feedback_button.dart
+++ b/lib/features/feedback/presentation/widgets/feedback_button.dart
@@ -3,12 +3,12 @@ import 'package:provider/provider.dart';
 
 import 'package:tapem/features/feedback/feedback_provider.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
-import 'package:tapem/core/providers/gym_provider.dart';
-
 class FeedbackButton extends StatelessWidget {
+  final String gymId;
   final String deviceId;
 
-  const FeedbackButton({Key? key, required this.deviceId}) : super(key: key);
+  const FeedbackButton({Key? key, required this.gymId, required this.deviceId})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -44,7 +44,6 @@ class FeedbackButton extends StatelessWidget {
                 final text = controller.text.trim();
                 if (text.isNotEmpty) {
                   final auth = context.read<AuthProvider>();
-                  final gymId = context.read<GymProvider>().currentGymId;
                   final userId = auth.userId ?? '';
                   await context.read<FeedbackProvider>().submitFeedback(
                     gymId: gymId,

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -210,6 +210,46 @@
     "description": "Validierungsmeldung, wenn Wiederholungen fehlen"
   },
 
+  "numberInvalid": "Zahl eingeben",
+  "@numberInvalid": {
+    "description": "Validierung, wenn eine Zahl erwartet wird"
+  },
+
+  "intRequired": "Ganzzahl",
+  "@intRequired": {
+    "description": "Validierung, wenn eine Ganzzahl erwartet wird"
+  },
+
+  "newSessionTitle": "Neue Session",
+  "@newSessionTitle": {
+    "description": "Überschrift für neue Session"
+  },
+
+  "pleaseCheckInputs": "Bitte Eingaben prüfen",
+  "@pleaseCheckInputs": {
+    "description": "Snackbar, wenn das Formular ungültig ist"
+  },
+
+  "noCompletedSets": "Keine abgeschlossenen Sätze",
+  "@noCompletedSets": {
+    "description": "Snackbar, wenn keine Sätze abgeschlossen sind"
+  },
+
+  "sessionSaved": "Session gespeichert",
+  "@sessionSaved": {
+    "description": "Snackbar nach erfolgreichem Speichern"
+  },
+
+  "setCompleteTooltip": "Satz abschließen",
+  "@setCompleteTooltip": {
+    "description": "Tooltip für Check-Button"
+  },
+
+  "setReopenTooltip": "Satz wieder öffnen",
+  "@setReopenTooltip": {
+    "description": "Tooltip wenn Satz abgeschlossen ist"
+  },
+
   "registerButton": "Registrieren",
   "@registerButton": {
     "description": "Beschriftung für den Registrieren-Knopf"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -210,6 +210,46 @@
     "description": "Validation when reps are missing"
   },
 
+  "numberInvalid": "Enter a number",
+  "@numberInvalid": {
+    "description": "Validation when a number is expected"
+  },
+
+  "intRequired": "Integer",
+  "@intRequired": {
+    "description": "Validation when an integer is expected"
+  },
+
+  "newSessionTitle": "New session",
+  "@newSessionTitle": {
+    "description": "Heading for new session"
+  },
+
+  "pleaseCheckInputs": "Please check inputs",
+  "@pleaseCheckInputs": {
+    "description": "Snackbar when form is invalid"
+  },
+
+  "noCompletedSets": "No completed sets",
+  "@noCompletedSets": {
+    "description": "Snackbar when no sets are completed"
+  },
+
+  "sessionSaved": "Session saved",
+  "@sessionSaved": {
+    "description": "Snackbar after successful save"
+  },
+
+  "setCompleteTooltip": "Complete set",
+  "@setCompleteTooltip": {
+    "description": "Tooltip for completing a set"
+  },
+
+  "setReopenTooltip": "Reopen set",
+  "@setReopenTooltip": {
+    "description": "Tooltip when set is completed"
+  },
+
   "registerButton": "Register",
   "@registerButton": {
     "description": "Label for the Register button"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -341,6 +341,30 @@ abstract class AppLocalizations {
   /// **'reps?'**
   String get repsRequired;
 
+  /// Validation when a number is expected
+  String get numberInvalid;
+
+  /// Validation when an integer is expected
+  String get intRequired;
+
+  /// Heading for new session
+  String get newSessionTitle;
+
+  /// Snackbar when form is invalid
+  String get pleaseCheckInputs;
+
+  /// Snackbar when no sets are completed
+  String get noCompletedSets;
+
+  /// Snackbar after successful save
+  String get sessionSaved;
+
+  /// Tooltip for completing a set
+  String get setCompleteTooltip;
+
+  /// Tooltip when set is completed
+  String get setReopenTooltip;
+
   /// Label for the Register button
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -140,6 +140,30 @@ class AppLocalizationsDe extends AppLocalizations {
   String get repsRequired => 'Wdh?';
 
   @override
+  String get numberInvalid => 'Zahl eingeben';
+
+  @override
+  String get intRequired => 'Ganzzahl';
+
+  @override
+  String get newSessionTitle => 'Neue Session';
+
+  @override
+  String get pleaseCheckInputs => 'Bitte Eingaben prüfen';
+
+  @override
+  String get noCompletedSets => 'Keine abgeschlossenen Sätze';
+
+  @override
+  String get sessionSaved => 'Session gespeichert';
+
+  @override
+  String get setCompleteTooltip => 'Satz abschließen';
+
+  @override
+  String get setReopenTooltip => 'Satz wieder öffnen';
+
+  @override
   String get registerButton => 'Registrieren';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -140,6 +140,30 @@ class AppLocalizationsEn extends AppLocalizations {
   String get repsRequired => 'reps?';
 
   @override
+  String get numberInvalid => 'Enter a number';
+
+  @override
+  String get intRequired => 'Integer';
+
+  @override
+  String get newSessionTitle => 'New session';
+
+  @override
+  String get pleaseCheckInputs => 'Please check inputs';
+
+  @override
+  String get noCompletedSets => 'No completed sets';
+
+  @override
+  String get sessionSaved => 'Session saved';
+
+  @override
+  String get setCompleteTooltip => 'Complete set';
+
+  @override
+  String get setReopenTooltip => 'Reopen set';
+
+  @override
   String get registerButton => 'Register';
 
   @override

--- a/test/widgets/set_card_test.dart
+++ b/test/widgets/set_card_test.dart
@@ -1,0 +1,67 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/device_provider.dart';
+import 'package:tapem/features/device/presentation/widgets/set_card.dart';
+import 'package:tapem/features/device/domain/usecases/get_devices_for_gym.dart';
+import 'package:tapem/features/device/domain/repositories/device_repository.dart';
+import 'package:tapem/features/device/domain/models/device.dart';
+
+class _FakeRepo implements DeviceRepository {
+  @override
+  Future<List<Device>> getDevicesForGym(String gymId) async => [];
+  @override
+  Future<void> createDevice(String gymId, Device device) => throw UnimplementedError();
+  @override
+  Future<Device?> getDeviceByNfcCode(String gymId, String nfcCode) => throw UnimplementedError();
+  @override
+  Future<void> deleteDevice(String gymId, String deviceId) => throw UnimplementedError();
+  @override
+  Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) => throw UnimplementedError();
+  @override
+  Future<void> setMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) => throw UnimplementedError();
+}
+
+void main() {
+  testWidgets('SetCard toggle locks fields and colors', (tester) async {
+    final provider = DeviceProvider(
+      firestore: FakeFirebaseFirestore(),
+      getDevicesForGym: GetDevicesForGym(_FakeRepo()),
+      log: (_, [__]) {},
+    );
+    provider.addSet();
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<DeviceProvider>.value(
+        value: provider,
+        child: MaterialApp(
+          home: Scaffold(
+            body: Form(
+              child: SetCard(index: 0, set: provider.sets[0]),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      tester.widget<TextFormField>(find.byType(TextFormField).first).readOnly,
+      false,
+    );
+
+    await tester.enterText(find.byType(TextFormField).first, '10');
+    await tester.enterText(find.byType(TextFormField).at(1), '5');
+    await tester.tap(find.byIcon(Icons.check_circle_outline));
+    await tester.pumpAndSettle();
+
+    expect(provider.completedCount, 1);
+    expect(
+      tester.widget<TextFormField>(find.byType(TextFormField).first).readOnly,
+      true,
+    );
+    final container = tester.widget<AnimatedContainer>(find.byType(AnimatedContainer));
+    final box = container.decoration as BoxDecoration;
+    expect(box.color, Colors.green.withOpacity(0.1));
+  });
+}


### PR DESCRIPTION
## Summary
- refactor device provider to track set completion and filter saved sets
- rebuild device screen with modern SetCard UI and validation
- wire FeedbackButton with explicit gymId and add localization strings

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689833d97a948320a9d25b96dbbeec0f