### PR TITLE
Fix device lookup when navigating from gym

### DIFF
--- a/lib/features/gym/presentation/screens/gym_screen.dart
+++ b/lib/features/gym/presentation/screens/gym_screen.dart
@@ -117,7 +117,7 @@ class _GymScreenState extends State<GymScreen>
                               device: d,
                               onTap: () {
                                 final nav = Navigator.of(context);
-                                final idStr = d.id.toString();
+                                final idStr = d.uid;
                                 if (d.isMulti) {
                                   nav.pushNamed(
                                     AppRouter.exerciseList,

--- a/lib/features/nfc/widgets/global_nfc_listener.dart
+++ b/lib/features/nfc/widgets/global_nfc_listener.dart
@@ -41,15 +41,15 @@ class _GlobalNfcListenerState extends State<GlobalNfcListener> {
         if (dev.isMulti) {
           navigatorKey.currentState?.pushNamed(
             AppRouter.exerciseList,
-            arguments: {'gymId': gymId, 'deviceId': dev.id},
+            arguments: {'gymId': gymId, 'deviceId': dev.uid},
           );
         } else {
           navigatorKey.currentState?.pushNamed(
             AppRouter.device,
             arguments: {
               'gymId': gymId,
-              'deviceId': dev.id,
-              'exerciseId': dev.id,
+              'deviceId': dev.uid,
+              'exerciseId': dev.uid,
             },
           );
         }

--- a/lib/features/nfc/widgets/nfc_scan_button.dart
+++ b/lib/features/nfc/widgets/nfc_scan_button.dart
@@ -67,15 +67,15 @@ class NfcScanButton extends StatelessWidget {
               if (dev.isMulti) {
                 Navigator.of(context).pushNamed(
                   AppRouter.exerciseList,
-                  arguments: {'gymId': gymId, 'deviceId': dev.id},
+                  arguments: {'gymId': gymId, 'deviceId': dev.uid},
                 );
               } else {
                 Navigator.of(context).pushNamed(
                   AppRouter.device,
                   arguments: {
                     'gymId': gymId,
-                    'deviceId': dev.id,
-                    'exerciseId': dev.id,
+                    'deviceId': dev.uid,
+                    'exerciseId': dev.uid,
                   },
                 );
               }


### PR DESCRIPTION
## Summary
- Use device `uid` instead of numeric `id` when routing from gym and NFC scans to device pages

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689982691b9c832084981d990a52dd87