### PR TITLE
DevicePage: swipe-to-delete, remove edit session, enforce one-save-per-day

### DIFF
--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -8,7 +8,7 @@ import 'package:tapem/l10n/app_localizations.dart';
 
 class SetCard extends StatefulWidget {
   final int index;
-  final Map<String, String> set;
+  final Map<String, dynamic> set;
   final Map<String, String>? previous;
 
   const SetCard({super.key, required this.index, required this.set, this.previous});
@@ -24,7 +24,8 @@ class _SetCardState extends State<SetCard> {
   Widget build(BuildContext context) {
     final prov = context.watch<DeviceProvider>();
     final loc = AppLocalizations.of(context)!;
-    final done = widget.set['done'] == 'true';
+    final doneVal = widget.set['done'];
+    final done = doneVal == 'true' || doneVal == true;
 
     final decoration = DeviceLevelStyle.widgetDecorationFor(
       prov.level,
@@ -73,7 +74,7 @@ class _SetCardState extends State<SetCard> {
                         Expanded(
                           child: TextFormField(
                             readOnly: done,
-                            initialValue: widget.set['weight'],
+                            initialValue: widget.set['weight'] as String?,
                             decoration: const InputDecoration(
                               labelText: 'kg',
                               isDense: true,
@@ -101,7 +102,7 @@ class _SetCardState extends State<SetCard> {
                         Expanded(
                           child: TextFormField(
                             readOnly: done,
-                            initialValue: widget.set['reps'],
+                            initialValue: widget.set['reps'] as String?,
                             decoration: const InputDecoration(
                               labelText: 'x',
                               isDense: true,
@@ -159,7 +160,7 @@ class _SetCardState extends State<SetCard> {
                             Expanded(
                               child: TextFormField(
                                 readOnly: done,
-                                initialValue: widget.set['rir'],
+                                initialValue: widget.set['rir'] as String?,
                                 decoration: const InputDecoration(
                                   labelText: 'RIR',
                                   isDense: true,
@@ -177,7 +178,7 @@ class _SetCardState extends State<SetCard> {
                               flex: 2,
                               child: TextFormField(
                                 readOnly: done,
-                                initialValue: widget.set['note'],
+                                initialValue: widget.set['note'] as String?,
                                 decoration: InputDecoration(
                                   labelText: loc.noteFieldLabel,
                                   isDense: true,

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -230,10 +230,23 @@
     "description": "Snackbar, wenn das Formular ungültig ist"
   },
 
-  "noCompletedSets": "Keine abgeschlossenen Sätze",
+  "noCompletedSets": "Keine abgeschlossenen Sätze.",
   "@noCompletedSets": {
     "description": "Snackbar, wenn keine Sätze abgeschlossen sind"
   },
+
+  "todayAlreadySaved": "Heute bereits gespeichert.",
+  "@todayAlreadySaved": {
+    "description": "Fehler wenn bereits eine Session gespeichert wurde"
+  },
+
+  "setRemoved": "Satz entfernt",
+  "@setRemoved": {
+    "description": "Snackbar nach Entfernen eines Satzes"
+  },
+
+  "undo": "Rückgängig",
+  "@undo": {"description": "Aktion zum Rückgängig machen"},
 
   "sessionSaved": "Session gespeichert",
   "@sessionSaved": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -230,10 +230,21 @@
     "description": "Snackbar when form is invalid"
   },
 
-  "noCompletedSets": "No completed sets",
+  "noCompletedSets": "No completed sets.",
   "@noCompletedSets": {
     "description": "Snackbar when no sets are completed"
   },
+
+  "todayAlreadySaved": "Already saved today.",
+  "@todayAlreadySaved": {
+    "description": "Error when a session has already been saved today"
+  },
+
+  "setRemoved": "Set removed",
+  "@setRemoved": {"description": "Snackbar after removing a set"},
+
+  "undo": "Undo",
+  "@undo": {"description": "Undo action"},
 
   "sessionSaved": "Session saved",
   "@sessionSaved": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -356,6 +356,15 @@ abstract class AppLocalizations {
   /// Snackbar when no sets are completed
   String get noCompletedSets;
 
+  /// Error when a session has already been saved today
+  String get todayAlreadySaved;
+
+  /// Snackbar after removing a set
+  String get setRemoved;
+
+  /// Label for undoing an action
+  String get undo;
+
   /// Snackbar after successful save
   String get sessionSaved;
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -152,7 +152,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get pleaseCheckInputs => 'Bitte Eingaben prüfen';
 
   @override
-  String get noCompletedSets => 'Keine abgeschlossenen Sätze';
+  String get noCompletedSets => 'Keine abgeschlossenen Sätze.';
+
+  @override
+  String get todayAlreadySaved => 'Heute bereits gespeichert.';
+
+  @override
+  String get setRemoved => 'Satz entfernt';
+
+  @override
+  String get undo => 'Rückgängig';
 
   @override
   String get sessionSaved => 'Session gespeichert';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -152,7 +152,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get pleaseCheckInputs => 'Please check inputs';
 
   @override
-  String get noCompletedSets => 'No completed sets';
+  String get noCompletedSets => 'No completed sets.';
+
+  @override
+  String get todayAlreadySaved => 'Already saved today.';
+
+  @override
+  String get setRemoved => 'Set removed';
+
+  @override
+  String get undo => 'Undo';
 
   @override
   String get sessionSaved => 'Session saved';

--- a/test/widgets/dismissible_session_list_test.dart
+++ b/test/widgets/dismissible_session_list_test.dart
@@ -1,0 +1,105 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/device_provider.dart';
+import 'package:tapem/features/device/presentation/widgets/set_card.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+import 'package:tapem/features/device/domain/usecases/get_devices_for_gym.dart';
+import 'package:tapem/features/device/domain/repositories/device_repository.dart';
+import 'package:tapem/features/device/domain/models/device.dart';
+
+class _FakeRepo implements DeviceRepository {
+  @override
+  Future<List<Device>> getDevicesForGym(String gymId) async => [];
+  @override
+  Future<void> createDevice(String gymId, Device device) => throw UnimplementedError();
+  @override
+  Future<Device?> getDeviceByNfcCode(String gymId, String nfcCode) => throw UnimplementedError();
+  @override
+  Future<void> deleteDevice(String gymId, String deviceId) => throw UnimplementedError();
+  @override
+  Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) => throw UnimplementedError();
+  @override
+  Future<void> setMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) => throw UnimplementedError();
+}
+
+class _TestList extends StatelessWidget {
+  const _TestList();
+  @override
+  Widget build(BuildContext context) {
+    final prov = context.watch<DeviceProvider>();
+    final loc = AppLocalizations.of(context)!;
+    return ListView(
+      children: [
+        for (var entry in prov.sets.asMap().entries)
+          Dismissible(
+            key: ValueKey('set-${entry.key}-${entry.value['number']}'),
+            direction: DismissDirection.endToStart,
+            background: const SizedBox.shrink(),
+            secondaryBackground: Container(
+              alignment: Alignment.centerRight,
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              color: Colors.red.withOpacity(0.15),
+              child: const Icon(Icons.delete, semanticLabel: 'Löschen'),
+            ),
+            onDismissed: (_) {
+              final removed = Map<String, dynamic>.from(entry.value);
+              final removedIndex = entry.key;
+              context.read<DeviceProvider>().removeSet(entry.key);
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(loc.setRemoved),
+                  action: SnackBarAction(
+                    label: loc.undo,
+                    onPressed: () => context
+                        .read<DeviceProvider>()
+                        .insertSetAt(removedIndex, removed),
+                  ),
+                ),
+              );
+            },
+            child: SetCard(index: entry.key, set: entry.value),
+          ),
+      ],
+    );
+  }
+}
+
+void main() {
+  testWidgets('swipe left deletes set with undo', (tester) async {
+    final provider = DeviceProvider(
+      firestore: FakeFirebaseFirestore(),
+      getDevicesForGym: GetDevicesForGym(_FakeRepo()),
+      log: (_, [__]) {},
+    );
+    provider.addSet();
+    provider.addSet();
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<DeviceProvider>.value(
+        value: provider,
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('de'),
+          home: const Scaffold(body: _TestList()),
+        ),
+      ),
+    );
+
+    expect(find.text('Session bearbeiten'), findsNothing);
+
+    final before = provider.sets.length;
+    await tester.drag(find.byType(Dismissible).first, const Offset(-500, 0));
+    await tester.pumpAndSettle();
+
+    expect(provider.sets.length, before - 1);
+    expect(find.text('Satz entfernt'), findsOneWidget);
+
+    await tester.tap(find.text('Rückgängig'));
+    await tester.pumpAndSettle();
+
+    expect(provider.sets.length, before);
+  });
+}


### PR DESCRIPTION
## Summary
- Remove deprecated edit-session logic and protect sessions from multiple saves per day with a Firestore query
- Add swipe-to-delete with undo for sets and disable save button when a session for today exists
- Extend localization strings and add tests for provider dedupe and swipe removal

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `dart format lib/core/providers/device_provider.dart lib/features/device/presentation/screens/device_screen.dart lib/features/device/presentation/widgets/set_card.dart lib/l10n/app_de.arb lib/l10n/app_en.arb lib/l10n/app_localizations.dart lib/l10n/app_localizations_de.dart lib/l10n/app_localizations_en.dart test/providers/device_provider_test.dart test/widgets/dismissible_session_list_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898d95484f0832089b9a7000a6970ac