### PR TITLE
feat(history): improve charts and layout

### DIFF
--- a/lib/core/utils/nice_scale.dart
+++ b/lib/core/utils/nice_scale.dart
@@ -1,0 +1,75 @@
+import 'dart:math' as math;
+
+class NiceScale {
+  final double min;
+  final double max;
+  final double tickSpacing;
+
+  const NiceScale._(this.min, this.max, this.tickSpacing);
+
+  factory NiceScale.fromValues(
+    List<double> values, {
+    int tickCount = 5,
+    bool forceMinZero = false,
+    bool clampMinZero = true,
+  }) {
+    if (values.isEmpty) {
+      return const NiceScale._(0, 1, 1);
+    }
+    double minV = values.reduce(math.min);
+    double maxV = values.reduce(math.max);
+
+    if (minV == maxV) {
+      double pad = math.max(minV.abs() * 0.05, 1);
+      minV -= pad;
+      maxV += pad;
+    } else {
+      final range = maxV - minV;
+      final pad = range * 0.1;
+      minV -= pad;
+      maxV += pad;
+    }
+
+    if (forceMinZero) {
+      minV = 0;
+    } else if (clampMinZero && minV < 0) {
+      minV = 0;
+    }
+
+    final range = maxV - minV;
+    final rawStep = range / (tickCount - 1);
+    final step = _niceNum(rawStep, round: true);
+    final niceMin = (minV / step).floor() * step;
+    final niceMax = (maxV / step).ceil() * step;
+    return NiceScale._(niceMin, niceMax, step);
+  }
+
+  static double _niceNum(double value, {bool round = false}) {
+    final exponent = (math.log(value) / math.ln10).floor();
+    final fraction = value / math.pow(10, exponent);
+
+    double niceFraction;
+    if (round) {
+      if (fraction < 1.5) {
+        niceFraction = 1;
+      } else if (fraction < 3) {
+        niceFraction = 2;
+      } else if (fraction < 7) {
+        niceFraction = 5;
+      } else {
+        niceFraction = 10;
+      }
+    } else {
+      if (fraction <= 1) {
+        niceFraction = 1;
+      } else if (fraction <= 2) {
+        niceFraction = 2;
+      } else if (fraction <= 5) {
+        niceFraction = 5;
+      } else {
+        niceFraction = 10;
+      }
+    }
+    return niceFraction * math.pow(10, exponent);
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -138,6 +138,30 @@
   "@historySessionsChartTitle": {
     "description": "Überschrift für den Sitzungsverlauf"
   },
+  "historyAxisDate": "Datum",
+  "@historyAxisDate": {
+    "description": "Achsentitel für Datum"
+  },
+  "historyAxisE1rm": "E1RM",
+  "@historyAxisE1rm": {
+    "description": "Achsentitel für E1RM-Chart"
+  },
+  "historyAxisSessions": "Sitzungen",
+  "@historyAxisSessions": {
+    "description": "Achsentitel für Sitzungs-Chart"
+  },
+  "historyNoData": "Keine Daten",
+  "@historyNoData": {
+    "description": "Placeholder wenn keine Verlaufsdaten vorhanden"
+  },
+  "historyE1rmChartSemantics": "E1RM-Verlauf",
+  "@historyE1rmChartSemantics": {
+    "description": "Semantik-Label für E1RM-Chart"
+  },
+  "historySessionsChartSemantics": "Sitzungen im Verlauf",
+  "@historySessionsChartSemantics": {
+    "description": "Semantik-Label für Sitzungs-Chart"
+  },
 
   "homeWelcome": "Willkommen, {user}",
   "@homeWelcome": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -138,6 +138,30 @@
   "@historySessionsChartTitle": {
     "description": "Heading for sessions over time chart"
   },
+  "historyAxisDate": "Date",
+  "@historyAxisDate": {
+    "description": "Axis title for date"
+  },
+  "historyAxisE1rm": "E1RM",
+  "@historyAxisE1rm": {
+    "description": "Axis title for E1RM chart"
+  },
+  "historyAxisSessions": "Sessions",
+  "@historyAxisSessions": {
+    "description": "Axis title for sessions chart"
+  },
+  "historyNoData": "No data",
+  "@historyNoData": {
+    "description": "Placeholder when no history data is available"
+  },
+  "historyE1rmChartSemantics": "E1RM over time chart",
+  "@historyE1rmChartSemantics": {
+    "description": "Semantics label for E1RM chart"
+  },
+  "historySessionsChartSemantics": "Sessions over time chart",
+  "@historySessionsChartSemantics": {
+    "description": "Semantics label for sessions chart"
+  },
 
   "homeWelcome": "Welcome, {user}",
   "@homeWelcome": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -263,6 +263,42 @@ abstract class AppLocalizations {
   /// **'Sessions over time'**
   String get historySessionsChartTitle;
 
+  /// Axis title for date
+  ///
+  /// In en, this message translates to:
+  /// **'Date'**
+  String get historyAxisDate;
+
+  /// Axis title for E1RM chart
+  ///
+  /// In en, this message translates to:
+  /// **'E1RM'**
+  String get historyAxisE1rm;
+
+  /// Axis title for sessions chart
+  ///
+  /// In en, this message translates to:
+  /// **'Sessions'**
+  String get historyAxisSessions;
+
+  /// Placeholder when no history data is available
+  ///
+  /// In en, this message translates to:
+  /// **'No data'**
+  String get historyNoData;
+
+  /// Semantics label for E1RM chart
+  ///
+  /// In en, this message translates to:
+  /// **'E1RM over time chart'**
+  String get historyE1rmChartSemantics;
+
+  /// Semantics label for sessions chart
+  ///
+  /// In en, this message translates to:
+  /// **'Sessions over time chart'**
+  String get historySessionsChartSemantics;
+
   /// Greeting on the Home screen
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -101,6 +101,24 @@ class AppLocalizationsDe extends AppLocalizations {
   String get historySessionsChartTitle => 'Sitzungen im Verlauf';
 
   @override
+  String get historyAxisDate => 'Datum';
+
+  @override
+  String get historyAxisE1rm => 'E1RM';
+
+  @override
+  String get historyAxisSessions => 'Sitzungen';
+
+  @override
+  String get historyNoData => 'Keine Daten';
+
+  @override
+  String get historyE1rmChartSemantics => 'E1RM-Verlauf';
+
+  @override
+  String get historySessionsChartSemantics => 'Sitzungen im Verlauf';
+
+  @override
   String homeWelcome(Object user) {
     return 'Willkommen, $user';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -101,6 +101,24 @@ class AppLocalizationsEn extends AppLocalizations {
   String get historySessionsChartTitle => 'Sessions over time';
 
   @override
+  String get historyAxisDate => 'Date';
+
+  @override
+  String get historyAxisE1rm => 'E1RM';
+
+  @override
+  String get historyAxisSessions => 'Sessions';
+
+  @override
+  String get historyNoData => 'No data';
+
+  @override
+  String get historyE1rmChartSemantics => 'E1RM over time chart';
+
+  @override
+  String get historySessionsChartSemantics => 'Sessions over time chart';
+
+  @override
   String homeWelcome(Object user) {
     return 'Welcome, $user';
   }

--- a/test/core/utils/nice_scale_test.dart
+++ b/test/core/utils/nice_scale_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/core/utils/nice_scale.dart';
+
+void main() {
+  test('broad range produces nice bounds', () {
+    final s = NiceScale.fromValues([2, 10, 12], tickCount: 5);
+    expect(s.min, 0);
+    expect(s.max >= 12, isTrue);
+    expect(s.tickSpacing > 0, isTrue);
+  });
+
+  test('single value expands range', () {
+    final s = NiceScale.fromValues([10], tickCount: 5);
+    expect(s.max > s.min, isTrue);
+    expect(s.min < 10 && s.max > 10, isTrue);
+  });
+
+  test('identical values expands range', () {
+    final s = NiceScale.fromValues([5, 5, 5], tickCount: 5);
+    expect(s.min < 5 && s.max > 5, isTrue);
+  });
+
+  test('forceMinZero clamps to zero', () {
+    final s = NiceScale.fromValues([1, 2, 3], tickCount: 5, forceMinZero: true);
+    expect(s.min, 0);
+  });
+}


### PR DESCRIPTION
## Summary
- add reusable nice-scale helper for chart axes
- overhaul HistoryScreen with circular KPI badges, data-driven axes, and scrollable slivers
- extend i18n for new axis labels and chart semantics

## Testing
- `flutter test test/core/utils/nice_scale_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689d5d3f033c8320ae24d39d85dc33f9