### PR TITLE
fix: resolve button radius and semantics flag

### DIFF
--- a/lib/core/widgets/brand_primary_button.dart
+++ b/lib/core/widgets/brand_primary_button.dart
@@ -19,7 +19,11 @@ class BrandPrimaryButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final surface = Theme.of(context).extension<AppBrandTheme>();
-    final radius = surface?.radius ?? BorderRadius.circular(AppRadius.button);
+    // `InkWell` requires a [BorderRadius], while the theme exposes a
+    // [BorderRadiusGeometry]. Cast to [BorderRadius] so the same radius can
+    // be used for the decoration and the ink ripple.
+    final borderRadius =
+        (surface?.radius ?? BorderRadius.circular(AppRadius.button)) as BorderRadius;
     final gradient = surface?.gradient ?? AppGradients.brandGradient;
     final shadow = surface?.shadow;
     final overlay = surface?.pressedOverlay ?? Colors.black26;
@@ -31,7 +35,7 @@ class BrandPrimaryButton extends StatelessWidget {
     return DecoratedBox(
       decoration: BoxDecoration(
         gradient: gradient,
-        borderRadius: radius,
+        borderRadius: borderRadius,
         boxShadow: shadow,
       ),
       child: Semantics(
@@ -40,7 +44,7 @@ class BrandPrimaryButton extends StatelessWidget {
         child: Material(
           type: MaterialType.transparency,
           child: InkWell(
-            borderRadius: radius,
+            borderRadius: borderRadius,
             splashColor: overlay,
             highlightColor: overlay,
             onTap: onPressed,

--- a/test/ui/brand_widgets_test.dart
+++ b/test/ui/brand_widgets_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';


### PR DESCRIPTION
## Summary
- fix BrandPrimaryButton to use BorderRadius with InkWell
- import SemanticsFlag for widget tests

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689d903f63508320a8b3360a7116dbc7