### PR TITLE
refactor: enforce enum exhaustiveness in widgets and tests

### DIFF
--- a/lib/features/device/presentation/widgets/muscle_chips.dart
+++ b/lib/features/device/presentation/widgets/muscle_chips.dart
@@ -23,7 +23,6 @@ class MuscleChips extends StatelessWidget {
       case MuscleRegion.legs:
         return 'Legs';
       case MuscleRegion.core:
-      default:
         return 'Core';
     }
   }
@@ -37,20 +36,20 @@ class MuscleChips extends StatelessWidget {
     final theme = Theme.of(context);
     final groups = context.watch<MuscleGroupProvider>().groups;
 
-    MuscleRegion _regionFor(String id, MuscleGroup? g) {
+    MuscleRegion regionFor(String id, MuscleGroup? g) {
       if (g != null) return g.region;
       return MuscleRegion.values.firstWhereOrNull((r) => r.name == id) ?? MuscleRegion.core;
     }
 
-    String _nameFor(String id) {
+    String nameFor(String id) {
       final g = groups.firstWhereOrNull((e) => e.id == id);
-      final region = _regionFor(id, g);
+      final region = regionFor(id, g);
       if (g != null && g.name.trim().isNotEmpty) return g.name;
       return _fallbackName(region);
     }
 
-    Widget _buildChip(String id, bool primary) {
-      final name = _nameFor(id);
+    Widget buildChip(String id, bool primary) {
+      final name = nameFor(id);
       final color = primary ? theme.colorScheme.primary : theme.colorScheme.tertiary;
       final textColor = primary ? theme.colorScheme.onPrimary : theme.colorScheme.tertiary;
       return Semantics(
@@ -74,8 +73,8 @@ class MuscleChips extends StatelessWidget {
       spacing: 4,
       runSpacing: 4,
       children: [
-        for (final id in primaryIds) _buildChip(id, true),
-        for (final id in secondaryIds) _buildChip(id, false),
+        for (final id in primaryIds) buildChip(id, true),
+        for (final id in secondaryIds) buildChip(id, false),
       ],
     );
   }

--- a/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
+++ b/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
@@ -50,7 +50,6 @@ class _DeviceMuscleAssignmentSheetState
       case MuscleRegion.legs:
         return 'Legs';
       case MuscleRegion.core:
-      default:
         return 'Core';
     }
   }

--- a/lib/features/survey/survey_provider.dart
+++ b/lib/features/survey/survey_provider.dart
@@ -23,7 +23,7 @@ class SurveyProvider extends ChangeNotifier {
   List<Survey> openSurveys = [];
   List<Survey> closedSurveys = [];
   String? _error;
-  bool _isLoading = false;
+  final bool _isLoading = false;
 
   String? get error => _error;
   bool get isLoading => _isLoading;

--- a/test/ui/gym/device_card_test.dart
+++ b/test/ui/gym/device_card_test.dart
@@ -10,7 +10,6 @@ import 'package:tapem/features/muscle_group/domain/repositories/muscle_group_rep
 import 'package:tapem/features/muscle_group/domain/usecases/get_muscle_groups_for_gym.dart';
 import 'package:tapem/features/muscle_group/domain/usecases/save_muscle_group.dart';
 import 'package:tapem/features/muscle_group/domain/usecases/delete_muscle_group.dart';
-import 'package:tapem/features/history/domain/repositories/history_repository.dart';
 import 'package:tapem/features/history/domain/usecases/get_history_for_device.dart';
 import 'package:tapem/features/history/domain/models/workout_log.dart';
 import 'package:tapem/features/device/domain/repositories/device_repository.dart';
@@ -28,9 +27,13 @@ class _DummyMuscleGroupRepo implements MuscleGroupRepository {
   Future<void> saveMuscleGroup(String gymId, MuscleGroup group) async {}
 }
 
-class _DummyHistoryRepo implements HistoryRepository {
+class _FakeHistoryRepo implements GetHistoryForDeviceRepository {
   @override
-  Future<List<WorkoutLog>> getHistory(String gymId, String deviceId, String userId) async => [];
+  Future<List<WorkoutLog>> getHistory({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+  }) async => [];
 }
 
 class _DummyDeviceRepo implements DeviceRepository {
@@ -59,7 +62,7 @@ MuscleGroupProvider _makeProvider() {
     getGroups: GetMuscleGroupsForGym(repo),
     saveGroup: SaveMuscleGroup(repo),
     deleteGroup: DeleteMuscleGroup(repo),
-    getHistory: GetHistoryForDevice(_DummyHistoryRepo()),
+    getHistory: GetHistoryForDevice(_FakeHistoryRepo()),
     updateDeviceGroups: UpdateDeviceMuscleGroupsUseCase(_DummyDeviceRepo()),
     setDeviceGroups: SetDeviceMuscleGroupsUseCase(_DummyDeviceRepo()),
   );

--- a/test/ui/gym/search_and_filters_test.dart
+++ b/test/ui/gym/search_and_filters_test.dart
@@ -8,7 +8,6 @@ import 'package:tapem/features/muscle_group/domain/repositories/muscle_group_rep
 import 'package:tapem/features/muscle_group/domain/usecases/get_muscle_groups_for_gym.dart';
 import 'package:tapem/features/muscle_group/domain/usecases/save_muscle_group.dart';
 import 'package:tapem/features/muscle_group/domain/usecases/delete_muscle_group.dart';
-import 'package:tapem/features/history/domain/repositories/history_repository.dart';
 import 'package:tapem/features/history/domain/usecases/get_history_for_device.dart';
 import 'package:tapem/features/history/domain/models/workout_log.dart';
 import 'package:tapem/features/device/domain/repositories/device_repository.dart';
@@ -27,9 +26,13 @@ class _DummyMuscleGroupRepo implements MuscleGroupRepository {
   Future<void> saveMuscleGroup(String gymId, MuscleGroup group) async {}
 }
 
-class _DummyHistoryRepo implements HistoryRepository {
+class _FakeHistoryRepo implements GetHistoryForDeviceRepository {
   @override
-  Future<List<WorkoutLog>> getHistory(String gymId, String deviceId, String userId) async => [];
+  Future<List<WorkoutLog>> getHistory({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+  }) async => [];
 }
 
 class _DummyDeviceRepo implements DeviceRepository {
@@ -59,7 +62,7 @@ class _TestMuscleGroupProvider extends MuscleGroupProvider {
           getGroups: GetMuscleGroupsForGym(_DummyMuscleGroupRepo()),
           saveGroup: SaveMuscleGroup(_DummyMuscleGroupRepo()),
           deleteGroup: DeleteMuscleGroup(_DummyMuscleGroupRepo()),
-          getHistory: GetHistoryForDevice(_DummyHistoryRepo()),
+          getHistory: GetHistoryForDevice(_FakeHistoryRepo()),
           updateDeviceGroups: UpdateDeviceMuscleGroupsUseCase(_DummyDeviceRepo()),
           setDeviceGroups: SetDeviceMuscleGroupsUseCase(_DummyDeviceRepo()),
         );

--- a/test/ui/timer/session_timer_bar_test.dart
+++ b/test/ui/timer/session_timer_bar_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tapem/ui/timer/session_timer_bar.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   testWidgets('SessionTimerBar ticks and completes respecting mute',
       (tester) async {
     final ticks = <Duration>[];
@@ -11,15 +12,15 @@ void main() {
     int soundCalls = 0;
     int hapticCalls = 0;
 
-    ServicesBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
       if (call.method == 'SystemSound.play') soundCalls++;
       if (call.method == 'HapticFeedback.mediumImpact') hapticCalls++;
       return null;
     });
     addTearDown(() {
-      ServicesBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(SystemChannels.platform, null);
+      messenger.setMockMethodCallHandler(SystemChannels.platform, null);
     });
 
     await tester.pumpWidget(MaterialApp(


### PR DESCRIPTION
## Summary
- remove default branches from `MuscleRegion` switches and rename local helpers in `MuscleChips`
- make `DeviceMuscleAssignmentSheet`'s switch exhaustive
- mark survey provider's loading flag as final
- add fake history repositories for gym tests and update timer test to modern messenger API

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68998ad372cc832099f464a362340300