### PR TITLE
feat: improve overlay keypad interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ Die zugehörigen Definitionen stehen in `project/roadmap/issues_pilot.json`.
 
 ---
 
+## Changelog
+
+- `OverlayNumericKeypadHost.closeOnOutsideTap` wurde entfernt. Nutze stattdessen
+  `outsideTapMode` (z. B. `OutsideTapMode.closeAfterTap`).
+
+---
+
 ## Häufige Probleme
 
 - Falls es nach dem Entfernen oder Hinzufügen von Abhängigkeiten zu "Target of URI doesn't exist" Fehlern kommt, hilft meist ein erneutes Ausführen von

--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -150,6 +150,7 @@ class SetCardState extends State<SetCard> {
     TextEditingController controller, {
     required bool allowDecimal,
   }) {
+    FocusScope.of(context).unfocus();
     context
         .read<OverlayNumericKeypadController>()
         .openFor(controller, allowDecimal: allowDecimal);

--- a/test/ui/overlay_numeric_keypad_test.dart
+++ b/test/ui/overlay_numeric_keypad_test.dart
@@ -56,5 +56,43 @@ void main() {
 
     expect(controller.allowDecimal, false);
   });
+
+  testWidgets('outside tap triggers button and closes keypad', (tester) async {
+    final controller = OverlayNumericKeypadController();
+    bool pressed = false;
+    final textCtrl = TextEditingController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OverlayNumericKeypadHost(
+          controller: controller,
+          outsideTapMode: OutsideTapMode.closeAfterTap,
+          child: Scaffold(
+            body: Column(
+              children: [
+                TextField(controller: textCtrl, readOnly: true, onTap: () {
+                  controller.openFor(textCtrl);
+                }),
+                TextButton(
+                  onPressed: () => pressed = true,
+                  child: const Text('Add'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    controller.openFor(textCtrl);
+    await tester.pumpAndSettle();
+    expect(controller.isOpen, true);
+
+    await tester.tap(find.text('Add'));
+    await tester.pumpAndSettle();
+
+    expect(pressed, true);
+    expect(controller.isOpen, false);
+  });
 }
 

--- a/test/widgets/set_card_test.dart
+++ b/test/widgets/set_card_test.dart
@@ -49,6 +49,7 @@ void main() {
           supportedLocales: AppLocalizations.supportedLocales,
           builder: (context, child) => OverlayNumericKeypadHost(
             controller: keypadController,
+            outsideTapMode: OutsideTapMode.closeAfterTap,
             child: child!,
           ),
           home: Scaffold(
@@ -70,8 +71,15 @@ void main() {
 
     await tester.enterText(find.byType(TextFormField).first, '10');
     await tester.enterText(find.byType(TextFormField).at(1), '5');
+
+    // Open keypad then toggle while open
+    await tester.tap(find.byType(TextFormField).first);
+    await tester.pumpAndSettle();
+    expect(keypadController.isOpen, true);
+
     await tester.tap(find.bySemanticsLabel('Complete set'));
     await tester.pumpAndSettle();
+    expect(keypadController.isOpen, false);
 
     expect(provider.completedCount, 1);
     expect(


### PR DESCRIPTION
## Summary
- allow pass-through taps while keypad open and close post-tap
- add done button and locale-aware number handling
- unfocus set card fields before opening custom keypad

## Testing
- `flutter test test/ui/overlay_numeric_keypad_test.dart test/widgets/set_card_test.dart test/widgets/dismissible_session_list_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c24d745d08320ab300421f018e950