### PR TITLE
Fix canonical muscle group map and update test repositories

### DIFF
--- a/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
+++ b/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
@@ -71,7 +71,7 @@ class _DeviceMuscleAssignmentSheetState
   }
 
   Map<MuscleRegion, MuscleGroup?> _canonical(List<MuscleGroup> groups) {
-    final map = {for (var r in MuscleRegion.values) r: null};
+    final map = <MuscleRegion, MuscleGroup?>{for (var r in MuscleRegion.values) r: null};
     final byRegion = <MuscleRegion, List<MuscleGroup>>{};
     for (final g in groups) {
       byRegion.putIfAbsent(g.region, () => []).add(g);

--- a/test/ui/gym/device_card_test.dart
+++ b/test/ui/gym/device_card_test.dart
@@ -25,6 +25,10 @@ class _DummyMuscleGroupRepo implements MuscleGroupRepository {
 
   @override
   Future<void> saveMuscleGroup(String gymId, MuscleGroup group) async {}
+
+  @override
+  Future<String> ensureRegionGroup(String gymId, MuscleRegion region) async =>
+      '${region.name}-id';
 }
 
 class _FakeHistoryRepo implements GetHistoryForDeviceRepository {

--- a/test/ui/gym/search_and_filters_test.dart
+++ b/test/ui/gym/search_and_filters_test.dart
@@ -24,6 +24,10 @@ class _DummyMuscleGroupRepo implements MuscleGroupRepository {
 
   @override
   Future<void> saveMuscleGroup(String gymId, MuscleGroup group) async {}
+
+  @override
+  Future<String> ensureRegionGroup(String gymId, MuscleRegion region) async =>
+      '${region.name}-id';
 }
 
 class _FakeHistoryRepo implements GetHistoryForDeviceRepository {

--- a/test/widgets/exercise_bottom_sheet_selected_preview_test.dart
+++ b/test/widgets/exercise_bottom_sheet_selected_preview_test.dart
@@ -27,6 +27,10 @@ class _FakeMuscleGroupRepo implements MuscleGroupRepository {
   Future<void> saveMuscleGroup(String gymId, MuscleGroup group) async {}
   @override
   Future<void> deleteMuscleGroup(String gymId, String groupId) async {}
+
+  @override
+  Future<String> ensureRegionGroup(String gymId, MuscleRegion region) async =>
+      '${region.name}-id';
 }
 
 class _FakeHistoryRepo implements GetHistoryForDeviceRepository {

--- a/test/widgets/muscle_group_list_selector_primary_secondary_test.dart
+++ b/test/widgets/muscle_group_list_selector_primary_secondary_test.dart
@@ -25,6 +25,10 @@ class _FakeMuscleGroupRepo implements MuscleGroupRepository {
   Future<void> saveMuscleGroup(String gymId, MuscleGroup group) async {}
   @override
   Future<void> deleteMuscleGroup(String gymId, String groupId) async {}
+
+  @override
+  Future<String> ensureRegionGroup(String gymId, MuscleRegion region) async =>
+      '${region.name}-id';
 }
 
 class _FakeHistoryRepo implements GetHistoryForDeviceRepository {

--- a/test/widgets/muscle_group_list_selector_test.dart
+++ b/test/widgets/muscle_group_list_selector_test.dart
@@ -25,6 +25,10 @@ class _FakeMuscleGroupRepo implements MuscleGroupRepository {
   Future<void> saveMuscleGroup(String gymId, MuscleGroup group) async {}
   @override
   Future<void> deleteMuscleGroup(String gymId, String groupId) async {}
+
+  @override
+  Future<String> ensureRegionGroup(String gymId, MuscleRegion region) async =>
+      '${region.name}-id';
 }
 
 class _FakeHistoryRepo implements GetHistoryForDeviceRepository {

--- a/test/widgets/muscle_group_list_selector_text_test.dart
+++ b/test/widgets/muscle_group_list_selector_text_test.dart
@@ -25,6 +25,10 @@ class _FakeMuscleGroupRepo implements MuscleGroupRepository {
   Future<void> saveMuscleGroup(String gymId, MuscleGroup group) async {}
   @override
   Future<void> deleteMuscleGroup(String gymId, String groupId) async {}
+
+  @override
+  Future<String> ensureRegionGroup(String gymId, MuscleRegion region) async =>
+      '${region.name}-id';
 }
 
 class _FakeHistoryRepo implements GetHistoryForDeviceRepository {

--- a/test/widgets/muscle_group_selector_test.dart
+++ b/test/widgets/muscle_group_selector_test.dart
@@ -25,6 +25,10 @@ class _FakeMuscleGroupRepo implements MuscleGroupRepository {
   Future<void> saveMuscleGroup(String gymId, MuscleGroup group) async {}
   @override
   Future<void> deleteMuscleGroup(String gymId, String groupId) async {}
+
+  @override
+  Future<String> ensureRegionGroup(String gymId, MuscleRegion region) async =>
+      '${region.name}-id';
 }
 
 class _FakeHistoryRepo implements GetHistoryForDeviceRepository {


### PR DESCRIPTION
## Summary
- Fix device muscle assignment sheet map to store `MuscleGroup?` values
- Implement `ensureRegionGroup` in test `MuscleGroupRepository` stubs

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689991a21fb8832087af11fc719cfc90