### PR TITLE
feat: add magenta gym theme

### DIFF
--- a/lib/core/providers/branding_provider.dart
+++ b/lib/core/providers/branding_provider.dart
@@ -24,14 +24,17 @@ class BrandingProvider extends ChangeNotifier {
   Branding? _branding;
   bool _isLoading = false;
   String? _error;
+  String? _gymId;
 
   Branding? get branding => _branding;
   bool get isLoading => _isLoading;
   String? get error => _error;
+  String? get gymId => _gymId;
 
   Future<void> loadBranding(String gymId) async {
     _isLoading = true;
     _error = null;
+    _gymId = gymId;
     notifyListeners();
     try {
       _branding = await _source.getBranding(gymId);
@@ -48,6 +51,7 @@ class BrandingProvider extends ChangeNotifier {
   void loadBrandingWithGym(String? gymId) {
     if (gymId == null || gymId.isEmpty) {
       _branding = null;
+      _gymId = null;
       notifyListeners();
       return;
     }

--- a/lib/core/theme/design_tokens.dart
+++ b/lib/core/theme/design_tokens.dart
@@ -30,6 +30,21 @@ class AppColors {
   static const Color accentAmber = Color(0xFFFFC107);
 }
 
+/// Color palette for the magenta themed gym.
+class MagentaColors {
+  static const Color primary500 = Color(0xFFFF70D0);
+  static const Color primary600 = Color(0xFFE845B6);
+  static const Color secondary = Color(0xFF9B5DE5);
+  static const Color focus = Color(0xFFFFA3E6);
+  static const Color pressedTint = Color(0xFF6E2F7E);
+  static const Color bg = Color(0xFF0B0F12);
+  static const Color surface1 = Color(0xFF12161C);
+  static const Color surface2 = Color(0xFF1A1F26);
+  static const Color textPrimary = Color(0xFFF6F7FA);
+  static const Color textSecondary = Color(0xFFC6CBD2);
+  static const Color textTertiary = Color(0xFF8C93A1);
+}
+
 /// Standard spacing values based on an 8px grid.
 class AppSpacing {
   static const double xs = 8.0;
@@ -67,12 +82,33 @@ class AppGradients {
     ],
   );
 
-  /// Primary gradient used for buttons and icons.
-  static const LinearGradient primary = LinearGradient(
-    begin: Alignment.topLeft,
-    end: Alignment.bottomRight,
+  /// Brand gradient used for primary UI elements.
+  static LinearGradient brandGradient = const LinearGradient(
+    begin: Alignment.centerLeft,
+    end: Alignment.centerRight,
     colors: [AppColors.accentMint, AppColors.accentTurquoise],
   );
+
+  /// Radial glow used for call-to-action highlights.
+  static RadialGradient ctaGlow = RadialGradient(
+    colors: [AppColors.accentMint.withOpacity(0.25), Colors.transparent],
+    radius: 0.6,
+  );
+
+  static void setBrandGradient(Color start, Color end) {
+    brandGradient = LinearGradient(
+      begin: Alignment.centerLeft,
+      end: Alignment.centerRight,
+      colors: [start, end],
+    );
+  }
+
+  static void setCtaGlow(Color color) {
+    ctaGlow = RadialGradient(
+      colors: [color.withOpacity(0.25), Colors.transparent],
+      radius: 0.6,
+    );
+  }
 }
 
 /// Animation durations.

--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -14,73 +14,83 @@ class AppTheme {
   static ThemeData _buildTheme({
     required Color primary,
     required Color secondary,
+    Color background = AppColors.background,
+    Color surface = AppColors.surface,
+    Color? surface2,
+    Color textPrimary = AppColors.textPrimary,
+    Color textSecondary = AppColors.textSecondary,
+    Color focus = AppColors.accentTurquoise,
+    Color? buttonColor,
   }) {
     final base = ThemeData(brightness: Brightness.dark);
     final scheme = ColorScheme.dark(
       primary: primary,
       secondary: secondary,
-      background: AppColors.background,
-      surface: AppColors.surface,
-      onPrimary: AppColors.textPrimary,
-      onSurface: AppColors.textSecondary,
+      background: background,
+      surface: surface,
+      onPrimary: textPrimary,
+      onSurface: textSecondary,
+      outline: focus,
     );
+    final btnColor = buttonColor ?? secondary;
+    final s2 = surface2 ?? surface;
     return base.copyWith(
       colorScheme: scheme,
-      scaffoldBackgroundColor: AppColors.background,
-      canvasColor: AppColors.surface,
-      cardColor: AppColors.surface,
-      hintColor: AppColors.textSecondary,
+      scaffoldBackgroundColor: background,
+      canvasColor: s2,
+      cardColor: surface,
+      hintColor: textSecondary,
       appBarTheme: const AppBarTheme(
         elevation: 0,
         backgroundColor: Colors.transparent,
         centerTitle: true,
       ),
       bottomNavigationBarTheme: BottomNavigationBarThemeData(
-        backgroundColor: AppColors.surface,
+        backgroundColor: surface,
         selectedItemColor: secondary,
-        unselectedItemColor: AppColors.textSecondary,
+        unselectedItemColor: textSecondary,
         showUnselectedLabels: true,
       ),
       textTheme: TextTheme(
         // Large display numbers
         displayLarge: GoogleFonts.inter(
-          color: AppColors.textPrimary,
+          color: textPrimary,
           fontSize: AppFontSizes.kpi,
           fontWeight: FontWeight.w700,
         ),
         titleLarge: GoogleFonts.inter(
-          color: AppColors.textPrimary,
+          color: textPrimary,
           fontSize: AppFontSizes.headline,
           fontWeight: FontWeight.w600,
         ),
         titleMedium: GoogleFonts.inter(
-          color: AppColors.textSecondary,
+          color: textSecondary,
           fontSize: AppFontSizes.title,
         ),
         bodyMedium: GoogleFonts.inter(
-          color: AppColors.textSecondary,
+          color: textSecondary,
           fontSize: AppFontSizes.body,
         ),
       ),
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
-        fillColor: AppColors.surface,
+        fillColor: surface,
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(AppRadius.button),
           borderSide: BorderSide(
-            color: AppColors.textSecondary.withOpacity(0.3),
+            color: textSecondary.withOpacity(0.3),
           ),
         ),
         focusedBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(AppRadius.button),
-          borderSide: BorderSide(color: secondary),
+          borderSide: BorderSide(color: focus),
         ),
-        hintStyle: TextStyle(color: AppColors.textSecondary.withOpacity(0.6)),
+        hintStyle: TextStyle(color: textSecondary.withOpacity(0.6)),
       ),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
-          backgroundColor: secondary,
-          foregroundColor: AppColors.textPrimary,
+          backgroundColor: btnColor,
+          foregroundColor: textPrimary,
           textStyle: const TextStyle(fontWeight: FontWeight.bold),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(AppRadius.button),
@@ -89,8 +99,8 @@ class AppTheme {
       ),
       outlinedButtonTheme: OutlinedButtonThemeData(
         style: OutlinedButton.styleFrom(
-          foregroundColor: secondary,
-          side: BorderSide(color: secondary.withOpacity(0.5)),
+          foregroundColor: btnColor,
+          side: BorderSide(color: btnColor.withOpacity(0.5)),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(AppRadius.button),
           ),
@@ -109,17 +119,33 @@ class AppTheme {
   static final ThemeData mintDarkTheme = _buildTheme(
     primary: AppColors.accentMint,
     secondary: AppColors.accentTurquoise,
+    buttonColor: AppColors.accentTurquoise,
   );
 
   /// An alternate theme that highlights amber accents (e.g. for warning states).
   static final ThemeData amberDarkTheme = _buildTheme(
     primary: AppColors.accentAmber,
     secondary: AppColors.accentTurquoise,
+    buttonColor: AppColors.accentTurquoise,
   );
 
   /// A neutral dark theme without strong branding accents.
   static final ThemeData neutralTheme = _buildTheme(
     primary: AppColors.accentTurquoise,
     secondary: AppColors.accentTurquoise,
+    buttonColor: AppColors.accentTurquoise,
+  );
+
+  /// Magenta dark theme for special gym branding.
+  static final ThemeData magentaDarkTheme = _buildTheme(
+    primary: MagentaColors.primary600,
+    secondary: MagentaColors.secondary,
+    background: MagentaColors.bg,
+    surface: MagentaColors.surface1,
+    surface2: MagentaColors.surface2,
+    textPrimary: MagentaColors.textPrimary,
+    textSecondary: MagentaColors.textSecondary,
+    focus: MagentaColors.focus,
+    buttonColor: MagentaColors.primary600,
   );
 }

--- a/lib/core/theme/theme_loader.dart
+++ b/lib/core/theme/theme_loader.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../features/gym/domain/models/branding.dart';
+import 'design_tokens.dart';
 import 'theme.dart';
 
 /// Lädt dynamisch Themes je nach Gym.
@@ -11,11 +12,43 @@ class ThemeLoader extends ChangeNotifier {
   /// Setzt das Standard-Dark-Theme.
   void loadDefault() {
     _currentTheme = AppTheme.mintDarkTheme;
+    AppGradients.setBrandGradient(
+      AppColors.accentMint,
+      AppColors.accentTurquoise,
+    );
+    AppGradients.setCtaGlow(AppColors.accentMint);
     notifyListeners();
   }
 
   /// Wendet Branding-Daten auf das aktuelle Theme an.
-  void applyBranding(Branding? branding) {
+  void applyBranding(String? gymId, Branding? branding) {
+    if (gymId == 'gym_01') {
+      if (branding == null) {
+        _applyMagentaDefaults();
+        return;
+      }
+      final primary = branding.primaryColor != null
+          ? _parseHex(branding.primaryColor!)
+          : MagentaColors.primary600;
+      final secondary = branding.secondaryColor != null
+          ? _parseHex(branding.secondaryColor!)
+          : MagentaColors.secondary;
+      final gradStart = branding.gradientStart != null
+          ? _parseHex(branding.gradientStart!)
+          : MagentaColors.primary500;
+      final gradEnd = branding.gradientEnd != null
+          ? _parseHex(branding.gradientEnd!)
+          : MagentaColors.secondary;
+      _currentTheme = AppTheme.customTheme(
+        primary: primary,
+        secondary: secondary,
+      );
+      AppGradients.setBrandGradient(gradStart, gradEnd);
+      AppGradients.setCtaGlow(MagentaColors.focus);
+      notifyListeners();
+      return;
+    }
+
     if (branding == null ||
         branding.primaryColor == null ||
         branding.secondaryColor == null) {
@@ -25,6 +58,18 @@ class ThemeLoader extends ChangeNotifier {
     final primary = _parseHex(branding.primaryColor!);
     final accent = _parseHex(branding.secondaryColor!);
     _currentTheme = AppTheme.customTheme(primary: primary, secondary: accent);
+    AppGradients.setBrandGradient(primary, accent);
+    AppGradients.setCtaGlow(primary);
+    notifyListeners();
+  }
+
+  void _applyMagentaDefaults() {
+    _currentTheme = AppTheme.magentaDarkTheme;
+    AppGradients.setBrandGradient(
+      MagentaColors.primary500,
+      MagentaColors.secondary,
+    );
+    AppGradients.setCtaGlow(MagentaColors.focus);
     notifyListeners();
   }
 

--- a/lib/core/widgets/gradient_button.dart
+++ b/lib/core/widgets/gradient_button.dart
@@ -15,7 +15,7 @@ class GradientButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return DecoratedBox(
       decoration: BoxDecoration(
-        gradient: AppGradients.primary,
+        gradient: AppGradients.brandGradient,
         borderRadius: BorderRadius.circular(AppRadius.button),
       ),
       child: ElevatedButton(

--- a/lib/features/gym/domain/models/branding.dart
+++ b/lib/features/gym/domain/models/branding.dart
@@ -2,18 +2,32 @@ class Branding {
   final String? logoUrl;
   final String? primaryColor;
   final String? secondaryColor;
+  final String? gradientStart;
+  final String? gradientEnd;
 
-  Branding({this.logoUrl, this.primaryColor, this.secondaryColor});
+  Branding({
+    this.logoUrl,
+    this.primaryColor,
+    this.secondaryColor,
+    this.gradientStart,
+    this.gradientEnd,
+  });
 
   factory Branding.fromMap(Map<String, dynamic> map) => Branding(
-    logoUrl: map['logoUrl'] as String?,
-    primaryColor: map['primaryColor'] as String?,
-    secondaryColor: map['secondaryColor'] as String?,
-  );
+        logoUrl: map['logoUrl'] as String?,
+        primaryColor:
+            (map['primary'] ?? map['primaryColor']) as String?,
+        secondaryColor:
+            (map['secondary'] ?? map['secondaryColor']) as String?,
+        gradientStart: map['gradientStart'] as String?,
+        gradientEnd: map['gradientEnd'] as String?,
+      );
 
   Map<String, dynamic> toMap() => {
     if (logoUrl != null) 'logoUrl': logoUrl,
     if (primaryColor != null) 'primaryColor': primaryColor,
     if (secondaryColor != null) 'secondaryColor': secondaryColor,
+    if (gradientStart != null) 'gradientStart': gradientStart,
+    if (gradientEnd != null) 'gradientEnd': gradientEnd,
   };
 }

--- a/lib/features/rank/presentation/device_level_style.dart
+++ b/lib/features/rank/presentation/device_level_style.dart
@@ -25,13 +25,14 @@ class DeviceLevelStyle {
     double opacity = 1.0,
     double brightness = -0.6,
   }) {
-    final colors =
-        AppGradients.primary.colors.map((c) => c.withOpacity(opacity)).toList();
+    final colors = AppGradients.brandGradient.colors
+        .map((c) => c.withOpacity(opacity))
+        .toList();
 
     return BoxDecoration(
       gradient: LinearGradient(
-        begin: AppGradients.primary.begin,
-        end: AppGradients.primary.end,
+        begin: AppGradients.brandGradient.begin,
+        end: AppGradients.brandGradient.end,
         colors: colors,
       ),
       borderRadius: BorderRadius.circular(AppRadius.card),

--- a/lib/features/training_details/presentation/widgets/day_sessions_overview.dart
+++ b/lib/features/training_details/presentation/widgets/day_sessions_overview.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
 import '../../domain/models/session.dart';
 
 class DaySessionsOverview extends StatelessWidget {
@@ -30,10 +31,11 @@ class DaySessionsOverview extends StatelessWidget {
   }
 
   Widget _buildCard(BuildContext context, Session session) {
-    return Card(
-      color: const Color(0xFF1E1E1E),
-      elevation: 4,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+    return Container(
+      decoration: BoxDecoration(
+        gradient: AppGradients.brandGradient,
+        borderRadius: BorderRadius.circular(12),
+      ),
       child: Padding(
         padding: const EdgeInsets.all(12.0),
         child: Column(
@@ -41,8 +43,8 @@ class DaySessionsOverview extends StatelessWidget {
           children: [
             Text(
               session.deviceName,
-              style: const TextStyle(
-                color: Colors.white,
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onPrimary,
                 fontSize: 16,
                 fontWeight: FontWeight.bold,
               ),
@@ -53,30 +55,36 @@ class DaySessionsOverview extends StatelessWidget {
                 padding: const EdgeInsets.symmetric(vertical: 2.0),
                 child: Row(
                   children: [
-                    const Icon(
+                    Icon(
                       Icons.fitness_center,
-                      color: Color(0xFF00E676),
+                      color: Theme.of(context).colorScheme.primary,
                       size: 16,
                     ),
                     const SizedBox(width: 4),
                     Text(
                       '${set.weight.toStringAsFixed(1)} kg',
-                      style: const TextStyle(
-                        color: Colors.white70,
+                      style: TextStyle(
+                        color: Theme.of(context)
+                            .colorScheme
+                            .onPrimary
+                            .withOpacity(0.7),
                         fontSize: 14,
                       ),
                     ),
                     const SizedBox(width: 8),
-                    const Icon(
+                    Icon(
                       Icons.repeat,
-                      color: Color(0xFF00BCD4),
+                      color: Theme.of(context).colorScheme.secondary,
                       size: 16,
                     ),
                     const SizedBox(width: 4),
                     Text(
                       '${set.reps} Wdh',
-                      style: const TextStyle(
-                        color: Colors.white70,
+                      style: TextStyle(
+                        color: Theme.of(context)
+                            .colorScheme
+                            .onPrimary
+                            .withOpacity(0.7),
                         fontSize: 14,
                       ),
                     ),

--- a/lib/features/xp/presentation/widgets/xp_gauge.dart
+++ b/lib/features/xp/presentation/widgets/xp_gauge.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
 
 /// A circular XP gauge that animates from 0 to the provided XP value.
 ///
@@ -40,21 +41,12 @@ class XpGauge extends StatelessWidget {
 
     // Helper to determine the colour at the current progress.
     Color progressColor(double value) {
-      // Mint green (#00E676) for the first 60%.
-      const mint = Color(0xFF00E676);
-      // Turquoise (#00BCD4) in the middle segment.
-      const turquoise = Color(0xFF00BCD4);
-      // Amber (#FFC107) when approaching the next level.
-      const amber = Color(0xFFFFC107);
-
-      if (value <= 0.6) {
-        return mint;
-      } else if (value <= 0.9) {
-        final t = (value - 0.6) / 0.3;
-        return Color.lerp(mint, turquoise, t)!;
+      final colors = AppGradients.brandGradient.colors;
+      if (colors.length == 1) return colors.first;
+      if (value <= 0.5) {
+        return colors.first;
       } else {
-        final t = (value - 0.9) / 0.1;
-        return Color.lerp(turquoise, amber, t)!;
+        return colors.last;
       }
     }
 
@@ -76,7 +68,8 @@ class XpGauge extends StatelessWidget {
                 valueColor: AlwaysStoppedAnimation<Color>(
                   progressColor(progress),
                 ),
-                backgroundColor: const Color(0xFF3A3A3A),
+                backgroundColor:
+                    Theme.of(context).colorScheme.onPrimary.withOpacity(0.2),
               ),
             ),
             // The label text in the centre of the gauge.
@@ -88,21 +81,27 @@ class XpGauge extends StatelessWidget {
                   style: TextStyle(
                     fontSize: size * 0.22,
                     fontWeight: FontWeight.w600,
-                    color: Colors.white,
+                    color: Theme.of(context).colorScheme.onPrimary,
                   ),
                 ),
                 Text(
                   '$currentXp XP',
                   style: TextStyle(
                     fontSize: size * 0.14,
-                    color: Colors.grey.shade400,
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onPrimary
+                        .withOpacity(0.6),
                   ),
                 ),
                 Text(
                   label,
                   style: TextStyle(
                     fontSize: size * 0.12,
-                    color: Colors.grey.shade500,
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onPrimary
+                        .withOpacity(0.5),
                   ),
                 ),
               ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -182,7 +182,7 @@ class AppEntry extends StatelessWidget {
           create: (_) => ThemeLoader()..loadDefault(),
           update: (_, branding, loader) {
             final l = loader ?? (ThemeLoader()..loadDefault());
-            l.applyBranding(branding.branding);
+            l.applyBranding(branding.gymId, branding.branding);
             return l;
           },
         ),

--- a/lib/ui/muscles/muscle_group_color.dart
+++ b/lib/ui/muscles/muscle_group_color.dart
@@ -4,12 +4,10 @@ import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
 Color colorForRegion(MuscleRegion region, ThemeData theme) {
   switch (region.category) {
     case MuscleCategory.upperFront:
-      return Colors.red.shade300;
-    case MuscleCategory.upperBack:
-      return Colors.blue.shade300;
     case MuscleCategory.core:
-      return Colors.purple.shade300;
+      return theme.colorScheme.primary;
+    case MuscleCategory.upperBack:
     case MuscleCategory.lower:
-      return Colors.teal.shade300;
+      return theme.colorScheme.secondary;
   }
 }

--- a/lib/ui/numeric_keypad/numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/numeric_keypad.dart
@@ -73,6 +73,15 @@ class NumericKeypadTheme {
     ctaHeight: ctaHeight ?? this.ctaHeight,
     textStyle: textStyle ?? this.textStyle,
   );
+
+  factory NumericKeypadTheme.fromTheme(ThemeData theme) => NumericKeypadTheme(
+        bg: theme.colorScheme.surface,
+        keyBg: theme.canvasColor,
+        keyFg: theme.colorScheme.onPrimary,
+        cta: theme.colorScheme.primary,
+        overlayPressed: theme.colorScheme.primary.withOpacity(0.15),
+        disabled: theme.colorScheme.onPrimary.withOpacity(0.4),
+      );
 }
 
 /// Convenience TextField (readOnly) – öffnet das Sheet bei Tap.
@@ -137,7 +146,7 @@ Future<void> showNumericKeypadSheet(
   NumericKeypadTheme? theme,
   bool usePlatformAdaptiveStyle = true,
 }) async {
-  final th = theme ?? const NumericKeypadTheme();
+  final th = theme ?? NumericKeypadTheme.fromTheme(Theme.of(context));
   await showModalBottomSheet(
     context: context,
     isScrollControlled: true,

--- a/test/theme/theme_loader_test.dart
+++ b/test/theme/theme_loader_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/core/theme/theme_loader.dart';
+import 'package:tapem/features/gym/domain/models/branding.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/core/theme/theme.dart';
+
+void main() {
+  group('ThemeLoader', () {
+    test('gym_01 without branding uses magenta theme', () {
+      final loader = ThemeLoader()..loadDefault();
+      loader.applyBranding('gym_01', null);
+      expect(loader.theme.colorScheme.primary, MagentaColors.primary600);
+    });
+
+    test('gym_01 with branding applies custom colors', () {
+      final loader = ThemeLoader()..loadDefault();
+      loader.applyBranding(
+        'gym_01',
+        Branding(primaryColor: '#123456', secondaryColor: '#654321'),
+      );
+      expect(loader.theme.colorScheme.primary,
+          equals(const Color(0xFF123456)));
+      expect(loader.theme.colorScheme.secondary,
+          equals(const Color(0xFF654321)));
+    });
+
+    test('other gyms keep default theme', () {
+      final loader = ThemeLoader()..loadDefault();
+      loader.applyBranding('other', null);
+      expect(loader.theme.colorScheme.primary, AppColors.accentMint);
+    });
+  });
+}

--- a/test/ui/numeric_keypad_theme_test.dart
+++ b/test/ui/numeric_keypad_theme_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/ui/numeric_keypad/numeric_keypad.dart';
+
+void main() {
+  testWidgets('NumericKeypadTheme uses theme colors', (tester) async {
+    late NumericKeypadTheme th;
+    final theme = ThemeData.dark().copyWith(
+      colorScheme: const ColorScheme.dark(
+        primary: Colors.red,
+        surface: Colors.black,
+        onPrimary: Colors.white,
+      ),
+      canvasColor: Colors.grey,
+    );
+    await tester.pumpWidget(MaterialApp(
+      theme: theme,
+      home: Builder(
+        builder: (context) {
+          th = NumericKeypadTheme.fromTheme(Theme.of(context));
+          return const SizedBox.shrink();
+        },
+      ),
+    ));
+    expect(th.bg, theme.colorScheme.surface);
+    expect(th.keyBg, theme.canvasColor);
+    expect(th.cta, theme.colorScheme.primary);
+  });
+}

--- a/test/widgets/day_sessions_overview_test.dart
+++ b/test/widgets/day_sessions_overview_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/features/training_details/domain/models/session.dart';
+import 'package:tapem/features/training_details/presentation/widgets/day_sessions_overview.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
+
+void main() {
+  testWidgets('Session card uses brand gradient', (tester) async {
+    final session = Session(
+      sessionId: 's1',
+      deviceId: 'd1',
+      deviceName: 'Device',
+      deviceDescription: '',
+      timestamp: DateTime.now(),
+      note: '',
+      sets: [SessionSet(weight: 10, reps: 5)],
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData.dark(),
+      home: DaySessionsOverview(sessions: [session]),
+    ));
+
+    final container = tester.widget<Container>(
+      find.descendant(
+        of: find.byType(DaySessionsOverview),
+        matching: find.byType(Container),
+      ).first,
+    );
+    final decoration = container.decoration as BoxDecoration;
+    expect(decoration.gradient, AppGradients.brandGradient);
+  });
+}


### PR DESCRIPTION
## Summary
- add magenta color palette and brand gradients
- support gym-specific theming with magenta defaults
- theme numeric keypad and session cards via tokens

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689ab1172a588320860f0dce46da6518