### PR TITLE
feat: integrate global numeric keypad

### DIFF
--- a/lib/features/admin/presentation/screens/challenge_admin_screen.dart
+++ b/lib/features/admin/presentation/screens/challenge_admin_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tapem/ui/numeric_keypad/overlay_numeric_keypad.dart';
 
 import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/gym_provider.dart';
@@ -138,13 +139,23 @@ class _ChallengeAdminScreenState extends State<ChallengeAdminScreen> {
             const SizedBox(height: 8),
             TextField(
               controller: _setCtrl,
-              keyboardType: TextInputType.number,
+              keyboardType: TextInputType.none,
+              readOnly: true,
+              autofocus: false,
+              onTap: () => context
+                  .read<OverlayNumericKeypadController>()
+                  .openFor(_setCtrl, allowDecimal: false),
               decoration: const InputDecoration(labelText: 'Benötigte Sätze'),
             ),
             const SizedBox(height: 8),
             TextField(
               controller: _xpCtrl,
-              keyboardType: TextInputType.number,
+              keyboardType: TextInputType.none,
+              readOnly: true,
+              autofocus: false,
+              onTap: () => context
+                  .read<OverlayNumericKeypadController>()
+                  .openFor(_xpCtrl, allowDecimal: false),
               decoration: const InputDecoration(labelText: 'XP-Reward'),
             ),
             const SizedBox(height: 8),

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -46,7 +46,6 @@ class DeviceScreen extends StatefulWidget {
 class _DeviceScreenState extends State<DeviceScreen> {
   final _formKey = GlobalKey<FormState>();
   bool _showTimer = true;
-  final _keypadController = OverlayNumericKeypadController();
 
   @override
   void initState() {
@@ -310,7 +309,6 @@ class _DeviceScreenState extends State<DeviceScreen> {
                             previous: entry.key < prov.lastSessionSets.length
                                 ? prov.lastSessionSets[entry.key]
                                 : null,
-                            keypadController: _keypadController,
                           ),
                         ),
                         if (entry.key < prov.sets.length - 1) ...[
@@ -411,10 +409,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
       );
     }
 
-    return OverlayNumericKeypadHost(
-      controller: _keypadController,
-      child: scaffold,
-    );
+    return scaffold;
   }
 }
 
@@ -473,52 +468,79 @@ class _PlannedTable extends StatelessWidget {
                     SizedBox(width: 24, child: Text(entrySet.value['number']!)),
                     const SizedBox(width: 12),
                     Expanded(
-                      child: TextFormField(
-                        key: ValueKey(
-                          'w-${entrySet.key}-${entrySet.value['weight']}',
-                        ),
-                        initialValue: entrySet.value['weight'],
-                        decoration: InputDecoration(
-                          labelText: 'kg',
-                          hintText: weightHint,
-                          isDense: true,
-                        ),
-                        keyboardType: const TextInputType.numberWithOptions(
-                          decimal: true,
-                        ),
-                        onChanged:
-                            (v) => prov.updateSet(entrySet.key, weight: v),
-                      ),
+                      child: Builder(builder: (context) {
+                        final ctr =
+                            TextEditingController(text: entrySet.value['weight']);
+                        return TextFormField(
+                          key: ValueKey(
+                            'w-${entrySet.key}-${entrySet.value['weight']}',
+                          ),
+                          controller: ctr,
+                          decoration: InputDecoration(
+                            labelText: 'kg',
+                            hintText: weightHint,
+                            isDense: true,
+                          ),
+                          readOnly: true,
+                          keyboardType: TextInputType.none,
+                          autofocus: false,
+                          onTap: () => context
+                              .read<OverlayNumericKeypadController>()
+                              .openFor(ctr, allowDecimal: true),
+                          onChanged:
+                              (v) => prov.updateSet(entrySet.key, weight: v),
+                        );
+                      }),
                     ),
                     const SizedBox(width: 12),
                     Expanded(
-                      child: TextFormField(
-                        key: ValueKey(
-                          'r-${entrySet.key}-${entrySet.value['reps']}',
-                        ),
-                        initialValue: entrySet.value['reps'],
-                        decoration: InputDecoration(
-                          labelText: 'x',
-                          hintText: repsHint,
-                          isDense: true,
-                        ),
-                        keyboardType: TextInputType.number,
-                        onChanged: (v) => prov.updateSet(entrySet.key, reps: v),
-                      ),
+                      child: Builder(builder: (context) {
+                        final ctr =
+                            TextEditingController(text: entrySet.value['reps']);
+                        return TextFormField(
+                          key: ValueKey(
+                            'r-${entrySet.key}-${entrySet.value['reps']}',
+                          ),
+                          controller: ctr,
+                          decoration: InputDecoration(
+                            labelText: 'x',
+                            hintText: repsHint,
+                            isDense: true,
+                          ),
+                          readOnly: true,
+                          keyboardType: TextInputType.none,
+                          autofocus: false,
+                          onTap: () => context
+                              .read<OverlayNumericKeypadController>()
+                              .openFor(ctr, allowDecimal: false),
+                          onChanged: (v) =>
+                              prov.updateSet(entrySet.key, reps: v),
+                        );
+                      }),
                     ),
                     const SizedBox(width: 12),
                     Expanded(
-                      child: TextFormField(
-                        key: ValueKey('rir-${entrySet.key}'),
-                        initialValue: entrySet.value['rir'],
-                        decoration: InputDecoration(
-                          labelText: 'RIR',
-                          hintText: rirHint,
-                          isDense: true,
-                        ),
-                        keyboardType: TextInputType.number,
-                        onChanged: (v) => prov.updateSet(entrySet.key, rir: v),
-                      ),
+                      child: Builder(builder: (context) {
+                        final ctr =
+                            TextEditingController(text: entrySet.value['rir']);
+                        return TextFormField(
+                          key: ValueKey('rir-${entrySet.key}'),
+                          controller: ctr,
+                          decoration: InputDecoration(
+                            labelText: 'RIR',
+                            hintText: rirHint,
+                            isDense: true,
+                          ),
+                          readOnly: true,
+                          keyboardType: TextInputType.none,
+                          autofocus: false,
+                          onTap: () => context
+                              .read<OverlayNumericKeypadController>()
+                              .openFor(ctr, allowDecimal: false),
+                          onChanged: (v) =>
+                              prov.updateSet(entrySet.key, rir: v),
+                        );
+                      }),
                     ),
                     const SizedBox(width: 12),
                     Expanded(

--- a/lib/features/training_plan/presentation/screens/plan_editor_screen.dart
+++ b/lib/features/training_plan/presentation/screens/plan_editor_screen.dart
@@ -24,7 +24,6 @@ class PlanEditorScreen extends StatefulWidget {
 class _PlanEditorScreenState extends State<PlanEditorScreen>
     with SingleTickerProviderStateMixin {
   late TabController _weekController;
-  final _keypadController = OverlayNumericKeypadController();
 
   @override
   void initState() {
@@ -36,7 +35,6 @@ class _PlanEditorScreenState extends State<PlanEditorScreen>
   @override
   void dispose() {
     _weekController.dispose();
-    _keypadController.dispose();
     super.dispose();
   }
 
@@ -106,8 +104,7 @@ class _PlanEditorScreenState extends State<PlanEditorScreen>
         body: TabBarView(
           controller: _weekController,
           children: [
-            for (var w in plan.weeks)
-              _WeekView(week: w, keypadController: _keypadController)
+            for (var w in plan.weeks) _WeekView(week: w)
           ],
         ),
         floatingActionButton: FloatingActionButton.extended(
@@ -140,10 +137,7 @@ class _PlanEditorScreenState extends State<PlanEditorScreen>
       ),
     );
 
-    return OverlayNumericKeypadHost(
-      controller: _keypadController,
-      child: scaffold,
-    );
+    return scaffold;
   }
 
   Future<DateTime?> _pickDay(BuildContext context, WeekBlock week) async {
@@ -172,8 +166,7 @@ class _PlanEditorScreenState extends State<PlanEditorScreen>
 
 class _WeekView extends StatefulWidget {
   final WeekBlock week;
-  final OverlayNumericKeypadController keypadController;
-  const _WeekView({required this.week, required this.keypadController});
+  const _WeekView({required this.week});
 
   @override
   State<_WeekView> createState() => _WeekViewState();
@@ -308,7 +301,6 @@ class _WeekViewState extends State<_WeekView>
                   dayIndex: i,
                   day: widget.week.days[i],
                   pickSource: () => _pickSourceDay(context),
-                  keypadController: widget.keypadController,
                 ),
             ],
           ),
@@ -323,14 +315,12 @@ class _DayView extends StatelessWidget {
   final int dayIndex;
   final DayEntry day;
   final Future<_DayRef?> Function() pickSource;
-  final OverlayNumericKeypadController keypadController;
 
   const _DayView({
     required this.weekNumber,
     required this.dayIndex,
     required this.day,
     required this.pickSource,
-    required this.keypadController,
   });
 
   @override
@@ -374,7 +364,6 @@ class _DayView extends StatelessWidget {
                 prov.updateExercise(weekNumber, day.date, exIndex, updated);
               }
             },
-            keypadController: keypadController,
           ),
         );
       },
@@ -386,13 +375,11 @@ class _PlanEntryEditor extends StatefulWidget {
   final ExerciseEntry entry;
   final ValueChanged<ExerciseEntry> onChanged;
   final VoidCallback onSelectDevice;
-  final OverlayNumericKeypadController keypadController;
 
   const _PlanEntryEditor({
     required this.entry,
     required this.onChanged,
     required this.onSelectDevice,
-    required this.keypadController,
   });
 
   @override
@@ -477,7 +464,8 @@ class _PlanEntryEditorState extends State<_PlanEntryEditor> {
                     ),
                     readOnly: true,
                     keyboardType: TextInputType.none,
-                    onTap: () => widget.keypadController
+                    onTap: () => context
+                        .read<OverlayNumericKeypadController>()
                         .openFor(_setsCtr, allowDecimal: false),
                     onChanged: (_) => _emitUpdate(),
                   ),
@@ -492,7 +480,8 @@ class _PlanEntryEditorState extends State<_PlanEntryEditor> {
                     ),
                     readOnly: true,
                     keyboardType: TextInputType.none,
-                    onTap: () => widget.keypadController
+                    onTap: () => context
+                        .read<OverlayNumericKeypadController>()
                         .openFor(_repsCtr, allowDecimal: false),
                     onChanged: (_) => _emitUpdate(),
                   ),
@@ -507,7 +496,8 @@ class _PlanEntryEditorState extends State<_PlanEntryEditor> {
                     ),
                     readOnly: true,
                     keyboardType: TextInputType.none,
-                    onTap: () => widget.keypadController
+                    onTap: () => context
+                        .read<OverlayNumericKeypadController>()
                         .openFor(_rirCtr, allowDecimal: false),
                     onChanged: (_) => _emitUpdate(),
                   ),

--- a/lib/features/training_plan/presentation/screens/plan_overview_screen.dart
+++ b/lib/features/training_plan/presentation/screens/plan_overview_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:tapem/ui/numeric_keypad/overlay_numeric_keypad.dart';
 
 import 'package:intl/intl.dart';
 
@@ -173,7 +174,12 @@ class _PlanOverviewScreenState extends State<PlanOverviewScreen> {
                           decoration: const InputDecoration(
                             labelText: 'Wochen',
                           ),
-                          keyboardType: TextInputType.number,
+                          keyboardType: TextInputType.none,
+                          readOnly: true,
+                          autofocus: false,
+                          onTap: () => context
+                              .read<OverlayNumericKeypadController>()
+                              .openFor(weeksCtr, allowDecimal: false),
                         ),
                       ],
                     ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,6 +36,7 @@ import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/features/feedback/feedback_provider.dart';
 import 'package:tapem/features/survey/survey_provider.dart';
 import 'features/gym/data/sources/firestore_gym_source.dart';
+import 'ui/numeric_keypad/overlay_numeric_keypad.dart';
 
 import 'features/nfc/data/nfc_service.dart';
 import 'features/nfc/domain/usecases/read_nfc_code.dart';
@@ -164,6 +165,7 @@ class AppEntry extends StatelessWidget {
         // App state
         ChangeNotifierProvider(create: (_) => AppProvider()),
         ChangeNotifierProvider(create: (_) => AuthProvider()),
+        ChangeNotifierProvider(create: (_) => OverlayNumericKeypadController()),
         ChangeNotifierProxyProvider<AuthProvider, BrandingProvider>(
           create: (_) => BrandingProvider(
             source: FirestoreGymSource(firestore: FirebaseFirestore.instance),
@@ -248,7 +250,9 @@ class MyApp extends StatelessWidget {
     if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
       app = GlobalNfcListener(child: app);
     }
-    return DynamicLinkListener(child: app);
+    app = DynamicLinkListener(child: app);
+    final keypadController = context.watch<OverlayNumericKeypadController>();
+    return OverlayNumericKeypadHost(controller: keypadController, child: app);
   }
 
   MaterialApp _buildApp(ThemeData theme, Locale? locale) {

--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -62,6 +62,8 @@ class OverlayNumericKeypadController extends ChangeNotifier {
     double? decimalStep,
     double? integerStep,
   }) {
+    FocusManager.instance.primaryFocus?.unfocus();
+    SystemChannels.textInput.invokeMethod('TextInput.hide');
     _target = controller;
     this.allowDecimal = allowDecimal;
     if (decimalStep != null) this.decimalStep = decimalStep;
@@ -137,14 +139,23 @@ class _OverlayNumericKeypadHostState extends State<OverlayNumericKeypadHost>
     final keypad =
         widget.controller.isOpen
             ? OverlayNumericKeypad(
-              controller: widget.controller,
-              theme: widget.theme,
-            )
+                controller: widget.controller,
+                theme: widget.theme,
+              )
             : const SizedBox.shrink();
+
+    Widget baseChild = widget.child;
+    if (widget.controller.isOpen) {
+      baseChild = MediaQuery.removeViewInsets(
+        context: context,
+        removeBottom: true,
+        child: baseChild,
+      );
+    }
 
     final content = Stack(
       children: [
-        widget.child,
+        baseChild,
         Align(
           alignment: Alignment.bottomCenter,
           child: AnimatedSwitcher(

--- a/test/widgets/dismissible_session_list_test.dart
+++ b/test/widgets/dismissible_session_list_test.dart
@@ -26,8 +26,7 @@ class _FakeRepo implements DeviceRepository {
 }
 
 class _TestList extends StatelessWidget {
-  final OverlayNumericKeypadController keypadController;
-  const _TestList(this.keypadController);
+  const _TestList();
   @override
   Widget build(BuildContext context) {
     final prov = context.watch<DeviceProvider>();
@@ -64,7 +63,6 @@ class _TestList extends StatelessWidget {
             child: SetCard(
               index: entry.key,
               set: entry.value,
-              keypadController: keypadController,
             ),
           ),
       ],
@@ -85,15 +83,20 @@ void main() {
     final keypadController = OverlayNumericKeypadController();
 
     await tester.pumpWidget(
-      ChangeNotifierProvider<DeviceProvider>.value(
-        value: provider,
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<DeviceProvider>.value(value: provider),
+          ChangeNotifierProvider<OverlayNumericKeypadController>.value(
+            value: keypadController,
+          ),
+        ],
         child: OverlayNumericKeypadHost(
           controller: keypadController,
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             locale: const Locale('de'),
-            home: Scaffold(body: _TestList(keypadController)),
+            home: const Scaffold(body: _TestList()),
           ),
         ),
       ),

--- a/test/widgets/set_card_test.dart
+++ b/test/widgets/set_card_test.dart
@@ -37,8 +37,13 @@ void main() {
     final keypadController = OverlayNumericKeypadController();
 
     await tester.pumpWidget(
-      ChangeNotifierProvider<DeviceProvider>.value(
-        value: provider,
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<DeviceProvider>.value(value: provider),
+          ChangeNotifierProvider<OverlayNumericKeypadController>.value(
+            value: keypadController,
+          ),
+        ],
         child: OverlayNumericKeypadHost(
           controller: keypadController,
           child: MaterialApp(
@@ -49,7 +54,6 @@ void main() {
                 child: SetCard(
                   index: 0,
                   set: provider.sets[0],
-                  keypadController: keypadController,
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- provide global OverlayNumericKeypadController and host
- replace native keyboards for numeric inputs with overlay keypad across key screens
- hide system keyboard when overlay opens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bd18d20ec832082d1d432e6b7b876