### PR TITLE
fix(keypad): route outside taps to targets

### DIFF
--- a/lib/ui/numeric_keypad/keypad_target_registry.dart
+++ b/lib/ui/numeric_keypad/keypad_target_registry.dart
@@ -1,0 +1,65 @@
+// lib/ui/numeric_keypad/keypad_target_registry.dart
+// Lightweight registry for numeric keypad routing targets.
+
+import 'dart:ui';
+import 'package:flutter/widgets.dart';
+
+/// Type of target handled by the keypad router.
+enum KeypadTargetType { numeric, plus, text }
+
+/// Target information used for routing taps from the keypad barrier.
+class KeypadTarget {
+  KeypadTarget({
+    required this.id,
+    required this.type,
+    required this.getRect,
+    this.focusNode,
+    this.controller,
+    this.allowDecimal = true,
+    this.integerStep,
+    this.decimalStep,
+    this.onCommand,
+  });
+
+  final String id;
+  final KeypadTargetType type;
+  final Rect Function() getRect;
+  final FocusNode? focusNode;
+  final TextEditingController? controller;
+  final bool allowDecimal;
+  final double? integerStep;
+  final double? decimalStep;
+  final VoidCallback? onCommand;
+}
+
+/// Global registry singleton.
+class KeypadTargetRegistry extends ChangeNotifier {
+  KeypadTargetRegistry._();
+
+  static final instance = KeypadTargetRegistry._();
+
+  final List<KeypadTarget> _targets = [];
+
+  List<KeypadTarget> get targets => List.unmodifiable(_targets);
+
+  void register(KeypadTarget target) {
+    _targets.add(target);
+    notifyListeners();
+  }
+
+  void unregister(KeypadTarget target) {
+    _targets.remove(target);
+    notifyListeners();
+  }
+}
+
+/// Utility to compute a global rect from a [GlobalKey].
+Rect globalRectFromKey(GlobalKey key) {
+  final ctx = key.currentContext;
+  if (ctx == null) return Rect.zero;
+  final box = ctx.findRenderObject() as RenderBox?;
+  if (box == null) return Rect.zero;
+  final offset = box.localToGlobal(Offset.zero);
+  return offset & box.size;
+}
+


### PR DESCRIPTION
## Summary
- add registry for keypad routing targets
- convert keypad barrier to route taps for numeric, plus, and text fields
- register SetCard inputs and controls with keypad router

## Testing
- `flutter format lib/ui/numeric_keypad/keypad_target_registry.dart lib/ui/numeric_keypad/overlay_numeric_keypad.dart lib/features/device/presentation/widgets/set_card.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a04715c5e88320bc30c5135e5b253f