### PR TITLE
feat: add local session draft persistence

### DIFF
--- a/lib/core/drafts/session_draft.dart
+++ b/lib/core/drafts/session_draft.dart
@@ -1,0 +1,111 @@
+import 'dart:convert';
+
+const int kDeviceDraftTtlMs = 60 * 60 * 1000; // 1 hour
+const int kDeviceDraftDebounceMs = 350;
+
+String buildDraftKey({
+  required String gymId,
+  required String userId,
+  required String deviceId,
+  String? exerciseId,
+  required bool isMulti,
+}) {
+  final ex = isMulti ? (exerciseId ?? '') : '-';
+  return '$gymId:$userId:$deviceId:$ex';
+}
+
+class SetDraft {
+  final int index;
+  final String weight;
+  final String reps;
+  final String? rir;
+  final String? tempo;
+  final String? note;
+  final bool done;
+
+  SetDraft({
+    required this.index,
+    this.weight = '',
+    this.reps = '',
+    this.rir,
+    this.tempo,
+    this.note,
+    this.done = false,
+  });
+
+  factory SetDraft.fromJson(Map<String, dynamic> json) => SetDraft(
+        index: json['index'] as int,
+        weight: json['weight'] as String? ?? '',
+        reps: json['reps'] as String? ?? '',
+        rir: json['rir'] as String?,
+        tempo: json['tempo'] as String?,
+        note: json['note'] as String?,
+        done: json['done'] as bool? ?? false,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'index': index,
+        'weight': weight,
+        'reps': reps,
+        if (rir != null) 'rir': rir,
+        if (tempo != null) 'tempo': tempo,
+        if (note != null) 'note': note,
+        'done': done,
+      };
+}
+
+class SessionDraft {
+  final String deviceId;
+  final String? exerciseId;
+  final int createdAt;
+  final int updatedAt;
+  final int ttlMs;
+  final String? units;
+  final String note;
+  final List<SetDraft> sets;
+  final int? version;
+
+  SessionDraft({
+    required this.deviceId,
+    this.exerciseId,
+    required this.createdAt,
+    required this.updatedAt,
+    this.ttlMs = kDeviceDraftTtlMs,
+    this.units,
+    this.note = '',
+    this.sets = const [],
+    this.version,
+  });
+
+  factory SessionDraft.fromJson(Map<String, dynamic> json) => SessionDraft(
+        deviceId: json['deviceId'] as String,
+        exerciseId: json['exerciseId'] as String?,
+        createdAt: json['createdAt'] as int,
+        updatedAt: json['updatedAt'] as int,
+        ttlMs: json['ttlMs'] as int? ?? kDeviceDraftTtlMs,
+        units: json['units'] as String?,
+        note: json['note'] as String? ?? '',
+        sets: (json['sets'] as List<dynamic>? ?? [])
+            .map((e) => SetDraft.fromJson(Map<String, dynamic>.from(e)))
+            .toList(),
+        version: json['version'] as int?,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'deviceId': deviceId,
+        if (exerciseId != null) 'exerciseId': exerciseId,
+        'createdAt': createdAt,
+        'updatedAt': updatedAt,
+        'ttlMs': ttlMs,
+        if (units != null) 'units': units,
+        'note': note,
+        'sets': sets.map((e) => e.toJson()).toList(),
+        if (version != null) 'version': version,
+      };
+
+  String encode() => jsonEncode(toJson());
+
+  factory SessionDraft.decode(String source) =>
+      SessionDraft.fromJson(jsonDecode(source) as Map<String, dynamic>);
+}
+

--- a/lib/core/drafts/session_draft_repository.dart
+++ b/lib/core/drafts/session_draft_repository.dart
@@ -1,0 +1,9 @@
+import 'session_draft.dart';
+
+abstract class SessionDraftRepository {
+  Future<SessionDraft?> get(String key);
+  Future<void> put(String key, SessionDraft draft);
+  Future<void> delete(String key);
+  Future<void> deleteExpired(int nowMs);
+  Future<void> deleteAll();
+}

--- a/lib/core/drafts/session_draft_repository_impl.dart
+++ b/lib/core/drafts/session_draft_repository_impl.dart
@@ -1,0 +1,62 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'session_draft.dart';
+import 'session_draft_repository.dart';
+
+const _prefix = 'sessionDraft/';
+
+class SessionDraftRepositoryImpl implements SessionDraftRepository {
+  @override
+  Future<SessionDraft?> get(String key) async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getString('$_prefix$key');
+    if (data == null) return null;
+    try {
+      return SessionDraft.decode(data);
+    } catch (_) {
+      await prefs.remove('$_prefix$key');
+      return null;
+    }
+  }
+
+  @override
+  Future<void> put(String key, SessionDraft draft) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('$_prefix$key', draft.encode());
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('$_prefix$key');
+  }
+
+  @override
+  Future<void> deleteExpired(int nowMs) async {
+    final prefs = await SharedPreferences.getInstance();
+    final keys = prefs.getKeys().where((k) => k.startsWith(_prefix)).toList();
+    for (final k in keys) {
+      final raw = prefs.getString(k);
+      if (raw == null) continue;
+      try {
+        final draft = SessionDraft.decode(raw);
+        if (nowMs - draft.updatedAt > draft.ttlMs) {
+          await prefs.remove(k);
+        }
+      } catch (_) {
+        await prefs.remove(k);
+      }
+    }
+  }
+
+  @override
+  Future<void> deleteAll() async {
+    final prefs = await SharedPreferences.getInstance();
+    final keys = prefs.getKeys().where((k) => k.startsWith(_prefix)).toList();
+    for (final k in keys) {
+      await prefs.remove(k);
+    }
+  }
+}

--- a/lib/core/providers/auth_provider.dart
+++ b/lib/core/providers/auth_provider.dart
@@ -11,6 +11,7 @@ import 'package:tapem/features/auth/domain/usecases/set_username.dart';
 import 'package:tapem/features/auth/domain/usecases/check_username_available.dart';
 import 'package:tapem/features/auth/domain/usecases/reset_password.dart';
 import 'package:tapem/features/auth/domain/usecases/set_show_in_leaderboard.dart';
+import 'package:tapem/core/drafts/session_draft_repository_impl.dart';
 
 class AuthProvider extends ChangeNotifier {
   final LoginUseCase _loginUC;
@@ -136,6 +137,7 @@ class AuthProvider extends ChangeNotifier {
       _selectedGymCode = null;
       final prefs = await SharedPreferences.getInstance();
       await prefs.remove('selectedGymCode');
+      await SessionDraftRepositoryImpl().deleteAll();
       _setLoading(false);
     }
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,6 +37,7 @@ import 'package:tapem/features/feedback/feedback_provider.dart';
 import 'package:tapem/features/survey/survey_provider.dart';
 import 'features/gym/data/sources/firestore_gym_source.dart';
 import 'ui/numeric_keypad/overlay_numeric_keypad.dart';
+import 'core/drafts/session_draft_repository_impl.dart';
 
 import 'features/nfc/data/nfc_service.dart';
 import 'features/nfc/domain/usecases/read_nfc_code.dart';
@@ -198,7 +199,10 @@ Future<void> main() async {
         ),
         ChangeNotifierProvider(create: (_) => GymProvider()),
         ChangeNotifierProvider(
-          create: (_) => DeviceProvider(firestore: FirebaseFirestore.instance),
+          create: (_) => DeviceProvider(
+            firestore: FirebaseFirestore.instance,
+            draftRepo: SessionDraftRepositoryImpl(),
+          ),
         ),
         ChangeNotifierProvider(create: (_) => TrainingPlanProvider()),
         ChangeNotifierProvider(create: (_) => HistoryProvider()),

--- a/test/core/drafts/session_draft_repository_test.dart
+++ b/test/core/drafts/session_draft_repository_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tapem/core/drafts/session_draft.dart';
+import 'package:tapem/core/drafts/session_draft_repository_impl.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late SessionDraftRepositoryImpl repo;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    repo = SessionDraftRepositoryImpl();
+  });
+
+  test('put/get/delete cycle', () async {
+    final key = buildDraftKey(
+      gymId: 'g1',
+      userId: 'u1',
+      deviceId: 'd1',
+      exerciseId: 'e1',
+      isMulti: true,
+    );
+    final draft = SessionDraft(
+      deviceId: 'd1',
+      exerciseId: 'e1',
+      createdAt: 1,
+      updatedAt: 1,
+      note: 'hi',
+      sets: [SetDraft(index: 1, weight: '10', reps: '5')],
+    );
+    await repo.put(key, draft);
+    final loaded = await repo.get(key);
+    expect(loaded?.note, 'hi');
+    await repo.delete(key);
+    final missing = await repo.get(key);
+    expect(missing, isNull);
+  });
+
+  test('deleteExpired removes outdated drafts', () async {
+    final key = buildDraftKey(
+      gymId: 'g1',
+      userId: 'u1',
+      deviceId: 'd1',
+      exerciseId: '-',
+      isMulti: false,
+    );
+    final oldDraft = SessionDraft(
+      deviceId: 'd1',
+      createdAt: 0,
+      updatedAt: 0,
+      note: '',
+    );
+    await repo.put(key, oldDraft);
+    await repo.deleteExpired(kDeviceDraftTtlMs + 1);
+    final loaded = await repo.get(key);
+    expect(loaded, isNull);
+  });
+
+  test('draftKey scoping for multi vs single device', () {
+    final k1 = buildDraftKey(
+      gymId: 'g',
+      userId: 'u',
+      deviceId: 'd',
+      isMulti: false,
+    );
+    final k2 = buildDraftKey(
+      gymId: 'g',
+      userId: 'u',
+      deviceId: 'd',
+      exerciseId: 'e',
+      isMulti: true,
+    );
+    expect(k1, 'g:u:d:-');
+    expect(k2, 'g:u:d:e');
+    expect(k1 == k2, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- add SessionDraft model and repo using SharedPreferences
- persist and restore device session inputs locally with debounce and TTL
- clear drafts on logout and after successful session save

## Testing
- `flutter test test/core/drafts/session_draft_repository_test.dart` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689e757eca408320a17f113dac198404