### PR TITLE
feat: filter history by exercise

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -92,9 +92,16 @@ class AppRouter {
         );
 
       case history:
-        final deviceId = settings.arguments as String? ?? '';
+        final args = settings.arguments as Map<String, dynamic>;
         return MaterialPageRoute(
-          builder: (_) => HistoryScreen(deviceId: deviceId),
+          builder: (_) => HistoryScreen(
+            deviceId: args['deviceId'] as String,
+            deviceName: args['deviceName'] as String,
+            deviceDescription: args['deviceDescription'] as String?,
+            isMulti: args['isMulti'] as bool? ?? false,
+            exerciseId: args['exerciseId'] as String?,
+            exerciseName: args['exerciseName'] as String?,
+          ),
         );
 
       case report:

--- a/lib/core/providers/history_provider.dart
+++ b/lib/core/providers/history_provider.dart
@@ -44,6 +44,7 @@ class HistoryProvider extends ChangeNotifier {
   Future<void> loadHistory({
     required BuildContext context,
     required String deviceId,
+    String? exerciseId,
   }) async {
     _isLoading = true;
     _error = null;
@@ -61,6 +62,7 @@ class HistoryProvider extends ChangeNotifier {
         gymId: gymId,
         deviceId: deviceId,
         userId: userId,
+        exerciseId: exerciseId,
       );
       _computeStats();
     } catch (e, st) {

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -166,9 +166,31 @@ class _DeviceScreenState extends State<DeviceScreen> {
               tooltip: 'Verlauf',
               onPressed: () {
                 _closeKeyboard();
-                Navigator.of(
-                  context,
-                ).pushNamed(AppRouter.history, arguments: widget.deviceId);
+                final deviceProv = context.read<DeviceProvider>();
+                String? exerciseName;
+                if (deviceProv.device?.isMulti ?? false) {
+                  final exProv = context.read<ExerciseProvider>();
+                  exerciseName = exProv.exercises
+                      .firstWhere(
+                        (e) => e.id == widget.exerciseId,
+                        orElse: () =>
+                            Exercise(id: '', name: 'Unknown', userId: ''),
+                      )
+                      .name;
+                }
+                Navigator.of(context).pushNamed(
+                  AppRouter.history,
+                  arguments: {
+                    'deviceId': widget.deviceId,
+                    'deviceName': deviceProv.device?.name ?? widget.deviceId,
+                    'deviceDescription': deviceProv.device?.description,
+                    'isMulti': deviceProv.device?.isMulti ?? false,
+                    if (deviceProv.device?.isMulti ?? false)
+                      'exerciseId': widget.exerciseId,
+                    if (deviceProv.device?.isMulti ?? false)
+                      'exerciseName': exerciseName,
+                  },
+                );
               },
             ),
           ],

--- a/lib/features/history/data/dtos/workout_log_dto.dart
+++ b/lib/features/history/data/dtos/workout_log_dto.dart
@@ -13,6 +13,7 @@ class WorkoutLogDto {
 
   final String userId;
   final String sessionId;
+  final String? exerciseId;
 
   @JsonKey(fromJson: _timestampToDate, toJson: _dateToTimestamp)
   final DateTime timestamp;
@@ -25,6 +26,7 @@ class WorkoutLogDto {
   WorkoutLogDto({
     required this.userId,
     required this.sessionId,
+    this.exerciseId,
     required this.timestamp,
     required this.weight,
     required this.reps,
@@ -50,6 +52,7 @@ class WorkoutLogDto {
     id: id,
     userId: userId,
     sessionId: sessionId,
+    exerciseId: exerciseId,
     timestamp: timestamp,
     weight: weight,
     reps: reps,

--- a/lib/features/history/data/dtos/workout_log_dto.g.dart
+++ b/lib/features/history/data/dtos/workout_log_dto.g.dart
@@ -10,6 +10,7 @@ WorkoutLogDto _$WorkoutLogDtoFromJson(Map<String, dynamic> json) =>
     WorkoutLogDto(
       userId: json['userId'] as String,
       sessionId: json['sessionId'] as String,
+      exerciseId: json['exerciseId'] as String?,
       timestamp: WorkoutLogDto._timestampToDate(json['timestamp'] as Timestamp),
       weight: (json['weight'] as num).toDouble(),
       reps: (json['reps'] as num).toInt(),
@@ -21,6 +22,7 @@ Map<String, dynamic> _$WorkoutLogDtoToJson(WorkoutLogDto instance) =>
     <String, dynamic>{
       'userId': instance.userId,
       'sessionId': instance.sessionId,
+      if (instance.exerciseId != null) 'exerciseId': instance.exerciseId,
       'timestamp': WorkoutLogDto._dateToTimestamp(instance.timestamp),
       'weight': instance.weight,
       'reps': instance.reps,

--- a/lib/features/history/data/repositories/history_repository_impl.dart
+++ b/lib/features/history/data/repositories/history_repository_impl.dart
@@ -13,11 +13,13 @@ class HistoryRepositoryImpl implements GetHistoryForDeviceRepository {
     required String gymId,
     required String deviceId,
     required String userId,
+    String? exerciseId,
   }) async {
     final dtos = await _source.getLogs(
       gymId: gymId,
       deviceId: deviceId,
       userId: userId,
+      exerciseId: exerciseId,
     );
     return dtos.map((d) => d.toModel()).toList();
   }

--- a/lib/features/history/data/sources/firestore_history_source.dart
+++ b/lib/features/history/data/sources/firestore_history_source.dart
@@ -14,17 +14,20 @@ class FirestoreHistorySource {
     required String gymId,
     required String deviceId,
     required String userId,
+    String? exerciseId,
   }) async {
-    final snapshot =
-        await _firestore
-            .collection('gyms')
-            .doc(gymId)
-            .collection('devices')
-            .doc(deviceId)
-            .collection('logs')
-            .where('userId', isEqualTo: userId)
-            .orderBy('timestamp', descending: true)
-            .get();
+    var query = _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('devices')
+        .doc(deviceId)
+        .collection('logs')
+        .where('userId', isEqualTo: userId);
+    if (exerciseId != null) {
+      query = query.where('exerciseId', isEqualTo: exerciseId);
+    }
+    // Composite index on userId+exerciseId+timestamp may be required.
+    final snapshot = await query.orderBy('timestamp', descending: true).get();
 
     return snapshot.docs.map((doc) => WorkoutLogDto.fromDocument(doc)).toList();
   }

--- a/lib/features/history/domain/models/workout_log.dart
+++ b/lib/features/history/domain/models/workout_log.dart
@@ -5,6 +5,7 @@ class WorkoutLog {
   final String id;
   final String userId;
   final String sessionId;
+  final String? exerciseId;
   final DateTime timestamp;
   final double weight;
   final int reps;
@@ -15,6 +16,7 @@ class WorkoutLog {
     required this.id,
     required this.userId,
     required this.sessionId,
+    this.exerciseId,
     required this.timestamp,
     required this.weight,
     required this.reps,

--- a/lib/features/history/domain/usecases/get_history_for_device.dart
+++ b/lib/features/history/domain/usecases/get_history_for_device.dart
@@ -8,6 +8,7 @@ abstract class GetHistoryForDeviceRepository {
     required String gymId,
     required String deviceId,
     required String userId,
+    String? exerciseId,
   });
 }
 
@@ -20,7 +21,12 @@ class GetHistoryForDevice {
     required String gymId,
     required String deviceId,
     required String userId,
+    String? exerciseId,
   }) {
-    return _repo.getHistory(gymId: gymId, deviceId: deviceId, userId: userId);
+    return _repo.getHistory(
+        gymId: gymId,
+        deviceId: deviceId,
+        userId: userId,
+        exerciseId: exerciseId);
   }
 }

--- a/lib/features/history/presentation/screens/history_screen.dart
+++ b/lib/features/history/presentation/screens/history_screen.dart
@@ -15,7 +15,20 @@ import 'package:tapem/core/theme/design_tokens.dart';
 
 class HistoryScreen extends StatefulWidget {
   final String deviceId;
-  const HistoryScreen({Key? key, required this.deviceId}) : super(key: key);
+  final String deviceName;
+  final String? deviceDescription;
+  final bool isMulti;
+  final String? exerciseId;
+  final String? exerciseName;
+  const HistoryScreen({
+    Key? key,
+    required this.deviceId,
+    required this.deviceName,
+    this.deviceDescription,
+    this.isMulti = false,
+    this.exerciseId,
+    this.exerciseName,
+  }) : super(key: key);
 
   @override
   State<HistoryScreen> createState() => _HistoryScreenState();
@@ -29,6 +42,7 @@ class _HistoryScreenState extends State<HistoryScreen> {
       context.read<HistoryProvider>().loadHistory(
             context: context,
             deviceId: widget.deviceId,
+            exerciseId: widget.isMulti ? widget.exerciseId : null,
           );
     });
   }
@@ -47,9 +61,13 @@ class _HistoryScreenState extends State<HistoryScreen> {
     if (prov.isLoading) {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
+    final title = widget.isMulti ? (widget.exerciseName ?? '') : widget.deviceName;
+    final subtitle = widget.deviceDescription ?? '';
+    final fullTitle =
+        subtitle.isNotEmpty ? '$title — $subtitle' : title;
     if (prov.error != null) {
       return Scaffold(
-        appBar: AppBar(title: Text(loc.historyTitle(widget.deviceId))),
+        appBar: AppBar(title: Text(fullTitle)),
         body: Center(child: Text('${loc.errorPrefix}: ${prov.error}')),
       );
     }
@@ -245,7 +263,7 @@ class _HistoryScreenState extends State<HistoryScreen> {
     }
 
     return Scaffold(
-      appBar: AppBar(title: Text(loc.historyTitle(widget.deviceId))),
+        appBar: AppBar(title: Text(fullTitle)),
       body: CustomScrollView(
         slivers: [
           SliverPadding(
@@ -339,7 +357,8 @@ class _HistoryScreenState extends State<HistoryScreen> {
                   child: _HistoryExpansionTile(
                     title: titleDate,
                     child: SessionExerciseCard(
-                      deviceName: widget.deviceId,
+                      title: title,
+                      subtitle: subtitle.isNotEmpty ? subtitle : null,
                       sets: sets,
                       padding: const EdgeInsets.all(12),
                     ),

--- a/lib/features/training_details/presentation/widgets/day_sessions_overview.dart
+++ b/lib/features/training_details/presentation/widgets/day_sessions_overview.dart
@@ -23,7 +23,8 @@ class DaySessionsOverview extends StatelessWidget {
                 (session) => SizedBox(
                   width: cardWidth,
                   child: SessionExerciseCard(
-                    deviceName: session.deviceName,
+                    title: session.deviceName,
+                    subtitle: session.deviceDescription,
                     sets: session.sets,
                   ),
                 ),

--- a/lib/features/training_details/presentation/widgets/session_exercise_card.dart
+++ b/lib/features/training_details/presentation/widgets/session_exercise_card.dart
@@ -4,13 +4,15 @@ import '../../domain/models/session.dart';
 
 /// A reusable card displaying a session's sets for a single device/exercise.
 class SessionExerciseCard extends StatelessWidget {
-  final String deviceName;
+  final String title;
+  final String? subtitle;
   final List<SessionSet> sets;
   final EdgeInsetsGeometry padding;
 
   const SessionExerciseCard({
     Key? key,
-    required this.deviceName,
+    required this.title,
+    this.subtitle,
     required this.sets,
     this.padding = const EdgeInsets.all(12.0),
   }) : super(key: key);
@@ -24,13 +26,23 @@ class SessionExerciseCard extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            deviceName,
+            title,
             style: TextStyle(
               color: theme.colorScheme.onPrimary,
               fontSize: 16,
               fontWeight: FontWeight.bold,
             ),
           ),
+          if (subtitle != null && subtitle!.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(
+              subtitle!,
+              style: TextStyle(
+                color: theme.colorScheme.onPrimary.withOpacity(0.7),
+                fontSize: 14,
+              ),
+            ),
+          ],
           const SizedBox(height: 8),
           for (final set in sets)
             Padding(

--- a/test/ui/gym/device_card_test.dart
+++ b/test/ui/gym/device_card_test.dart
@@ -37,6 +37,7 @@ class _FakeHistoryRepo implements GetHistoryForDeviceRepository {
     required String gymId,
     required String deviceId,
     required String userId,
+    String? exerciseId,
   }) async => [];
 }
 

--- a/test/ui/gym/search_and_filters_test.dart
+++ b/test/ui/gym/search_and_filters_test.dart
@@ -36,6 +36,7 @@ class _FakeHistoryRepo implements GetHistoryForDeviceRepository {
     required String gymId,
     required String deviceId,
     required String userId,
+    String? exerciseId,
   }) async => [];
 }
 

--- a/test/widgets/exercise_bottom_sheet_selected_preview_test.dart
+++ b/test/widgets/exercise_bottom_sheet_selected_preview_test.dart
@@ -35,7 +35,12 @@ class _FakeMuscleGroupRepo implements MuscleGroupRepository {
 
 class _FakeHistoryRepo implements GetHistoryForDeviceRepository {
   @override
-  Future<List<WorkoutLog>> getHistory({required String gymId, required String deviceId, required String userId}) async => [];
+  Future<List<WorkoutLog>> getHistory({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    String? exerciseId,
+  }) async => [];
 }
 
 class _FakeDeviceRepo implements DeviceRepository {

--- a/test/widgets/muscle_group_list_selector_primary_secondary_test.dart
+++ b/test/widgets/muscle_group_list_selector_primary_secondary_test.dart
@@ -37,6 +37,7 @@ class _FakeHistoryRepo implements GetHistoryForDeviceRepository {
     required String gymId,
     required String deviceId,
     required String userId,
+    String? exerciseId,
   }) async => [];
 }
 

--- a/test/widgets/muscle_group_list_selector_test.dart
+++ b/test/widgets/muscle_group_list_selector_test.dart
@@ -33,7 +33,12 @@ class _FakeMuscleGroupRepo implements MuscleGroupRepository {
 
 class _FakeHistoryRepo implements GetHistoryForDeviceRepository {
   @override
-  Future<List<WorkoutLog>> getHistory({required String gymId, required String deviceId, required String userId}) async => [];
+  Future<List<WorkoutLog>> getHistory({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    String? exerciseId,
+  }) async => [];
 }
 
 class _FakeDeviceRepo implements DeviceRepository {

--- a/test/widgets/muscle_group_list_selector_text_test.dart
+++ b/test/widgets/muscle_group_list_selector_text_test.dart
@@ -33,7 +33,12 @@ class _FakeMuscleGroupRepo implements MuscleGroupRepository {
 
 class _FakeHistoryRepo implements GetHistoryForDeviceRepository {
   @override
-  Future<List<WorkoutLog>> getHistory({required String gymId, required String deviceId, required String userId}) async => [];
+  Future<List<WorkoutLog>> getHistory({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    String? exerciseId,
+  }) async => [];
 }
 
 class _FakeDeviceRepo implements DeviceRepository {

--- a/test/widgets/muscle_group_selector_test.dart
+++ b/test/widgets/muscle_group_selector_test.dart
@@ -33,7 +33,12 @@ class _FakeMuscleGroupRepo implements MuscleGroupRepository {
 
 class _FakeHistoryRepo implements GetHistoryForDeviceRepository {
   @override
-  Future<List<WorkoutLog>> getHistory({required String gymId, required String deviceId, required String userId}) async => [];
+  Future<List<WorkoutLog>> getHistory({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    String? exerciseId,
+  }) async => [];
 }
 
 class _FakeDeviceRepo implements DeviceRepository {


### PR DESCRIPTION
## Summary
- include optional exerciseId in workout logs and Firestore queries
- route history screens with human-readable device/exercise titles
- show formatted titles in history and session cards

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d7ca181b48320ab2ea23076197e23