### PR TITLE
feat(exercise): preview selected muscle groups

### DIFF
--- a/lib/features/device/presentation/widgets/exercise_bottom_sheet.dart
+++ b/lib/features/device/presentation/widgets/exercise_bottom_sheet.dart
@@ -6,6 +6,7 @@ import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/features/device/domain/models/exercise.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/ui/muscles/muscle_group_selector.dart';
+import 'package:tapem/features/device/presentation/widgets/muscle_chips.dart';
 
 class ExerciseBottomSheet extends StatefulWidget {
   final String gymId;
@@ -52,6 +53,7 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
     final loc = AppLocalizations.of(context)!;
     final auth = context.read<AuthProvider>();
     final userId = auth.userId!;
+    final theme = Theme.of(context);
 
     final canSave =
         _nameCtr.text.trim().isNotEmpty && _selected.isNotEmpty;
@@ -90,6 +92,30 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
               style: const TextStyle(fontWeight: FontWeight.bold),
             ),
           ),
+          if (_selected.isNotEmpty) ...[
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+              child: Text(
+                loc.exerciseSelectedMuscleGroups,
+                style: theme.textTheme.labelLarge,
+              ),
+            ),
+            Semantics(
+              container: true,
+              label: loc.exerciseSelectedMuscleGroups,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: MuscleChips(muscleGroupIds: _selected.toList()),
+              ),
+            ),
+          ] else
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+              child: Text(
+                loc.exerciseNoMuscleGroups,
+                style: theme.textTheme.bodySmall,
+              ),
+            ),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: TextField(

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -458,6 +458,8 @@
   "@exerciseNameLabel": {"description": "Label für Namensfeld"},
   "exerciseMuscleGroupsLabel": "Muskelgruppen",
   "@exerciseMuscleGroupsLabel": {"description": "Überschrift Muskelgruppen"},
+  "exerciseSelectedMuscleGroups": "Ausgewählt",
+  "@exerciseSelectedMuscleGroups": {"description": "Überschrift ausgewählte Muskelgruppen"},
   "exerciseSearchMuscleGroupsHint": "Muskelgruppen durchsuchen...",
   "@exerciseSearchMuscleGroupsHint": {"description": "Hint für Muskelgruppensuche"},
   "exerciseNoMuscleGroups": "Keine Muskelgruppen verfügbar",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -455,6 +455,8 @@
   "@exerciseNameLabel": {"description": "Exercise name label"},
   "exerciseMuscleGroupsLabel": "Muscle groups",
   "@exerciseMuscleGroupsLabel": {"description": "Header muscle groups"},
+  "exerciseSelectedMuscleGroups": "Selected",
+  "@exerciseSelectedMuscleGroups": {"description": "Header for selected muscle groups"},
   "exerciseSearchMuscleGroupsHint": "Search muscle groups...",
   "@exerciseSearchMuscleGroupsHint": {"description": "Hint for muscle group search"},
   "exerciseNoMuscleGroups": "No muscle groups available",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -764,6 +764,9 @@ abstract class AppLocalizations {
   /// Header muscle groups
   String get exerciseMuscleGroupsLabel;
 
+  /// Header for selected muscle groups
+  String get exerciseSelectedMuscleGroups;
+
   /// Hint for muscle group search field
   String get exerciseSearchMuscleGroupsHint;
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -362,6 +362,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get exerciseMuscleGroupsLabel => 'Muskelgruppen';
 
   @override
+  String get exerciseSelectedMuscleGroups => 'Ausgewählt';
+
+  @override
   String get exerciseSearchMuscleGroupsHint => 'Muskelgruppen durchsuchen...';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -362,6 +362,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get exerciseMuscleGroupsLabel => 'Muscle groups';
 
   @override
+  String get exerciseSelectedMuscleGroups => 'Selected';
+
+  @override
   String get exerciseSearchMuscleGroupsHint => 'Search muscle groups...';
 
   @override

--- a/lib/ui/muscles/muscle_group_card.dart
+++ b/lib/ui/muscles/muscle_group_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
+import 'package:tapem/l10n/app_localizations.dart';
 
 import 'muscle_group_color.dart';
 
@@ -18,15 +19,21 @@ class MuscleGroupCard extends StatelessWidget {
     );
     if (group.id.isEmpty) return const SizedBox.shrink();
     final theme = Theme.of(context);
+    final loc = AppLocalizations.of(context)!;
     return Semantics(
-      label: 'Muskelgruppe: ${group.name}',
+      label: loc.a11yMgSelected(group.name),
       child: Chip(
         visualDensity: VisualDensity.compact,
         avatar: CircleAvatar(
           backgroundColor: colorForRegion(group.region, theme),
           radius: 6,
         ),
-        label: Text(group.name),
+        label: Text(
+          group.name,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          softWrap: false,
+        ),
       ),
     );
   }

--- a/lib/ui/muscles/muscle_group_selector.dart
+++ b/lib/ui/muscles/muscle_group_selector.dart
@@ -63,6 +63,7 @@ class _MuscleGroupSelectorState extends State<MuscleGroupSelector> {
     }
 
     return SingleChildScrollView(
+      physics: const BouncingScrollPhysics(), // POLISH: smoother scroll in bottom sheet
       child: Wrap(
         spacing: 4,
         runSpacing: 4,

--- a/test/widgets/exercise_bottom_sheet_selected_preview_test.dart
+++ b/test/widgets/exercise_bottom_sheet_selected_preview_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/muscle_group_provider.dart';
+import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
+import 'package:tapem/features/device/presentation/widgets/exercise_bottom_sheet.dart';
+import 'package:tapem/features/device/presentation/widgets/muscle_chips.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/features/muscle_group/domain/repositories/muscle_group_repository.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/get_muscle_groups_for_gym.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/save_muscle_group.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/delete_muscle_group.dart';
+import 'package:tapem/features/history/domain/usecases/get_history_for_device.dart';
+import 'package:tapem/features/device/domain/usecases/update_device_muscle_groups_usecase.dart';
+import 'package:tapem/features/device/domain/usecases/set_device_muscle_groups_usecase.dart';
+import 'package:tapem/features/device/domain/repositories/device_repository.dart';
+import 'package:tapem/features/history/domain/models/workout_log.dart';
+import 'package:tapem/features/device/domain/models/device.dart';
+
+class _FakeMuscleGroupRepo implements MuscleGroupRepository {
+  final List<MuscleGroup> groups;
+  _FakeMuscleGroupRepo(this.groups);
+  @override
+  Future<List<MuscleGroup>> getMuscleGroups(String gymId) async => groups;
+  @override
+  Future<void> saveMuscleGroup(String gymId, MuscleGroup group) async {}
+  @override
+  Future<void> deleteMuscleGroup(String gymId, String groupId) async {}
+}
+
+class _FakeHistoryRepo implements GetHistoryForDeviceRepository {
+  @override
+  Future<List<WorkoutLog>> getHistory({required String gymId, required String deviceId, required String userId}) async => [];
+}
+
+class _FakeDeviceRepo implements DeviceRepository {
+  @override
+  Future<void> createDevice(String gymId, Device device) async {}
+  @override
+  Future<void> deleteDevice(String gymId, String deviceId) async {}
+  @override
+  Future<Device?> getDeviceByNfcCode(String gymId, String nfcCode) async => null;
+  @override
+  Future<List<Device>> getDevicesForGym(String gymId) async => [];
+  @override
+  Future<void> setMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
+  @override
+  Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
+}
+
+class FakeMuscleGroupProvider extends MuscleGroupProvider {
+  final List<MuscleGroup> _groups;
+  FakeMuscleGroupProvider(this._groups)
+      : super(
+          getGroups: GetMuscleGroupsForGym(_FakeMuscleGroupRepo(_groups)),
+          saveGroup: SaveMuscleGroup(_FakeMuscleGroupRepo(_groups)),
+          deleteGroup: DeleteMuscleGroup(_FakeMuscleGroupRepo(_groups)),
+          getHistory: GetHistoryForDevice(_FakeHistoryRepo()),
+          updateDeviceGroups: UpdateDeviceMuscleGroupsUseCase(_FakeDeviceRepo()),
+          setDeviceGroups: SetDeviceMuscleGroupsUseCase(_FakeDeviceRepo()),
+        );
+
+  @override
+  bool get isLoading => false;
+
+  @override
+  List<MuscleGroup> get groups => _groups;
+
+  @override
+  Future<void> loadGroups(BuildContext context) async {}
+}
+
+class _FakeAuthProvider extends ChangeNotifier implements AuthProvider {
+  @override
+  String? get userId => 'user1';
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  final groups = [
+    MuscleGroup(id: '1', name: 'Latissimus dorsi', region: MuscleRegion.back),
+  ];
+
+  testWidgets('preview updates when selecting muscle groups', (tester) async {
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<MuscleGroupProvider>.value(
+            value: FakeMuscleGroupProvider(groups),
+          ),
+          ChangeNotifierProvider<AuthProvider>.value(
+            value: _FakeAuthProvider(),
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: ExerciseBottomSheet(
+              gymId: 'g1',
+              deviceId: 'd1',
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('No muscle groups available'), findsOneWidget);
+    await tester.tap(find.text('Latissimus dorsi'));
+    await tester.pump();
+    expect(find.text('Selected'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(MuscleChips),
+        matching: find.text('Latissimus dorsi'),
+      ),
+      findsOneWidget,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- show selected muscle groups in add-exercise sheet
- support chip semantics and overflow
- add localization for selected muscle groups

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `flutter format lib/features/device/presentation/widgets/exercise_bottom_sheet.dart lib/ui/muscles/muscle_group_selector.dart lib/ui/muscles/muscle_group_card.dart lib/l10n/app_en.arb lib/l10n/app_de.arb lib/l10n/app_localizations.dart lib/l10n/app_localizations_en.dart lib/l10n/app_localizations_de.dart test/widgets/exercise_bottom_sheet_selected_preview_test.dart` *(fails: command not found)*
- `dart test test/widgets/exercise_bottom_sheet_selected_preview_test.dart` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6899356b50ec8320b5fce80ed9987d27