### PR TITLE
feat: add list-based muscle group selector

### DIFF
--- a/lib/features/device/presentation/widgets/exercise_bottom_sheet.dart
+++ b/lib/features/device/presentation/widgets/exercise_bottom_sheet.dart
@@ -5,8 +5,7 @@ import 'package:tapem/core/providers/exercise_provider.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/features/device/domain/models/exercise.dart';
 import 'package:tapem/l10n/app_localizations.dart';
-import 'package:tapem/ui/muscles/muscle_group_selector.dart';
-import 'package:tapem/features/device/presentation/widgets/muscle_chips.dart';
+import 'package:tapem/ui/muscles/muscle_group_list_selector.dart';
 
 class ExerciseBottomSheet extends StatefulWidget {
   final String gymId;
@@ -53,8 +52,6 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
     final loc = AppLocalizations.of(context)!;
     final auth = context.read<AuthProvider>();
     final userId = auth.userId!;
-    final theme = Theme.of(context);
-
     final canSave =
         _nameCtr.text.trim().isNotEmpty && _selectedGroupIds.isNotEmpty;
 
@@ -92,31 +89,6 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
               style: const TextStyle(fontWeight: FontWeight.bold),
             ),
           ),
-          if (_selectedGroupIds.isNotEmpty) ...[
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-              child: Text(
-                loc.exerciseSelectedMuscleGroups,
-                style: theme.textTheme.labelLarge,
-              ),
-            ),
-            Semantics(
-              container: true,
-              label: loc.exerciseSelectedMuscleGroups,
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 12),
-                child:
-                    MuscleChips(muscleGroupIds: _selectedGroupIds.toList()),
-              ),
-            ),
-          ] else
-            Padding(
-              padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-              child: Text(
-              loc.exerciseNoMuscleGroups,
-                style: theme.textTheme.bodySmall,
-              ),
-            ),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: TextField(
@@ -130,7 +102,7 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
           const SizedBox(height: 8),
           SizedBox(
             height: 240,
-            child: MuscleGroupSelector(
+            child: MuscleGroupListSelector(
               initialSelection: _selectedGroupIds.toList(),
               filter: _query,
               onChanged: (ids) => setState(() {

--- a/lib/ui/muscles/muscle_group_list_selector.dart
+++ b/lib/ui/muscles/muscle_group_list_selector.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/muscle_group_provider.dart';
+import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
+import 'muscle_group_color.dart';
+
+class MuscleGroupListSelector extends StatefulWidget {
+  final List<String> initialSelection;
+  final ValueChanged<List<String>> onChanged;
+  final String filter;
+
+  const MuscleGroupListSelector({
+    super.key,
+    required this.initialSelection,
+    required this.onChanged,
+    this.filter = '',
+  });
+
+  @override
+  State<MuscleGroupListSelector> createState() => _MuscleGroupListSelectorState();
+}
+
+class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
+  late Set<String> _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = widget.initialSelection.toSet();
+  }
+
+  void _toggle(String id) {
+    setState(() {
+      if (_selected.contains(id)) {
+        _selected.remove(id);
+      } else {
+        _selected.add(id);
+      }
+      widget.onChanged(_selected.toList());
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    final prov = context.watch<MuscleGroupProvider>();
+    final theme = Theme.of(context);
+
+    if (prov.isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    final groups = prov.groups
+        .where((g) => g.name.toLowerCase().contains(widget.filter.toLowerCase()))
+        .toList()
+      ..sort((a, b) => a.name.compareTo(b.name));
+
+    if (groups.isEmpty) {
+      return Center(child: Text(loc.exerciseNoMuscleGroups));
+    }
+
+    return ListView.separated(
+      shrinkWrap: true,
+      physics: const BouncingScrollPhysics(),
+      itemBuilder: (context, index) {
+        final g = groups[index];
+        final selected = _selected.contains(g.id);
+        return ListTile(
+          onTap: () => _toggle(g.id),
+          leading: CircleAvatar(
+            backgroundColor: colorForRegion(g.region, theme),
+          ),
+          title: Text(
+            g.name,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          trailing: Checkbox(
+            value: selected,
+            onChanged: (_) => _toggle(g.id),
+          ),
+        );
+      },
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemCount: groups.length,
+    );
+  }
+}
+

--- a/test/widgets/muscle_group_list_selector_test.dart
+++ b/test/widgets/muscle_group_list_selector_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/ui/muscles/muscle_group_list_selector.dart';
+import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
+import 'package:tapem/core/providers/muscle_group_provider.dart';
+import 'package:tapem/features/muscle_group/domain/repositories/muscle_group_repository.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/get_muscle_groups_for_gym.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/save_muscle_group.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/delete_muscle_group.dart';
+import 'package:tapem/features/history/domain/usecases/get_history_for_device.dart';
+import 'package:tapem/features/device/domain/usecases/update_device_muscle_groups_usecase.dart';
+import 'package:tapem/features/device/domain/usecases/set_device_muscle_groups_usecase.dart';
+import 'package:tapem/features/device/domain/repositories/device_repository.dart';
+import 'package:tapem/features/history/domain/models/workout_log.dart';
+import 'package:tapem/features/device/domain/models/device.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
+class _FakeMuscleGroupRepo implements MuscleGroupRepository {
+  final List<MuscleGroup> groups;
+  _FakeMuscleGroupRepo(this.groups);
+  @override
+  Future<List<MuscleGroup>> getMuscleGroups(String gymId) async => groups;
+  @override
+  Future<void> saveMuscleGroup(String gymId, MuscleGroup group) async {}
+  @override
+  Future<void> deleteMuscleGroup(String gymId, String groupId) async {}
+}
+
+class _FakeHistoryRepo implements GetHistoryForDeviceRepository {
+  @override
+  Future<List<WorkoutLog>> getHistory({required String gymId, required String deviceId, required String userId}) async => [];
+}
+
+class _FakeDeviceRepo implements DeviceRepository {
+  @override
+  Future<void> createDevice(String gymId, Device device) async {}
+  @override
+  Future<void> deleteDevice(String gymId, String deviceId) async {}
+  @override
+  Future<Device?> getDeviceByNfcCode(String gymId, String nfcCode) async => null;
+  @override
+  Future<List<Device>> getDevicesForGym(String gymId) async => [];
+  @override
+  Future<void> setMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
+  @override
+  Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
+}
+
+class FakeMuscleGroupProvider extends MuscleGroupProvider {
+  final List<MuscleGroup> _groups;
+  FakeMuscleGroupProvider(this._groups)
+      : super(
+          getGroups: GetMuscleGroupsForGym(_FakeMuscleGroupRepo(_groups)),
+          saveGroup: SaveMuscleGroup(_FakeMuscleGroupRepo(_groups)),
+          deleteGroup: DeleteMuscleGroup(_FakeMuscleGroupRepo(_groups)),
+          getHistory: GetHistoryForDevice(_FakeHistoryRepo()),
+          updateDeviceGroups: UpdateDeviceMuscleGroupsUseCase(_FakeDeviceRepo()),
+          setDeviceGroups: SetDeviceMuscleGroupsUseCase(_FakeDeviceRepo()),
+        );
+
+  @override
+  bool get isLoading => false;
+
+  @override
+  List<MuscleGroup> get groups => _groups;
+
+  @override
+  Future<void> loadGroups(BuildContext context) async {}
+}
+
+void main() {
+  final groups = [
+    MuscleGroup(id: '1', name: 'Chest', region: MuscleRegion.chest),
+    MuscleGroup(id: '2', name: 'Back', region: MuscleRegion.back),
+  ];
+
+  testWidgets('MuscleGroupListSelector shows names and toggles', (tester) async {
+    List<String> selected = [];
+    await tester.pumpWidget(
+      ChangeNotifierProvider<MuscleGroupProvider>.value(
+        value: FakeMuscleGroupProvider(groups),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: MuscleGroupListSelector(
+              initialSelection: const [],
+              onChanged: (ids) => selected = ids,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Back'), findsOneWidget);
+    final backTile = find.ancestor(of: find.text('Back'), matching: find.byType(ListTile));
+    final backCheckbox = find.descendant(of: backTile, matching: find.byType(Checkbox));
+    expect(tester.widget<Checkbox>(backCheckbox).value, isFalse);
+    await tester.tap(backTile);
+    await tester.pumpAndSettle();
+    expect(tester.widget<Checkbox>(backCheckbox).value, isTrue);
+    expect(selected, ['2']);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add vertical MuscleGroupListSelector widget with checkbox toggle support
- replace chip selector in exercise bottom sheet with new list selector
- cover list selector with widget test

## Testing
- `flutter test test/widgets/muscle_group_list_selector_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689943641c3083209f6d4c05e9143c6b