### PR TITLE
fix(device): remove redundant null check and update tests

### DIFF
--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -124,7 +124,7 @@ class _SetCardState extends State<SetCard> {
                         IconButton(
                           onPressed: () {
                             final form = Form.of(context);
-                            if (form != null && !form.validate()) {
+                            if (!form.validate()) {
                               HapticFeedback.lightImpact();
                               return;
                             }

--- a/test/widgets/set_card_test.dart
+++ b/test/widgets/set_card_test.dart
@@ -46,7 +46,7 @@ void main() {
     );
 
     expect(
-      tester.widget<TextFormField>(find.byType(TextFormField).first).readOnly,
+      tester.widget<TextField>(find.byType(TextField).first).readOnly,
       false,
     );
 
@@ -57,7 +57,7 @@ void main() {
 
     expect(provider.completedCount, 1);
     expect(
-      tester.widget<TextFormField>(find.byType(TextFormField).first).readOnly,
+      tester.widget<TextField>(find.byType(TextField).first).readOnly,
       true,
     );
     final container = tester.widget<AnimatedContainer>(find.byType(AnimatedContainer));


### PR DESCRIPTION
## Summary
- remove redundant FormState null check in SetCard
- update tests to assert `TextField.readOnly`

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_6898370487a88320b783023eb46178ff