### PR TITLE
feat(device): add session snapshot models and repository support

### DIFF
--- a/lib/features/device/data/repositories/device_repository_impl.dart
+++ b/lib/features/device/data/repositories/device_repository_impl.dart
@@ -3,7 +3,9 @@
 import '../dtos/device_dto.dart';
 import '../sources/firestore_device_source.dart';
 import '../../domain/models/device.dart';
+import '../../domain/models/device_session_snapshot.dart';
 import '../../domain/repositories/device_repository.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class DeviceRepositoryImpl implements DeviceRepository {
   final FirestoreDeviceSource _source;
@@ -63,6 +65,39 @@ class DeviceRepositoryImpl implements DeviceRepository {
       deviceId,
       primaryGroups,
       secondaryGroups,
+    );
+  }
+
+  @override
+  Future<void> writeSessionSnapshot(String gymId, DeviceSessionSnapshot snapshot) {
+    return _source.writeSessionSnapshot(gymId, snapshot);
+  }
+
+  @override
+  Future<List<DeviceSessionSnapshot>> fetchSessionSnapshotsPaginated({
+    required String gymId,
+    required String deviceId,
+    required int limit,
+    DocumentSnapshot? startAfter,
+  }) {
+    return _source.fetchSessionSnapshotsPaginated(
+      gymId: gymId,
+      deviceId: deviceId,
+      limit: limit,
+      startAfter: startAfter,
+    );
+  }
+
+  @override
+  Future<DeviceSessionSnapshot?> getSnapshotBySessionId({
+    required String gymId,
+    required String deviceId,
+    required String sessionId,
+  }) {
+    return _source.getSnapshotBySessionId(
+      gymId: gymId,
+      deviceId: deviceId,
+      sessionId: sessionId,
     );
   }
 }

--- a/lib/features/device/domain/models/device_session_snapshot.dart
+++ b/lib/features/device/domain/models/device_session_snapshot.dart
@@ -1,0 +1,110 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:meta/meta.dart';
+
+/// Immutable snapshot of a device session.
+@immutable
+class DeviceSessionSnapshot {
+  final String sessionId;
+  final String deviceId;
+  final String? exerciseId;
+  final DateTime createdAt;
+  final String? note;
+  final List<SetEntry> sets;
+  final int renderVersion;
+  final Map<String, dynamic>? uiHints;
+
+  const DeviceSessionSnapshot({
+    required this.sessionId,
+    required this.deviceId,
+    this.exerciseId,
+    required this.createdAt,
+    this.note,
+    required this.sets,
+    this.renderVersion = 1,
+    this.uiHints,
+  });
+
+  factory DeviceSessionSnapshot.fromJson(Map<String, dynamic> j) {
+    return DeviceSessionSnapshot(
+      sessionId: j['sessionId'] as String,
+      deviceId: j['deviceId'] as String,
+      exerciseId: j['exerciseId'] as String?,
+      createdAt: (j['createdAt'] as Timestamp).toDate(),
+      note: j['note'] as String?,
+      sets: (j['sets'] as List<dynamic>? ?? [])
+          .map((e) => SetEntry.fromJson(Map<String, dynamic>.from(e)))
+          .toList(),
+      renderVersion: j['renderVersion'] as int? ?? 1,
+      uiHints: j['uiHints'] as Map<String, dynamic>?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'sessionId': sessionId,
+        'deviceId': deviceId,
+        'exerciseId': exerciseId,
+        'createdAt': Timestamp.fromDate(createdAt),
+        'note': note,
+        'sets': sets.map((s) => s.toJson()).toList(),
+        'renderVersion': renderVersion,
+        'uiHints': uiHints,
+      };
+}
+
+class SetEntry {
+  final num kg;
+  final int reps;
+  final int? rir;
+  final bool done;
+  final String? note;
+  final List<DropEntry> drops;
+
+  const SetEntry({
+    required this.kg,
+    required this.reps,
+    this.rir,
+    this.done = false,
+    this.note,
+    this.drops = const [],
+  });
+
+  factory SetEntry.fromJson(Map<String, dynamic> j) => SetEntry(
+        kg: j['kg'] as num,
+        reps: j['reps'] as int,
+        rir: j['rir'] as int?,
+        done: j['done'] as bool? ?? false,
+        note: j['note'] as String?,
+        drops: (j['drops'] as List<dynamic>? ?? [])
+            .map((e) => DropEntry.fromJson(Map<String, dynamic>.from(e)))
+            .toList(),
+      );
+
+  Map<String, dynamic> toJson() => {
+        'kg': kg,
+        'reps': reps,
+        'rir': rir,
+        'done': done,
+        'note': note,
+        'drops': drops.map((d) => d.toJson()).toList(),
+      };
+}
+
+class DropEntry {
+  final num kg;
+  final int reps;
+
+  const DropEntry({
+    required this.kg,
+    required this.reps,
+  });
+
+  factory DropEntry.fromJson(Map<String, dynamic> j) => DropEntry(
+        kg: j['kg'] as num,
+        reps: j['reps'] as int,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'kg': kg,
+        'reps': reps,
+      };
+}

--- a/lib/features/device/domain/repositories/device_repository.dart
+++ b/lib/features/device/domain/repositories/device_repository.dart
@@ -1,6 +1,8 @@
 // lib/features/device/domain/repositories/device_repository.dart
 
 import '../models/device.dart';
+import '../models/device_session_snapshot.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 abstract class DeviceRepository {
   Future<List<Device>> getDevicesForGym(String gymId);
@@ -23,4 +25,19 @@ abstract class DeviceRepository {
     List<String> primaryGroups,
     List<String> secondaryGroups,
   );
+
+  Future<void> writeSessionSnapshot(String gymId, DeviceSessionSnapshot snapshot);
+
+  Future<List<DeviceSessionSnapshot>> fetchSessionSnapshotsPaginated({
+    required String gymId,
+    required String deviceId,
+    required int limit,
+    DocumentSnapshot? startAfter,
+  });
+
+  Future<DeviceSessionSnapshot?> getSnapshotBySessionId({
+    required String gymId,
+    required String deviceId,
+    required String sessionId,
+  });
 }

--- a/test/features/device/domain/models/device_session_snapshot_test.dart
+++ b/test/features/device/domain/models/device_session_snapshot_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
+
+void main() {
+  test('DeviceSessionSnapshot serialization', () {
+    final snapshot = DeviceSessionSnapshot(
+      sessionId: 's1',
+      deviceId: 'd1',
+      exerciseId: 'e1',
+      createdAt: DateTime.fromMillisecondsSinceEpoch(0),
+      note: 'note',
+      sets: const [
+        SetEntry(
+          kg: 20,
+          reps: 10,
+          rir: 2,
+          done: true,
+          note: 'set',
+          drops: [DropEntry(kg: 10, reps: 5)],
+        ),
+      ],
+    );
+
+    final json = snapshot.toJson();
+    expect(json['sessionId'], 's1');
+    expect(json['deviceId'], 'd1');
+    expect((json['createdAt'] as Timestamp).millisecondsSinceEpoch, 0);
+
+    final decoded = DeviceSessionSnapshot.fromJson(json);
+    expect(decoded.sessionId, snapshot.sessionId);
+    expect(decoded.sets.first.drops.first.kg, 10);
+  });
+}


### PR DESCRIPTION
## Summary
- introduce `DeviceSessionSnapshot` model with set and drop entries
- extend device repository and Firestore source to handle session snapshots
- add unit test for snapshot serialization

## Testing
- `flutter test test/features/device/domain/models/device_session_snapshot_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a21f8a2ff08320a47610186cf74e78