### PR TITLE
Fix MuscleChips parameter usage in device screens

### DIFF
--- a/lib/features/device/presentation/screens/exercise_list_screen.dart
+++ b/lib/features/device/presentation/screens/exercise_list_screen.dart
@@ -97,7 +97,10 @@ class _ExerciseListScreenState extends State<ExerciseListScreen> {
           return ListTile(
             leading: const Icon(Icons.fitness_center),
             title: Text(ex.name),
-            subtitle: MuscleChips(muscleGroupIds: ex.muscleGroupIds),
+            subtitle: MuscleChips(
+              primaryIds: ex.muscleGroupIds,
+              secondaryIds: const [],
+            ),
             onTap: () {
               Navigator.of(context).pushNamed(
                 AppRouter.device,

--- a/lib/features/device/presentation/widgets/exercise_header.dart
+++ b/lib/features/device/presentation/widgets/exercise_header.dart
@@ -32,7 +32,10 @@ class ExerciseHeader extends StatelessWidget {
                 children: [
                   Text(name, style: Theme.of(context).textTheme.titleMedium),
                   const SizedBox(height: 4),
-                  MuscleChips(muscleGroupIds: muscleGroupIds),
+                  MuscleChips(
+                    primaryIds: muscleGroupIds,
+                    secondaryIds: const [],
+                  ),
                 ],
               ),
             ),


### PR DESCRIPTION
## Summary
- adjust exercise list subtitle to use primary and secondary muscle IDs
- update exercise header to supply muscle IDs with new constructor

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689988be459c8320a3f4d60205bb8ce2