### PR TITLE
feat(ui): align history page with brand styling

### DIFF
--- a/lib/core/widgets/brand_gradient_card.dart
+++ b/lib/core/widgets/brand_gradient_card.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import '../theme/brand_surface_theme.dart';
+import '../theme/design_tokens.dart';
+
+/// Reusable card container with the brand gradient and rounded corners.
+class BrandGradientCard extends StatelessWidget {
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+  final BorderRadiusGeometry? borderRadius;
+  final VoidCallback? onTap;
+
+  const BrandGradientCard({
+    super.key,
+    required this.child,
+    this.padding,
+    this.borderRadius,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final surface = theme.extension<BrandSurfaceTheme>();
+    final radius = borderRadius ?? surface?.radius ?? BorderRadius.circular(AppRadius.card);
+    final gradient = surface?.gradient ?? AppGradients.brandGradient;
+    final shadow = surface?.shadow;
+    final overlay = surface?.pressedOverlay ?? Colors.black26;
+
+    Widget content = Container(
+      decoration: BoxDecoration(
+        gradient: gradient,
+        borderRadius: radius,
+        boxShadow: shadow,
+      ),
+      padding: padding ?? const EdgeInsets.all(AppSpacing.sm),
+      child: child,
+    );
+
+    if (onTap != null) {
+      content = Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          borderRadius: radius,
+          splashColor: overlay,
+          highlightColor: overlay,
+          onTap: onTap,
+          child: content,
+        ),
+      );
+    }
+
+    return content;
+  }
+}
+
+/// Gradient header used for expansion tiles.
+class BrandGradientHeader extends StatelessWidget {
+  final Widget child;
+  final bool expanded;
+  final VoidCallback? onTap;
+  final EdgeInsetsGeometry? padding;
+
+  const BrandGradientHeader({
+    super.key,
+    required this.child,
+    this.expanded = false,
+    this.onTap,
+    this.padding,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final surface = Theme.of(context).extension<BrandSurfaceTheme>();
+    final baseRadius = surface?.radius as BorderRadius? ?? BorderRadius.circular(AppRadius.card);
+    final radius = expanded
+        ? BorderRadius.only(topLeft: baseRadius.topLeft, topRight: baseRadius.topRight)
+        : baseRadius;
+    return BrandGradientCard(
+      borderRadius: radius,
+      padding: padding ?? const EdgeInsets.symmetric(vertical: AppSpacing.sm, horizontal: AppSpacing.sm),
+      onTap: onTap,
+      child: child,
+    );
+  }
+}

--- a/lib/features/history/presentation/screens/history_screen.dart
+++ b/lib/features/history/presentation/screens/history_screen.dart
@@ -9,6 +9,9 @@ import 'package:tapem/features/history/domain/models/workout_log.dart';
 import 'package:tapem/features/training_details/domain/models/session.dart';
 import 'package:tapem/features/training_details/presentation/widgets/session_exercise_card.dart';
 import 'package:tapem/l10n/app_localizations.dart';
+import 'package:tapem/core/widgets/brand_gradient_card.dart';
+import 'package:tapem/core/theme/brand_surface_theme.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
 
 class HistoryScreen extends StatefulWidget {
   final String deviceId;
@@ -333,19 +336,12 @@ class _HistoryScreenState extends State<HistoryScreen> {
                     .toList();
                 return Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-                  child: Card(
-                    child: ExpansionTile(
-                      title: Text(
-                        titleDate,
-                        style: const TextStyle(fontWeight: FontWeight.bold),
-                      ),
-                      children: [
-                        SessionExerciseCard(
-                          deviceName: widget.deviceId,
-                          sets: sets,
-                          padding: const EdgeInsets.all(12),
-                        ),
-                      ],
+                  child: _HistoryExpansionTile(
+                    title: titleDate,
+                    child: SessionExerciseCard(
+                      deviceName: widget.deviceId,
+                      sets: sets,
+                      padding: const EdgeInsets.all(12),
                     ),
                   ),
                 );
@@ -366,9 +362,9 @@ class _HistoryScreenState extends State<HistoryScreen> {
       child: SizedBox(
         width: 80,
         height: 80,
-        child: Card(
-          color: theme.colorScheme.primaryContainer,
-          shape: const CircleBorder(),
+        child: BrandGradientCard(
+          borderRadius: BorderRadius.circular(40),
+          padding: EdgeInsets.zero,
           child: Center(
             child: Column(
               mainAxisSize: MainAxisSize.min,
@@ -376,15 +372,76 @@ class _HistoryScreenState extends State<HistoryScreen> {
                 Text(
                   value,
                   style: theme.textTheme.titleMedium
-                      ?.copyWith(fontWeight: FontWeight.bold),
+                      ?.copyWith(fontWeight: FontWeight.bold, color: theme.colorScheme.onPrimary),
                 ),
                 const SizedBox(height: 4),
-                Text(label, style: theme.textTheme.bodySmall),
+                Text(
+                  label,
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(color: theme.colorScheme.onPrimary.withOpacity(0.8)),
+                ),
               ],
             ),
           ),
         ),
       ),
+    );
+  }
+}
+
+class _HistoryExpansionTile extends StatefulWidget {
+  final String title;
+  final Widget child;
+  const _HistoryExpansionTile({required this.title, required this.child});
+
+  @override
+  State<_HistoryExpansionTile> createState() => _HistoryExpansionTileState();
+}
+
+class _HistoryExpansionTileState extends State<_HistoryExpansionTile> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final surface = theme.extension<BrandSurfaceTheme>();
+    final baseRadius = surface?.radius as BorderRadius? ?? BorderRadius.circular(AppRadius.card);
+    final bottomRadius = BorderRadius.only(
+      bottomLeft: baseRadius.bottomLeft,
+      bottomRight: baseRadius.bottomRight,
+    );
+    final onPrimary = theme.colorScheme.onPrimary;
+
+    return Column(
+      children: [
+        BrandGradientHeader(
+          expanded: _expanded,
+          onTap: () => setState(() => _expanded = !_expanded),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  widget.title,
+                  style: TextStyle(fontWeight: FontWeight.bold, color: onPrimary),
+                ),
+              ),
+              Icon(
+                _expanded ? Icons.expand_less : Icons.expand_more,
+                color: onPrimary,
+              ),
+            ],
+          ),
+        ),
+        if (_expanded)
+          Container(
+            decoration: BoxDecoration(
+              color: theme.colorScheme.surface,
+              borderRadius: bottomRadius,
+            ),
+            padding: const EdgeInsets.all(AppSpacing.sm),
+            child: widget.child,
+          ),
+      ],
     );
   }
 }

--- a/lib/features/training_details/presentation/widgets/session_exercise_card.dart
+++ b/lib/features/training_details/presentation/widgets/session_exercise_card.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:tapem/core/theme/brand_surface_theme.dart';
-import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/core/widgets/brand_gradient_card.dart';
 import '../../domain/models/session.dart';
 
 /// A reusable card displaying a session's sets for a single device/exercise.
@@ -19,64 +18,56 @@ class SessionExerciseCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final surface = theme.extension<BrandSurfaceTheme>();
-    return Container(
-      decoration: BoxDecoration(
-        gradient: surface?.gradient ?? AppGradients.brandGradient,
-        borderRadius: surface?.radius ?? BorderRadius.circular(12),
-        boxShadow: surface?.shadow,
-      ),
-      child: Padding(
-        padding: padding,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              deviceName,
-              style: TextStyle(
-                color: theme.colorScheme.onPrimary,
-                fontSize: 16,
-                fontWeight: FontWeight.bold,
+    return BrandGradientCard(
+      padding: padding,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            deviceName,
+            style: TextStyle(
+              color: theme.colorScheme.onPrimary,
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 8),
+          for (final set in sets)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 2.0),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.fitness_center,
+                    color: theme.colorScheme.primary,
+                    size: 16,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    '${set.weight.toStringAsFixed(1)} kg',
+                    style: TextStyle(
+                      color: theme.colorScheme.onPrimary.withOpacity(0.7),
+                      fontSize: 14,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Icon(
+                    Icons.repeat,
+                    color: theme.colorScheme.secondary,
+                    size: 16,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    '${set.reps} Wdh',
+                    style: TextStyle(
+                      color: theme.colorScheme.onPrimary.withOpacity(0.7),
+                      fontSize: 14,
+                    ),
+                  ),
+                ],
               ),
             ),
-            const SizedBox(height: 8),
-            for (final set in sets)
-              Padding(
-                padding: const EdgeInsets.symmetric(vertical: 2.0),
-                child: Row(
-                  children: [
-                    Icon(
-                      Icons.fitness_center,
-                      color: theme.colorScheme.primary,
-                      size: 16,
-                    ),
-                    const SizedBox(width: 4),
-                    Text(
-                      '${set.weight.toStringAsFixed(1)} kg',
-                      style: TextStyle(
-                        color: theme.colorScheme.onPrimary.withOpacity(0.7),
-                        fontSize: 14,
-                      ),
-                    ),
-                    const SizedBox(width: 8),
-                    Icon(
-                      Icons.repeat,
-                      color: theme.colorScheme.secondary,
-                      size: 16,
-                    ),
-                    const SizedBox(width: 4),
-                    Text(
-                      '${set.reps} Wdh',
-                      style: TextStyle(
-                        color: theme.colorScheme.onPrimary.withOpacity(0.7),
-                        fontSize: 14,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-          ],
-        ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add reusable BrandGradientCard and BrandGradientHeader for branded surfaces
- style history KPI rings and workout sections with brand gradient
- refactor SessionExerciseCard to reuse BrandGradientCard

## Testing
- `dart format lib/core/widgets/brand_gradient_card.dart lib/features/training_details/presentation/widgets/session_exercise_card.dart lib/features/history/presentation/screens/history_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d6d9257788320a5802b5218dc5de7