### PR TITLE
Import foundation for setEquals

### DIFF
--- a/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
+++ b/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
@@ -1,5 +1,5 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:collection/collection.dart';
 import 'package:provider/provider.dart';
 
 import 'package:tapem/core/providers/muscle_group_provider.dart';
@@ -370,7 +370,6 @@ class _DeviceMuscleAssignmentSheetState
     final name = (g?.name.trim().isNotEmpty ?? false)
         ? g!.name
         : _regionLabel(loc, region);
-    final selected = _selectedPrimaryId == id;
     return Semantics(
       label: '$name, ${loc.muscleTabsPrimary}',
       child: InkWell(


### PR DESCRIPTION
## Summary
- import `package:flutter/foundation.dart` to use `setEquals`
- remove unused variable from `_buildPrimaryRow`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a38a73a608320bd4841f842e13928