### PR TITLE
fix: handle long press on muscle group chip

### DIFF
--- a/lib/ui/muscles/muscle_group_list_selector.dart
+++ b/lib/ui/muscles/muscle_group_list_selector.dart
@@ -217,25 +217,27 @@ class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
               label: entry.displayName,
               child: SizedBox(
                 height: 48,
-                child: FilterChip(
-                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                  avatar: CircleAvatar(
-                    backgroundColor: colorForRegion(entry.region, theme),
-                    radius: 8,
-                  ),
-                  label: Text(
-                    entry.displayName,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  selected: isSel,
-                  onSelected: (_) => _toggleSelect(entry.key, entry.region),
+                child: GestureDetector(
                   onLongPress: () async {
                     final id =
                         await _ensureIdForRegion(entry.region, entry.key);
                     _setPrimary(id);
                   },
-                  selectedColor: isPri ? green : blue,
-                  showCheckmark: true,
+                  child: FilterChip(
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    avatar: CircleAvatar(
+                      backgroundColor: colorForRegion(entry.region, theme),
+                      radius: 8,
+                    ),
+                    label: Text(
+                      entry.displayName,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    selected: isSel,
+                    onSelected: (_) => _toggleSelect(entry.key, entry.region),
+                    selectedColor: isPri ? green : blue,
+                    showCheckmark: true,
+                  ),
                 ),
               ),
             );


### PR DESCRIPTION
## Summary
- wrap muscle group `FilterChip` with `GestureDetector` to support long-press handling

## Testing
- `dart format lib/ui/muscles/muscle_group_list_selector.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d33f65dd08320b8d4852e5e3e3f48