### PR TITLE
fix(device): use theme color for device card border

### DIFF
--- a/lib/ui/devices/device_card.dart
+++ b/lib/ui/devices/device_card.dart
@@ -30,7 +30,7 @@ class DeviceCard extends StatelessWidget {
         color: theme.colorScheme.surfaceVariant,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(14),
-          side: BorderSide(color: theme.colorScheme.outlineVariant),
+          side: BorderSide(color: theme.colorScheme.primary),
         ),
         child: InkWell(
           borderRadius: BorderRadius.circular(14),


### PR DESCRIPTION
## Summary
- apply theme primary color to device card outline

## Testing
- `flutter format lib/ui/devices/device_card.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689db3fca5cc8320a103055786571123