### PR TITLE
fix(timer): assert localization non-null

### DIFF
--- a/lib/ui/timer/session_timer_bar.dart
+++ b/lib/ui/timer/session_timer_bar.dart
@@ -70,7 +70,7 @@ class _SessionTimerBarState extends State<SessionTimerBar>
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final loc = AppLocalizations.of(context);
+    final loc = AppLocalizations.of(context)!;
     return ValueListenableBuilder<Duration>(
       valueListenable: _controller.remaining,
       builder: (context, remaining, _) {


### PR DESCRIPTION
## Summary
- guard SessionTimerBar localization lookup with non-null assertion

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d21f214508320a3cce8b641f9bbe7