### PR TITLE
Fix device card gradient and keypad increment

### DIFF
--- a/lib/features/gym/presentation/widgets/device_card.dart
+++ b/lib/features/gym/presentation/widgets/device_card.dart
@@ -56,9 +56,9 @@ class _DeviceCardState extends State<DeviceCard> {
                       radius: 28,
                       backgroundColor: Colors.transparent,
                       child: DecoratedBox(
-                        decoration: const BoxDecoration(
+                        decoration: BoxDecoration(
                           shape: BoxShape.circle,
-                          gradient: AppGradients.primary,
+                          gradient: AppGradients.brandGradient,
                         ),
                         child: Center(
                           child: Text(initial, style: theme.textTheme.titleLarge),

--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -210,7 +210,7 @@ class OverlayNumericKeypad extends StatelessWidget {
                         Clipboard.setData(ClipboardData(text: controller.target?.text ?? ''));
                         HapticFeedback.lightImpact();
                       },
-                      onPlus: () => _increment(controller, +1),
+                      onPlus: () => _increment(controller, 1),
                       onMinus: () => _increment(controller, -1),
                       onBackspace: () => _applyToken(controller, 'del'),
                     ),


### PR DESCRIPTION
## Summary
- use AppGradients.brandGradient in device card and drop const
- fix keypad increment call to avoid invalid prefix operator

## Testing
- `dart format lib/features/gym/presentation/widgets/device_card.dart lib/ui/numeric_keypad/overlay_numeric_keypad.dart` *(command not found)*
- `flutter analyze` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689aff407c848320bc6771c6ced5caa5