### PR TITLE
feat: enable device card navigation and assignment lists

### DIFF
--- a/lib/features/gym/presentation/screens/gym_screen.dart
+++ b/lib/features/gym/presentation/screens/gym_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/core/providers/gym_provider.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
+import 'package:tapem/app_router.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/ui/common/search_and_filters.dart';
@@ -112,7 +113,31 @@ class _GymScreenState extends State<GymScreen>
                           return Padding(
                             padding: const EdgeInsets.symmetric(
                                 horizontal: 16, vertical: 8),
-                            child: DeviceCard(device: d),
+                            child: DeviceCard(
+                              device: d,
+                              onTap: () {
+                                final nav = Navigator.of(context);
+                                final idStr = d.id.toString();
+                                if (d.isMulti) {
+                                  nav.pushNamed(
+                                    AppRouter.exerciseList,
+                                    arguments: {
+                                      'gymId': gymId,
+                                      'deviceId': idStr,
+                                    },
+                                  );
+                                } else {
+                                  nav.pushNamed(
+                                    AppRouter.device,
+                                    arguments: {
+                                      'gymId': gymId,
+                                      'deviceId': idStr,
+                                      'exerciseId': idStr,
+                                    },
+                                  );
+                                }
+                              },
+                            ),
                           );
                         },
                       ),

--- a/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
+++ b/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
+import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
 import 'package:tapem/ui/muscles/muscle_group_color.dart';
 
 class DeviceMuscleAssignmentSheet extends StatefulWidget {
@@ -17,135 +18,213 @@ class DeviceMuscleAssignmentSheet extends StatefulWidget {
   });
 
   @override
-  State<DeviceMuscleAssignmentSheet> createState() => _DeviceMuscleAssignmentSheetState();
+  State<DeviceMuscleAssignmentSheet> createState() =>
+      _DeviceMuscleAssignmentSheetState();
 }
 
-class _DeviceMuscleAssignmentSheetState extends State<DeviceMuscleAssignmentSheet> {
-  late Set<String> _primary;
+class _DeviceMuscleAssignmentSheetState
+    extends State<DeviceMuscleAssignmentSheet> {
+  String? _primaryId;
   late Set<String> _secondary;
+  String _query = '';
 
   @override
   void initState() {
     super.initState();
-    _primary = widget.initialPrimary.toSet();
-    _secondary = widget.initialSecondary.toSet();
+    _primaryId =
+        widget.initialPrimary.isEmpty ? null : widget.initialPrimary.first;
+    _secondary = widget.initialSecondary.toSet()..remove(_primaryId);
   }
 
-  void _togglePrimary(String id) {
-    setState(() {
-      if (_primary.contains(id)) {
-        _primary.remove(id);
-      } else {
-        _primary.add(id);
-        _secondary.remove(id);
-      }
-    });
-  }
-
-  void _toggleSecondary(String id) {
-    setState(() {
-      if (_secondary.contains(id)) {
-        _secondary.remove(id);
-      } else {
-        _secondary.add(id);
-        _primary.remove(id);
-      }
-    });
+  String _displayName(MuscleGroup g) {
+    if (g.name.trim().isNotEmpty) return g.name;
+    switch (g.region) {
+      case MuscleRegion.chest:
+        return 'Chest';
+      case MuscleRegion.back:
+        return 'Back';
+      case MuscleRegion.shoulders:
+        return 'Shoulders';
+      case MuscleRegion.arms:
+        return 'Arms';
+      case MuscleRegion.legs:
+        return 'Legs';
+      case MuscleRegion.core:
+      default:
+        return 'Core';
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final groups = context.watch<MuscleGroupProvider>().groups;
+    final filtered = groups
+        .where((g) =>
+            _displayName(g).toLowerCase().contains(_query.toLowerCase()))
+        .toList();
+
     return SafeArea(
       child: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
-          mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text('${widget.deviceName} – Muskelgruppen',
                 style: theme.textTheme.titleLarge),
             const SizedBox(height: 16),
-            Text('Primär', style: theme.textTheme.titleMedium),
-            const SizedBox(height: 8),
-            Wrap(
-              spacing: 4,
-              runSpacing: 4,
-              children: [
-                for (final g in groups)
-                  FilterChip(
-                    key: ValueKey('p-${g.id}'),
-                    avatar: CircleAvatar(
-                      backgroundColor: colorForRegion(g.region, theme),
-                      radius: 6,
-                    ),
-                    label: Text(g.name,
-                        maxLines: 1, overflow: TextOverflow.ellipsis),
-                    selected: _primary.contains(g.id),
-                    selectedColor: theme.colorScheme.primary,
-                    checkmarkColor: theme.colorScheme.onPrimary,
-                    labelStyle: TextStyle(
-                      color: _primary.contains(g.id)
-                          ? theme.colorScheme.onPrimary
-                          : theme.colorScheme.onSurface,
-                    ),
-                    onSelected: (_) => _togglePrimary(g.id),
-                  ),
-              ],
+            TextField(
+              decoration: const InputDecoration(
+                prefixIcon: Icon(Icons.search),
+                hintText: 'Search',
+              ),
+              onChanged: (v) => setState(() => _query = v),
             ),
             const SizedBox(height: 16),
-            Text('Sekundär', style: theme.textTheme.titleMedium),
-            const SizedBox(height: 8),
-            Wrap(
-              spacing: 4,
-              runSpacing: 4,
-              children: [
-                for (final g in groups)
-                  FilterChip(
-                    key: ValueKey('s-${g.id}'),
-                    avatar: CircleAvatar(
-                      backgroundColor: colorForRegion(g.region, theme),
-                      radius: 6,
-                    ),
-                    label: Text(g.name,
-                        maxLines: 1, overflow: TextOverflow.ellipsis),
-                    selected: _secondary.contains(g.id),
-                    selectedColor: theme.colorScheme.secondary,
-                    checkmarkColor: theme.colorScheme.onSecondary,
-                    labelStyle: TextStyle(
-                      color: _secondary.contains(g.id)
-                          ? theme.colorScheme.onSecondary
-                          : theme.colorScheme.onSurface,
-                    ),
-                    onSelected: (_) => _toggleSecondary(g.id),
-                  ),
-              ],
+            Expanded(
+              child: ListView(
+                children: [
+                  Text('Primär', style: theme.textTheme.titleMedium),
+                  const SizedBox(height: 8),
+                  for (final g in filtered) _buildPrimaryRow(g, theme),
+                  const SizedBox(height: 16),
+                  Text('Sekundär', style: theme.textTheme.titleMedium),
+                  const SizedBox(height: 8),
+                  for (final g in filtered) _buildSecondaryRow(g, theme),
+                ],
+              ),
             ),
             const SizedBox(height: 24),
             Row(
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 TextButton(
-                  onPressed: () => Navigator.pop(context),
+                  onPressed: () => Navigator.pop(context, false),
                   child: const Text('Abbrechen'),
                 ),
                 const SizedBox(width: 8),
                 ElevatedButton(
                   onPressed: () async {
-                    await context.read<MuscleGroupProvider>().updateDeviceAssignments(
+                    await context
+                        .read<MuscleGroupProvider>()
+                        .updateDeviceAssignments(
                           context,
                           widget.deviceId,
-                          _primary.toList(),
-                          _secondary.toList(),
+                          _primaryId == null
+                              ? const []
+                              : <String>[_primaryId!],
+                          _secondary
+                              .where((id) => id != _primaryId)
+                              .toList(),
                         );
-                    if (mounted) Navigator.pop(context);
+                    if (!mounted) return;
+                    Navigator.pop(context, true);
                   },
                   child: const Text('Speichern'),
                 ),
               ],
             ),
           ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPrimaryRow(MuscleGroup g, ThemeData theme) {
+    final name = _displayName(g);
+    return Semantics(
+      label: '$name, Primary selector',
+      child: InkWell(
+        onTap: () {
+          setState(() {
+            _primaryId = g.id;
+            _secondary.remove(g.id);
+          });
+        },
+        child: SizedBox(
+          height: 48,
+          child: Row(
+            children: [
+              CircleAvatar(backgroundColor: colorForRegion(g.region, theme)),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(color: theme.colorScheme.onSurface),
+                ),
+              ),
+              Radio<String>(
+                value: g.id,
+                groupValue: _primaryId,
+                onChanged: (id) {
+                  setState(() {
+                    _primaryId = id;
+                    if (id != null) _secondary.remove(id);
+                  });
+                },
+                fillColor: MaterialStateProperty.resolveWith(
+                    (states) => theme.colorScheme.primary),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSecondaryRow(MuscleGroup g, ThemeData theme) {
+    final name = _displayName(g);
+    final checked = _secondary.contains(g.id);
+    final disabled = _primaryId == g.id;
+    return Semantics(
+      label: '$name, Secondary selector',
+      child: InkWell(
+        onTap: disabled
+            ? null
+            : () {
+                setState(() {
+                  if (checked) {
+                    _secondary.remove(g.id);
+                  } else {
+                    _secondary.add(g.id);
+                  }
+                });
+              },
+        child: SizedBox(
+          height: 48,
+          child: Row(
+            children: [
+              CircleAvatar(backgroundColor: colorForRegion(g.region, theme)),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(color: theme.colorScheme.onSurface),
+                ),
+              ),
+              Checkbox(
+                value: checked,
+                onChanged: disabled
+                    ? null
+                    : (v) {
+                        setState(() {
+                          if (v == true) {
+                            _secondary.add(g.id);
+                          } else {
+                            _secondary.remove(g.id);
+                          }
+                        });
+                      },
+                fillColor: MaterialStateProperty.resolveWith(
+                    (states) => theme.colorScheme.tertiary),
+                checkColor: theme.colorScheme.onTertiary,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/ui/devices/device_card.dart
+++ b/lib/ui/devices/device_card.dart
@@ -20,62 +20,66 @@ class DeviceCard extends StatelessWidget {
     ];
     return Semantics(
       label: '${device.name}, ${brand.isNotEmpty ? '$brand, ' : ''}ID $idText',
-      child: GestureDetector(
-        onTap: onTap,
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          decoration: BoxDecoration(
-            color: theme.colorScheme.surfaceVariant,
-            borderRadius: BorderRadius.circular(14),
-            border: Border.all(color: theme.colorScheme.outlineVariant),
-          ),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      device.name,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: theme.textTheme.titleMedium,
-                    ),
-                    if (brand.isNotEmpty)
-                      Padding(
-                        padding: const EdgeInsets.only(top: 4),
-                        child: Text(
-                          brand,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.onSurfaceVariant,
+      button: true,
+      child: Material(
+        color: theme.colorScheme.surfaceVariant,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(14),
+          side: BorderSide(color: theme.colorScheme.outlineVariant),
+        ),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(14),
+          onTap: () => onTap?.call(),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        device.name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.titleMedium,
+                      ),
+                      if (brand.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 4),
+                          child: Text(
+                            brand,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
                           ),
                         ),
-                      ),
-                  ],
+                    ],
+                  ),
                 ),
-              ),
-              const SizedBox(width: 12),
-              ConstrainedBox(
-                constraints: const BoxConstraints(minWidth: 120, maxWidth: 180),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: [
-                    Text('ID: $idText', style: theme.textTheme.labelSmall),
-                    if (!device.isMulti && muscleIds.isNotEmpty)
-                      Padding(
-                        padding: const EdgeInsets.only(top: 6),
-                        child: Align(
-                          alignment: Alignment.centerRight,
-                          child: MuscleChips(muscleGroupIds: muscleIds),
+                const SizedBox(width: 12),
+                ConstrainedBox(
+                  constraints: const BoxConstraints(minWidth: 120, maxWidth: 180),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text('ID: $idText', style: theme.textTheme.labelSmall),
+                      if (!device.isMulti && muscleIds.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 6),
+                          child: Align(
+                            alignment: Alignment.centerRight,
+                            child: MuscleChips(muscleGroupIds: muscleIds),
+                          ),
                         ),
-                      ),
-                  ],
+                    ],
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- make DeviceCard tappable with onTap callback
- navigate to device or exercise list based on type
- refactor muscle assignment sheet into primary/secondary lists

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68997f7cf1808320904f29b7512c4af0