### PR TITLE
feat: show muscle group chips and patch devices

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -97,6 +97,20 @@ class DeviceProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  void patchDeviceGroups(
+    String deviceId,
+    List<String> primaryGroups,
+    List<String> secondaryGroups,
+  ) {
+    final i = _devices.indexWhere((d) => d.uid == deviceId);
+    if (i == -1) return;
+    _devices[i] = _devices[i].copyWith(
+      primaryMuscleGroups: primaryGroups,
+      secondaryMuscleGroups: secondaryGroups,
+    );
+    notifyListeners();
+  }
+
   /// Lädt Gerätedaten, letzte Session und Notiz
   Future<void> loadDevice({
     required String gymId,

--- a/lib/core/providers/gym_provider.dart
+++ b/lib/core/providers/gym_provider.dart
@@ -43,4 +43,18 @@ class GymProvider extends ChangeNotifier {
       notifyListeners();
     }
   }
+
+  void patchDeviceGroups(
+    String deviceId,
+    List<String> primaryGroups,
+    List<String> secondaryGroups,
+  ) {
+    final i = _devices.indexWhere((d) => d.uid == deviceId);
+    if (i == -1) return;
+    _devices[i] = _devices[i].copyWith(
+      primaryMuscleGroups: primaryGroups,
+      secondaryMuscleGroups: secondaryGroups,
+    );
+    notifyListeners();
+  }
 }

--- a/lib/core/providers/muscle_group_provider.dart
+++ b/lib/core/providers/muscle_group_provider.dart
@@ -232,14 +232,8 @@ class MuscleGroupProvider extends ChangeNotifier {
     await _setDeviceGroups.execute(
       gymId,
       deviceId,
-      primaryGroupIds.map((id) {
-        final g = _groups.firstWhere((e) => e.id == id);
-        return g.region.name;
-      }).toList(),
-      secondaryGroupIds.map((id) {
-        final g = _groups.firstWhere((e) => e.id == id);
-        return g.region.name;
-      }).toList(),
+      primaryGroupIds,
+      secondaryGroupIds,
     );
 
     await loadGroups(context);

--- a/lib/features/device/presentation/widgets/muscle_chips.dart
+++ b/lib/features/device/presentation/widgets/muscle_chips.dart
@@ -1,20 +1,81 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
-import 'package:tapem/ui/muscles/muscle_group_card.dart';
+import 'package:tapem/core/providers/muscle_group_provider.dart';
+import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
 
 class MuscleChips extends StatelessWidget {
-  final List<String> muscleGroupIds;
-  const MuscleChips({super.key, required this.muscleGroupIds});
+  final List<String> primaryIds;
+  final List<String> secondaryIds;
+  const MuscleChips({super.key, required this.primaryIds, required this.secondaryIds});
+
+  String _fallbackName(MuscleRegion region) {
+    switch (region) {
+      case MuscleRegion.chest:
+        return 'Chest';
+      case MuscleRegion.back:
+        return 'Back';
+      case MuscleRegion.shoulders:
+        return 'Shoulders';
+      case MuscleRegion.arms:
+        return 'Arms';
+      case MuscleRegion.legs:
+        return 'Legs';
+      case MuscleRegion.core:
+      default:
+        return 'Core';
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    if (muscleGroupIds.isEmpty) return const SizedBox.shrink();
+    if (primaryIds.isEmpty && secondaryIds.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final theme = Theme.of(context);
+    final groups = context.watch<MuscleGroupProvider>().groups;
+
+    MuscleRegion _regionFor(String id, MuscleGroup? g) {
+      if (g != null) return g.region;
+      return MuscleRegion.values.firstWhereOrNull((r) => r.name == id) ?? MuscleRegion.core;
+    }
+
+    String _nameFor(String id) {
+      final g = groups.firstWhereOrNull((e) => e.id == id);
+      final region = _regionFor(id, g);
+      if (g != null && g.name.trim().isNotEmpty) return g.name;
+      return _fallbackName(region);
+    }
+
+    Widget _buildChip(String id, bool primary) {
+      final name = _nameFor(id);
+      final color = primary ? theme.colorScheme.primary : theme.colorScheme.tertiary;
+      final textColor = primary ? theme.colorScheme.onPrimary : theme.colorScheme.tertiary;
+      return Semantics(
+        label: '$name, ${primary ? 'primär' : 'sekundär'}',
+        child: Chip(
+          visualDensity: VisualDensity.compact,
+          backgroundColor: primary ? color : Colors.transparent,
+          shape: primary ? null : StadiumBorder(side: BorderSide(color: color)),
+          label: Text(
+            name,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(color: textColor),
+          ),
+        ),
+      );
+    }
+
     return Wrap(
+      alignment: WrapAlignment.end,
       spacing: 4,
       runSpacing: 4,
       children: [
-        for (final id in muscleGroupIds)
-          MuscleGroupCard(muscleGroupId: id),
+        for (final id in primaryIds) _buildChip(id, true),
+        for (final id in secondaryIds) _buildChip(id, false),
       ],
     );
   }

--- a/lib/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/core/providers/device_provider.dart';
+import 'package:tapem/core/providers/gym_provider.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart';
@@ -67,7 +68,7 @@ class _MuscleGroupAdminScreenState extends State<MuscleGroupAdminScreen> {
   }
 
   Future<void> _openAssignSheet(Device d) async {
-    await showModalBottomSheet(
+    final res = await showModalBottomSheet<Map<String, List<String>>>(
       context: context,
       isScrollControlled: true,
       builder: (_) => DeviceMuscleAssignmentSheet(
@@ -77,11 +78,14 @@ class _MuscleGroupAdminScreenState extends State<MuscleGroupAdminScreen> {
         initialSecondary: d.secondaryMuscleGroups,
       ),
     );
-    final auth = context.read<AuthProvider>();
-    final gymId = auth.gymCode ?? '';
-    await context.read<DeviceProvider>().loadDevices(gymId);
-    await context.read<MuscleGroupProvider>().loadGroups(context);
-    if (mounted) setState(() {});
+    if (res != null) {
+      context
+          .read<DeviceProvider>()
+          .patchDeviceGroups(d.uid, res['primary'] ?? [], res['secondary'] ?? []);
+      context
+          .read<GymProvider>()
+          .patchDeviceGroups(d.uid, res['primary'] ?? [], res['secondary'] ?? []);
+    }
   }
 
   @override

--- a/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
+++ b/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
@@ -99,26 +99,27 @@ class _DeviceMuscleAssignmentSheetState
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 TextButton(
-                  onPressed: () => Navigator.pop(context, false),
+                  onPressed: () => Navigator.pop(context),
                   child: const Text('Abbrechen'),
                 ),
                 const SizedBox(width: 8),
                 ElevatedButton(
                   onPressed: () async {
-                    await context
-                        .read<MuscleGroupProvider>()
-                        .updateDeviceAssignments(
+                    final primary =
+                        _primaryId == null ? const <String>[] : <String>[_primaryId!];
+                    final secondary =
+                        _secondary.where((id) => id != _primaryId).toList();
+                    await context.read<MuscleGroupProvider>().updateDeviceAssignments(
                           context,
                           widget.deviceId,
-                          _primaryId == null
-                              ? const []
-                              : <String>[_primaryId!],
-                          _secondary
-                              .where((id) => id != _primaryId)
-                              .toList(),
+                          primary,
+                          secondary,
                         );
                     if (!mounted) return;
-                    Navigator.pop(context, true);
+                    Navigator.pop(context, {
+                      'primary': primary,
+                      'secondary': secondary,
+                    });
                   },
                   child: const Text('Speichern'),
                 ),

--- a/lib/ui/devices/device_card.dart
+++ b/lib/ui/devices/device_card.dart
@@ -1,23 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/features/device/presentation/widgets/muscle_chips.dart';
-import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
 
 class DeviceCard extends StatelessWidget {
   final Device device;
-  final List<MuscleGroup>? groupsForDevice;
   final VoidCallback? onTap;
-  const DeviceCard({super.key, required this.device, this.groupsForDevice, this.onTap});
+  const DeviceCard({super.key, required this.device, this.onTap});
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final brand = device.description;
     final idText = device.id.toString();
-    final muscleIds = [
-      ...device.primaryMuscleGroups,
-      ...device.secondaryMuscleGroups,
-    ];
     return Semantics(
       label: '${device.name}, ${brand.isNotEmpty ? '$brand, ' : ''}ID $idText',
       button: true,
@@ -67,12 +61,17 @@ class DeviceCard extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.end,
                     children: [
                       Text('ID: $idText', style: theme.textTheme.labelSmall),
-                      if (!device.isMulti && muscleIds.isNotEmpty)
+                      if (!device.isMulti &&
+                          (device.primaryMuscleGroups.isNotEmpty ||
+                              device.secondaryMuscleGroups.isNotEmpty))
                         Padding(
                           padding: const EdgeInsets.only(top: 6),
                           child: Align(
                             alignment: Alignment.centerRight,
-                            child: MuscleChips(muscleGroupIds: muscleIds),
+                            child: MuscleChips(
+                              primaryIds: device.primaryMuscleGroups,
+                              secondaryIds: device.secondaryMuscleGroups,
+                            ),
                           ),
                         ),
                     ],

--- a/test/providers/device_provider_test.dart
+++ b/test/providers/device_provider_test.dart
@@ -323,6 +323,25 @@ void main() {
 
       expect(provider.error, 'Heute bereits gespeichert.');
     });
+
+    test('patchDeviceGroups updates device and notifies', () async {
+      final provider = DeviceProvider(
+        firestore: FakeFirebaseFirestore(),
+        getDevicesForGym: GetDevicesForGym(
+          FakeDeviceRepository([
+            Device(uid: 'd1', id: 1, name: 'D'),
+          ]),
+        ),
+        log: (_, [__]) {},
+      );
+      await provider.loadDevices('g1');
+      var calls = 0;
+      provider.addListener(() => calls++);
+      provider.patchDeviceGroups('d1', ['p'], ['s']);
+      expect(provider.devices.first.primaryMuscleGroups, ['p']);
+      expect(provider.devices.first.secondaryMuscleGroups, ['s']);
+      expect(calls, 1);
+    });
   });
 }
 

--- a/test/ui/gym/device_card_test.dart
+++ b/test/ui/gym/device_card_test.dart
@@ -88,6 +88,7 @@ void main() {
       name: 'Bench',
       description: 'Eleiko',
       primaryMuscleGroups: const ['chest'],
+      secondaryMuscleGroups: const ['back'],
     );
     await tester.pumpWidget(
       MaterialApp(
@@ -118,6 +119,33 @@ void main() {
       ),
     );
     expect(find.byType(MuscleChips), findsNothing);
+  });
+
+  testWidgets('orders primary then secondary chips with styles', (tester) async {
+    final device = Device(
+      uid: '1',
+      id: 1,
+      name: 'Bench',
+      description: 'Eleiko',
+      primaryMuscleGroups: const ['chest'],
+      secondaryMuscleGroups: const ['back'],
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ChangeNotifierProvider(
+          create: (_) => _makeProvider(),
+          child: DeviceCard(device: device),
+        ),
+      ),
+    );
+    final chips = tester.widgetList<Chip>(find.byType(Chip)).toList();
+    final context = tester.element(find.byType(DeviceCard));
+    final theme = Theme.of(context);
+    expect((chips[0].label as Text).data, 'Chest');
+    expect(chips[0].backgroundColor, theme.colorScheme.primary);
+    expect((chips[1].label as Text).data, 'Back');
+    final shape = chips[1].shape as StadiumBorder;
+    expect(shape.side.color, theme.colorScheme.tertiary);
   });
 }
 


### PR DESCRIPTION
## Summary
- display primary and secondary muscle group chips on device cards
- return muscle group assignments from admin sheet and patch providers for live updates
- add device and gym provider helpers for patching muscle group assignments

## Testing
- `flutter format lib/features/device/presentation/widgets/muscle_chips.dart lib/ui/devices/device_card.dart lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart lib/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart lib/core/providers/device_provider.dart lib/core/providers/gym_provider.dart lib/core/providers/muscle_group_provider.dart test/ui/gym/device_card_test.dart test/providers/device_provider_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689985e444508320b1885d98b7720125