### PR TITLE
feat(theme): normalize gym_01 brightness

### DIFF
--- a/lib/core/theme/theme_loader.dart
+++ b/lib/core/theme/theme_loader.dart
@@ -25,6 +25,8 @@ class ThemeLoader extends ChangeNotifier {
     if (gymId == 'gym_01') {
       if (branding == null) {
         _applyMagentaDefaults();
+        MagentaTones.normalizeFromGradient(AppGradients.brandGradient);
+        notifyListeners();
         return;
       }
       final primary = branding.primaryColor != null
@@ -45,6 +47,7 @@ class ThemeLoader extends ChangeNotifier {
       );
       AppGradients.setBrandGradient(gradStart, gradEnd);
       AppGradients.setCtaGlow(MagentaColors.focus);
+      MagentaTones.normalizeFromGradient(AppGradients.brandGradient);
       notifyListeners();
       return;
     }
@@ -70,7 +73,7 @@ class ThemeLoader extends ChangeNotifier {
       MagentaColors.secondary,
     );
     AppGradients.setCtaGlow(MagentaColors.focus);
-    notifyListeners();
+    MagentaTones.normalizeFromGradient(AppGradients.brandGradient);
   }
 
   Color _parseHex(String hex) {

--- a/test/theme/theme_loader_test.dart
+++ b/test/theme/theme_loader_test.dart
@@ -30,5 +30,26 @@ void main() {
       loader.applyBranding('other', null);
       expect(loader.theme.colorScheme.primary, AppColors.accentMint);
     });
+
+    test('gym_01 surfaces are normalised to reference luminance', () {
+      final loader = ThemeLoader()..loadDefault();
+      loader.applyBranding('gym_01', null);
+
+      final anchor = MagentaTones.brightnessAnchor;
+      final grad = AppGradients.brandGradient;
+      final gradLum =
+          grad.colors.map((c) => c.computeLuminance()).reduce((a, b) => a + b) /
+              grad.colors.length;
+      expect((gradLum - anchor).abs(), lessThanOrEqualTo(0.02));
+      expect(
+          (MagentaTones.surface1.computeLuminance() - anchor).abs(),
+          lessThanOrEqualTo(0.02));
+      expect(
+          (MagentaTones.surface2.computeLuminance() - (anchor + 0.025)).abs(),
+          lessThanOrEqualTo(0.02));
+      expect(
+          (MagentaTones.control.computeLuminance() - (anchor + 0.01)).abs(),
+          lessThanOrEqualTo(0.02));
+    });
   });
 }


### PR DESCRIPTION
## Summary
- add HSL-based tone helpers and dynamic tokens for magenta branding
- normalize gym_01 gradients and surfaces to last-session luminance reference
- test brightness anchor and tone deltas within ΔL≤0.02

## Testing
- `flutter analyze` *(command not found)*
- `flutter test test/theme/theme_loader_test.dart` *(command not found)*
- `apt-get update` *(failed: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689abc6c8c3883209b0dfa1ab8f718ae