### PR TITLE
feat: support multi drop sets

### DIFF
--- a/lib/core/drafts/session_draft.dart
+++ b/lib/core/drafts/session_draft.dart
@@ -14,6 +14,23 @@ String buildDraftKey({
   return '$gymId:$userId:$deviceId:$ex';
 }
 
+class DropSetDraft {
+  final String weight;
+  final String reps;
+
+  DropSetDraft({this.weight = '', this.reps = ''});
+
+  factory DropSetDraft.fromJson(Map<String, dynamic> json) => DropSetDraft(
+        weight: json['weight'] as String? ?? '',
+        reps: json['reps'] as String? ?? '',
+      );
+
+  Map<String, dynamic> toJson() => {
+        'weight': weight,
+        'reps': reps,
+      };
+}
+
 class SetDraft {
   final int index;
   final String weight;
@@ -21,8 +38,7 @@ class SetDraft {
   final String? rir;
   final String? tempo;
   final String? note;
-  final String? dropWeight;
-  final String? dropReps;
+  final List<DropSetDraft> dropSets;
   final bool done;
 
   SetDraft({
@@ -32,22 +48,31 @@ class SetDraft {
     this.rir,
     this.tempo,
     this.note,
-    this.dropWeight,
-    this.dropReps,
+    this.dropSets = const [],
     this.done = false,
   });
 
-  factory SetDraft.fromJson(Map<String, dynamic> json) => SetDraft(
-        index: json['index'] as int,
-        weight: json['weight'] as String? ?? '',
-        reps: json['reps'] as String? ?? '',
-        rir: json['rir'] as String?,
-        tempo: json['tempo'] as String?,
-        note: json['note'] as String?,
-        dropWeight: json['dropWeight'] as String?,
-        dropReps: json['dropReps'] as String?,
-        done: json['done'] as bool? ?? false,
-      );
+  factory SetDraft.fromJson(Map<String, dynamic> json) {
+    final List<dynamic>? dropsRaw = json['dropSets'] as List<dynamic>?;
+    List<DropSetDraft> drops =
+        dropsRaw?.map((e) => DropSetDraft.fromJson(Map<String, dynamic>.from(e))).toList() ?? [];
+    // backward compatibility: old single drop fields
+    final dw = json['dropWeight'] as String?;
+    final dr = json['dropReps'] as String?;
+    if (drops.isEmpty && (dw != null || dr != null)) {
+      drops = [DropSetDraft(weight: dw ?? '', reps: dr ?? '')];
+    }
+    return SetDraft(
+      index: json['index'] as int,
+      weight: json['weight'] as String? ?? '',
+      reps: json['reps'] as String? ?? '',
+      rir: json['rir'] as String?,
+      tempo: json['tempo'] as String?,
+      note: json['note'] as String?,
+      dropSets: drops,
+      done: json['done'] as bool? ?? false,
+    );
+  }
 
   Map<String, dynamic> toJson() => {
         'index': index,
@@ -56,8 +81,8 @@ class SetDraft {
         if (rir != null) 'rir': rir,
         if (tempo != null) 'tempo': tempo,
         if (note != null) 'note': note,
-        if (dropWeight != null) 'dropWeight': dropWeight,
-        if (dropReps != null) 'dropReps': dropReps,
+        if (dropSets.isNotEmpty)
+          'dropSets': dropSets.map((e) => e.toJson()).toList(),
         'done': done,
       };
 }

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -343,7 +343,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                                         ),
                                       ),
                                       const SizedBox(height: 8),
-                                      for (var set in prov.lastSessionSets)
+                                      for (var set in prov.lastSessionSets) ...[
                                         Row(
                                           crossAxisAlignment:
                                               CrossAxisAlignment.start,
@@ -360,17 +360,6 @@ class _DeviceScreenState extends State<DeviceScreen> {
                                             ),
                                             const SizedBox(width: 16),
                                             Text('${set['reps']} x'),
-                                            if (set['dropWeight'] != null &&
-                                                set['dropWeight']!
-                                                    .isNotEmpty) ...[
-                                              const SizedBox(width: 16),
-                                              Text(
-                                                '↘︎ ${set['dropWeight']} kg × ${set['dropReps']}',
-                                                style: Theme.of(context)
-                                                    .textTheme
-                                                    .bodySmall,
-                                              ),
-                                            ],
                                             if (set['rir'] != null &&
                                                 set['rir']!.isNotEmpty) ...[
                                               const SizedBox(width: 16),
@@ -385,6 +374,18 @@ class _DeviceScreenState extends State<DeviceScreen> {
                                             ],
                                           ],
                                         ),
+                                        for (final drop in (set['dropSets'] as List? ?? []))
+                                          Padding(
+                                            padding:
+                                                const EdgeInsets.only(left: 40),
+                                            child: Text(
+                                              '↘︎ ${drop['weight']} kg × ${drop['reps']}',
+                                              style: Theme.of(context)
+                                                  .textTheme
+                                                  .bodySmall,
+                                            ),
+                                          ),
+                                      ],
                                       if (prov.lastSessionNote.isNotEmpty) ...[
                                         const SizedBox(height: 8),
                                         Text('Notiz: ${prov.lastSessionNote}'),

--- a/lib/features/history/data/dtos/workout_log_dto.dart
+++ b/lib/features/history/data/dtos/workout_log_dto.dart
@@ -24,6 +24,7 @@ class WorkoutLogDto {
   final String? note;
   final double? dropWeightKg;
   final int? dropReps;
+  final List<DropSetDto>? dropSets;
 
   WorkoutLogDto({
     required this.userId,
@@ -36,6 +37,7 @@ class WorkoutLogDto {
     this.note,
     this.dropWeightKg,
     this.dropReps,
+    this.dropSets,
   });
 
   factory WorkoutLogDto.fromJson(Map<String, dynamic> json) =>
@@ -62,10 +64,26 @@ class WorkoutLogDto {
     reps: reps,
     rir: rir,
     note: note,
-    dropWeightKg: dropWeightKg,
-    dropReps: dropReps,
+    dropSets: dropSets?.map((e) => DropSet(weightKg: e.weightKg, reps: e.reps)).toList() ??
+        (dropWeightKg != null && dropReps != null
+            ? [DropSet(weightKg: dropWeightKg!, reps: dropReps!)]
+            : []),
   );
 
   static DateTime _timestampToDate(Timestamp ts) => ts.toDate();
   static Timestamp _dateToTimestamp(DateTime date) => Timestamp.fromDate(date);
+}
+
+class DropSetDto {
+  final double weightKg;
+  final int reps;
+
+  DropSetDto({required this.weightKg, required this.reps});
+
+  factory DropSetDto.fromJson(Map<String, dynamic> json) => DropSetDto(
+        weightKg: (json['weightKg'] as num).toDouble(),
+        reps: (json['reps'] as num).toInt(),
+      );
+
+  Map<String, dynamic> toJson() => {'weightKg': weightKg, 'reps': reps};
 }

--- a/lib/features/history/data/dtos/workout_log_dto.g.dart
+++ b/lib/features/history/data/dtos/workout_log_dto.g.dart
@@ -18,6 +18,9 @@ WorkoutLogDto _$WorkoutLogDtoFromJson(Map<String, dynamic> json) =>
       note: json['setNote'] as String?,
       dropWeightKg: (json['dropWeightKg'] as num?)?.toDouble(),
       dropReps: (json['dropReps'] as num?)?.toInt(),
+      dropSets: (json['dropSets'] as List<dynamic>?)
+          ?.map((e) => DropSetDto.fromJson(e as Map<String, dynamic>))
+          .toList(),
     );
 
 Map<String, dynamic> _$WorkoutLogDtoToJson(WorkoutLogDto instance) =>
@@ -32,4 +35,6 @@ Map<String, dynamic> _$WorkoutLogDtoToJson(WorkoutLogDto instance) =>
       if (instance.note != null) 'setNote': instance.note,
       if (instance.dropWeightKg != null) 'dropWeightKg': instance.dropWeightKg,
       if (instance.dropReps != null) 'dropReps': instance.dropReps,
+      if (instance.dropSets != null)
+        'dropSets': instance.dropSets!.map((e) => e.toJson()).toList(),
     };

--- a/lib/features/history/domain/models/workout_log.dart
+++ b/lib/features/history/domain/models/workout_log.dart
@@ -11,8 +11,7 @@ class WorkoutLog {
   final int reps;
   final int? rir;
   final String? note;
-  final double? dropWeightKg;
-  final int? dropReps;
+  final List<DropSet> dropSets;
 
   WorkoutLog({
     required this.id,
@@ -24,7 +23,13 @@ class WorkoutLog {
     required this.reps,
     this.rir,
     this.note,
-    this.dropWeightKg,
-    this.dropReps,
+    this.dropSets = const [],
   });
+}
+
+class DropSet {
+  final double weightKg;
+  final int reps;
+
+  DropSet({required this.weightKg, required this.reps});
 }

--- a/lib/features/history/presentation/screens/history_screen.dart
+++ b/lib/features/history/presentation/screens/history_screen.dart
@@ -353,8 +353,12 @@ class _HistoryScreenState extends State<HistoryScreen> {
                     .map((l) => SessionSet(
                           weight: l.weight,
                           reps: l.reps,
-                          dropWeightKg: l.dropWeightKg,
-                          dropReps: l.dropReps,
+                          dropSets: l.dropSets
+                              .map((d) => DropSet(
+                                    weightKg: d.weightKg,
+                                    reps: d.reps,
+                                  ))
+                              .toList(),
                         ))
                     .toList();
                 return Padding(

--- a/lib/features/training_details/data/dtos/session_dto.dart
+++ b/lib/features/training_details/data/dtos/session_dto.dart
@@ -10,8 +10,7 @@ class SessionDto {
   final DateTime timestamp;
   final double weight;
   final int reps;
-  final double? dropWeightKg;
-  final int? dropReps;
+  final List<DropSetDto> dropSets;
   final String note;
   final DocumentReference<Map<String, dynamic>> reference;
 
@@ -22,8 +21,7 @@ class SessionDto {
     required this.timestamp,
     required this.weight,
     required this.reps,
-    this.dropWeightKg,
-    this.dropReps,
+    this.dropSets = const [],
     required this.note,
     required this.reference,
   });
@@ -42,10 +40,38 @@ class SessionDto {
       timestamp: (data['timestamp'] as Timestamp).toDate(),
       weight: (data['weight'] as num).toDouble(),
       reps: (data['reps'] as num).toInt(),
-      dropWeightKg: (data['dropWeightKg'] as num?)?.toDouble(),
-      dropReps: (data['dropReps'] as num?)?.toInt(),
+      dropSets: _readDropSets(data),
       note: data['note'] as String? ?? '',
       reference: doc.reference,
     );
   }
+
+  static List<DropSetDto> _readDropSets(Map<String, dynamic> data) {
+    final raw = data['dropSets'];
+    if (raw is List) {
+      return raw
+          .map((e) => DropSetDto.fromJson(Map<String, dynamic>.from(e)))
+          .toList();
+    }
+    final dw = (data['dropWeightKg'] as num?)?.toDouble();
+    final dr = (data['dropReps'] as num?)?.toInt();
+    if (dw != null && dr != null) {
+      return [DropSetDto(weightKg: dw, reps: dr)];
+    }
+    return [];
+  }
+}
+
+class DropSetDto {
+  final double weightKg;
+  final int reps;
+
+  DropSetDto({required this.weightKg, required this.reps});
+
+  factory DropSetDto.fromJson(Map<String, dynamic> json) => DropSetDto(
+        weightKg: (json['weightKg'] as num).toDouble(),
+        reps: (json['reps'] as num).toInt(),
+      );
+
+  Map<String, dynamic> toJson() => {'weightKg': weightKg, 'reps': reps};
 }

--- a/lib/features/training_details/data/repositories/session_repository_impl.dart
+++ b/lib/features/training_details/data/repositories/session_repository_impl.dart
@@ -58,8 +58,9 @@ class SessionRepositoryImpl implements SessionRepository {
           .map((dto) => SessionSet(
                 weight: dto.weight,
                 reps: dto.reps,
-                dropWeightKg: dto.dropWeightKg,
-                dropReps: dto.dropReps,
+                dropSets: dto.dropSets
+                    .map((ds) => DropSet(weightKg: ds.weightKg, reps: ds.reps))
+                    .toList(),
               ))
           .toList();
 

--- a/lib/features/training_details/domain/models/session.dart
+++ b/lib/features/training_details/domain/models/session.dart
@@ -22,12 +22,18 @@ class Session {
 class SessionSet {
   final double weight;
   final int reps;
-  final double? dropWeightKg;
-  final int? dropReps;
+  final List<DropSet> dropSets;
+
   SessionSet({
     required this.weight,
     required this.reps,
-    this.dropWeightKg,
-    this.dropReps,
+    this.dropSets = const [],
   });
+}
+
+class DropSet {
+  final double weightKg;
+  final int reps;
+
+  DropSet({required this.weightKg, required this.reps});
 }

--- a/lib/features/training_details/presentation/widgets/session_exercise_card.dart
+++ b/lib/features/training_details/presentation/widgets/session_exercise_card.dart
@@ -80,11 +80,11 @@ class SessionExerciseCard extends StatelessWidget {
                       ),
                     ],
                   ),
-                  if (set.dropWeightKg != null && set.dropReps != null)
+                  for (final drop in set.dropSets)
                     Padding(
                       padding: const EdgeInsets.only(left: 20, top: 2),
                       child: Text(
-                        '↘︎ ${set.dropWeightKg!.toStringAsFixed(1)} kg × ${set.dropReps}',
+                        '↘︎ ${drop.weightKg.toStringAsFixed(1)} kg × ${drop.reps}',
                         style: TextStyle(
                           color: onBrand.withOpacity(0.6),
                           fontSize: 12,

--- a/test/providers/device_provider_test.dart
+++ b/test/providers/device_provider_test.dart
@@ -99,8 +99,9 @@ void main() {
         'weight': 50.0,
         'reps': 10,
         'note': 'n',
-        'dropWeightKg': 40.0,
-        'dropReps': 5,
+        'dropSets': [
+          {'weightKg': 40.0, 'reps': 5},
+        ],
       });
       await logsCol.add({
         'deviceId': 'd1',
@@ -142,8 +143,8 @@ void main() {
 
       expect(provider.device?.uid, 'd1');
       expect(provider.lastSessionSets.length, 2);
-      expect(provider.lastSessionSets.first['dropWeight'], '40.0');
-      expect(provider.lastSessionSets.first['dropReps'], '5');
+      expect(provider.lastSessionSets.first['dropSets'][0]['weight'], '40.0');
+      expect(provider.lastSessionSets.first['dropSets'][0]['reps'], '5');
     });
 
     testWidgets('saveWorkoutSession writes log and adds XP', (tester) async {
@@ -168,7 +169,9 @@ void main() {
         userId: 'u1',
       );
       provider.updateSet(0,
-          weight: '70', reps: '6', dropWeight: '60', dropReps: '5');
+          weight: '70', reps: '6', dropSets: [
+        {'weight': '60', 'reps': '5'}
+      ]);
       provider.toggleSetDone(0);
       provider.setNote('test');
 
@@ -203,8 +206,10 @@ void main() {
           .collection('logs')
           .get();
       expect(logs.docs.length, 1);
-      expect(logs.docs.first.data()['dropWeightKg'], 60.0);
-      expect(logs.docs.first.data()['dropReps'], 5);
+      final drop = logs.docs.first.data()['dropSets'] as List;
+      expect(drop.length, 1);
+      expect(drop.first['weightKg'], 60.0);
+      expect(drop.first['reps'], 5);
       expect(xpRepo.calls, 1);
       expect(chRepo.calls, 1);
     });


### PR DESCRIPTION
## Summary
- allow multiple drop sets with new dropSets model
- update SetCard UI and last session rendering for multiple drops
- adjust persistence, history, and tests for dropSets

## Testing
- `fvm flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a035828a5883209036833c9ff445ef