### PR TITLE
fix: resolve type mismatches in device and history screens

### DIFF
--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -75,7 +75,7 @@ enum SetCardSize { regular, dense }
 class SetCard extends StatefulWidget {
   final int index;
   final Map<String, dynamic> set;
-  final Map<String, String>? previous;
+  final Map<String, dynamic>? previous;
   final SetCardSize size;
   const SetCard({
     super.key,

--- a/lib/features/history/presentation/screens/history_screen.dart
+++ b/lib/features/history/presentation/screens/history_screen.dart
@@ -5,8 +5,9 @@ import 'package:provider/provider.dart';
 
 import 'package:tapem/core/providers/history_provider.dart';
 import 'package:tapem/core/utils/nice_scale.dart';
-import 'package:tapem/features/history/domain/models/workout_log.dart';
-import 'package:tapem/features/training_details/domain/models/session.dart';
+import 'package:tapem/features/history/domain/models/workout_log.dart' as history;
+import 'package:tapem/features/training_details/domain/models/session.dart'
+    as session_models;
 import 'package:tapem/features/training_details/presentation/widgets/session_exercise_card.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
@@ -99,7 +100,7 @@ class _HistoryScreenState extends State<HistoryScreen> {
         ? 1
         : (sessionPoints.length / 6).ceil().clamp(1, sessionPoints.length);
 
-    final sessionsMap = <String, List<WorkoutLog>>{};
+    final sessionsMap = <String, List<history.WorkoutLog>>{};
     for (var log in prov.logs) {
       sessionsMap.putIfAbsent(log.sessionId, () => []).add(log);
     }
@@ -350,11 +351,11 @@ class _HistoryScreenState extends State<HistoryScreen> {
                     .format(logs.first.timestamp);
 
                 final sets = logs
-                    .map((l) => SessionSet(
+                    .map((l) => session_models.SessionSet(
                           weight: l.weight,
                           reps: l.reps,
                           dropSets: l.dropSets
-                              .map((d) => DropSet(
+                              .map((d) => session_models.DropSet(
                                     weightKg: d.weightKg,
                                     reps: d.reps,
                                   ))


### PR DESCRIPTION
## Summary
- accept dynamic map for previous set in SetCard
- disambiguate DropSet imports in history screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a03fc9a6308320981a914392dc4946