### PR TITLE
feat: canonical muscle assignment sheet with reset

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -111,6 +111,14 @@ class DeviceProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  void applyMuscleAssignments(
+    String deviceId,
+    List<String> primaryGroups,
+    List<String> secondaryGroups,
+  ) {
+    patchDeviceGroups(deviceId, primaryGroups, secondaryGroups);
+  }
+
   /// Lädt Gerätedaten, letzte Session und Notiz
   Future<void> loadDevice({
     required String gymId,

--- a/lib/features/muscle_group/data/repositories/muscle_group_repository_impl.dart
+++ b/lib/features/muscle_group/data/repositories/muscle_group_repository_impl.dart
@@ -21,4 +21,9 @@ class MuscleGroupRepositoryImpl implements MuscleGroupRepository {
   Future<void> deleteMuscleGroup(String gymId, String groupId) {
     return _source.deleteMuscleGroup(gymId, groupId);
   }
+
+  @override
+  Future<String> ensureRegionGroup(String gymId, MuscleRegion region) {
+    return _source.ensureRegionGroup(gymId, region);
+  }
 }

--- a/lib/features/muscle_group/domain/repositories/muscle_group_repository.dart
+++ b/lib/features/muscle_group/domain/repositories/muscle_group_repository.dart
@@ -4,4 +4,5 @@ abstract class MuscleGroupRepository {
   Future<List<MuscleGroup>> getMuscleGroups(String gymId);
   Future<void> saveMuscleGroup(String gymId, MuscleGroup group);
   Future<void> deleteMuscleGroup(String gymId, String groupId);
+  Future<String> ensureRegionGroup(String gymId, MuscleRegion region);
 }

--- a/lib/features/muscle_group/domain/usecases/ensure_region_group.dart
+++ b/lib/features/muscle_group/domain/usecases/ensure_region_group.dart
@@ -1,0 +1,10 @@
+import '../models/muscle_group.dart';
+import '../repositories/muscle_group_repository.dart';
+
+class EnsureRegionGroup {
+  final MuscleGroupRepository _repo;
+  EnsureRegionGroup(this._repo);
+
+  Future<String> execute(String gymId, MuscleRegion region) =>
+      _repo.ensureRegionGroup(gymId, region);
+}

--- a/test/ui/muscle_groups/assignment_sheet_test.dart
+++ b/test/ui/muscle_groups/assignment_sheet_test.dart
@@ -1,16 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
 import 'package:tapem/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart';
-import 'package:tapem/core/providers/muscle_group_provider.dart';
 
-class FakeMuscleGroupProvider extends ChangeNotifier
-    implements MuscleGroupProvider {
+class FakeMuscleGroupProvider extends ChangeNotifier implements MuscleGroupProvider {
   final List<MuscleGroup> _groups;
-  String? lastDeviceId;
   List<String>? lastPrimary;
   List<String>? lastSecondary;
+  MuscleRegion? ensuredRegion;
 
   FakeMuscleGroupProvider(this._groups);
 
@@ -22,12 +21,19 @@ class FakeMuscleGroupProvider extends ChangeNotifier
   List<MuscleGroup> get groups => _groups;
   @override
   Map<String, int> get counts => {};
+
   @override
   Future<void> loadGroups(BuildContext context) async {}
+
+  @override
+  Future<String?> ensureRegionGroup(BuildContext context, MuscleRegion region) async {
+    ensuredRegion = region;
+    return '${region.name}-id';
+  }
+
   @override
   Future<void> updateDeviceAssignments(BuildContext context, String deviceId,
       List<String> primaryGroupIds, List<String> secondaryGroupIds) async {
-    lastDeviceId = deviceId;
     lastPrimary = primaryGroupIds;
     lastSecondary = secondaryGroupIds;
   }
@@ -36,68 +42,89 @@ class FakeMuscleGroupProvider extends ChangeNotifier
   noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
-void main() {
-  testWidgets('toggling and saving calls updateDeviceAssignments',
-      (tester) async {
-    final prov = FakeMuscleGroupProvider([
-      MuscleGroup(
-        id: 'm1',
-        name: 'Chest',
-        region: MuscleRegion.chest,
-        primaryDeviceIds: const [],
-        secondaryDeviceIds: const [],
-        exerciseIds: const [],
-      ),
-      MuscleGroup(
-        id: 'm2',
-        name: 'Back',
-        region: MuscleRegion.back,
-        primaryDeviceIds: const [],
-        secondaryDeviceIds: const [],
-        exerciseIds: const [],
-      ),
-    ]);
-
-    await tester.pumpWidget(
-      ChangeNotifierProvider<MuscleGroupProvider>.value(
-        value: prov,
-        child: MaterialApp(
-          home: Scaffold(
-            body: Builder(
-              builder: (context) => TextButton(
-                onPressed: () {
-                  showModalBottomSheet(
-                    context: context,
-                    builder: (_) => const DeviceMuscleAssignmentSheet(
-                      deviceId: 'd1',
-                      deviceName: 'Device',
-                      initialPrimary: [],
-                      initialSecondary: [],
-                    ),
-                  );
-                },
-                child: const Text('open'),
-              ),
+Future<void> _openSheet(WidgetTester tester, MuscleGroupProvider prov) async {
+  await tester.pumpWidget(
+    ChangeNotifierProvider<MuscleGroupProvider>.value(
+      value: prov,
+      child: MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => TextButton(
+              onPressed: () {
+                showModalBottomSheet(
+                  context: context,
+                  builder: (_) => const DeviceMuscleAssignmentSheet(
+                    deviceId: 'd1',
+                    deviceName: 'Device',
+                    initialPrimary: [],
+                    initialSecondary: [],
+                  ),
+                );
+              },
+              child: const Text('open'),
             ),
           ),
         ),
       ),
-    );
+    ),
+  );
 
-    await tester.tap(find.text('open'));
-    await tester.pumpAndSettle();
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+}
 
-    await tester.tap(find.widgetWithText(FilterChip, 'Chest').first);
-    await tester.pump();
+void main() {
+  testWidgets('shows six unique primary options with arms and core', (tester) async {
+    final prov = FakeMuscleGroupProvider([
+      MuscleGroup(id: 'c1', name: 'Chest', region: MuscleRegion.chest),
+      MuscleGroup(id: 'c2', name: 'Pecs', region: MuscleRegion.chest),
+      MuscleGroup(id: 'b1', name: 'Back', region: MuscleRegion.back),
+      MuscleGroup(id: 'b2', name: 'Back2', region: MuscleRegion.back),
+      MuscleGroup(id: 's1', name: 'Shoulders', region: MuscleRegion.shoulders),
+      MuscleGroup(id: 'l1', name: 'Legs', region: MuscleRegion.legs),
+      MuscleGroup(id: 'a1', name: 'Arms', region: MuscleRegion.arms),
+      MuscleGroup(id: 'co1', name: 'Core', region: MuscleRegion.core),
+    ]);
 
-    await tester.tap(find.widgetWithText(FilterChip, 'Back').last);
+    await _openSheet(tester, prov);
+
+    expect(find.byType(Radio), findsNWidgets(6));
+    expect(find.bySemanticsLabel('Arms, primär auswählen'), findsOneWidget);
+    expect(find.bySemanticsLabel('Core, primär auswählen'), findsOneWidget);
+    expect(find.bySemanticsLabel('Chest, primär auswählen'), findsOneWidget);
+    expect(find.bySemanticsLabel('Back, primär auswählen'), findsOneWidget);
+  });
+
+  testWidgets('saving creates missing region and assigns', (tester) async {
+    final prov = FakeMuscleGroupProvider([
+      MuscleGroup(id: 'c1', name: 'Chest', region: MuscleRegion.chest),
+    ]);
+
+    await _openSheet(tester, prov);
+
+    await tester.tap(find.bySemanticsLabel('Arms, primär auswählen'));
     await tester.pump();
 
     await tester.tap(find.text('Speichern'));
     await tester.pumpAndSettle();
 
-    expect(prov.lastDeviceId, 'd1');
-    expect(prov.lastPrimary, ['m1']);
-    expect(prov.lastSecondary, ['m2']);
+    expect(prov.ensuredRegion, MuscleRegion.arms);
+    expect(prov.lastPrimary, ['arms-id']);
+    expect(prov.lastSecondary, isEmpty);
+  });
+
+  testWidgets('reset clears assignments', (tester) async {
+    final prov = FakeMuscleGroupProvider([
+      MuscleGroup(id: 'c1', name: 'Chest', region: MuscleRegion.chest),
+    ]);
+
+    await _openSheet(tester, prov);
+
+    await tester.tap(find.text('Zurücksetzen'));
+    await tester.pumpAndSettle();
+
+    expect(prov.lastPrimary, isEmpty);
+    expect(prov.lastSecondary, isEmpty);
+    expect(find.byType(DeviceMuscleAssignmentSheet), findsNothing);
   });
 }


### PR DESCRIPTION
## Summary
- show canonical six muscle group options with search and reset
- auto-create missing region groups and patch device state on save
- add provider and firestore support for ensureRegionGroup

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68998f4fdb188320be43a53c50e2ed76