### PR TITLE
feat: revamp muscle group admin UI

### DIFF
--- a/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
+++ b/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/muscle_group_provider.dart';
+import 'package:tapem/ui/muscles/muscle_group_color.dart';
+
+class DeviceMuscleAssignmentSheet extends StatefulWidget {
+  final String deviceId;
+  final String deviceName;
+  final List<String> initialPrimary;
+  final List<String> initialSecondary;
+  const DeviceMuscleAssignmentSheet({
+    super.key,
+    required this.deviceId,
+    required this.deviceName,
+    required this.initialPrimary,
+    required this.initialSecondary,
+  });
+
+  @override
+  State<DeviceMuscleAssignmentSheet> createState() => _DeviceMuscleAssignmentSheetState();
+}
+
+class _DeviceMuscleAssignmentSheetState extends State<DeviceMuscleAssignmentSheet> {
+  late Set<String> _primary;
+  late Set<String> _secondary;
+
+  @override
+  void initState() {
+    super.initState();
+    _primary = widget.initialPrimary.toSet();
+    _secondary = widget.initialSecondary.toSet();
+  }
+
+  void _togglePrimary(String id) {
+    setState(() {
+      if (_primary.contains(id)) {
+        _primary.remove(id);
+      } else {
+        _primary.add(id);
+        _secondary.remove(id);
+      }
+    });
+  }
+
+  void _toggleSecondary(String id) {
+    setState(() {
+      if (_secondary.contains(id)) {
+        _secondary.remove(id);
+      } else {
+        _secondary.add(id);
+        _primary.remove(id);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final groups = context.watch<MuscleGroupProvider>().groups;
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('${widget.deviceName} – Muskelgruppen',
+                style: theme.textTheme.titleLarge),
+            const SizedBox(height: 16),
+            Text('Primär', style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 4,
+              runSpacing: 4,
+              children: [
+                for (final g in groups)
+                  FilterChip(
+                    key: ValueKey('p-${g.id}'),
+                    avatar: CircleAvatar(
+                      backgroundColor: colorForRegion(g.region, theme),
+                      radius: 6,
+                    ),
+                    label: Text(g.name,
+                        maxLines: 1, overflow: TextOverflow.ellipsis),
+                    selected: _primary.contains(g.id),
+                    selectedColor: theme.colorScheme.primary,
+                    checkmarkColor: theme.colorScheme.onPrimary,
+                    labelStyle: TextStyle(
+                      color: _primary.contains(g.id)
+                          ? theme.colorScheme.onPrimary
+                          : theme.colorScheme.onSurface,
+                    ),
+                    onSelected: (_) => _togglePrimary(g.id),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Text('Sekundär', style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 4,
+              runSpacing: 4,
+              children: [
+                for (final g in groups)
+                  FilterChip(
+                    key: ValueKey('s-${g.id}'),
+                    avatar: CircleAvatar(
+                      backgroundColor: colorForRegion(g.region, theme),
+                      radius: 6,
+                    ),
+                    label: Text(g.name,
+                        maxLines: 1, overflow: TextOverflow.ellipsis),
+                    selected: _secondary.contains(g.id),
+                    selectedColor: theme.colorScheme.secondary,
+                    checkmarkColor: theme.colorScheme.onSecondary,
+                    labelStyle: TextStyle(
+                      color: _secondary.contains(g.id)
+                          ? theme.colorScheme.onSecondary
+                          : theme.colorScheme.onSurface,
+                    ),
+                    onSelected: (_) => _toggleSecondary(g.id),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Abbrechen'),
+                ),
+                const SizedBox(width: 8),
+                ElevatedButton(
+                  onPressed: () async {
+                    await context.read<MuscleGroupProvider>().updateDeviceAssignments(
+                          context,
+                          widget.deviceId,
+                          _primary.toList(),
+                          _secondary.toList(),
+                        );
+                    if (mounted) Navigator.pop(context);
+                  },
+                  child: const Text('Speichern'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/ui/devices/device_card.dart
+++ b/lib/ui/devices/device_card.dart
@@ -6,7 +6,8 @@ import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
 class DeviceCard extends StatelessWidget {
   final Device device;
   final List<MuscleGroup>? groupsForDevice;
-  const DeviceCard({super.key, required this.device, this.groupsForDevice});
+  final VoidCallback? onTap;
+  const DeviceCard({super.key, required this.device, this.groupsForDevice, this.onTap});
 
   @override
   Widget build(BuildContext context) {
@@ -19,60 +20,63 @@ class DeviceCard extends StatelessWidget {
     ];
     return Semantics(
       label: '${device.name}, ${brand.isNotEmpty ? '$brand, ' : ''}ID $idText',
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        decoration: BoxDecoration(
-          color: theme.colorScheme.surfaceVariant,
-          borderRadius: BorderRadius.circular(14),
-          border: Border.all(color: theme.colorScheme.outlineVariant),
-        ),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    device.name,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: theme.textTheme.titleMedium,
-                  ),
-                  if (brand.isNotEmpty)
-                    Padding(
-                      padding: const EdgeInsets.only(top: 4),
-                      child: Text(
-                        brand,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surfaceVariant,
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(color: theme.colorScheme.outlineVariant),
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      device.name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.titleMedium,
+                    ),
+                    if (brand.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 4),
+                        child: Text(
+                          brand,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
                         ),
                       ),
-                    ),
-                ],
+                  ],
+                ),
               ),
-            ),
-            const SizedBox(width: 12),
-            ConstrainedBox(
-              constraints: const BoxConstraints(minWidth: 120, maxWidth: 180),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  Text('ID: $idText', style: theme.textTheme.labelSmall),
-                  if (!device.isMulti && muscleIds.isNotEmpty)
-                    Padding(
-                      padding: const EdgeInsets.only(top: 6),
-                      child: Align(
-                        alignment: Alignment.centerRight,
-                        child: MuscleChips(muscleGroupIds: muscleIds),
+              const SizedBox(width: 12),
+              ConstrainedBox(
+                constraints: const BoxConstraints(minWidth: 120, maxWidth: 180),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text('ID: $idText', style: theme.textTheme.labelSmall),
+                    if (!device.isMulti && muscleIds.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 6),
+                        child: Align(
+                          alignment: Alignment.centerRight,
+                          child: MuscleChips(muscleGroupIds: muscleIds),
+                        ),
                       ),
-                    ),
-                ],
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/test/ui/muscle_groups/admin_list_filters_test.dart
+++ b/test/ui/muscle_groups/admin_list_filters_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/core/providers/device_provider.dart';
+import 'package:tapem/core/providers/muscle_group_provider.dart';
+import 'package:tapem/features/device/domain/models/device.dart';
+import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
+import 'package:tapem/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
+class FakeAuthProvider extends ChangeNotifier implements AuthProvider {
+  @override
+  String? get gymCode => 'g1';
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class FakeDeviceProvider extends ChangeNotifier implements DeviceProvider {
+  final List<Device> _devices;
+  FakeDeviceProvider(this._devices);
+  @override
+  List<Device> get devices => _devices;
+  @override
+  bool get isLoading => false;
+  @override
+  Future<void> loadDevices(String gymId) async {}
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class FakeMuscleGroupProvider extends ChangeNotifier
+    implements MuscleGroupProvider {
+  final List<MuscleGroup> _groups;
+  FakeMuscleGroupProvider(this._groups);
+  @override
+  bool get isLoading => false;
+  @override
+  String? get error => null;
+  @override
+  List<MuscleGroup> get groups => _groups;
+  @override
+  Map<String, int> get counts => {};
+  @override
+  Future<void> loadGroups(BuildContext context) async {}
+  @override
+  Future<void> updateDeviceAssignments(BuildContext context, String deviceId,
+          List<String> primaryGroupIds, List<String> secondaryGroupIds) async {}
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  testWidgets('lists non-multi devices and filters by muscle', (tester) async {
+    final devices = [
+      Device(
+        uid: '1',
+        id: 1,
+        name: 'A',
+        description: 'BrandA',
+        primaryMuscleGroups: const ['m1'],
+      ),
+      Device(
+        uid: '2',
+        id: 2,
+        name: 'B',
+        description: 'BrandB',
+        isMulti: true,
+        primaryMuscleGroups: const ['m1'],
+      ),
+      Device(
+        uid: '3',
+        id: 3,
+        name: 'C',
+        description: 'BrandC',
+        primaryMuscleGroups: const ['m2'],
+      ),
+    ];
+
+    final groups = [
+      MuscleGroup(
+        id: 'm1',
+        name: 'Chest',
+        region: MuscleRegion.chest,
+        primaryDeviceIds: const [],
+        secondaryDeviceIds: const [],
+        exerciseIds: const [],
+      ),
+      MuscleGroup(
+        id: 'm2',
+        name: 'Back',
+        region: MuscleRegion.back,
+        primaryDeviceIds: const [],
+        secondaryDeviceIds: const [],
+        exerciseIds: const [],
+      ),
+    ];
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<AuthProvider>(create: (_) => FakeAuthProvider()),
+          ChangeNotifierProvider<DeviceProvider>(
+              create: (_) => FakeDeviceProvider(devices)),
+          ChangeNotifierProvider<MuscleGroupProvider>(
+              create: (_) => FakeMuscleGroupProvider(groups)),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const MuscleGroupAdminScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('A'), findsOneWidget);
+    expect(find.text('C'), findsOneWidget);
+    expect(find.text('B'), findsNothing);
+
+    await tester.tap(find.text('Muskel'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Chest'));
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('A'), findsOneWidget);
+    expect(find.text('C'), findsNothing);
+
+    await tester.tap(find.text('A'));
+    await tester.pumpAndSettle();
+    expect(find.text('A – Muskelgruppen'), findsOneWidget);
+  });
+}

--- a/test/ui/muscle_groups/assignment_sheet_test.dart
+++ b/test/ui/muscle_groups/assignment_sheet_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
+import 'package:tapem/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart';
+import 'package:tapem/core/providers/muscle_group_provider.dart';
+
+class FakeMuscleGroupProvider extends ChangeNotifier
+    implements MuscleGroupProvider {
+  final List<MuscleGroup> _groups;
+  String? lastDeviceId;
+  List<String>? lastPrimary;
+  List<String>? lastSecondary;
+
+  FakeMuscleGroupProvider(this._groups);
+
+  @override
+  bool get isLoading => false;
+  @override
+  String? get error => null;
+  @override
+  List<MuscleGroup> get groups => _groups;
+  @override
+  Map<String, int> get counts => {};
+  @override
+  Future<void> loadGroups(BuildContext context) async {}
+  @override
+  Future<void> updateDeviceAssignments(BuildContext context, String deviceId,
+      List<String> primaryGroupIds, List<String> secondaryGroupIds) async {
+    lastDeviceId = deviceId;
+    lastPrimary = primaryGroupIds;
+    lastSecondary = secondaryGroupIds;
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  testWidgets('toggling and saving calls updateDeviceAssignments',
+      (tester) async {
+    final prov = FakeMuscleGroupProvider([
+      MuscleGroup(
+        id: 'm1',
+        name: 'Chest',
+        region: MuscleRegion.chest,
+        primaryDeviceIds: const [],
+        secondaryDeviceIds: const [],
+        exerciseIds: const [],
+      ),
+      MuscleGroup(
+        id: 'm2',
+        name: 'Back',
+        region: MuscleRegion.back,
+        primaryDeviceIds: const [],
+        secondaryDeviceIds: const [],
+        exerciseIds: const [],
+      ),
+    ]);
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<MuscleGroupProvider>.value(
+        value: prov,
+        child: MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => TextButton(
+                onPressed: () {
+                  showModalBottomSheet(
+                    context: context,
+                    builder: (_) => const DeviceMuscleAssignmentSheet(
+                      deviceId: 'd1',
+                      deviceName: 'Device',
+                      initialPrimary: [],
+                      initialSecondary: [],
+                    ),
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(FilterChip, 'Chest').first);
+    await tester.pump();
+
+    await tester.tap(find.widgetWithText(FilterChip, 'Back').last);
+    await tester.pump();
+
+    await tester.tap(find.text('Speichern'));
+    await tester.pumpAndSettle();
+
+    expect(prov.lastDeviceId, 'd1');
+    expect(prov.lastPrimary, ['m1']);
+    expect(prov.lastSecondary, ['m2']);
+  });
+}


### PR DESCRIPTION
## Summary
- make DeviceCard tappable via optional callback
- add DeviceMuscleAssignmentSheet for per-device muscle selection
- redesign MuscleGroupAdminScreen with search, filters and direct assignment
- add widget tests covering list filtering and assignment sheet

## Testing
- `flutter test test/ui/muscle_groups/assignment_sheet_test.dart test/ui/muscle_groups/admin_list_filters_test.dart` *(fails: command not found: flutter)*
- `apt-get update` *(fails: repository ... is not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68997b0b7fbc83209a07f691ddc36380