### PR TITLE
fix(device): prevent overlay tap leaks

### DIFF
--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -178,6 +178,20 @@ class SetCardState extends State<SetCard> {
       _dropWeightFocuses.add(wf);
       _dropRepsFocuses.add(rf);
     });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final i = _dropWeightCtrls.length - 1;
+      if (i < 0) return;
+      FocusScope.of(context).requestFocus(_dropWeightFocuses[i]);
+      _openKeypad(_dropWeightCtrls[i], allowDecimal: true);
+      final ctx = _dropWeightFocuses[i].context;
+      if (ctx != null) {
+        Scrollable.ensureVisible(
+          ctx,
+          alignment: 0.5,
+          duration: const Duration(milliseconds: 200),
+        );
+      }
+    });
   }
 
   String? _validateDrop(int i, String? _) {


### PR DESCRIPTION
## Summary
- stop keypad overlay taps from reaching underlying widgets and log ignored vs dismiss
- autofocus newly added drop set fields and keep keypad visible

## Testing
- `dart format lib/ui/numeric_keypad/overlay_numeric_keypad.dart lib/features/device/presentation/widgets/set_card.dart` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68a04349a524832097b4826135a074f3