### PR TITLE
Display muscle group names with region fallbacks

### DIFF
--- a/lib/features/device/presentation/widgets/exercise_bottom_sheet.dart
+++ b/lib/features/device/presentation/widgets/exercise_bottom_sheet.dart
@@ -26,8 +26,8 @@ class ExerciseBottomSheet extends StatefulWidget {
 class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
   late TextEditingController _nameCtr;
   late TextEditingController _searchCtr;
-  final Set<String> _selectedGroupIds = {};
-  String _query = '';
+  List<String> _selectedGroupIds = [];
+  String _filter = '';
 
   @override
   void initState() {
@@ -96,20 +96,16 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
               decoration: InputDecoration(
                 hintText: loc.exerciseSearchMuscleGroupsHint,
               ),
-              onChanged: (v) => setState(() => _query = v),
+              onChanged: (v) => setState(() => _filter = v),
             ),
           ),
           const SizedBox(height: 8),
           SizedBox(
-            height: 240,
+            height: 280,
             child: MuscleGroupListSelector(
-              initialSelection: _selectedGroupIds.toList(),
-              filter: _query,
-              onChanged: (ids) => setState(() {
-                _selectedGroupIds
-                  ..clear()
-                  ..addAll(ids);
-              }),
+              initialSelection: _selectedGroupIds,
+              filter: _filter,
+              onChanged: (ids) => setState(() => _selectedGroupIds = ids),
             ),
           ),
           Row(
@@ -132,7 +128,7 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
                             widget.deviceId,
                             name,
                             userId,
-                            muscleGroupIds: _selectedGroupIds.toList(),
+                            muscleGroupIds: _selectedGroupIds,
                           );
                         } else {
                           await exProv.updateExercise(
@@ -141,11 +137,11 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
                             widget.exercise!.id,
                             name,
                             userId,
-                            muscleGroupIds: _selectedGroupIds.toList(),
+                            muscleGroupIds: _selectedGroupIds,
                           );
                           ex = widget.exercise!.copyWith(
                             name: name,
-                            muscleGroupIds: _selectedGroupIds.toList(),
+                            muscleGroupIds: _selectedGroupIds,
                           );
                         }
                         await context
@@ -153,7 +149,7 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
                             .assignExercise(
                               context,
                               ex.id,
-                              _selectedGroupIds.toList(),
+                              _selectedGroupIds,
                             );
                         if (!mounted) return;
                         Navigator.pop(context, ex);

--- a/test/widgets/muscle_group_list_selector_text_test.dart
+++ b/test/widgets/muscle_group_list_selector_text_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/ui/muscles/muscle_group_list_selector.dart';
+import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
+import 'package:tapem/core/providers/muscle_group_provider.dart';
+import 'package:tapem/features/muscle_group/domain/repositories/muscle_group_repository.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/get_muscle_groups_for_gym.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/save_muscle_group.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/delete_muscle_group.dart';
+import 'package:tapem/features/history/domain/usecases/get_history_for_device.dart';
+import 'package:tapem/features/device/domain/usecases/update_device_muscle_groups_usecase.dart';
+import 'package:tapem/features/device/domain/usecases/set_device_muscle_groups_usecase.dart';
+import 'package:tapem/features/device/domain/repositories/device_repository.dart';
+import 'package:tapem/features/history/domain/models/workout_log.dart';
+import 'package:tapem/features/device/domain/models/device.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
+class _FakeMuscleGroupRepo implements MuscleGroupRepository {
+  final List<MuscleGroup> groups;
+  _FakeMuscleGroupRepo(this.groups);
+  @override
+  Future<List<MuscleGroup>> getMuscleGroups(String gymId) async => groups;
+  @override
+  Future<void> saveMuscleGroup(String gymId, MuscleGroup group) async {}
+  @override
+  Future<void> deleteMuscleGroup(String gymId, String groupId) async {}
+}
+
+class _FakeHistoryRepo implements GetHistoryForDeviceRepository {
+  @override
+  Future<List<WorkoutLog>> getHistory({required String gymId, required String deviceId, required String userId}) async => [];
+}
+
+class _FakeDeviceRepo implements DeviceRepository {
+  @override
+  Future<void> createDevice(String gymId, Device device) async {}
+  @override
+  Future<void> deleteDevice(String gymId, String deviceId) async {}
+  @override
+  Future<Device?> getDeviceByNfcCode(String gymId, String nfcCode) async => null;
+  @override
+  Future<List<Device>> getDevicesForGym(String gymId) async => [];
+  @override
+  Future<void> setMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
+  @override
+  Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
+}
+
+class FakeMuscleGroupProvider extends MuscleGroupProvider {
+  final List<MuscleGroup> _groups;
+  FakeMuscleGroupProvider(this._groups)
+      : super(
+          getGroups: GetMuscleGroupsForGym(_FakeMuscleGroupRepo(_groups)),
+          saveGroup: SaveMuscleGroup(_FakeMuscleGroupRepo(_groups)),
+          deleteGroup: DeleteMuscleGroup(_FakeMuscleGroupRepo(_groups)),
+          getHistory: GetHistoryForDevice(_FakeHistoryRepo()),
+          updateDeviceGroups: UpdateDeviceMuscleGroupsUseCase(_FakeDeviceRepo()),
+          setDeviceGroups: SetDeviceMuscleGroupsUseCase(_FakeDeviceRepo()),
+        );
+
+  @override
+  bool get isLoading => false;
+
+  @override
+  List<MuscleGroup> get groups => _groups;
+
+  @override
+  Future<void> loadGroups(BuildContext context) async {}
+}
+
+void main() {
+  testWidgets('zeigt Fallback-Namen, wenn group.name leer ist', (tester) async {
+    final groups = [MuscleGroup(id: '1', name: '', region: MuscleRegion.back)];
+    List<String> selected = [];
+    await tester.pumpWidget(
+      ChangeNotifierProvider<MuscleGroupProvider>.value(
+        value: FakeMuscleGroupProvider(groups),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: MuscleGroupListSelector(
+              initialSelection: const [],
+              onChanged: (ids) => selected = ids,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Back'), findsOneWidget);
+    final checkboxFinder = find.byType(Checkbox);
+    expect(tester.widget<Checkbox>(checkboxFinder).value, isFalse);
+    await tester.tap(find.text('Back'));
+    await tester.pumpAndSettle();
+    expect(tester.widget<Checkbox>(checkboxFinder).value, isTrue);
+    expect(selected, ['1']);
+  });
+}


### PR DESCRIPTION
## Summary
- Show muscle group name text between avatar and checkbox in selection list
- Use region fallback names when group names are empty
- Update exercise bottom sheet to use new selector component
- Add widget test for fallback name visibility and selection

## Testing
- `flutter test test/widgets/muscle_group_list_selector_text_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689949c289548320bdb7f5f98f209fc7