### PR TITLE
feat: reintroduce allowDecimal parameter

### DIFF
--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -58,12 +58,12 @@ class OverlayNumericKeypadController extends ChangeNotifier {
 
   void openFor(
     TextEditingController controller, {
-    bool allowDecimalParam = true,
+    bool allowDecimal = true,
     double? decimalStep,
     double? integerStep,
   }) {
     _target = controller;
-    allowDecimal = allowDecimalParam;
+    this.allowDecimal = allowDecimal;
     if (decimalStep != null) this.decimalStep = decimalStep;
     if (integerStep != null) this.integerStep = integerStep;
     FocusManager.instance.primaryFocus?.unfocus();

--- a/test/ui/overlay_numeric_keypad_test.dart
+++ b/test/ui/overlay_numeric_keypad_test.dart
@@ -37,5 +37,24 @@ void main() {
     await tester.pumpAndSettle();
     expect(controller.isOpen, false);
   });
+
+  testWidgets('allowDecimal parameter sets controller flag', (tester) async {
+    final controller = OverlayNumericKeypadController();
+    final textCtrl = TextEditingController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OverlayNumericKeypadHost(
+          controller: controller,
+          child: const SizedBox.shrink(),
+        ),
+      ),
+    );
+
+    controller.openFor(textCtrl, allowDecimal: false);
+    await tester.pump();
+
+    expect(controller.allowDecimal, false);
+  });
 }
 


### PR DESCRIPTION
## Summary
- restore `allowDecimal` named parameter on `OverlayNumericKeypadController.openFor`
- add regression test covering `allowDecimal` flag

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689bdea557dc83209827d419ae379a99