### PR TITLE
fix build errors in widgets and device screen

### DIFF
--- a/lib/core/widgets/brand_gradient_card.dart
+++ b/lib/core/widgets/brand_gradient_card.dart
@@ -21,7 +21,9 @@ class BrandGradientCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final surface = theme.extension<BrandSurfaceTheme>();
-    final radius = borderRadius ?? surface?.radius ?? BorderRadius.circular(AppRadius.card);
+    final BorderRadius radius =
+        (borderRadius ?? surface?.radius ?? BorderRadius.circular(AppRadius.card))
+            as BorderRadius;
     final gradient = surface?.gradient ?? AppGradients.brandGradient;
     final shadow = surface?.shadow;
     final overlay = surface?.pressedOverlay ?? Colors.black26;

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -129,14 +129,6 @@ class _DeviceScreenState extends State<DeviceScreen> {
       widget.exerciseId,
       DateTime.now(),
     );
-    final exProv = context.watch<ExerciseProvider>();
-    Exercise? currentExercise;
-    try {
-      currentExercise = exProv.exercises.firstWhere(
-        (e) => e.id == widget.exerciseId,
-      );
-    } catch (_) {}
-
     _dlog(
       'build() isLoading=${prov.isLoading} error=${prov.error} sets=${prov.sets.length}',
     );


### PR DESCRIPTION
## Summary
- cast brand gradient card radius to BorderRadius to match InkWell API
- remove unused currentExercise variable from device screen

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689d7171ed4c832097124777a3e5d83c