### PR TITLE
fix(ui): resolve SearchBar import conflict

### DIFF
--- a/lib/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide SearchBar;
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/auth_provider.dart';

--- a/lib/ui/common/filter_chips_row.dart
+++ b/lib/ui/common/filter_chips_row.dart
@@ -21,7 +21,6 @@ class FilterChipsRow extends StatelessWidget {
   });
 
   Future<void> _showSortSheet(BuildContext context) async {
-    final loc = AppLocalizations.of(context)!;
     final res = await showModalBottomSheet<SortOrder>(
       context: context,
       builder: (ctx) => SafeArea(


### PR DESCRIPTION
## Summary
- hide Flutter's SearchBar to use project-specific SearchBar widget
- remove unused local variable in filter chip row

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899ed37d7c08320a96cc422c51129e8