### PR TITLE
feat: expand muscle groups

### DIFF
--- a/lib/features/device/presentation/widgets/muscle_chips.dart
+++ b/lib/features/device/presentation/widgets/muscle_chips.dart
@@ -14,16 +14,42 @@ class MuscleChips extends StatelessWidget {
     switch (region) {
       case MuscleRegion.chest:
         return 'Chest';
-      case MuscleRegion.back:
-        return 'Back';
-      case MuscleRegion.shoulders:
-        return 'Shoulders';
-      case MuscleRegion.arms:
-        return 'Arms';
-      case MuscleRegion.legs:
-        return 'Legs';
-      case MuscleRegion.core:
-        return 'Core';
+      case MuscleRegion.anteriorDeltoid:
+        return 'Anterior Deltoid';
+      case MuscleRegion.biceps:
+        return 'Biceps';
+      case MuscleRegion.wristFlexors:
+        return 'Wrist Flexors';
+      case MuscleRegion.lats:
+        return 'Lats';
+      case MuscleRegion.midBack:
+        return 'Mid Back';
+      case MuscleRegion.posteriorDeltoid:
+        return 'Posterior Deltoid';
+      case MuscleRegion.upperTrapezius:
+        return 'Upper Trapezius';
+      case MuscleRegion.triceps:
+        return 'Triceps';
+      case MuscleRegion.rectusAbdominis:
+        return 'Rectus Abdominis';
+      case MuscleRegion.obliques:
+        return 'Obliques';
+      case MuscleRegion.transversusAbdominis:
+        return 'Transversus Abdominis';
+      case MuscleRegion.quadriceps:
+        return 'Quadriceps';
+      case MuscleRegion.hamstrings:
+        return 'Hamstrings';
+      case MuscleRegion.glutes:
+        return 'Glutes';
+      case MuscleRegion.adductors:
+        return 'Adductors';
+      case MuscleRegion.abductors:
+        return 'Abductors';
+      case MuscleRegion.calves:
+        return 'Calves';
+      case MuscleRegion.tibialisAnterior:
+        return 'Tibialis Anterior';
     }
   }
 
@@ -38,7 +64,7 @@ class MuscleChips extends StatelessWidget {
 
     MuscleRegion regionFor(String id, MuscleGroup? g) {
       if (g != null) return g.region;
-      return MuscleRegion.values.firstWhereOrNull((r) => r.name == id) ?? MuscleRegion.core;
+      return MuscleRegion.values.firstWhereOrNull((r) => r.name == id) ?? MuscleRegion.rectusAbdominis;
     }
 
     String nameFor(String id) {

--- a/lib/features/muscle_group/data/dtos/muscle_group_dto.dart
+++ b/lib/features/muscle_group/data/dtos/muscle_group_dto.dart
@@ -28,7 +28,7 @@ class MuscleGroupDto {
       name: data['name'] as String? ?? '',
       region: MuscleRegion.values.firstWhere(
         (r) => r.name == data['region'],
-        orElse: () => MuscleRegion.core,
+        orElse: () => MuscleRegion.rectusAbdominis,
       ),
       primaryDeviceIds:
           (data['primaryDeviceIds'] as List<dynamic>? ?? [])
@@ -65,6 +65,7 @@ class MuscleGroupDto {
   Map<String, dynamic> toJson() => {
     'name': name,
     'region': region.name,
+    'majorCategory': region.category.name,
     'primaryDeviceIds': primaryDeviceIds,
     'secondaryDeviceIds': secondaryDeviceIds,
     'exerciseIds': exerciseIds,

--- a/lib/features/muscle_group/data/sources/firestore_muscle_group_source.dart
+++ b/lib/features/muscle_group/data/sources/firestore_muscle_group_source.dart
@@ -46,21 +46,5 @@ class FirestoreMuscleGroupSource {
   }
 
   String _canonicalName(MuscleRegion region) => region.name.toLowerCase();
-
-  String _canonicalLabel(MuscleRegion region) {
-    switch (region) {
-      case MuscleRegion.chest:
-        return 'chest';
-      case MuscleRegion.back:
-        return 'back';
-      case MuscleRegion.shoulders:
-        return 'shoulders';
-      case MuscleRegion.arms:
-        return 'arms';
-      case MuscleRegion.core:
-        return 'core';
-      case MuscleRegion.legs:
-        return 'legs';
-    }
-  }
+  String _canonicalLabel(MuscleRegion region) => region.name;
 }

--- a/lib/features/muscle_group/domain/models/muscle_group.dart
+++ b/lib/features/muscle_group/domain/models/muscle_group.dart
@@ -1,4 +1,29 @@
-enum MuscleRegion { chest, back, shoulders, arms, core, legs }
+enum MuscleCategory { upperFront, upperBack, core, lower }
+
+enum MuscleRegion {
+  chest(MuscleCategory.upperFront),
+  anteriorDeltoid(MuscleCategory.upperFront),
+  biceps(MuscleCategory.upperFront),
+  wristFlexors(MuscleCategory.upperFront),
+  lats(MuscleCategory.upperBack),
+  midBack(MuscleCategory.upperBack),
+  posteriorDeltoid(MuscleCategory.upperBack),
+  upperTrapezius(MuscleCategory.upperBack),
+  triceps(MuscleCategory.upperBack),
+  rectusAbdominis(MuscleCategory.core),
+  obliques(MuscleCategory.core),
+  transversusAbdominis(MuscleCategory.core),
+  quadriceps(MuscleCategory.lower),
+  hamstrings(MuscleCategory.lower),
+  glutes(MuscleCategory.lower),
+  adductors(MuscleCategory.lower),
+  abductors(MuscleCategory.lower),
+  calves(MuscleCategory.lower),
+  tibialisAnterior(MuscleCategory.lower);
+
+  final MuscleCategory category;
+  const MuscleRegion(this.category);
+}
 
 class MuscleGroup {
   final String id;
@@ -11,13 +36,14 @@ class MuscleGroup {
   MuscleGroup({
     required this.id,
     required this.name,
-    this.region = MuscleRegion.core,
+    this.region = MuscleRegion.rectusAbdominis,
     List<String>? primaryDeviceIds,
     List<String>? secondaryDeviceIds,
     List<String>? exerciseIds,
-  }) : primaryDeviceIds = List.unmodifiable(primaryDeviceIds ?? []),
-       secondaryDeviceIds = List.unmodifiable(secondaryDeviceIds ?? []),
-       exerciseIds = List.unmodifiable(exerciseIds ?? []);
+  })
+      : primaryDeviceIds = List.unmodifiable(primaryDeviceIds ?? []),
+        secondaryDeviceIds = List.unmodifiable(secondaryDeviceIds ?? []),
+        exerciseIds = List.unmodifiable(exerciseIds ?? []);
 
   /// Convenience getter combining both device lists
   List<String> get deviceIds =>
@@ -45,7 +71,7 @@ class MuscleGroup {
         name: json['name'] as String? ?? '',
         region: MuscleRegion.values.firstWhere(
           (r) => r.name == json['region'],
-          orElse: () => MuscleRegion.core,
+          orElse: () => MuscleRegion.rectusAbdominis,
         ),
         primaryDeviceIds:
             (json['primaryDeviceIds'] as List<dynamic>? ?? [])
@@ -64,6 +90,7 @@ class MuscleGroup {
   Map<String, dynamic> toJson() => {
     'name': name,
     'region': region.name,
+    'majorCategory': region.category.name,
     'primaryDeviceIds': primaryDeviceIds,
     'secondaryDeviceIds': secondaryDeviceIds,
     'exerciseIds': exerciseIds,

--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
@@ -76,18 +76,20 @@ class _MuscleGroupScreenState extends State<MuscleGroupScreen> {
             final xpMap = <String, double>{
               'head': 0,
               'chest': regionXp[MuscleRegion.chest] ?? 0,
-              'core': regionXp[MuscleRegion.core] ?? 0,
-              'pelvis': regionXp[MuscleRegion.core] ?? 0,
-              'upper_arm_left': regionXp[MuscleRegion.arms] ?? 0,
-              'upper_arm_right': regionXp[MuscleRegion.arms] ?? 0,
-              'forearm_left': regionXp[MuscleRegion.arms] ?? 0,
-              'forearm_right': regionXp[MuscleRegion.arms] ?? 0,
-              'thigh_left': regionXp[MuscleRegion.legs] ?? 0,
-              'thigh_right': regionXp[MuscleRegion.legs] ?? 0,
-              'calf_left': regionXp[MuscleRegion.legs] ?? 0,
-              'calf_right': regionXp[MuscleRegion.legs] ?? 0,
-              'foot_left': regionXp[MuscleRegion.legs] ?? 0,
-              'foot_right': regionXp[MuscleRegion.legs] ?? 0,
+              'core': (regionXp[MuscleRegion.rectusAbdominis] ?? 0) +
+                  (regionXp[MuscleRegion.obliques] ?? 0) +
+                  (regionXp[MuscleRegion.transversusAbdominis] ?? 0),
+              'pelvis': regionXp[MuscleRegion.glutes] ?? 0,
+              'upper_arm_left': regionXp[MuscleRegion.biceps] ?? 0,
+              'upper_arm_right': regionXp[MuscleRegion.triceps] ?? 0,
+              'forearm_left': regionXp[MuscleRegion.wristFlexors] ?? 0,
+              'forearm_right': regionXp[MuscleRegion.wristFlexors] ?? 0,
+              'thigh_left': regionXp[MuscleRegion.quadriceps] ?? 0,
+              'thigh_right': regionXp[MuscleRegion.hamstrings] ?? 0,
+              'calf_left': regionXp[MuscleRegion.calves] ?? 0,
+              'calf_right': regionXp[MuscleRegion.calves] ?? 0,
+              'foot_left': regionXp[MuscleRegion.tibialisAnterior] ?? 0,
+              'foot_right': regionXp[MuscleRegion.tibialisAnterior] ?? 0,
             };
 
             final values = xpMap.values;

--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
@@ -78,18 +78,20 @@ class _MuscleGroupScreenNewState extends State<MuscleGroupScreenNew> {
     final xpMap = <String, int>{
       'head': 0,
       'chest': regionXp[MuscleRegion.chest] ?? 0,
-      'core': regionXp[MuscleRegion.core] ?? 0,
-      'pelvis': regionXp[MuscleRegion.core] ?? 0,
-      'upper_arm_left': regionXp[MuscleRegion.arms] ?? 0,
-      'upper_arm_right': regionXp[MuscleRegion.arms] ?? 0,
-      'forearm_left': regionXp[MuscleRegion.arms] ?? 0,
-      'forearm_right': regionXp[MuscleRegion.arms] ?? 0,
-      'thigh_left': regionXp[MuscleRegion.legs] ?? 0,
-      'thigh_right': regionXp[MuscleRegion.legs] ?? 0,
-      'calf_left': regionXp[MuscleRegion.legs] ?? 0,
-      'calf_right': regionXp[MuscleRegion.legs] ?? 0,
-      'foot_left': regionXp[MuscleRegion.legs] ?? 0,
-      'foot_right': regionXp[MuscleRegion.legs] ?? 0,
+      'core': (regionXp[MuscleRegion.rectusAbdominis] ?? 0) +
+          (regionXp[MuscleRegion.obliques] ?? 0) +
+          (regionXp[MuscleRegion.transversusAbdominis] ?? 0),
+      'pelvis': regionXp[MuscleRegion.glutes] ?? 0,
+      'upper_arm_left': regionXp[MuscleRegion.biceps] ?? 0,
+      'upper_arm_right': regionXp[MuscleRegion.triceps] ?? 0,
+      'forearm_left': regionXp[MuscleRegion.wristFlexors] ?? 0,
+      'forearm_right': regionXp[MuscleRegion.wristFlexors] ?? 0,
+      'thigh_left': regionXp[MuscleRegion.quadriceps] ?? 0,
+      'thigh_right': regionXp[MuscleRegion.hamstrings] ?? 0,
+      'calf_left': regionXp[MuscleRegion.calves] ?? 0,
+      'calf_right': regionXp[MuscleRegion.calves] ?? 0,
+      'foot_left': regionXp[MuscleRegion.tibialisAnterior] ?? 0,
+      'foot_right': regionXp[MuscleRegion.tibialisAnterior] ?? 0,
     };
 
     final values = xpMap.values.map((e) => e.toDouble());

--- a/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
+++ b/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
@@ -40,27 +40,66 @@ class _DeviceMuscleAssignmentSheetState
 
   static const List<MuscleRegion> _order = [
     MuscleRegion.chest,
-    MuscleRegion.shoulders,
-    MuscleRegion.legs,
-    MuscleRegion.back,
-    MuscleRegion.arms,
-    MuscleRegion.core,
+    MuscleRegion.anteriorDeltoid,
+    MuscleRegion.biceps,
+    MuscleRegion.wristFlexors,
+    MuscleRegion.lats,
+    MuscleRegion.midBack,
+    MuscleRegion.posteriorDeltoid,
+    MuscleRegion.upperTrapezius,
+    MuscleRegion.triceps,
+    MuscleRegion.rectusAbdominis,
+    MuscleRegion.obliques,
+    MuscleRegion.transversusAbdominis,
+    MuscleRegion.quadriceps,
+    MuscleRegion.hamstrings,
+    MuscleRegion.glutes,
+    MuscleRegion.adductors,
+    MuscleRegion.abductors,
+    MuscleRegion.calves,
+    MuscleRegion.tibialisAnterior,
   ];
 
   String _regionLabel(MuscleRegion region) {
     switch (region) {
       case MuscleRegion.chest:
         return 'Chest';
-      case MuscleRegion.back:
-        return 'Back';
-      case MuscleRegion.shoulders:
-        return 'Shoulders';
-      case MuscleRegion.arms:
-        return 'Arms';
-      case MuscleRegion.legs:
-        return 'Legs';
-      case MuscleRegion.core:
-        return 'Core';
+      case MuscleRegion.anteriorDeltoid:
+        return 'Anterior Deltoid';
+      case MuscleRegion.biceps:
+        return 'Biceps';
+      case MuscleRegion.wristFlexors:
+        return 'Wrist Flexors';
+      case MuscleRegion.lats:
+        return 'Lats';
+      case MuscleRegion.midBack:
+        return 'Mid Back';
+      case MuscleRegion.posteriorDeltoid:
+        return 'Posterior Deltoid';
+      case MuscleRegion.upperTrapezius:
+        return 'Upper Trapezius';
+      case MuscleRegion.triceps:
+        return 'Triceps';
+      case MuscleRegion.rectusAbdominis:
+        return 'Rectus Abdominis';
+      case MuscleRegion.obliques:
+        return 'Obliques';
+      case MuscleRegion.transversusAbdominis:
+        return 'Transversus Abdominis';
+      case MuscleRegion.quadriceps:
+        return 'Quadriceps';
+      case MuscleRegion.hamstrings:
+        return 'Hamstrings';
+      case MuscleRegion.glutes:
+        return 'Glutes';
+      case MuscleRegion.adductors:
+        return 'Adductors';
+      case MuscleRegion.abductors:
+        return 'Abductors';
+      case MuscleRegion.calves:
+        return 'Calves';
+      case MuscleRegion.tibialisAnterior:
+        return 'Tibialis Anterior';
     }
   }
 
@@ -76,13 +115,8 @@ class _DeviceMuscleAssignmentSheetState
     for (final g in groups) {
       byRegion.putIfAbsent(g.region, () => []).add(g);
     }
-    const canonicalNames = {
-      MuscleRegion.chest: 'chest',
-      MuscleRegion.back: 'back',
-      MuscleRegion.shoulders: 'shoulders',
-      MuscleRegion.arms: 'arms',
-      MuscleRegion.legs: 'legs',
-      MuscleRegion.core: 'core',
+    final canonicalNames = {
+      for (var r in MuscleRegion.values) r: r.name.toLowerCase()
     };
     for (final r in MuscleRegion.values) {
       final list = byRegion[r];

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -491,5 +491,13 @@
   "@a11yMgUnselected": {
     "description": "Semantik für nicht ausgewählte Muskelgruppe",
     "placeholders": {"name": {}}
-  }
+  },
+  "muscleCatUpperFront": "Oberkörper – vorne",
+  "@muscleCatUpperFront": {"description": "Bereichslabel Oberkörper vorne"},
+  "muscleCatUpperBack": "Oberkörper – hinten",
+  "@muscleCatUpperBack": {"description": "Bereichslabel Oberkörper hinten"},
+  "muscleCatCore": "Rumpf",
+  "@muscleCatCore": {"description": "Bereichslabel Rumpf"},
+  "muscleCatLower": "Unterkörper",
+  "@muscleCatLower": {"description": "Bereichslabel Unterkörper"}
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -488,5 +488,13 @@
   "@a11yMgUnselected": {
     "description": "Semantics for unselected muscle group",
     "placeholders": {"name": {}}
-  }
+  },
+  "muscleCatUpperFront": "Upper body - front",
+  "@muscleCatUpperFront": {"description": "Section label for front upper body"},
+  "muscleCatUpperBack": "Upper body - back",
+  "@muscleCatUpperBack": {"description": "Section label for back upper body"},
+  "muscleCatCore": "Core",
+  "@muscleCatCore": {"description": "Section label for core"},
+  "muscleCatLower": "Lower body",
+  "@muscleCatLower": {"description": "Section label for lower body"}
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -805,6 +805,11 @@ abstract class AppLocalizations {
 
   /// Semantics label for unselected muscle group
   String a11yMgUnselected(Object name);
+
+  String get muscleCatUpperFront;
+  String get muscleCatUpperBack;
+  String get muscleCatCore;
+  String get muscleCatLower;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -407,4 +407,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String a11yMgUnselected(Object name) {
     return 'Muskelgruppe: $name, nicht ausgewählt';
   }
+
+  @override
+  String get muscleCatUpperFront => 'Oberkörper – vorne';
+
+  @override
+  String get muscleCatUpperBack => 'Oberkörper – hinten';
+
+  @override
+  String get muscleCatCore => 'Rumpf';
+
+  @override
+  String get muscleCatLower => 'Unterkörper';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -407,4 +407,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String a11yMgUnselected(Object name) {
     return 'Muscle group: $name, not selected';
   }
+
+  @override
+  String get muscleCatUpperFront => 'Upper body - front';
+
+  @override
+  String get muscleCatUpperBack => 'Upper body - back';
+
+  @override
+  String get muscleCatCore => 'Core';
+
+  @override
+  String get muscleCatLower => 'Lower body';
 }

--- a/lib/ui/muscles/muscle_group_card.dart
+++ b/lib/ui/muscles/muscle_group_card.dart
@@ -15,7 +15,7 @@ class MuscleGroupCard extends StatelessWidget {
     final prov = context.watch<MuscleGroupProvider>();
     final group = prov.groups.firstWhere(
       (g) => g.id == muscleGroupId,
-      orElse: () => MuscleGroup(id: '', name: '', region: MuscleRegion.core),
+      orElse: () => MuscleGroup(id: '', name: '', region: MuscleRegion.rectusAbdominis),
     );
     if (group.id.isEmpty) return const SizedBox.shrink();
     final theme = Theme.of(context);

--- a/lib/ui/muscles/muscle_group_color.dart
+++ b/lib/ui/muscles/muscle_group_color.dart
@@ -2,18 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
 
 Color colorForRegion(MuscleRegion region, ThemeData theme) {
-  switch (region) {
-    case MuscleRegion.chest:
+  switch (region.category) {
+    case MuscleCategory.upperFront:
       return Colors.red.shade300;
-    case MuscleRegion.back:
+    case MuscleCategory.upperBack:
       return Colors.blue.shade300;
-    case MuscleRegion.shoulders:
-      return Colors.orange.shade300;
-    case MuscleRegion.arms:
-      return Colors.green.shade300;
-    case MuscleRegion.core:
+    case MuscleCategory.core:
       return Colors.purple.shade300;
-    case MuscleRegion.legs:
+    case MuscleCategory.lower:
       return Colors.teal.shade300;
   }
 }

--- a/lib/ui/muscles/muscle_group_list_selector.dart
+++ b/lib/ui/muscles/muscle_group_list_selector.dart
@@ -26,11 +26,24 @@ class MuscleGroupListSelector extends StatefulWidget {
 class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
   static const List<MuscleRegion> _ordered = [
     MuscleRegion.chest,
-    MuscleRegion.back,
-    MuscleRegion.shoulders,
-    MuscleRegion.arms,
-    MuscleRegion.legs,
-    MuscleRegion.core,
+    MuscleRegion.anteriorDeltoid,
+    MuscleRegion.biceps,
+    MuscleRegion.wristFlexors,
+    MuscleRegion.lats,
+    MuscleRegion.midBack,
+    MuscleRegion.posteriorDeltoid,
+    MuscleRegion.upperTrapezius,
+    MuscleRegion.triceps,
+    MuscleRegion.rectusAbdominis,
+    MuscleRegion.obliques,
+    MuscleRegion.transversusAbdominis,
+    MuscleRegion.quadriceps,
+    MuscleRegion.hamstrings,
+    MuscleRegion.glutes,
+    MuscleRegion.adductors,
+    MuscleRegion.abductors,
+    MuscleRegion.calves,
+    MuscleRegion.tibialisAnterior,
   ];
 
   late List<String> _selected;
@@ -47,16 +60,42 @@ class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
     switch (r) {
       case MuscleRegion.chest:
         return 'Chest';
-      case MuscleRegion.back:
-        return 'Back';
-      case MuscleRegion.shoulders:
-        return 'Shoulders';
-      case MuscleRegion.arms:
-        return 'Arms';
-      case MuscleRegion.legs:
-        return 'Legs';
-      case MuscleRegion.core:
-        return 'Core';
+      case MuscleRegion.anteriorDeltoid:
+        return 'Anterior Deltoid';
+      case MuscleRegion.biceps:
+        return 'Biceps';
+      case MuscleRegion.wristFlexors:
+        return 'Wrist Flexors';
+      case MuscleRegion.lats:
+        return 'Lats';
+      case MuscleRegion.midBack:
+        return 'Mid Back';
+      case MuscleRegion.posteriorDeltoid:
+        return 'Posterior Deltoid';
+      case MuscleRegion.upperTrapezius:
+        return 'Upper Trapezius';
+      case MuscleRegion.triceps:
+        return 'Triceps';
+      case MuscleRegion.rectusAbdominis:
+        return 'Rectus Abdominis';
+      case MuscleRegion.obliques:
+        return 'Obliques';
+      case MuscleRegion.transversusAbdominis:
+        return 'Transversus Abdominis';
+      case MuscleRegion.quadriceps:
+        return 'Quadriceps';
+      case MuscleRegion.hamstrings:
+        return 'Hamstrings';
+      case MuscleRegion.glutes:
+        return 'Glutes';
+      case MuscleRegion.adductors:
+        return 'Adductors';
+      case MuscleRegion.abductors:
+        return 'Abductors';
+      case MuscleRegion.calves:
+        return 'Calves';
+      case MuscleRegion.tibialisAnterior:
+        return 'Tibialis Anterior';
     }
   }
 

--- a/lib/ui/muscles/muscle_group_selector.dart
+++ b/lib/ui/muscles/muscle_group_selector.dart
@@ -62,39 +62,69 @@ class _MuscleGroupSelectorState extends State<MuscleGroupSelector> {
       return Center(child: Text(loc.exerciseNoMuscleGroups));
     }
 
+    final Map<MuscleCategory, List<MuscleGroup>> grouped = {};
+    for (final g in groups) {
+      grouped.putIfAbsent(g.region.category, () => []).add(g);
+    }
+
+    String catLabel(MuscleCategory c) {
+      switch (c) {
+        case MuscleCategory.upperFront:
+          return loc.muscleCatUpperFront;
+        case MuscleCategory.upperBack:
+          return loc.muscleCatUpperBack;
+        case MuscleCategory.core:
+          return loc.muscleCatCore;
+        case MuscleCategory.lower:
+          return loc.muscleCatLower;
+      }
+    }
+
     return SingleChildScrollView(
-      physics: const BouncingScrollPhysics(), // POLISH: smoother scroll in bottom sheet
-      child: Wrap(
-        spacing: 4,
-        runSpacing: 4,
+      physics: const BouncingScrollPhysics(),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          for (final g in groups)
-            Semantics(
-              label: _selected.contains(g.id)
-                  ? loc.a11yMgSelected(g.name)
-                  : loc.a11yMgUnselected(g.name),
-              child: FilterChip(
-                key: ValueKey(g.id),
-                avatar: CircleAvatar(
-                  backgroundColor: colorForRegion(g.region, theme),
-                  radius: 6,
-                ),
-                label: Text(
-                  g.name,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                selected: _selected.contains(g.id),
-                selectedColor: theme.colorScheme.primary,
-                checkmarkColor: theme.colorScheme.onPrimary,
-                labelStyle: TextStyle(
-                  color: _selected.contains(g.id)
-                      ? theme.colorScheme.onPrimary
-                      : theme.colorScheme.onSurface,
-                ),
-                onSelected: (_) => _toggle(g.id),
+          for (final cat in MuscleCategory.values)
+            if (grouped[cat] != null) ...[
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 12.0),
+                child: Text(catLabel(cat), style: theme.textTheme.titleMedium),
               ),
-            ),
+              Wrap(
+                spacing: 4,
+                runSpacing: 4,
+                children: [
+                  for (final g in grouped[cat]!)
+                    Semantics(
+                      label: _selected.contains(g.id)
+                          ? loc.a11yMgSelected(g.name)
+                          : loc.a11yMgUnselected(g.name),
+                      child: FilterChip(
+                        key: ValueKey(g.id),
+                        avatar: CircleAvatar(
+                          backgroundColor: colorForRegion(g.region, theme),
+                          radius: 6,
+                        ),
+                        label: Text(
+                          g.name,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        selected: _selected.contains(g.id),
+                        selectedColor: theme.colorScheme.primary,
+                        checkmarkColor: theme.colorScheme.onPrimary,
+                        labelStyle: TextStyle(
+                          color: _selected.contains(g.id)
+                              ? theme.colorScheme.onPrimary
+                              : theme.colorScheme.onSurface,
+                        ),
+                        onSelected: (_) => _toggle(g.id),
+                      ),
+                    ),
+                ],
+              ),
+            ],
         ],
       ),
     );

--- a/test/ui/gym/search_and_filters_test.dart
+++ b/test/ui/gym/search_and_filters_test.dart
@@ -125,7 +125,7 @@ class _HarnessState extends State<_Harness> {
 void main() {
   final groups = [
     MuscleGroup(id: 'chest', name: 'Chest', region: MuscleRegion.chest),
-    MuscleGroup(id: 'legs', name: 'Legs', region: MuscleRegion.legs),
+    MuscleGroup(id: 'legs', name: 'Quadriceps', region: MuscleRegion.quadriceps),
   ];
   testWidgets('muscle filter reduces list', (tester) async {
     await tester.pumpWidget(

--- a/test/ui/muscle_groups/admin_list_filters_test.dart
+++ b/test/ui/muscle_groups/admin_list_filters_test.dart
@@ -128,8 +128,8 @@ void main() {
       ),
       MuscleGroup(
         id: 'm2',
-        name: 'Back',
-        region: MuscleRegion.back,
+        name: 'Lats',
+        region: MuscleRegion.lats,
         primaryDeviceIds: const [],
         secondaryDeviceIds: const [],
         exerciseIds: const [],
@@ -202,8 +202,8 @@ void main() {
       ),
       MuscleGroup(
         id: 'm2',
-        name: 'Back',
-        region: MuscleRegion.back,
+        name: 'Lats',
+        region: MuscleRegion.lats,
         primaryDeviceIds: const [],
         secondaryDeviceIds: const [],
         exerciseIds: const [],

--- a/test/ui/muscle_groups/assignment_sheet_test.dart
+++ b/test/ui/muscle_groups/assignment_sheet_test.dart
@@ -78,21 +78,21 @@ void main() {
     final prov = FakeMuscleGroupProvider([
       MuscleGroup(id: 'c1', name: 'Chest', region: MuscleRegion.chest),
       MuscleGroup(id: 'c2', name: 'Pecs', region: MuscleRegion.chest),
-      MuscleGroup(id: 'b1', name: 'Back', region: MuscleRegion.back),
-      MuscleGroup(id: 'b2', name: 'Back2', region: MuscleRegion.back),
-      MuscleGroup(id: 's1', name: 'Shoulders', region: MuscleRegion.shoulders),
-      MuscleGroup(id: 'l1', name: 'Legs', region: MuscleRegion.legs),
-      MuscleGroup(id: 'a1', name: 'Arms', region: MuscleRegion.arms),
-      MuscleGroup(id: 'co1', name: 'Core', region: MuscleRegion.core),
+      MuscleGroup(id: 'b1', name: 'Lats', region: MuscleRegion.lats),
+      MuscleGroup(id: 'b2', name: 'Mid Back', region: MuscleRegion.midBack),
+      MuscleGroup(id: 's1', name: 'Anterior Deltoid', region: MuscleRegion.anteriorDeltoid),
+      MuscleGroup(id: 'l1', name: 'Quadriceps', region: MuscleRegion.quadriceps),
+      MuscleGroup(id: 'a1', name: 'Biceps', region: MuscleRegion.biceps),
+      MuscleGroup(id: 'co1', name: 'Rectus Abdominis', region: MuscleRegion.rectusAbdominis),
     ]);
 
     await _openSheet(tester, prov);
 
     expect(find.byType(Radio), findsNWidgets(6));
-    expect(find.bySemanticsLabel('Arms, primär auswählen'), findsOneWidget);
-    expect(find.bySemanticsLabel('Core, primär auswählen'), findsOneWidget);
+    expect(find.bySemanticsLabel('Biceps, primär auswählen'), findsOneWidget);
+    expect(find.bySemanticsLabel('Rectus Abdominis, primär auswählen'), findsOneWidget);
     expect(find.bySemanticsLabel('Chest, primär auswählen'), findsOneWidget);
-    expect(find.bySemanticsLabel('Back, primär auswählen'), findsOneWidget);
+    expect(find.bySemanticsLabel('Lats, primär auswählen'), findsOneWidget);
   });
 
   testWidgets('saving creates missing region and assigns', (tester) async {
@@ -102,14 +102,14 @@ void main() {
 
     await _openSheet(tester, prov);
 
-    await tester.tap(find.bySemanticsLabel('Arms, primär auswählen'));
+    await tester.tap(find.bySemanticsLabel('Biceps, primär auswählen'));
     await tester.pump();
 
     await tester.tap(find.text('Speichern'));
     await tester.pumpAndSettle();
 
-    expect(prov.ensuredRegion, MuscleRegion.arms);
-    expect(prov.lastPrimary, ['arms-id']);
+    expect(prov.ensuredRegion, MuscleRegion.biceps);
+    expect(prov.lastPrimary, ['biceps-id']);
     expect(prov.lastSecondary, isEmpty);
   });
 

--- a/test/widgets/exercise_bottom_sheet_selected_preview_test.dart
+++ b/test/widgets/exercise_bottom_sheet_selected_preview_test.dart
@@ -84,7 +84,7 @@ class _FakeAuthProvider extends ChangeNotifier implements AuthProvider {
 
 void main() {
   final groups = [
-    MuscleGroup(id: '1', name: 'Latissimus dorsi', region: MuscleRegion.back),
+    MuscleGroup(id: '1', name: 'Latissimus dorsi', region: MuscleRegion.lats),
   ];
 
   testWidgets('preview updates when selecting muscle groups', (tester) async {

--- a/test/widgets/muscle_group_list_selector_primary_secondary_test.dart
+++ b/test/widgets/muscle_group_list_selector_primary_secondary_test.dart
@@ -100,8 +100,8 @@ void main() {
   final groups = [
     MuscleGroup(id: 'c1', name: '', region: MuscleRegion.chest),
     MuscleGroup(id: 'chestId', name: 'Chest', region: MuscleRegion.chest),
-    MuscleGroup(id: 'b1', name: '', region: MuscleRegion.back),
-    MuscleGroup(id: 'backId', name: 'Back', region: MuscleRegion.back),
+    MuscleGroup(id: 'b1', name: '', region: MuscleRegion.lats),
+    MuscleGroup(id: 'backId', name: 'Lats', region: MuscleRegion.lats),
   ];
 
   testWidgets('handles primary/secondary selection and on-demand creation',

--- a/test/widgets/muscle_group_list_selector_test.dart
+++ b/test/widgets/muscle_group_list_selector_test.dart
@@ -76,7 +76,7 @@ class FakeMuscleGroupProvider extends MuscleGroupProvider {
 void main() {
   final groups = [
     MuscleGroup(id: '1', name: 'Chest', region: MuscleRegion.chest),
-    MuscleGroup(id: '2', name: 'Back', region: MuscleRegion.back),
+    MuscleGroup(id: '2', name: 'Lats', region: MuscleRegion.lats),
   ];
 
   testWidgets('MuscleGroupListSelector shows names and toggles', (tester) async {

--- a/test/widgets/muscle_group_list_selector_text_test.dart
+++ b/test/widgets/muscle_group_list_selector_text_test.dart
@@ -75,7 +75,7 @@ class FakeMuscleGroupProvider extends MuscleGroupProvider {
 
 void main() {
   testWidgets('zeigt Fallback-Namen, wenn group.name leer ist', (tester) async {
-    final groups = [MuscleGroup(id: '1', name: '', region: MuscleRegion.back)];
+    final groups = [MuscleGroup(id: '1', name: '', region: MuscleRegion.lats)];
     List<String> selected = [];
     await tester.pumpWidget(
       ChangeNotifierProvider<MuscleGroupProvider>.value(

--- a/test/widgets/muscle_group_selector_test.dart
+++ b/test/widgets/muscle_group_selector_test.dart
@@ -76,7 +76,7 @@ class FakeMuscleGroupProvider extends MuscleGroupProvider {
 void main() {
   final groups = [
     MuscleGroup(id: '1', name: 'Chest', region: MuscleRegion.chest),
-    MuscleGroup(id: '2', name: 'Back', region: MuscleRegion.back),
+    MuscleGroup(id: '2', name: 'Lats', region: MuscleRegion.lats),
   ];
 
   testWidgets('MuscleGroupSelector shows names and toggles', (tester) async {


### PR DESCRIPTION
## Summary
- expand `MuscleRegion` enum to detailed muscles and add `MuscleCategory`
- group muscle selection UI by major categories and update colors
- add localization strings for new categories

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899f33bcdb083208c88f072d6f943cd