### PR TITLE
feat: refine muscle group selector with primary/secondary logic

### DIFF
--- a/lib/features/device/presentation/widgets/exercise_bottom_sheet.dart
+++ b/lib/features/device/presentation/widgets/exercise_bottom_sheet.dart
@@ -103,6 +103,7 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
           SizedBox(
             height: 280,
             child: MuscleGroupListSelector(
+              deviceId: widget.deviceId,
               initialSelection: _selectedGroupIds,
               filter: _filter,
               onChanged: (ids) => setState(() => _selectedGroupIds = ids),

--- a/lib/ui/muscles/muscle_group_list_selector.dart
+++ b/lib/ui/muscles/muscle_group_list_selector.dart
@@ -7,12 +7,14 @@ import 'package:tapem/l10n/app_localizations.dart';
 import 'muscle_group_color.dart';
 
 class MuscleGroupListSelector extends StatefulWidget {
+  final String? deviceId;
   final List<String> initialSelection;
   final ValueChanged<List<String>> onChanged;
   final String filter;
 
   const MuscleGroupListSelector({
     super.key,
+    this.deviceId,
     required this.initialSelection,
     required this.onChanged,
     this.filter = '',
@@ -23,12 +25,23 @@ class MuscleGroupListSelector extends StatefulWidget {
 }
 
 class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
+  static const List<MuscleRegion> _ordered = [
+    MuscleRegion.chest,
+    MuscleRegion.back,
+    MuscleRegion.shoulders,
+    MuscleRegion.arms,
+    MuscleRegion.legs,
+    MuscleRegion.core,
+  ];
+
   late List<String> _selected;
+  String? _primaryId;
 
   @override
   void initState() {
     super.initState();
     _selected = List.of(widget.initialSelection);
+    _primaryId = _selected.isNotEmpty ? _selected.first : null;
   }
 
   String _regionFallbackName(MuscleRegion r) {
@@ -48,15 +61,64 @@ class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
     }
   }
 
-  void _toggle(String id) {
+  void _emit() => widget.onChanged(
+        _primaryId == null
+            ? []
+            : [
+                _primaryId!,
+                ..._selected.where((id) => id != _primaryId),
+              ],
+      );
+
+  void _toggleSelect(String id) {
     setState(() {
       if (_selected.contains(id)) {
         _selected.remove(id);
+        if (_primaryId == id) {
+          _primaryId = _selected.isNotEmpty ? _selected.first : null;
+        }
       } else {
         _selected.add(id);
+        _primaryId ??= id;
       }
     });
-    widget.onChanged(_selected);
+    _emit();
+  }
+
+  void _setPrimary(String id) {
+    if (!_selected.contains(id)) {
+      _selected.add(id);
+    }
+    setState(() => _primaryId = id);
+    _emit();
+  }
+
+  Map<MuscleRegion, MuscleGroup?> _buildCanonical(List<MuscleGroup> all) {
+    final Map<MuscleRegion, MuscleGroup?> canonical = {
+      for (final r in _ordered) r: null
+    };
+
+    for (final g in all) {
+      final current = canonical[g.region];
+      if (current == null) {
+        canonical[g.region] = g;
+        continue;
+      }
+
+      final preferByDevice = widget.deviceId != null &&
+          (g.primaryDeviceIds.contains(widget.deviceId) ||
+              g.secondaryDeviceIds.contains(widget.deviceId));
+      final currentByDevice = widget.deviceId != null &&
+          (current.primaryDeviceIds.contains(widget.deviceId) ||
+              current.secondaryDeviceIds.contains(widget.deviceId));
+      final preferByName = g.name.isNotEmpty && current.name.isEmpty;
+
+      if ((preferByDevice && !currentByDevice) || preferByName) {
+        canonical[g.region] = g;
+      }
+    }
+
+    return canonical;
   }
 
   @override
@@ -69,60 +131,98 @@ class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
       return const Center(child: CircularProgressIndicator());
     }
 
-    final groups = prov.groups
-        .where((g) {
-          final name = g.name.isNotEmpty ? g.name : _regionFallbackName(g.region);
-          return name.toLowerCase().contains(widget.filter.toLowerCase());
-        })
-        .toList()
-      ..sort((a, b) => a.name.compareTo(b.name));
+    final canonical = _buildCanonical(prov.groups);
 
-    if (groups.isEmpty) {
+    final entries = <_Entry>[];
+    for (final r in _ordered) {
+      final g = canonical[r];
+      var name = g != null && g.name.isNotEmpty ? g.name : _regionFallbackName(r);
+      if (g == null) {
+        name = '$name - not configured';
+      }
+      if (name.toLowerCase().contains(widget.filter.toLowerCase())) {
+        entries.add(_Entry(region: r, group: g, displayName: name));
+      }
+    }
+
+    if (entries.isEmpty) {
       return Center(child: Text(loc.exerciseNoMuscleGroups));
     }
+
+    final Color primaryFill = Colors.green;
+    final Color secondaryFill = Colors.blueAccent;
 
     return ListView.separated(
       shrinkWrap: true,
       physics: const BouncingScrollPhysics(),
       itemBuilder: (context, index) {
-        final g = groups[index];
-        final selected = _selected.contains(g.id);
-        final displayName = g.name.isNotEmpty ? g.name : _regionFallbackName(g.region);
-        final textStyle = theme.textTheme.bodyLarge?.copyWith(color: theme.colorScheme.onSurface);
-        return InkWell(
-          onTap: () => _toggle(g.id),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-            child: Row(
-              children: [
-                CircleAvatar(
-                  radius: 16,
-                  backgroundColor: colorForRegion(g.region, theme),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Text(
-                    displayName,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: textStyle,
-                  ),
-                ),
-                Checkbox(
-                  value: selected,
-                  onChanged: (_) => _toggle(g.id),
-                ),
-              ],
+        final entry = entries[index];
+        final g = entry.group;
+        final disabled = g == null;
+        final isSelected = g != null && _selected.contains(g.id);
+        final isPrimary = g != null && _primaryId == g.id;
+        final textStyle = theme.textTheme.bodyLarge?.copyWith(
+          color: theme.colorScheme.onSurface,
+        );
+
+        Widget trailing;
+        if (disabled) {
+          trailing = const Icon(Icons.block);
+        } else {
+          trailing = Checkbox(
+            value: isSelected,
+            onChanged: (_) => _toggleSelect(g.id),
+            fillColor: MaterialStateProperty.resolveWith(
+              (states) => states.contains(MaterialState.selected)
+                  ? (isPrimary ? primaryFill : secondaryFill)
+                  : null,
             ),
+            checkColor: Colors.white,
+          );
+        }
+
+        final row = Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+          child: Row(
+            children: [
+              CircleAvatar(
+                radius: 16,
+                backgroundColor: colorForRegion(entry.region, theme),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  entry.displayName,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: textStyle,
+                ),
+              ),
+              trailing,
+            ],
           ),
+        );
+
+        return InkWell(
+          onTap: disabled ? null : () => _toggleSelect(g!.id),
+          onLongPress: disabled ? null : () => _setPrimary(g!.id),
+          child: disabled ? Opacity(opacity: 0.5, child: row) : row,
         );
       },
       separatorBuilder: (_, __) => Divider(
         color: theme.colorScheme.outlineVariant,
         height: 1,
       ),
-      itemCount: groups.length,
+      itemCount: entries.length,
     );
   }
+}
+
+class _Entry {
+  final MuscleRegion region;
+  final MuscleGroup? group;
+  final String displayName;
+
+  _Entry({required this.region, required this.group, required this.displayName});
 }
 

--- a/test/widgets/muscle_group_list_selector_dedup_primary_test.dart
+++ b/test/widgets/muscle_group_list_selector_dedup_primary_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/muscle_group_provider.dart';
+import 'package:tapem/features/device/domain/models/device.dart';
+import 'package:tapem/features/device/domain/repositories/device_repository.dart';
+import 'package:tapem/features/device/domain/usecases/set_device_muscle_groups_usecase.dart';
+import 'package:tapem/features/device/domain/usecases/update_device_muscle_groups_usecase.dart';
+import 'package:tapem/features/history/domain/models/workout_log.dart';
+import 'package:tapem/features/history/domain/usecases/get_history_for_device.dart';
+import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
+import 'package:tapem/features/muscle_group/domain/repositories/muscle_group_repository.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/delete_muscle_group.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/get_muscle_groups_for_gym.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/save_muscle_group.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+import 'package:tapem/ui/muscles/muscle_group_list_selector.dart';
+
+class _FakeMuscleGroupRepo implements MuscleGroupRepository {
+  final List<MuscleGroup> groups;
+  _FakeMuscleGroupRepo(this.groups);
+  @override
+  Future<List<MuscleGroup>> getMuscleGroups(String gymId) async => groups;
+  @override
+  Future<void> saveMuscleGroup(String gymId, MuscleGroup group) async {}
+  @override
+  Future<void> deleteMuscleGroup(String gymId, String groupId) async {}
+}
+
+class _FakeHistoryRepo implements GetHistoryForDeviceRepository {
+  @override
+  Future<List<WorkoutLog>> getHistory({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+  }) async => [];
+}
+
+class _FakeDeviceRepo implements DeviceRepository {
+  @override
+  Future<void> createDevice(String gymId, Device device) async {}
+  @override
+  Future<void> deleteDevice(String gymId, String deviceId) async {}
+  @override
+  Future<Device?> getDeviceByNfcCode(String gymId, String nfcCode) async => null;
+  @override
+  Future<List<Device>> getDevicesForGym(String gymId) async => [];
+  @override
+  Future<void> setMuscleGroups(
+      String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
+  @override
+  Future<void> updateMuscleGroups(
+      String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
+}
+
+class _FakeMuscleGroupProvider extends MuscleGroupProvider {
+  final List<MuscleGroup> _groups;
+  _FakeMuscleGroupProvider(this._groups)
+      : super(
+          getGroups: GetMuscleGroupsForGym(_FakeMuscleGroupRepo(_groups)),
+          saveGroup: SaveMuscleGroup(_FakeMuscleGroupRepo(_groups)),
+          deleteGroup: DeleteMuscleGroup(_FakeMuscleGroupRepo(_groups)),
+          getHistory: GetHistoryForDevice(_FakeHistoryRepo()),
+          updateDeviceGroups: UpdateDeviceMuscleGroupsUseCase(_FakeDeviceRepo()),
+          setDeviceGroups: SetDeviceMuscleGroupsUseCase(_FakeDeviceRepo()),
+        );
+
+  @override
+  bool get isLoading => false;
+
+  @override
+  List<MuscleGroup> get groups => _groups;
+
+  @override
+  Future<void> loadGroups(BuildContext context) async {}
+}
+
+void main() {
+  final groups = [
+    MuscleGroup(id: 'c1', name: '', region: MuscleRegion.chest),
+    MuscleGroup(id: 'c2', name: 'Chest', region: MuscleRegion.chest),
+    MuscleGroup(id: 'c3', name: 'Other Chest', region: MuscleRegion.chest),
+    MuscleGroup(id: 'b1', name: 'Back', region: MuscleRegion.back),
+    MuscleGroup(id: 'b2', name: 'Other Back', region: MuscleRegion.back),
+  ];
+
+  testWidgets('dedups regions and handles primary/secondary selection', (tester) async {
+    List<String> changed = [];
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<MuscleGroupProvider>.value(
+        value: _FakeMuscleGroupProvider(groups),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: MuscleGroupListSelector(
+              initialSelection: const [],
+              filter: '',
+              onChanged: (ids) => changed = ids,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(InkWell), findsNWidgets(6));
+
+    final armsTile = find.widgetWithText(InkWell, 'Arms - not configured');
+    expect(find.descendant(of: armsTile, matching: find.byType(Checkbox)), findsNothing);
+    expect(find.descendant(of: armsTile, matching: find.byIcon(Icons.block)), findsOneWidget);
+
+    final coreTile = find.widgetWithText(InkWell, 'Core - not configured');
+    expect(find.descendant(of: coreTile, matching: find.byType(Checkbox)), findsNothing);
+
+    final backTile = find.widgetWithText(InkWell, 'Back');
+    await tester.tap(backTile);
+    await tester.pumpAndSettle();
+    final backCheckbox = find.descendant(of: backTile, matching: find.byType(Checkbox));
+    var color = (tester.widget<Checkbox>(backCheckbox).fillColor!)
+        .resolve({MaterialState.selected});
+    expect(color, Colors.green);
+
+    final chestTile = find.widgetWithText(InkWell, 'Chest');
+    await tester.tap(chestTile);
+    await tester.pumpAndSettle();
+    final chestCheckbox = find.descendant(of: chestTile, matching: find.byType(Checkbox));
+    color = (tester.widget<Checkbox>(chestCheckbox).fillColor!)
+        .resolve({MaterialState.selected});
+    expect(color, Colors.blueAccent);
+
+    await tester.longPress(chestTile);
+    await tester.pumpAndSettle();
+
+    final chestColor =
+        (tester.widget<Checkbox>(chestCheckbox).fillColor!).resolve({MaterialState.selected});
+    final backColor =
+        (tester.widget<Checkbox>(backCheckbox).fillColor!).resolve({MaterialState.selected});
+    expect(chestColor, Colors.green);
+    expect(backColor, Colors.blueAccent);
+    expect(changed, ['c2', 'b1']);
+  });
+}
+


### PR DESCRIPTION
## Summary
- dedupe muscle groups per region and allow primary/secondary selection with colored checkboxes
- show disabled rows for unconfigured regions
- integrate selector in exercise bottom sheet and add tests for dedup/primary behavior

## Testing
- `flutter test test/widgets/muscle_group_list_selector_dedup_primary_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68994ee9d0fc8320a6da34db0a129613