### PR TITLE
refactor: responsive numeric keypad bottom sheet

### DIFF
--- a/lib/ui/numeric_keypad/action_rail.dart
+++ b/lib/ui/numeric_keypad/action_rail.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+
 import 'key_button.dart';
 
+/// Vertical rail with action keys used by the numeric keypad.
 class ActionRail extends StatelessWidget {
   final VoidCallback onHide;
   final VoidCallback onPaste;
@@ -8,7 +10,15 @@ class ActionRail extends StatelessWidget {
   final VoidCallback onPlus;
   final VoidCallback onMinus;
   final VoidCallback onClose;
-  final double buttonSize;
+  final GestureLongPressStartCallback? onPlusLongPressStart;
+  final GestureLongPressEndCallback? onPlusLongPressEnd;
+  final GestureLongPressStartCallback? onMinusLongPressStart;
+  final GestureLongPressEndCallback? onMinusLongPressEnd;
+  final double keySize;
+  final bool canPaste;
+  final bool canCopy;
+  final bool canPlus;
+  final bool canMinus;
 
   const ActionRail({
     super.key,
@@ -18,49 +28,65 @@ class ActionRail extends StatelessWidget {
     required this.onPlus,
     required this.onMinus,
     required this.onClose,
-    required this.buttonSize,
+    required this.keySize,
+    this.onPlusLongPressStart,
+    this.onPlusLongPressEnd,
+    this.onMinusLongPressStart,
+    this.onMinusLongPressEnd,
+    this.canPaste = true,
+    this.canCopy = true,
+    this.canPlus = true,
+    this.canMinus = true,
   });
 
   @override
   Widget build(BuildContext context) {
     return Column(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: [
         KeyButton(
-          size: buttonSize,
+          icon: const Icon(Icons.keyboard_hide),
           semanticsLabel: 'Tastatur ausblenden',
-          onPressed: onHide,
-          child: const Icon(Icons.keyboard_hide),
+          onTap: onHide,
+          size: keySize,
         ),
         KeyButton(
-          size: buttonSize,
+          icon: const Icon(Icons.content_paste),
           semanticsLabel: 'Einfügen',
-          onPressed: onPaste,
-          child: const Icon(Icons.content_paste),
+          onTap: canPaste ? onPaste : null,
+          size: keySize,
+          enabled: canPaste,
         ),
         KeyButton(
-          size: buttonSize,
+          icon: const Icon(Icons.copy),
           semanticsLabel: 'Kopieren',
-          onPressed: onCopy,
-          child: const Icon(Icons.copy),
+          onTap: canCopy ? onCopy : null,
+          size: keySize,
+          enabled: canCopy,
         ),
         KeyButton(
-          size: buttonSize,
+          icon: const Icon(Icons.add),
           semanticsLabel: 'Plus',
-          onPressed: onPlus,
-          child: const Icon(Icons.add),
+          onTap: canPlus ? onPlus : null,
+          onLongPressStart: canPlus ? onPlusLongPressStart : null,
+          onLongPressEnd: canPlus ? onPlusLongPressEnd : null,
+          size: keySize,
+          enabled: canPlus,
         ),
         KeyButton(
-          size: buttonSize,
+          icon: const Icon(Icons.remove),
           semanticsLabel: 'Minus',
-          onPressed: onMinus,
-          child: const Icon(Icons.remove),
+          onTap: canMinus ? onMinus : null,
+          onLongPressStart: canMinus ? onMinusLongPressStart : null,
+          onLongPressEnd: canMinus ? onMinusLongPressEnd : null,
+          size: keySize,
+          enabled: canMinus,
         ),
         KeyButton(
-          size: buttonSize,
+          icon: const Icon(Icons.close),
           semanticsLabel: 'Schließen',
-          onPressed: onClose,
-          child: const Icon(Icons.close),
+          onTap: onClose,
+          size: keySize,
         ),
       ],
     );

--- a/lib/ui/numeric_keypad/key_button.dart
+++ b/lib/ui/numeric_keypad/key_button.dart
@@ -1,24 +1,49 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:tapem/core/theme/brand_surface_theme.dart';
 
+/// Brand aware square button used by the numeric keypad.
 class KeyButton extends StatefulWidget {
-  final Widget child;
-  final VoidCallback? onPressed;
+  /// Icon widget displayed in the centre of the button. Either [icon] or
+  /// [label] must be provided.
+  final Widget? icon;
+
+  /// Text label displayed in the centre of the button. Either [icon] or
+  /// [label] must be provided.
+  final String? label;
+
+  /// Callback for a regular tap.
+  final VoidCallback? onTap;
+
+  /// Callback when a long press starts. Used for auto‑repeat.
   final GestureLongPressStartCallback? onLongPressStart;
+
+  /// Callback when a long press ends.
   final GestureLongPressEndCallback? onLongPressEnd;
+
+  /// Square dimension of the key.
   final double size;
+
+  /// Semantics label for accessibility.
   final String semanticsLabel;
+
+  /// Whether the key is enabled.
+  final bool enabled;
 
   const KeyButton({
     super.key,
-    required this.child,
-    required this.onPressed,
+    this.icon,
+    this.label,
+    required this.onTap,
     this.onLongPressStart,
     this.onLongPressEnd,
     required this.size,
     required this.semanticsLabel,
-  });
+    this.enabled = true,
+  }) : assert(icon != null || label != null,
+            'Either icon or label must be provided');
 
   @override
   State<KeyButton> createState() => _KeyButtonState();
@@ -26,6 +51,7 @@ class KeyButton extends StatefulWidget {
 
 class _KeyButtonState extends State<KeyButton> {
   bool _pressed = false;
+  bool _focused = false;
 
   void _setPressed(bool v) => setState(() => _pressed = v);
 
@@ -34,44 +60,71 @@ class _KeyButtonState extends State<KeyButton> {
     final surface = Theme.of(context).extension<BrandSurfaceTheme>();
     final radius = surface?.radius ?? BorderRadius.circular(8);
     final overlay = surface?.pressedOverlay ?? Colors.black26;
+    final focusRing = surface?.focusRing ?? Colors.transparent;
+
+    final child = widget.icon ??
+        DefaultTextStyle.merge(style: surface?.textStyle, child: Text(widget.label!));
 
     return Semantics(
       label: widget.semanticsLabel,
       button: true,
+      enabled: widget.enabled,
       child: SizedBox.square(
-        dimension: widget.size,
-        child: Material(
-          color: Colors.transparent,
+        dimension: math.max(widget.size, 44),
+        child: FocusableActionDetector(
+          enabled: widget.enabled,
+          onShowFocusHighlight: (v) => setState(() => _focused = v),
           child: GestureDetector(
-            onTap: () {
-              HapticFeedback.selectionClick();
-              widget.onPressed?.call();
-            },
+            onTap: widget.enabled
+                ? () {
+                    HapticFeedback.selectionClick();
+                    widget.onTap?.call();
+                  }
+                : null,
             onTapDown: (_) => _setPressed(true),
             onTapUp: (_) => _setPressed(false),
             onTapCancel: () => _setPressed(false),
-            onLongPressStart: (d) {
-              _setPressed(true);
-              widget.onLongPressStart?.call(d);
-            },
-            onLongPressEnd: (d) {
-              _setPressed(false);
-              widget.onLongPressEnd?.call(d);
-            },
+            onLongPressStart: widget.enabled
+                ? (d) {
+                    _setPressed(true);
+                    HapticFeedback.selectionClick();
+                    widget.onLongPressStart?.call(d);
+                  }
+                : null,
+            onLongPressEnd: widget.enabled
+                ? (d) {
+                    _setPressed(false);
+                    widget.onLongPressEnd?.call(d);
+                  }
+                : null,
             child: DecoratedBox(
               decoration: BoxDecoration(
                 gradient: surface?.gradient,
                 borderRadius: radius,
                 boxShadow: surface?.shadow,
+                border: _focused
+                    ? Border.all(color: focusRing, width: 2)
+                    : null,
               ),
               child: Stack(
                 children: [
-                  Center(child: DefaultTextStyle.merge(style: surface?.textStyle, child: widget.child)),
+                  Center(child: child),
                   if (_pressed)
                     Positioned.fill(
                       child: DecoratedBox(
                         decoration: BoxDecoration(
                           color: overlay,
+                          borderRadius: radius,
+                        ),
+                      ),
+                    ),
+                  if (!widget.enabled)
+                    Positioned.fill(
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          color: Theme.of(context)
+                              .disabledColor
+                              .withOpacity(0.4),
                           borderRadius: radius,
                         ),
                       ),
@@ -85,4 +138,5 @@ class _KeyButtonState extends State<KeyButton> {
     );
   }
 }
+
 


### PR DESCRIPTION
## Summary
- redesign numeric keypad sheet to clamp height and compute square key size
- introduce brand-themed KeyButton with icon/label, focus and disabled states
- add ActionRail with vertically spaced action keys and long-press repeat hooks

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ae22774e483208687520e93c74106