### PR TITLE
feat: add brand surface theme for gym_01

### DIFF
--- a/lib/core/theme/brand_surface_theme.dart
+++ b/lib/core/theme/brand_surface_theme.dart
@@ -1,0 +1,107 @@
+import 'dart:math' as math;
+import 'dart:ui' show lerpDouble;
+
+import 'package:flutter/material.dart';
+
+import 'design_tokens.dart';
+
+/// Theme extension that describes the shared brand surface used by call-to-
+/// action elements in `gym_01`.
+class BrandSurfaceTheme extends ThemeExtension<BrandSurfaceTheme> {
+  final LinearGradient gradient;
+  final BorderRadiusGeometry radius;
+  final List<BoxShadow> shadow;
+  final Color pressedOverlay;
+  final Color focusRing;
+  final TextStyle textStyle;
+  final double height;
+  final EdgeInsetsGeometry padding;
+  final double luminanceRef;
+
+  const BrandSurfaceTheme({
+    required this.gradient,
+    required this.radius,
+    required this.shadow,
+    required this.pressedOverlay,
+    required this.focusRing,
+    required this.textStyle,
+    required this.height,
+    required this.padding,
+    required this.luminanceRef,
+  });
+
+  @override
+  BrandSurfaceTheme copyWith({
+    LinearGradient? gradient,
+    BorderRadiusGeometry? radius,
+    List<BoxShadow>? shadow,
+    Color? pressedOverlay,
+    Color? focusRing,
+    TextStyle? textStyle,
+    double? height,
+    EdgeInsetsGeometry? padding,
+    double? luminanceRef,
+  }) {
+    return BrandSurfaceTheme(
+      gradient: gradient ?? this.gradient,
+      radius: radius ?? this.radius,
+      shadow: shadow ?? this.shadow,
+      pressedOverlay: pressedOverlay ?? this.pressedOverlay,
+      focusRing: focusRing ?? this.focusRing,
+      textStyle: textStyle ?? this.textStyle,
+      height: height ?? this.height,
+      padding: padding ?? this.padding,
+      luminanceRef: luminanceRef ?? this.luminanceRef,
+    );
+  }
+
+  @override
+  BrandSurfaceTheme lerp(ThemeExtension<BrandSurfaceTheme>? other, double t) {
+    if (other is! BrandSurfaceTheme) return this;
+    return BrandSurfaceTheme(
+      gradient: LinearGradient(
+        begin: gradient.begin,
+        end: gradient.end,
+        colors: List.generate(
+          gradient.colors.length,
+          (i) => Color.lerp(gradient.colors[i], other.gradient.colors[i], t)!,
+        ),
+      ),
+      radius: BorderRadius.lerp(radius as BorderRadius?, other.radius as BorderRadius?, t) ?? radius,
+      shadow: _lerpShadowList(shadow, other.shadow, t),
+      pressedOverlay: Color.lerp(pressedOverlay, other.pressedOverlay, t) ?? pressedOverlay,
+      focusRing: Color.lerp(focusRing, other.focusRing, t) ?? focusRing,
+      textStyle: TextStyle.lerp(textStyle, other.textStyle, t) ?? textStyle,
+      height: lerpDouble(height, other.height, t) ?? height,
+      padding: EdgeInsets.lerp(padding as EdgeInsets?, other.padding as EdgeInsets?, t) ?? padding,
+      luminanceRef: lerpDouble(luminanceRef, other.luminanceRef, t) ?? luminanceRef,
+    );
+  }
+
+  static List<BoxShadow> _lerpShadowList(List<BoxShadow> a, List<BoxShadow> b, double t) {
+    final count = math.max(a.length, b.length);
+    return List.generate(count, (i) {
+      final sa = i < a.length ? a[i] : const BoxShadow();
+      final sb = i < b.length ? b[i] : const BoxShadow();
+      return BoxShadow.lerp(sa, sb, t)!;
+    });
+  }
+
+  /// Creates the magenta/violet CTA preset used for `gym_01`.
+  static BrandSurfaceTheme magentaCta() {
+    final gradient = AppGradients.brandGradient;
+    final lums = gradient.colors.map((c) => c.computeLuminance());
+    final lum = lums.reduce((a, b) => a + b) / gradient.colors.length;
+    return BrandSurfaceTheme(
+      gradient: gradient,
+      radius: BorderRadius.circular(AppRadius.button),
+      shadow: const [BoxShadow(color: Colors.black54, blurRadius: 8, offset: Offset(0, 4))],
+      pressedOverlay: MagentaColors.pressedTint.withOpacity(0.3),
+      focusRing: MagentaColors.focus,
+      textStyle: const TextStyle(fontWeight: FontWeight.bold),
+      height: 48,
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      luminanceRef: lum,
+    );
+  }
+}

--- a/lib/core/theme/theme_loader.dart
+++ b/lib/core/theme/theme_loader.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../features/gym/domain/models/branding.dart';
 import 'design_tokens.dart';
 import 'theme.dart';
+import 'brand_surface_theme.dart';
 
 /// Lädt dynamisch Themes je nach Gym.
 class ThemeLoader extends ChangeNotifier {
@@ -26,6 +27,7 @@ class ThemeLoader extends ChangeNotifier {
       if (branding == null) {
         _applyMagentaDefaults();
         MagentaTones.normalizeFromGradient(AppGradients.brandGradient);
+        _attachBrandSurface();
         notifyListeners();
         return;
       }
@@ -48,6 +50,7 @@ class ThemeLoader extends ChangeNotifier {
       AppGradients.setBrandGradient(gradStart, gradEnd);
       AppGradients.setCtaGlow(MagentaColors.focus);
       MagentaTones.normalizeFromGradient(AppGradients.brandGradient);
+      _attachBrandSurface();
       notifyListeners();
       return;
     }
@@ -74,11 +77,17 @@ class ThemeLoader extends ChangeNotifier {
     );
     AppGradients.setCtaGlow(MagentaColors.focus);
     MagentaTones.normalizeFromGradient(AppGradients.brandGradient);
+    _attachBrandSurface();
   }
 
   Color _parseHex(String hex) {
     hex = hex.replaceFirst('#', '');
     if (hex.length == 6) hex = 'FF$hex';
     return Color(int.parse(hex, radix: 16));
+  }
+
+  void _attachBrandSurface() {
+    final ext = BrandSurfaceTheme.magentaCta();
+    _currentTheme = _currentTheme.copyWith(extensions: [ext]);
   }
 }

--- a/lib/core/widgets/gradient_button.dart
+++ b/lib/core/widgets/gradient_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../theme/design_tokens.dart';
+import '../theme/brand_surface_theme.dart';
 
 class GradientButton extends StatelessWidget {
   final VoidCallback? onPressed;
@@ -13,18 +14,22 @@ class GradientButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final surface = Theme.of(context).extension<BrandSurfaceTheme>();
+    final radius = surface?.radius ?? BorderRadius.circular(AppRadius.button);
     return DecoratedBox(
       decoration: BoxDecoration(
-        gradient: AppGradients.brandGradient,
-        borderRadius: BorderRadius.circular(AppRadius.button),
+        gradient: surface?.gradient ?? AppGradients.brandGradient,
+        borderRadius: radius,
+        boxShadow: surface?.shadow,
       ),
       child: ElevatedButton(
         style: ElevatedButton.styleFrom(
           backgroundColor: Colors.transparent,
           shadowColor: Colors.transparent,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(AppRadius.button),
-          ),
+          textStyle: surface?.textStyle,
+          minimumSize: Size.fromHeight(surface?.height ?? 40),
+          padding: surface?.padding as EdgeInsets? ?? const EdgeInsets.symmetric(horizontal: 16),
+          shape: RoundedRectangleBorder(borderRadius: radius),
         ),
         onPressed: onPressed,
         child: child,

--- a/lib/features/training_details/presentation/widgets/day_sessions_overview.dart
+++ b/lib/features/training_details/presentation/widgets/day_sessions_overview.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/core/theme/brand_surface_theme.dart';
 import '../../domain/models/session.dart';
 
 class DaySessionsOverview extends StatelessWidget {
@@ -33,8 +34,16 @@ class DaySessionsOverview extends StatelessWidget {
   Widget _buildCard(BuildContext context, Session session) {
     return Container(
       decoration: BoxDecoration(
-        gradient: AppGradients.brandGradient,
-        borderRadius: BorderRadius.circular(12),
+        gradient: Theme.of(context)
+                .extension<BrandSurfaceTheme>()
+                ?.gradient ??
+            AppGradients.brandGradient,
+        borderRadius: Theme.of(context)
+                .extension<BrandSurfaceTheme>()
+                ?.radius ??
+            BorderRadius.circular(12),
+        boxShadow:
+            Theme.of(context).extension<BrandSurfaceTheme>()?.shadow,
       ),
       child: Padding(
         padding: const EdgeInsets.all(12.0),


### PR DESCRIPTION
## Summary
- introduce `BrandSurfaceTheme` extension capturing CTA gradient, radius and other attributes
- hook theme loader to attach brand surface when `gym_01` branding is active
- align `GradientButton` and session cards to use shared brand surface tokens

## Testing
- `flutter format lib/core/theme/brand_surface_theme.dart lib/core/theme/theme_loader.dart lib/core/widgets/gradient_button.dart lib/features/training_details/presentation/widgets/day_sessions_overview.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ac0d00fd08320871466c349b88fdc