### PR TITLE
feat(timer): restart on play, fixed durations, remove speaker, add +/- controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ lib/
 
 Weitere Details zum State-Management stehen in [docs/provider_structure.md](docs/provider_structure.md).
 
+Eine Übersicht über die Steuerung des Pausen-Timers findet sich in [docs/device_timer.md](docs/device_timer.md).
+
 ---
 
 ## Voraussetzungen

--- a/docs/device_timer.md
+++ b/docs/device_timer.md
@@ -1,0 +1,21 @@
+# Device timer
+
+The device page includes a rest timer with a restartable play button and fixed durations.
+
+## Controls
+
+- **Play** – starts or restarts the countdown from the selected duration.
+- **+ / –** – adjust the next countdown duration without affecting a running timer.
+- The current selection is shown between the buttons.
+
+## Allowed durations
+
+| Seconds |
+|---------|
+| 60 |
+| 90 |
+| 120 |
+| 150 |
+| 180 |
+
+The countdown displays minutes and seconds. Pressing Play while the timer is running restarts it from the selected duration.

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -193,7 +193,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
               Padding(
                 padding: const EdgeInsets.all(8),
                 child: SessionTimerBar(
-                  total: const Duration(seconds: 90),
+                  initialDuration: const Duration(seconds: 90),
                   onClose: () => setState(() => _showTimer = false),
                 ),
               ),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -368,6 +368,16 @@
     "description": "Beschriftung für Auswahl der Timer-Dauer"
   },
 
+  "timerIncrease": "Timerdauer erhöhen",
+  "@timerIncrease": {
+    "description": "Schaltfläche Timerdauer erhöhen"
+  },
+
+  "timerDecrease": "Timerdauer verringern",
+  "@timerDecrease": {
+    "description": "Schaltfläche Timerdauer verringern"
+  },
+
   "userNotFound": "Nutzer nicht gefunden.",
   "@userNotFound": {
     "description": "Fehlermeldung, wenn Nutzer nicht gefunden wurde"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -366,6 +366,16 @@
     "description": "Label for timer duration dropdown"
   },
 
+  "timerIncrease": "Increase timer duration",
+  "@timerIncrease": {
+    "description": "Tooltip for increasing timer duration"
+  },
+
+  "timerDecrease": "Decrease timer duration",
+  "@timerDecrease": {
+    "description": "Tooltip for decreasing timer duration"
+  },
+
   "userNotFound": "User not found.",
   "@userNotFound": {
     "description": "Error when no user is found"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -533,6 +533,18 @@ abstract class AppLocalizations {
   /// **'Duration'**
   String get timerDuration;
 
+  /// Tooltip for increasing timer duration
+  ///
+  /// In en, this message translates to:
+  /// **'Increase timer duration'**
+  String get timerIncrease;
+
+  /// Tooltip for decreasing timer duration
+  ///
+  /// In en, this message translates to:
+  /// **'Decrease timer duration'**
+  String get timerDecrease;
+
   /// Error when no user is found
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -240,6 +240,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get timerDuration => 'Dauer';
 
   @override
+  String get timerIncrease => 'Timerdauer erhöhen';
+
+  @override
+  String get timerDecrease => 'Timerdauer verringern';
+
+  @override
   String get userNotFound => 'Nutzer nicht gefunden.';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -240,6 +240,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get timerDuration => 'Duration';
 
   @override
+  String get timerIncrease => 'Increase timer duration';
+
+  @override
+  String get timerDecrease => 'Decrease timer duration';
+
+  @override
   String get userNotFound => 'User not found.';
 
   @override

--- a/lib/ui/timer/session_timer_controller.dart
+++ b/lib/ui/timer/session_timer_controller.dart
@@ -3,12 +3,13 @@ import 'package:flutter/scheduler.dart';
 
 class SessionTimerController {
   SessionTimerController({
-    required this.total,
+    required Duration total,
     bool initiallyRunning = false,
     this.onTick,
     this.onDone,
     required TickerProvider vsync,
-  })  : remaining = ValueNotifier(total),
+  })  : _total = total,
+        remaining = ValueNotifier(total),
         running = ValueNotifier(initiallyRunning) {
     _ticker = vsync.createTicker(_onTick);
     if (initiallyRunning) {
@@ -16,7 +17,7 @@ class SessionTimerController {
     }
   }
 
-  final Duration total;
+  Duration _total;
   final ValueNotifier<Duration> remaining;
   final ValueNotifier<bool> running;
   final ValueChanged<Duration>? onTick;
@@ -30,7 +31,7 @@ class SessionTimerController {
     final dt = elapsed - _lastTick;
     _lastTick = elapsed;
     _elapsed += dt;
-    final left = total - _elapsed;
+    final left = _total - _elapsed;
     if (left <= Duration.zero) {
       remaining.value = Duration.zero;
       running.value = false;
@@ -67,7 +68,7 @@ class SessionTimerController {
     _ticker.stop();
     _elapsed = Duration.zero;
     _lastTick = Duration.zero;
-    remaining.value = total;
+      remaining.value = _total;
     running.value = false;
   }
 
@@ -76,5 +77,13 @@ class SessionTimerController {
     remaining.dispose();
     running.dispose();
   }
+
+  void startWith(Duration total) {
+    _total = total;
+    reset();
+    resume();
+  }
+
+  Duration get total => _total;
 }
 

--- a/test/ui/timer/session_timer_bar_test.dart
+++ b/test/ui/timer/session_timer_bar_test.dart
@@ -1,64 +1,91 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/ui/timer/session_timer_bar.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: child,
+    );
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  testWidgets('SessionTimerBar ticks and completes respecting mute',
-      (tester) async {
-    final ticks = <Duration>[];
-    bool done = false;
-    int soundCalls = 0;
-    int hapticCalls = 0;
 
-    final messenger =
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
-    messenger.setMockMethodCallHandler(SystemChannels.platform, (call) async {
-      if (call.method == 'SystemSound.play') soundCalls++;
-      if (call.method == 'HapticFeedback.mediumImpact') hapticCalls++;
-      return null;
-    });
-    addTearDown(() {
-      messenger.setMockMethodCallHandler(SystemChannels.platform, null);
-    });
+  testWidgets('Play restarts from selected duration', (tester) async {
+    await tester.pumpWidget(
+        _wrap(const SessionTimerBar(initialDuration: Duration(seconds: 60))));
 
-    await tester.pumpWidget(MaterialApp(
-      home: SessionTimerBar(
-        total: const Duration(seconds: 2),
-        initiallyRunning: true,
-        onTick: ticks.add,
-        onDone: () => done = true,
-      ),
-    ));
-
-    expect(find.text('00:02'), findsOneWidget);
+    await tester.tap(find.byIcon(Icons.play_arrow));
+    await tester.pump();
     await tester.pump(const Duration(seconds: 1));
-    expect(find.text('00:01'), findsOneWidget);
-    expect(ticks.last, const Duration(seconds: 1));
+    expect(find.text('00:59'), findsOneWidget);
 
+    await tester.tap(find.byIcon(Icons.play_arrow));
+    await tester.pump();
+    expect(find.text('01:00'), findsOneWidget);
+  });
+
+  testWidgets('Plus and minus clamp to allowed durations', (tester) async {
+    await tester.pumpWidget(
+        _wrap(const SessionTimerBar(initialDuration: Duration(seconds: 90))));
+    final plus = find.byIcon(Icons.add);
+    final minus = find.byIcon(Icons.remove);
+
+    expect(find.text('90 s'), findsOneWidget);
+    await tester.tap(plus);
+    await tester.pump();
+    expect(find.text('120 s'), findsOneWidget);
+
+    await tester.tap(plus);
+    await tester.pump();
+    await tester.tap(plus);
+    await tester.pump();
+    expect(find.text('180 s'), findsOneWidget);
+
+    await tester.tap(plus);
+    await tester.pump();
+    expect(find.text('180 s'), findsOneWidget);
+
+    await tester.tap(minus);
+    await tester.pump();
+    await tester.tap(minus);
+    await tester.pump();
+    await tester.tap(minus);
+    await tester.pump();
+    await tester.tap(minus);
+    await tester.pump();
+    expect(find.text('60 s'), findsOneWidget);
+
+    await tester.tap(minus);
+    await tester.pump();
+    expect(find.text('60 s'), findsOneWidget);
+  });
+
+  testWidgets('Changing duration does not affect running timer', (tester) async {
+    await tester.pumpWidget(
+        _wrap(const SessionTimerBar(initialDuration: Duration(seconds: 60))));
+
+    await tester.tap(find.byIcon(Icons.play_arrow));
+    await tester.pump();
     await tester.pump(const Duration(seconds: 1));
-    expect(done, isTrue);
-    expect(soundCalls, 1);
-    expect(hapticCalls, 1);
+    expect(find.text('00:59'), findsOneWidget);
 
-    done = false;
-    soundCalls = 0;
-    hapticCalls = 0;
+    await tester.tap(find.byIcon(Icons.add));
+    await tester.pump();
+    expect(find.text('00:59'), findsOneWidget);
+  });
 
-    await tester.pumpWidget(MaterialApp(
-      home: SessionTimerBar(
-        total: const Duration(seconds: 1),
-        initiallyRunning: true,
-        muted: true,
-        onDone: () => done = true,
-      ),
-    ));
+  testWidgets('Timer cleans up on unmount', (tester) async {
+    await tester.pumpWidget(
+        _wrap(const SessionTimerBar(initialDuration: Duration(seconds: 60))));
 
+    await tester.tap(find.byIcon(Icons.play_arrow));
+    await tester.pump();
     await tester.pump(const Duration(seconds: 1));
-    expect(done, isTrue);
-    expect(soundCalls, 0);
-    expect(hapticCalls, 1);
+
+    await tester.pumpWidget(_wrap(const SizedBox.shrink()));
+    await tester.pump(const Duration(seconds: 1));
   });
 }
-


### PR DESCRIPTION
## Summary
- restart session timer on play using selected duration
- allow selecting fixed durations with +/- buttons and remove speaker icon
- document timer controls and update localization

## Testing
- `flutter test test/ui/timer/session_timer_bar_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d1e4e7250832086df2765a598ad11