### PR TITLE
refactor: redesign gym page

### DIFF
--- a/lib/features/gym/presentation/screens/gym_screen.dart
+++ b/lib/features/gym/presentation/screens/gym_screen.dart
@@ -1,44 +1,32 @@
-// lib/features/gym/presentation/screens/gym_screen.dart
-
-import 'dart:async';
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:tapem/l10n/app_localizations.dart';
-import 'package:collection/collection.dart';
-import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
-import 'package:flutter_sticky_header/flutter_sticky_header.dart';
-
-import 'package:tapem/app_router.dart';
-import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/core/providers/gym_provider.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
-import '../widgets/device_card.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+import 'package:tapem/ui/common/search_and_filters.dart';
+import 'package:tapem/ui/devices/device_card.dart';
 
 class GymScreen extends StatefulWidget {
-  const GymScreen({Key? key}) : super(key: key);
+  const GymScreen({super.key});
 
   @override
   State<GymScreen> createState() => _GymScreenState();
 }
 
-class _GymScreenState extends State<GymScreen> {
-  final TextEditingController _searchCtr = TextEditingController();
-  final ScrollController _scrollCtr = ScrollController();
-  final Map<String, GlobalKey> _headerKeys = {};
-  Timer? _debounce;
+class _GymScreenState extends State<GymScreen>
+    with AutomaticKeepAliveClientMixin {
   String _query = '';
-  final Set<String> _groupFilter = {};
-  bool _single = true;
-  bool _multi = true;
+  Set<String> _muscles = {};
+  SortOrder _sort = SortOrder.az;
+
+  @override
+  bool get wantKeepAlive => true;
 
   @override
   void initState() {
     super.initState();
-    _searchCtr.addListener(_onQueryChanged);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final auth = context.read<AuthProvider>();
       final gym = context.read<GymProvider>();
@@ -51,76 +39,28 @@ class _GymScreenState extends State<GymScreen> {
     });
   }
 
-  @override
-  void dispose() {
-    _debounce?.cancel();
-    _searchCtr.dispose();
-    _scrollCtr.dispose();
-    super.dispose();
-  }
-
-  void _onQueryChanged() {
-    _debounce?.cancel();
-    _debounce = Timer(const Duration(milliseconds: 300), () {
-      setState(() => _query = _searchCtr.text);
-    });
-  }
-
-  List<Device> _applyFilters(List<Device> devices) {
-    var res =
-        devices.where((d) {
-          final q = _query.toLowerCase();
-          final matches =
-              d.name.toLowerCase().contains(q) ||
-              d.description.toLowerCase().contains(q);
-          return matches;
-        }).toList();
-    if (_groupFilter.isNotEmpty) {
-      res =
-          res
-              .where((d) => d.muscleGroups.any((g) => _groupFilter.contains(g)))
-              .toList();
-    }
-    if (_single && !_multi) {
-      res = res.where((d) => !d.isMulti).toList();
-    } else if (_multi && !_single) {
-      res = res.where((d) => d.isMulti).toList();
-    }
+  List<Device> _filtered(List<Device> devices) {
+    final q = _query.toLowerCase();
+    var res = devices.where((d) {
+      final nameMatch = d.name.toLowerCase().contains(q);
+      final brandMatch = d.description.toLowerCase().contains(q);
+      return nameMatch || brandMatch;
+    }).where((d) {
+      if (d.isMulti || _muscles.isEmpty) return true;
+      final all = {...d.primaryMuscleGroups, ...d.secondaryMuscleGroups};
+      return all.any(_muscles.contains);
+    }).toList();
+    res.sort((a, b) =>
+        _sort == SortOrder.az ? a.name.compareTo(b.name) : b.name.compareTo(a.name));
     return res;
-  }
-
-  Map<String, List<Device>> _groupByLetter(List<Device> devices) {
-    final groups = groupBy(
-      devices,
-      (Device d) => d.name.isNotEmpty ? d.name[0].toUpperCase() : '#',
-    );
-    final sortedKeys = groups.keys.toList()..sort();
-    return {for (final k in sortedKeys) k: groups[k]!};
-  }
-
-  int _crossAxisCount(BuildContext context) {
-    final w = MediaQuery.of(context).size.width;
-    if (w >= 900) return 3;
-    if (w >= 600) return 2;
-    return 1;
-  }
-
-  void _jumpToLetter(String letter) {
-    final key = _headerKeys[letter];
-    if (key != null && key.currentContext != null) {
-      Scrollable.ensureVisible(
-        key.currentContext!,
-        duration: AppDurations.short,
-      );
-    }
   }
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     final loc = AppLocalizations.of(context)!;
     final auth = context.read<AuthProvider>();
     final gymProv = context.watch<GymProvider>();
-    final groupProv = context.watch<MuscleGroupProvider>();
     final gymId = auth.gymCode ?? '';
 
     if (gymProv.isLoading) {
@@ -133,223 +73,55 @@ class _GymScreenState extends State<GymScreen> {
       );
     }
 
-    final devices = _applyFilters(gymProv.devices);
-    final grouped = _groupByLetter(devices);
-    final letters = grouped.keys.toList();
+    final devices = _filtered(gymProv.devices);
 
     return Scaffold(
-      body: Stack(
-        children: [
-          RefreshIndicator(
-            onRefresh: () async => gymProv.loadGymData(gymId),
-            child: CustomScrollView(
-              controller: _scrollCtr,
-              physics: const BouncingScrollPhysics(),
-              slivers: [
-                SliverAppBar(
-                  pinned: true,
-                  title: Text(loc.gymTitle),
-                  backgroundColor: Theme.of(
-                    context,
-                  ).colorScheme.surface.withOpacity(0.9),
-                ),
-                SliverPersistentHeader(
-                  pinned: true,
-                  delegate: _SearchHeaderDelegate(
-                    controller: _searchCtr,
-                    groups:
-                        groupProv.groups
-                            .map((g) => g.region.name)
-                            .toSet()
-                            .toList(),
-                    selectedGroups: _groupFilter,
-                    showSingle: _single,
-                    showMulti: _multi,
-                    onGroupToggle:
-                        (g) => setState(() {
-                          if (_groupFilter.contains(g)) {
-                            _groupFilter.remove(g);
-                          } else {
-                            _groupFilter.add(g);
-                          }
-                        }),
-                    onToggleSingle: (v) => setState(() => _single = v),
-                    onToggleMulti: (v) => setState(() => _multi = v),
-                  ),
-                ),
-                if (devices.isEmpty)
-                  SliverFillRemaining(
-                    child: Center(child: Text(loc.gymNoDevices)),
-                  )
-                else
-                  for (final entry in grouped.entries)
-                    SliverStickyHeader(
-                      header: Container(
-                        key: _headerKeys.putIfAbsent(
-                          entry.key,
-                          () => GlobalKey(),
-                        ),
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 16,
-                          vertical: 8,
-                        ),
-                        color: Theme.of(context).colorScheme.surface,
-                        child: Text(
-                          entry.key,
-                          style: Theme.of(context).textTheme.titleLarge,
-                        ),
-                      ),
-                      sliver: SliverPadding(
-                        padding: const EdgeInsets.all(8),
-                        sliver: SliverMasonryGrid.count(
-                          crossAxisCount: _crossAxisCount(context),
-                          mainAxisSpacing: 8,
-                          crossAxisSpacing: 8,
-                          childCount: entry.value.length,
-                          itemBuilder: (c, i) {
-                            final d = entry.value[i];
-                            return DeviceCard(
-                              device: d,
-                              onTap: () {
-                                if (d.isMulti) {
-                                  Navigator.of(context).pushNamed(
-                                    AppRouter.exerciseList,
-                                    arguments: {
-                                      'gymId': gymId,
-                                      'deviceId': d.uid,
-                                    },
-                                  );
-                                } else {
-                                  Navigator.of(context).pushNamed(
-                                    AppRouter.device,
-                                    arguments: {
-                                      'gymId': gymId,
-                                      'deviceId': d.uid,
-                                      'exerciseId': d.uid,
-                                    },
-                                  );
-                                }
-                              },
-                            );
-                          },
-                        ),
-                      ),
-                    ),
-              ],
+      appBar: AppBar(title: Text(loc.gymTitle)),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: SearchAndFilters(
+                query: _query,
+                onQuery: (v) => setState(() => _query = v),
+                sort: _sort,
+                onSort: (v) => setState(() => _sort = v),
+                muscleFilterIds: _muscles,
+                onMuscleFilter: (v) => setState(() => _muscles = v),
+              ),
             ),
-          ),
-          Positioned(
-            right: 4,
-            top: 100,
-            bottom: 100,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                for (final l in letters)
-                  GestureDetector(
-                    onTap: () => _jumpToLetter(l),
-                    child: Padding(
-                      padding: const EdgeInsets.all(2),
-                      child: Text(
-                        l,
-                        style: Theme.of(context).textTheme.labelLarge,
+            Expanded(
+              child: RefreshIndicator(
+                onRefresh: () async => gymProv.loadGymData(gymId),
+                child: devices.isEmpty
+                    ? ListView(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        children: [
+                          SizedBox(
+                            height: MediaQuery.of(context).size.height * 0.5,
+                            child: Center(child: Text(loc.gymNoDevices)),
+                          ),
+                        ],
+                      )
+                    : ListView.builder(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        itemCount: devices.length,
+                        itemBuilder: (ctx, i) {
+                          final d = devices[i];
+                          return Padding(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 16, vertical: 8),
+                            child: DeviceCard(device: d),
+                          );
+                        },
                       ),
-                    ),
-                  ),
-              ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
 }
 
-class _SearchHeaderDelegate extends SliverPersistentHeaderDelegate {
-  final TextEditingController controller;
-  final List<String> groups;
-  final Set<String> selectedGroups;
-  final bool showSingle;
-  final bool showMulti;
-  final ValueChanged<String> onGroupToggle;
-  final ValueChanged<bool> onToggleSingle;
-  final ValueChanged<bool> onToggleMulti;
-
-  _SearchHeaderDelegate({
-    required this.controller,
-    required this.groups,
-    required this.selectedGroups,
-    required this.showSingle,
-    required this.showMulti,
-    required this.onGroupToggle,
-    required this.onToggleSingle,
-    required this.onToggleMulti,
-  });
-
-  @override
-  double get maxExtent => 128;
-
-  @override
-  double get minExtent => 128;
-
-  @override
-  Widget build(
-    BuildContext context,
-    double shrinkOffset,
-    bool overlapsContent,
-  ) {
-    return Container(
-      color: Theme.of(context).scaffoldBackgroundColor.withOpacity(0.9),
-      padding: const EdgeInsets.all(8),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          TextField(
-            controller: controller,
-            decoration: InputDecoration(
-              hintText: 'Search devices',
-              prefixIcon: const Icon(Icons.search),
-            ),
-          ),
-          const SizedBox(height: 8),
-          SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: Row(
-              children: [
-                FilterChip(
-                  label: const Text('Single'),
-                  selected: showSingle,
-                  onSelected: onToggleSingle,
-                ),
-                const SizedBox(width: 4),
-                FilterChip(
-                  label: const Text('Multi'),
-                  selected: showMulti,
-                  onSelected: onToggleMulti,
-                ),
-                const SizedBox(width: 4),
-                for (final g in groups)
-                  Padding(
-                    padding: const EdgeInsets.only(right: 4),
-                    child: FilterChip(
-                      label: Text(g),
-                      selected: selectedGroups.contains(g),
-                      onSelected: (_) => onGroupToggle(g),
-                    ),
-                  ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  @override
-  bool shouldRebuild(covariant _SearchHeaderDelegate oldDelegate) {
-    return oldDelegate.groups != groups ||
-        oldDelegate.selectedGroups != selectedGroups ||
-        oldDelegate.showSingle != showSingle ||
-        oldDelegate.showMulti != showMulti;
-  }
-}

--- a/lib/ui/common/search_and_filters.dart
+++ b/lib/ui/common/search_and_filters.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/muscle_group_provider.dart';
+import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
+enum SortOrder { az, za }
+
+class SearchAndFilters extends StatefulWidget {
+  final String query;
+  final ValueChanged<String> onQuery;
+  final SortOrder sort;
+  final ValueChanged<SortOrder> onSort;
+  final Set<String> muscleFilterIds;
+  final ValueChanged<Set<String>> onMuscleFilter;
+  const SearchAndFilters({
+    super.key,
+    required this.query,
+    required this.onQuery,
+    required this.sort,
+    required this.onSort,
+    required this.muscleFilterIds,
+    required this.onMuscleFilter,
+  });
+
+  @override
+  State<SearchAndFilters> createState() => _SearchAndFiltersState();
+}
+
+class _SearchAndFiltersState extends State<SearchAndFilters> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.query);
+  }
+
+  @override
+  void didUpdateWidget(covariant SearchAndFilters oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.query != widget.query && _controller.text != widget.query) {
+      _controller.text = widget.query;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _showSortSheet() async {
+    final res = await showModalBottomSheet<SortOrder>(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              title: const Text('A→Z'),
+              onTap: () => Navigator.pop(ctx, SortOrder.az),
+            ),
+            ListTile(
+              title: const Text('Z→A'),
+              onTap: () => Navigator.pop(ctx, SortOrder.za),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (res != null) widget.onSort(res);
+  }
+
+  Future<void> _showMuscleSheet() async {
+    final prov = context.read<MuscleGroupProvider>();
+    final groups = prov.groups;
+    final selected = Set<String>.from(widget.muscleFilterIds);
+    await showModalBottomSheet(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setSt) => SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    for (final g in groups)
+                      FilterChip(
+                        label: Text(g.name),
+                        selected: selected.contains(g.id),
+                        onSelected: (v) {
+                          setSt(() {
+                            if (v) {
+                              selected.add(g.id);
+                            } else {
+                              selected.remove(g.id);
+                            }
+                          });
+                        },
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton(
+                    onPressed: () => Navigator.pop(ctx),
+                    child: const Text('OK'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    widget.onMuscleFilter(selected);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final loc = AppLocalizations.of(context)!;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        TextField(
+          controller: _controller,
+          onChanged: widget.onQuery,
+          decoration: InputDecoration(
+            hintText: loc.multiDeviceSearchHint,
+            prefixIcon: const Icon(Icons.search),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(12),
+              borderSide: BorderSide.none,
+            ),
+            filled: true,
+            contentPadding: const EdgeInsets.symmetric(vertical: 0),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            FilterChip(
+              label: const Text('Name'),
+              selected: widget.sort == SortOrder.za,
+              onSelected: (_) => _showSortSheet(),
+              shape: const StadiumBorder(),
+              selectedColor: theme.colorScheme.primaryContainer,
+              showCheckmark: false,
+            ),
+            const SizedBox(width: 8),
+            FilterChip(
+              label: const Text('Muskel'),
+              selected: widget.muscleFilterIds.isNotEmpty,
+              onSelected: (_) => _showMuscleSheet(),
+              shape: const StadiumBorder(),
+              selectedColor: theme.colorScheme.primaryContainer,
+              showCheckmark: false,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+

--- a/lib/ui/devices/device_card.dart
+++ b/lib/ui/devices/device_card.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:tapem/features/device/domain/models/device.dart';
+import 'package:tapem/features/device/presentation/widgets/muscle_chips.dart';
+import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
+
+class DeviceCard extends StatelessWidget {
+  final Device device;
+  final List<MuscleGroup>? groupsForDevice;
+  const DeviceCard({super.key, required this.device, this.groupsForDevice});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final brand = device.description;
+    final idText = device.id.toString();
+    final muscleIds = [
+      ...device.primaryMuscleGroups,
+      ...device.secondaryMuscleGroups,
+    ];
+    return Semantics(
+      label: '${device.name}, ${brand.isNotEmpty ? '$brand, ' : ''}ID $idText',
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceVariant,
+          borderRadius: BorderRadius.circular(14),
+          border: Border.all(color: theme.colorScheme.outlineVariant),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    device.name,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.titleMedium,
+                  ),
+                  if (brand.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Text(
+                        brand,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 12),
+            ConstrainedBox(
+              constraints: const BoxConstraints(minWidth: 120, maxWidth: 180),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Text('ID: $idText', style: theme.textTheme.labelSmall),
+                  if (!device.isMulti && muscleIds.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 6),
+                      child: Align(
+                        alignment: Alignment.centerRight,
+                        child: MuscleChips(muscleGroupIds: muscleIds),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/test/ui/gym/device_card_test.dart
+++ b/test/ui/gym/device_card_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/features/device/domain/models/device.dart';
+import 'package:tapem/ui/devices/device_card.dart';
+import 'package:tapem/features/device/presentation/widgets/muscle_chips.dart';
+import 'package:tapem/core/providers/muscle_group_provider.dart';
+import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
+import 'package:tapem/features/muscle_group/domain/repositories/muscle_group_repository.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/get_muscle_groups_for_gym.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/save_muscle_group.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/delete_muscle_group.dart';
+import 'package:tapem/features/history/domain/repositories/history_repository.dart';
+import 'package:tapem/features/history/domain/usecases/get_history_for_device.dart';
+import 'package:tapem/features/history/domain/models/workout_log.dart';
+import 'package:tapem/features/device/domain/repositories/device_repository.dart';
+import 'package:tapem/features/device/domain/usecases/update_device_muscle_groups_usecase.dart';
+import 'package:tapem/features/device/domain/usecases/set_device_muscle_groups_usecase.dart';
+
+class _DummyMuscleGroupRepo implements MuscleGroupRepository {
+  @override
+  Future<void> deleteMuscleGroup(String gymId, String groupId) async {}
+
+  @override
+  Future<List<MuscleGroup>> getMuscleGroups(String gymId) async => [];
+
+  @override
+  Future<void> saveMuscleGroup(String gymId, MuscleGroup group) async {}
+}
+
+class _DummyHistoryRepo implements HistoryRepository {
+  @override
+  Future<List<WorkoutLog>> getHistory(String gymId, String deviceId, String userId) async => [];
+}
+
+class _DummyDeviceRepo implements DeviceRepository {
+  @override
+  Future<void> createDevice(String gymId, Device device) async {}
+
+  @override
+  Future<void> deleteDevice(String gymId, String deviceId) async {}
+
+  @override
+  Future<Device?> getDeviceByNfcCode(String gymId, String nfcCode) async => null;
+
+  @override
+  Future<List<Device>> getDevicesForGym(String gymId) async => [];
+
+  @override
+  Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
+
+  @override
+  Future<void> setMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
+}
+
+MuscleGroupProvider _makeProvider() {
+  final repo = _DummyMuscleGroupRepo();
+  return MuscleGroupProvider(
+    getGroups: GetMuscleGroupsForGym(repo),
+    saveGroup: SaveMuscleGroup(repo),
+    deleteGroup: DeleteMuscleGroup(repo),
+    getHistory: GetHistoryForDevice(_DummyHistoryRepo()),
+    updateDeviceGroups: UpdateDeviceMuscleGroupsUseCase(_DummyDeviceRepo()),
+    setDeviceGroups: SetDeviceMuscleGroupsUseCase(_DummyDeviceRepo()),
+  );
+}
+
+void main() {
+  testWidgets('renders name, brand and id', (tester) async {
+    final device = Device(uid: '1', id: 1, name: 'Bench', description: 'Eleiko');
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ChangeNotifierProvider(
+          create: (_) => _makeProvider(),
+          child: DeviceCard(device: device),
+        ),
+      ),
+    );
+    expect(find.text('Bench'), findsOneWidget);
+    expect(find.text('Eleiko'), findsOneWidget);
+    expect(find.text('ID: 1'), findsOneWidget);
+  });
+
+  testWidgets('shows chips when not multi', (tester) async {
+    final device = Device(
+      uid: '1',
+      id: 1,
+      name: 'Bench',
+      description: 'Eleiko',
+      primaryMuscleGroups: const ['chest'],
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ChangeNotifierProvider(
+          create: (_) => _makeProvider(),
+          child: DeviceCard(device: device),
+        ),
+      ),
+    );
+    expect(find.byType(MuscleChips), findsOneWidget);
+  });
+
+  testWidgets('hides chips when multi', (tester) async {
+    final device = Device(
+      uid: '1',
+      id: 1,
+      name: 'Multi',
+      description: 'Eleiko',
+      isMulti: true,
+      primaryMuscleGroups: const ['chest'],
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ChangeNotifierProvider(
+          create: (_) => _makeProvider(),
+          child: DeviceCard(device: device),
+        ),
+      ),
+    );
+    expect(find.byType(MuscleChips), findsNothing);
+  });
+}
+

--- a/test/ui/gym/search_and_filters_test.dart
+++ b/test/ui/gym/search_and_filters_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/muscle_group_provider.dart';
+import 'package:tapem/features/device/domain/models/device.dart';
+import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
+import 'package:tapem/features/muscle_group/domain/repositories/muscle_group_repository.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/get_muscle_groups_for_gym.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/save_muscle_group.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/delete_muscle_group.dart';
+import 'package:tapem/features/history/domain/repositories/history_repository.dart';
+import 'package:tapem/features/history/domain/usecases/get_history_for_device.dart';
+import 'package:tapem/features/history/domain/models/workout_log.dart';
+import 'package:tapem/features/device/domain/repositories/device_repository.dart';
+import 'package:tapem/features/device/domain/usecases/update_device_muscle_groups_usecase.dart';
+import 'package:tapem/features/device/domain/usecases/set_device_muscle_groups_usecase.dart';
+import 'package:tapem/ui/common/search_and_filters.dart';
+
+class _DummyMuscleGroupRepo implements MuscleGroupRepository {
+  @override
+  Future<void> deleteMuscleGroup(String gymId, String groupId) async {}
+
+  @override
+  Future<List<MuscleGroup>> getMuscleGroups(String gymId) async => [];
+
+  @override
+  Future<void> saveMuscleGroup(String gymId, MuscleGroup group) async {}
+}
+
+class _DummyHistoryRepo implements HistoryRepository {
+  @override
+  Future<List<WorkoutLog>> getHistory(String gymId, String deviceId, String userId) async => [];
+}
+
+class _DummyDeviceRepo implements DeviceRepository {
+  @override
+  Future<void> createDevice(String gymId, Device device) async {}
+
+  @override
+  Future<void> deleteDevice(String gymId, String deviceId) async {}
+
+  @override
+  Future<Device?> getDeviceByNfcCode(String gymId, String nfcCode) async => null;
+
+  @override
+  Future<List<Device>> getDevicesForGym(String gymId) async => [];
+
+  @override
+  Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
+
+  @override
+  Future<void> setMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
+}
+
+class _TestMuscleGroupProvider extends MuscleGroupProvider {
+  final List<MuscleGroup> _groupsOverride;
+  _TestMuscleGroupProvider(this._groupsOverride)
+      : super(
+          getGroups: GetMuscleGroupsForGym(_DummyMuscleGroupRepo()),
+          saveGroup: SaveMuscleGroup(_DummyMuscleGroupRepo()),
+          deleteGroup: DeleteMuscleGroup(_DummyMuscleGroupRepo()),
+          getHistory: GetHistoryForDevice(_DummyHistoryRepo()),
+          updateDeviceGroups: UpdateDeviceMuscleGroupsUseCase(_DummyDeviceRepo()),
+          setDeviceGroups: SetDeviceMuscleGroupsUseCase(_DummyDeviceRepo()),
+        );
+  @override
+  List<MuscleGroup> get groups => _groupsOverride;
+}
+
+class _Harness extends StatefulWidget {
+  const _Harness();
+  @override
+  State<_Harness> createState() => _HarnessState();
+}
+
+class _HarnessState extends State<_Harness> {
+  String query = '';
+  SortOrder sort = SortOrder.az;
+  Set<String> muscles = {};
+  final devices = [
+    Device(uid: '1', id: 1, name: 'Alpha', primaryMuscleGroups: const ['chest'], description: ''),
+    Device(uid: '2', id: 2, name: 'Beta', primaryMuscleGroups: const ['legs'], description: ''),
+  ];
+  @override
+  Widget build(BuildContext context) {
+    final filtered = devices.where((d) {
+      final matchesName = d.name.toLowerCase().contains(query.toLowerCase());
+      if (d.isMulti || muscles.isEmpty) {
+        return matchesName;
+      }
+      final all = {...d.primaryMuscleGroups, ...d.secondaryMuscleGroups};
+      return matchesName && all.any(muscles.contains);
+    }).toList()
+      ..sort((a, b) => sort == SortOrder.az ? a.name.compareTo(b.name) : b.name.compareTo(a.name));
+    return Column(
+      children: [
+        SearchAndFilters(
+          query: query,
+          onQuery: (v) => setState(() => query = v),
+          sort: sort,
+          onSort: (v) => setState(() => sort = v),
+          muscleFilterIds: muscles,
+          onMuscleFilter: (v) => setState(() => muscles = v),
+        ),
+        Expanded(
+          child: ListView(
+            children: [
+              for (var i = 0; i < filtered.length; i++)
+                Text(filtered[i].name, key: ValueKey('device-$i')),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+void main() {
+  final groups = [
+    MuscleGroup(id: 'chest', name: 'Chest', region: MuscleRegion.chest),
+    MuscleGroup(id: 'legs', name: 'Legs', region: MuscleRegion.legs),
+  ];
+  testWidgets('muscle filter reduces list', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ChangeNotifierProvider<MuscleGroupProvider>.value(
+          value: _TestMuscleGroupProvider(groups),
+          child: const Scaffold(body: _Harness()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Alpha'), findsOneWidget);
+    expect(find.text('Beta'), findsOneWidget);
+    await tester.tap(find.text('Muskel'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Chest'));
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+    expect(find.text('Alpha'), findsOneWidget);
+    expect(find.text('Beta'), findsNothing);
+  });
+
+  testWidgets('sort name Z→A', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ChangeNotifierProvider<MuscleGroupProvider>.value(
+          value: _TestMuscleGroupProvider(groups),
+          child: const Scaffold(body: _Harness()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Name'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Z→A'));
+    await tester.pumpAndSettle();
+    final first = tester.widget<Text>(find.byKey(const ValueKey('device-0')));
+    expect(first.data, 'Beta');
+  });
+}
+


### PR DESCRIPTION
## Summary
- add reusable search and filter header widget
- introduce compact device card for gym device listing
- refactor gym screen to use new header and device cards with client-side filtering and sorting
- add tests for device card and search/filter interactions

## Testing
- `flutter format lib/ui/devices/device_card.dart lib/ui/common/search_and_filters.dart lib/features/gym/presentation/screens/gym_screen.dart test/ui/gym/device_card_test.dart test/ui/gym/search_and_filters_test.dart` *(fails: command not found)*
- `flutter test test/ui/gym/device_card_test.dart test/ui/gym/search_and_filters_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689973f85bd88320a9177ec2f7acb104