### PR TITLE
feat(device): add daily dedupe index and save state

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Weitere Details zum State-Management stehen in [docs/provider_structure.md](docs
    - `GoogleService-Info.plist` in `ios/Runner/`
    - Details siehe [docs/environment-setup.md](docs/environment-setup.md)
 
+5. **Firestore-Indexe deployen**
+   ```bash
+   firebase deploy --only firestore:indexes
+   ```
+   Ohne die Indexe schlagen bestimmte Abfragen fehl (z. B. "Heute bereits gespeichert?").
+
 Hinweis: `.gitignore` schützt diese Dateien. Weitere Regeln stehen in [docs/secrets-policy.md](docs/secrets-policy.md).
 
 Die Dateien `pubspec.lock` und – sobald vorhanden – `ios/Podfile.lock` werden versioniert, um reproduzierbare Builds zu gewährleisten.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -48,6 +48,24 @@
         { "fieldPath": "start", "order": "ASCENDING" },
         { "fieldPath": "end", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "logs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "exerciseId", "order": "ASCENDING" },
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "timestamp", "order": "ASCENDING" },
+        { "fieldPath": "__name__", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "logs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "sessionId", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -289,7 +289,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                 const SizedBox(width: 12),
                 Expanded(
                   child: GradientButton(
-                    onPressed: prov.hasSessionToday
+                    onPressed: prov.hasSessionToday || prov.isSaving
                         ? null
                         : () async {
                             if (!_formKey.currentState!.validate()) {
@@ -305,30 +305,28 @@ class _DeviceScreenState extends State<DeviceScreen> {
                               );
                               return;
                             }
-                            try {
-                              await prov.saveWorkoutSession(
-                                context: context,
-                                gymId: widget.gymId,
-                                userId: context
-                                    .read<AuthProvider>()
-                                    .userId!,
-                                showInLeaderboard: context
-                                        .read<AuthProvider>()
-                                        .showInLeaderboard ??
-                                    true,
-                              );
+                            final auth = context.read<AuthProvider>();
+                            final ok = await prov.saveWorkoutSession(
+                              context: context,
+                              gymId: widget.gymId,
+                              userId: auth.userId!,
+                              showInLeaderboard:
+                                  auth.showInLeaderboard ?? true,
+                            );
+                            if (!ok) {
+                              final msg = prov.error ?? 'Speichern fehlgeschlagen.';
                               ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(content: Text(loc.sessionSaved)),
+                                SnackBar(content: Text(msg)),
                               );
-                            } catch (e) {
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(
-                                    content:
-                                        Text('${loc.errorPrefix}: $e')),
-                              );
+                              return;
                             }
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(content: Text(loc.sessionSaved)),
+                            );
                           },
-                    child: Text(loc.saveButton),
+                    child: prov.isSaving
+                        ? const CircularProgressIndicator()
+                        : Text(loc.saveButton),
                   ),
                 ),
               ],

--- a/lib/features/gym/presentation/widgets/device_card.dart
+++ b/lib/features/gym/presentation/widgets/device_card.dart
@@ -44,46 +44,50 @@ class _DeviceCardState extends State<DeviceCard> {
             onTapDown: _onTapDown,
             onTapCancel: _onTapEnd,
             onTapUp: _onTapEnd,
-            child: Padding(
-              padding: const EdgeInsets.all(AppSpacing.sm),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  CircleAvatar(
-                    radius: 28,
-                    backgroundColor: Colors.transparent,
-                    child: DecoratedBox(
-                      decoration: const BoxDecoration(
-                        shape: BoxShape.circle,
-                        gradient: AppGradients.primary,
-                      ),
-                      child: Center(
-                        child: Text(initial, style: theme.textTheme.titleLarge),
+            child: SizedBox(
+              height: 140,
+              child: Padding(
+                padding: const EdgeInsets.all(AppSpacing.sm),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    CircleAvatar(
+                      radius: 28,
+                      backgroundColor: Colors.transparent,
+                      child: DecoratedBox(
+                        decoration: const BoxDecoration(
+                          shape: BoxShape.circle,
+                          gradient: AppGradients.primary,
+                        ),
+                        child: Center(
+                          child: Text(initial, style: theme.textTheme.titleLarge),
+                        ),
                       ),
                     ),
-                  ),
-                  const SizedBox(height: AppSpacing.xs),
-                  Text(
-                    device.name,
-                    style: theme.textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
-                  ),
-                  if (subtitle.isNotEmpty)
+                    const SizedBox(height: AppSpacing.xs),
                     Text(
-                      subtitle,
+                      device.name,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    if (subtitle.isNotEmpty)
+                      Text(
+                        subtitle,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    const SizedBox(height: AppSpacing.xs),
+                    Text(
+                      'ID: $idText',
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
-                      style: theme.textTheme.bodyMedium,
+                      style: theme.textTheme.bodySmall,
                     ),
-                  const SizedBox(height: AppSpacing.xs),
-                  Text(
-                    'ID: $idText',
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: theme.textTheme.bodySmall,
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),

--- a/test/providers/device_provider_test.dart
+++ b/test/providers/device_provider_test.dart
@@ -181,12 +181,13 @@ void main() {
       );
 
       final ctx = tester.element(find.byType(SizedBox));
-      await provider.saveWorkoutSession(
+      final ok = await provider.saveWorkoutSession(
         context: ctx,
         gymId: 'g1',
         userId: 'u1',
         showInLeaderboard: false,
       );
+      expect(ok, isTrue);
 
       final logs = await firestore
           .collection('gyms')
@@ -229,12 +230,13 @@ void main() {
       );
 
       final ctx = tester.element(find.byType(SizedBox));
-      await provider.saveWorkoutSession(
+      final ok = await provider.saveWorkoutSession(
         context: ctx,
         gymId: 'g1',
         userId: 'u1',
         showInLeaderboard: false,
       );
+      expect(ok, isFalse);
 
       final logs = await firestore
           .collection('gyms')
@@ -301,21 +303,23 @@ void main() {
       );
 
       final ctx = tester.element(find.byType(SizedBox));
-      await provider.saveWorkoutSession(
+      var ok = await provider.saveWorkoutSession(
         context: ctx,
         gymId: 'g1',
         userId: 'u1',
         showInLeaderboard: false,
       );
+      expect(ok, isTrue);
 
       provider.updateSet(0, weight: '70', reps: '6');
       provider.toggleSetDone(0);
-      await provider.saveWorkoutSession(
+      ok = await provider.saveWorkoutSession(
         context: ctx,
         gymId: 'g1',
         userId: 'u1',
         showInLeaderboard: false,
       );
+      expect(ok, isFalse);
 
       expect(provider.error, 'Heute bereits gespeichert.');
     });


### PR DESCRIPTION
## Summary
- add Firestore composite indexes for logs
- return bool from saveWorkoutSession and track saving state
- wire up save button to feedback on success/failure and disable while saving
- cap DeviceCard height to avoid overflow
- document index deployment and update tests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898e00c917c8320a491cc8edd966208