### PR TITLE
feat: add primary/secondary muscle group selector for multi devices

### DIFF
--- a/lib/core/providers/muscle_group_provider.dart
+++ b/lib/core/providers/muscle_group_provider.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:collection/collection.dart';
+import 'package:uuid/uuid.dart';
 
 import "../../main.dart";
 import '../providers/auth_provider.dart';
@@ -134,6 +136,26 @@ class MuscleGroupProvider extends ChangeNotifier {
     if (gymId == null) return;
     await _deleteGroup.execute(gymId, groupId);
     await loadGroups(context);
+  }
+
+  Future<MuscleGroup> getOrCreateByRegion(
+    BuildContext ctx,
+    MuscleRegion region, {
+    String? defaultName,
+  }) async {
+    final existing = _groups.firstWhereOrNull((g) => g.region == region);
+    if (existing != null) return existing;
+    final g = MuscleGroup(
+      id: const Uuid().v4(),
+      name: defaultName ?? region.toString(),
+      region: region,
+      primaryDeviceIds: const [],
+      secondaryDeviceIds: const [],
+      exerciseIds: const [],
+    );
+    await saveGroup(ctx, g);
+    await loadGroups(ctx);
+    return _groups.firstWhereOrNull((x) => x.id == g.id) ?? g;
   }
 
   Future<void> assignDevice(

--- a/lib/features/device/presentation/widgets/exercise_bottom_sheet.dart
+++ b/lib/features/device/presentation/widgets/exercise_bottom_sheet.dart
@@ -103,10 +103,9 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
           SizedBox(
             height: 280,
             child: MuscleGroupListSelector(
-              deviceId: widget.deviceId,
               initialSelection: _selectedGroupIds,
-              filter: _filter,
               onChanged: (ids) => setState(() => _selectedGroupIds = ids),
+              filter: _filter,
             ),
           ),
           Row(


### PR DESCRIPTION
## Summary
- implement muscle group list with fixed region order, primary/secondary logic, and on-demand group creation
- add provider helper `getOrCreateByRegion`
- integrate selector into exercise bottom sheet
- test primary/secondary selection and dynamic group creation

## Testing
- `flutter test test/widgets/muscle_group_list_selector_primary_secondary_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68995747b958832095ac6ac8f0243c0b