### PR TITLE
Apply brand widgets across core pages

### DIFF
--- a/lib/core/theme/app_brand_theme.dart
+++ b/lib/core/theme/app_brand_theme.dart
@@ -18,6 +18,7 @@ class AppBrandTheme extends ThemeExtension<AppBrandTheme> {
   final EdgeInsetsGeometry padding;
   final double luminanceRef;
   final Color onBrand;
+  final Color outline;
 
   const AppBrandTheme({
     required this.gradient,
@@ -30,6 +31,7 @@ class AppBrandTheme extends ThemeExtension<AppBrandTheme> {
     required this.padding,
     required this.luminanceRef,
     required this.onBrand,
+    required this.outline,
   });
 
   @override
@@ -44,6 +46,7 @@ class AppBrandTheme extends ThemeExtension<AppBrandTheme> {
     EdgeInsetsGeometry? padding,
     double? luminanceRef,
     Color? onBrand,
+    Color? outline,
   }) {
     return AppBrandTheme(
       gradient: gradient ?? this.gradient,
@@ -56,6 +59,7 @@ class AppBrandTheme extends ThemeExtension<AppBrandTheme> {
       padding: padding ?? this.padding,
       luminanceRef: luminanceRef ?? this.luminanceRef,
       onBrand: onBrand ?? this.onBrand,
+      outline: outline ?? this.outline,
     );
   }
 
@@ -80,6 +84,7 @@ class AppBrandTheme extends ThemeExtension<AppBrandTheme> {
       padding: EdgeInsets.lerp(padding as EdgeInsets?, other.padding as EdgeInsets?, t) ?? padding,
       luminanceRef: lerpDouble(luminanceRef, other.luminanceRef, t) ?? luminanceRef,
       onBrand: Color.lerp(onBrand, other.onBrand, t) ?? onBrand,
+      outline: Color.lerp(outline, other.outline, t) ?? outline,
     );
   }
 
@@ -108,6 +113,7 @@ class AppBrandTheme extends ThemeExtension<AppBrandTheme> {
       padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
       luminanceRef: lum,
       onBrand: AppColors.textPrimary,
+      outline: gradient.colors.first,
     );
   }
 
@@ -127,6 +133,7 @@ class AppBrandTheme extends ThemeExtension<AppBrandTheme> {
       padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
       luminanceRef: lum,
       onBrand: MagentaColors.textPrimary,
+      outline: gradient.colors.first,
     );
   }
 }

--- a/lib/core/widgets/brand_action_tile.dart
+++ b/lib/core/widgets/brand_action_tile.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+import 'brand_gradient_card.dart';
+
+/// Navigable tile using the brand gradient background.
+class BrandActionTile extends StatelessWidget {
+  final Widget? leading;
+  final IconData? leadingIcon;
+  final String title;
+  final String? subtitle;
+  final Widget? trailing;
+  final VoidCallback? onTap;
+
+  const BrandActionTile({
+    super.key,
+    this.leading,
+    this.leadingIcon,
+    required this.title,
+    this.subtitle,
+    this.trailing,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BrandGradientCard(
+      onTap: onTap,
+      child: ListTile(
+        contentPadding: EdgeInsets.zero,
+        leading: leading ?? (leadingIcon != null ? Icon(leadingIcon) : null),
+        title: Text(title),
+        subtitle: subtitle != null ? Text(subtitle!) : null,
+        trailing: trailing ?? const Icon(Icons.chevron_right),
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/brand_outlined_card.dart
+++ b/lib/core/widgets/brand_outlined_card.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_brand_theme.dart';
+import '../theme/design_tokens.dart';
+
+/// Card container with a brand-coloured outline.
+class BrandOutlinedCard extends StatelessWidget {
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+  final VoidCallback? onTap;
+
+  const BrandOutlinedCard({
+    super.key,
+    required this.child,
+    this.padding,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final surface = Theme.of(context).extension<AppBrandTheme>();
+    final radius = (surface?.radius ?? BorderRadius.circular(AppRadius.card)) as BorderRadius;
+    final borderColor = surface?.outline ?? AppGradients.brandGradient.colors.first;
+    final shadow = surface?.shadow;
+
+    Widget content = Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        borderRadius: radius,
+        border: Border.all(color: borderColor, width: 1),
+        boxShadow: shadow,
+      ),
+      padding: padding ?? const EdgeInsets.all(AppSpacing.sm),
+      child: child,
+    );
+
+    if (onTap != null) {
+      content = Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          borderRadius: radius,
+          onTap: onTap,
+          child: content,
+        ),
+      );
+    }
+
+    return content;
+  }
+}

--- a/lib/features/admin/presentation/screens/admin_dashboard_screen.dart
+++ b/lib/features/admin/presentation/screens/admin_dashboard_screen.dart
@@ -14,6 +14,7 @@ import 'package:tapem/features/device/domain/usecases/get_devices_for_gym.dart';
 import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/core/widgets/brand_primary_button.dart';
 
 class AdminDashboardScreen extends StatefulWidget {
   const AdminDashboardScreen({Key? key}) : super(key: key);
@@ -188,43 +189,65 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen> {
           _loading
               ? const Center(child: CircularProgressIndicator())
               : Padding(
-                padding: const EdgeInsets.all(16),
+                padding: const EdgeInsets.all(AppSpacing.sm),
                 child: Column(
                   children: [
-                    ElevatedButton.icon(
-                      icon: const Icon(Icons.add),
-                      label: const Text('Gerät anlegen'),
+                    BrandPrimaryButton(
                       onPressed: _showCreateDialog,
+                      child: const Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(Icons.add),
+                          SizedBox(width: AppSpacing.xs),
+                          Text('Gerät anlegen'),
+                        ],
+                      ),
                     ),
-                    const SizedBox(height: 8),
-                    ElevatedButton.icon(
-                      icon: const Icon(Icons.fitness_center),
-                      label: const Text('Muskelgruppen'),
+                    const SizedBox(height: AppSpacing.sm),
+                    BrandPrimaryButton(
                       onPressed: () {
-                        Navigator.of(
-                          context,
-                        ).pushNamed(AppRouter.manageMuscleGroups);
+                        Navigator.of(context)
+                            .pushNamed(AppRouter.manageMuscleGroups);
                       },
+                      child: const Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(Icons.fitness_center),
+                          SizedBox(width: AppSpacing.xs),
+                          Text('Muskelgruppen'),
+                        ],
+                      ),
                     ),
-                    const SizedBox(height: 8),
-                    ElevatedButton.icon(
-                      icon: const Icon(Icons.brush),
-                      label: const Text('Branding'),
+                    const SizedBox(height: AppSpacing.sm),
+                    BrandPrimaryButton(
                       onPressed: () {
                         Navigator.of(context).pushNamed(AppRouter.branding);
                       },
+                      child: const Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(Icons.brush),
+                          SizedBox(width: AppSpacing.xs),
+                          Text('Branding'),
+                        ],
+                      ),
                     ),
-                    const SizedBox(height: 8),
-                    ElevatedButton.icon(
-                      icon: const Icon(Icons.flag),
-                      label: const Text('Challenges verwalten'),
+                    const SizedBox(height: AppSpacing.sm),
+                    BrandPrimaryButton(
                       onPressed: () {
-                        Navigator.of(
-                          context,
-                        ).pushNamed(AppRouter.manageChallenges);
+                        Navigator.of(context)
+                            .pushNamed(AppRouter.manageChallenges);
                       },
+                      child: const Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(Icons.flag),
+                          SizedBox(width: AppSpacing.xs),
+                          Text('Challenges verwalten'),
+                        ],
+                      ),
                     ),
-                    const SizedBox(height: 24),
+                    const SizedBox(height: AppSpacing.md),
                     Expanded(
                       child: ListView.separated(
                         itemCount: _devices.length,

--- a/lib/features/gym/presentation/widgets/device_card.dart
+++ b/lib/features/gym/presentation/widgets/device_card.dart
@@ -1,9 +1,9 @@
 // lib/features/gym/presentation/widgets/device_card.dart
-import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/core/utils/context_extensions.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/core/widgets/brand_outlined_card.dart';
 
 class DeviceCard extends StatefulWidget {
   final Device device;
@@ -33,17 +33,12 @@ class _DeviceCardState extends State<DeviceCard> {
       child: AnimatedScale(
         duration: AppDurations.short,
         scale: _scale,
-        child: Card(
-          elevation: 4,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(AppRadius.card),
-          ),
-          child: InkWell(
-            borderRadius: BorderRadius.circular(AppRadius.card),
+        child: GestureDetector(
+          onTapDown: _onTapDown,
+          onTapCancel: _onTapEnd,
+          onTapUp: _onTapEnd,
+          child: BrandOutlinedCard(
             onTap: widget.onTap,
-            onTapDown: _onTapDown,
-            onTapCancel: _onTapEnd,
-            onTapUp: _onTapEnd,
             child: SizedBox(
               height: 140,
               child: Padding(

--- a/lib/features/rank/presentation/screens/rank_screen.dart
+++ b/lib/features/rank/presentation/screens/rank_screen.dart
@@ -3,6 +3,8 @@ import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/rank_provider.dart';
 import 'package:tapem/app_router.dart';
 import 'package:tapem/features/challenges/presentation/screens/challenge_tab.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/core/widgets/brand_action_tile.dart';
 
 class RankScreen extends StatefulWidget {
   final String gymId;
@@ -49,38 +51,24 @@ class _RankScreenState extends State<RankScreen>
             controller: _tabController,
             children: [
               ListView(
+                padding: const EdgeInsets.all(AppSpacing.sm),
                 children: [
-                  Card(
-                    margin: const EdgeInsets.all(8),
-                    child: ListTile(
-                      title: const Text('XP je Muskelgruppe'),
-                      trailing: const Icon(Icons.chevron_right),
-                      onTap:
-                          () => Navigator.of(
-                            context,
-                          ).pushNamed(AppRouter.xpOverview),
-                    ),
+                  BrandActionTile(
+                    title: 'XP je Muskelgruppe',
+                    onTap: () =>
+                        Navigator.of(context).pushNamed(AppRouter.xpOverview),
                   ),
-                  Card(
-                    margin: const EdgeInsets.symmetric(horizontal: 8),
-                    child: ListTile(
-                      title: const Text('XP je Trainingstag'),
-                      trailing: const Icon(Icons.chevron_right),
-                      onTap:
-                          () =>
-                              Navigator.of(context).pushNamed(AppRouter.dayXp),
-                    ),
+                  const SizedBox(height: AppSpacing.sm),
+                  BrandActionTile(
+                    title: 'XP je Trainingstag',
+                    onTap: () =>
+                        Navigator.of(context).pushNamed(AppRouter.dayXp),
                   ),
-                  Card(
-                    margin: const EdgeInsets.all(8),
-                    child: ListTile(
-                      title: const Text('XP je Gerät'),
-                      trailing: const Icon(Icons.chevron_right),
-                      onTap:
-                          () => Navigator.of(
-                            context,
-                          ).pushNamed(AppRouter.deviceXp),
-                    ),
+                  const SizedBox(height: AppSpacing.sm),
+                  BrandActionTile(
+                    title: 'XP je Gerät',
+                    onTap: () =>
+                        Navigator.of(context).pushNamed(AppRouter.deviceXp),
                   ),
                 ],
               ),

--- a/lib/features/report/presentation/screens/report_screen_new.dart
+++ b/lib/features/report/presentation/screens/report_screen_new.dart
@@ -9,6 +9,8 @@ import '../../../survey/survey_provider.dart';
 import '../../../survey/survey.dart';
 import '../../../survey/presentation/widgets/create_survey_sheet.dart';
 import '../../../../core/providers/report_provider.dart';
+import '../../../../core/theme/design_tokens.dart';
+import '../../../../core/widgets/brand_action_tile.dart';
 
 class ReportScreenNew extends StatelessWidget {
   final String gymId;
@@ -30,60 +32,45 @@ class ReportScreenNew extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Report')),
       body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(AppSpacing.sm),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             DeviceUsageChart(usageData: data),
-            const SizedBox(height: 24),
-            Card(
-              elevation: 2,
-              child: ListTile(
-                leading: const Icon(Icons.feedback_outlined),
-                title: const Text('Feedback'),
-                subtitle: Text(
-                  openCount > 0
-                      ? '$openCount offene Einträge'
-                      : 'Kein offenes Feedback',
-                ),
-                trailing: const Icon(Icons.chevron_right),
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => FeedbackOverviewScreen(gymId: gymId),
-                    ),
-                  );
-                },
-              ),
+            const SizedBox(height: AppSpacing.md),
+            BrandActionTile(
+              leadingIcon: Icons.feedback_outlined,
+              title: 'Feedback',
+              subtitle: openCount > 0
+                  ? '$openCount offene Einträge'
+                  : 'Kein offenes Feedback',
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => FeedbackOverviewScreen(gymId: gymId),
+                  ),
+                );
+              },
             ),
-            const SizedBox(height: 16),
-            Card(
-              elevation: 2,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  ListTile(
-                    leading: const Icon(Icons.add_circle_outline),
-                    title: const Text('Umfrage erstellen'),
-                    onTap: () => _showCreateSurveyDialog(context),
+            const SizedBox(height: AppSpacing.sm),
+            BrandActionTile(
+              leadingIcon: Icons.add_circle_outline,
+              title: 'Umfrage erstellen',
+              onTap: () => _showCreateSurveyDialog(context),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            BrandActionTile(
+              leadingIcon: Icons.poll,
+              title: 'Umfragen ansehen',
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => SurveyOverviewScreen(gymId: gymId),
                   ),
-                  const Divider(height: 1),
-                  ListTile(
-                    leading: const Icon(Icons.poll),
-                    title: const Text('Umfragen ansehen'),
-                    trailing: const Icon(Icons.chevron_right),
-                    onTap: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => SurveyOverviewScreen(gymId: gymId),
-                        ),
-                      );
-                    },
-                  ),
-                ],
-              ),
+                );
+              },
             ),
           ],
         ),

--- a/lib/features/training_plan/presentation/screens/plan_overview_screen.dart
+++ b/lib/features/training_plan/presentation/screens/plan_overview_screen.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/ui/numeric_keypad/overlay_numeric_keypad.dart';
 
-import 'package:intl/intl.dart';
-
 import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/training_plan_provider.dart';
+import '../../../../core/theme/design_tokens.dart';
+import '../../../../core/widgets/brand_primary_button.dart';
 import 'plan_editor_screen.dart';
 import 'import_plan_screen.dart';
 
@@ -107,11 +107,9 @@ class _PlanOverviewScreenState extends State<PlanOverviewScreen> {
       ),
       floatingActionButton: Column(
         mainAxisAlignment: MainAxisAlignment.end,
+        crossAxisAlignment: CrossAxisAlignment.end,
         children: [
-          FloatingActionButton.extended(
-            heroTag: 'import',
-            icon: const Icon(Icons.upload_file),
-            label: const Text('Importieren'),
+          BrandPrimaryButton(
             onPressed: () {
               Navigator.of(context)
                   .push(
@@ -119,12 +117,17 @@ class _PlanOverviewScreenState extends State<PlanOverviewScreen> {
                   )
                   .then((_) => _reload());
             },
+            child: const Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.upload_file),
+                SizedBox(width: AppSpacing.xs),
+                Text('Importieren'),
+              ],
+            ),
           ),
-          const SizedBox(height: 12),
-          FloatingActionButton.extended(
-            heroTag: 'new',
-            icon: const Icon(Icons.add),
-            label: const Text('Neu'),
+          const SizedBox(height: AppSpacing.sm),
+          BrandPrimaryButton(
             onPressed: () async {
               final cfg = await _askConfig(context);
               if (cfg != null && context.mounted) {
@@ -143,6 +146,14 @@ class _PlanOverviewScreenState extends State<PlanOverviewScreen> {
                     .then((_) => _reload());
               }
             },
+            child: const Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.add),
+                SizedBox(width: AppSpacing.xs),
+                Text('Neu'),
+              ],
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- extend `AppBrandTheme` with an `outline` color token
- add reusable `BrandActionTile` and `BrandOutlinedCard` widgets
- refactor report, admin, rank, training plan, and gym device pages to use brand-styled tiles and buttons

## Testing
- `flutter format lib/core/theme/app_brand_theme.dart lib/core/widgets/brand_action_tile.dart lib/core/widgets/brand_outlined_card.dart lib/features/admin/presentation/screens/admin_dashboard_screen.dart lib/features/gym/presentation/widgets/device_card.dart lib/features/rank/presentation/screens/rank_screen.dart lib/features/report/presentation/screens/report_screen_new.dart lib/features/training_plan/presentation/screens/plan_overview_screen.dart` *(command not found)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d9abec9048320b07e33ffd68b2639