### PR TITLE
feat(device): keep overlay keypad open and scroll session list

### DIFF
--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -87,10 +87,10 @@ class SetCard extends StatefulWidget {
   });
 
   @override
-  State<SetCard> createState() => _SetCardState();
+  State<SetCard> createState() => SetCardState();
 }
 
-class _SetCardState extends State<SetCard> {
+class SetCardState extends State<SetCard> {
   late final TextEditingController _weightCtrl;
   late final TextEditingController _repsCtrl;
   late final TextEditingController _rirCtrl;
@@ -153,6 +153,17 @@ class _SetCardState extends State<SetCard> {
     context
         .read<OverlayNumericKeypadController>()
         .openFor(controller, allowDecimal: allowDecimal);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      Scrollable.ensureVisible(
+        context,
+        alignment: 0.1,
+        duration: const Duration(milliseconds: 200),
+      );
+    });
+  }
+
+  void focusWeight() {
+    _openKeypad(_weightCtrl, allowDecimal: true);
   }
 
   @override

--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -52,9 +52,11 @@ class OverlayNumericKeypadController extends ChangeNotifier {
   bool allowDecimal = true;
   double decimalStep = 2.5; // z.B. Gewichte
   double integerStep = 1.0; // z.B. Wiederholungen
+  double _contentHeight = 0.0;
 
   bool get isOpen => _isOpen;
   TextEditingController? get target => _target;
+  double get keypadContentHeight => _isOpen ? _contentHeight : 0.0;
 
   void openFor(
     TextEditingController controller, {
@@ -74,7 +76,15 @@ class OverlayNumericKeypadController extends ChangeNotifier {
 
   void close() {
     _isOpen = false;
+    _contentHeight = 0.0;
     notifyListeners();
+  }
+
+  void _updateContentHeight(double height) {
+    if (_contentHeight != height) {
+      _contentHeight = height;
+      notifyListeners();
+    }
   }
 }
 
@@ -86,6 +96,7 @@ class OverlayNumericKeypadHost extends StatefulWidget {
   final Widget child;
   final NumericKeypadTheme theme;
   final bool interceptAndroidBack; // Back schließt Tastatur statt Route
+  final bool closeOnOutsideTap;
 
   const OverlayNumericKeypadHost({
     super.key,
@@ -93,6 +104,7 @@ class OverlayNumericKeypadHost extends StatefulWidget {
     required this.child,
     this.theme = const NumericKeypadTheme(),
     this.interceptAndroidBack = true,
+    this.closeOnOutsideTap = false,
   });
 
   @override
@@ -147,7 +159,7 @@ class _OverlayNumericKeypadHostState extends State<OverlayNumericKeypadHost>
     Widget result = Stack(
       children: [
         widget.child,
-        if (widget.controller.isOpen)
+        if (widget.controller.isOpen && widget.closeOnOutsideTap)
           Positioned.fill(
             child: GestureDetector(
               behavior: HitTestBehavior.opaque,
@@ -234,6 +246,7 @@ class OverlayNumericKeypad extends StatelessWidget {
 
     // Innenhöhe = contentH abzüglich Sheet-Paddings (oben+unten)
     final innerH = contentH - (gap + gap);
+    controller._updateContentHeight(contentH);
 
     // Zellhöhe & Aspect aus der echten Innenhöhe
     final cellH = (innerH - 3 * gap) / 4.0;


### PR DESCRIPTION
## Summary
- avoid closing the overlay keypad on outside taps and expose its content height
- make "Neue Session" set cards scrollable with padding equal to keypad height
- keep keypad open when adding a set and scroll the focused card into view

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bf11f80d88320b20c83c36cc7b839