### PR TITLE
Add session snapshot pagination and device pager scaffolding

### DIFF
--- a/lib/features/device/domain/models/device_session_snapshot.dart
+++ b/lib/features/device/domain/models/device_session_snapshot.dart
@@ -1,5 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart' show immutable;
 
 /// Immutable snapshot of a device session.
 @immutable

--- a/lib/features/device/domain/repositories/device_repository.dart
+++ b/lib/features/device/domain/repositories/device_repository.dart
@@ -40,4 +40,6 @@ abstract class DeviceRepository {
     required String deviceId,
     required String sessionId,
   });
+
+  DocumentSnapshot? get lastSnapshotCursor;
 }

--- a/lib/features/device/presentation/widgets/device_pager.dart
+++ b/lib/features/device/presentation/widgets/device_pager.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:tapem/core/providers/device_provider.dart';
+import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
+import 'set_card.dart';
+
+class DevicePager extends StatefulWidget {
+  final Widget editablePage;
+  final DeviceProvider provider;
+  final String gymId;
+  final String deviceId;
+  const DevicePager({
+    super.key,
+    required this.editablePage,
+    required this.provider,
+    required this.gymId,
+    required this.deviceId,
+  });
+
+  @override
+  State<DevicePager> createState() => _DevicePagerState();
+}
+
+class _DevicePagerState extends State<DevicePager> {
+  late final PageController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = PageController();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final prov = widget.provider;
+    final itemCount = 1 + prov.sessionSnapshots.length;
+    return Stack(
+      children: [
+        PageView.builder(
+          controller: _controller,
+          itemCount: itemCount,
+          onPageChanged: (index) {
+            if (index >= itemCount - 2 && prov.hasMoreSnapshots) {
+              prov.loadMoreSnapshots(
+                gymId: widget.gymId,
+                deviceId: widget.deviceId,
+              );
+            }
+          },
+          itemBuilder: (context, index) {
+            if (index == 0) return widget.editablePage;
+            final snap = prov.sessionSnapshots[index - 1];
+            return ReadOnlySnapshotPage(
+              snapshot: snap,
+              onJumpToCurrent: () => _controller.animateToPage(
+                0,
+                duration: const Duration(milliseconds: 300),
+                curve: Curves.easeInOut,
+              ),
+            );
+          },
+        ),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTap: () => _controller.previousPage(
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.easeInOut,
+            ),
+            child: const SizedBox(width: 28),
+          ),
+        ),
+        Align(
+          alignment: Alignment.centerRight,
+          child: GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTap: () => _controller.nextPage(
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.easeInOut,
+            ),
+            child: const SizedBox(width: 28),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class ReadOnlySnapshotPage extends StatelessWidget {
+  final DeviceSessionSnapshot snapshot;
+  final VoidCallback onJumpToCurrent;
+  const ReadOnlySnapshotPage({
+    super.key,
+    required this.snapshot,
+    required this.onJumpToCurrent,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              Text(
+                DateFormat('dd.MM.yyyy HH:mm').format(snapshot.createdAt),
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 16),
+              for (var i = 0; i < snapshot.sets.length; i++)
+                SetCard(
+                  index: i,
+                  set: {
+                    'number': '${i + 1}',
+                    'weight': snapshot.sets[i].kg.toString(),
+                    'reps': snapshot.sets[i].reps.toString(),
+                    'rir': snapshot.sets[i].rir?.toString() ?? '',
+                    'note': snapshot.sets[i].note,
+                    'dropWeight': snapshot.sets[i].drops.isNotEmpty
+                        ? snapshot.sets[i].drops.first.kg.toString()
+                        : '',
+                    'dropReps': snapshot.sets[i].drops.isNotEmpty
+                        ? snapshot.sets[i].drops.first.reps.toString()
+                        : '',
+                    'done': snapshot.sets[i].done,
+                  },
+                  readOnly: true,
+                  size: SetCardSize.dense,
+                ),
+              if (snapshot.note != null && snapshot.note!.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(top: 16),
+                  child: Text(snapshot.note!),
+                ),
+            ],
+          ),
+        ),
+        TextButton(
+          onPressed: onJumpToCurrent,
+          child: const Text('Zur aktuellen Session'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -77,12 +77,14 @@ class SetCard extends StatefulWidget {
   final Map<String, dynamic> set;
   final Map<String, String>? previous;
   final SetCardSize size;
+  final bool readOnly;
   const SetCard({
     super.key,
     required this.index,
     required this.set,
     this.previous,
     this.size = SetCardSize.regular,
+    this.readOnly = false,
   });
 
   @override
@@ -131,48 +133,50 @@ class SetCardState extends State<SetCard> {
     _dropWeightFocus = FocusNode();
     _dropRepsFocus = FocusNode();
 
-    _weightCtrl.addListener(() {
-      if (_muteCtrls) return;
-      _slog(widget.index, 'weight → "${_weightCtrl.text}"');
-      context.read<DeviceProvider>().updateSet(
-        widget.index,
-        weight: _weightCtrl.text,
-      );
-    });
-    _repsCtrl.addListener(() {
-      if (_muteCtrls) return;
-      _slog(widget.index, 'reps → "${_repsCtrl.text}"');
-      context.read<DeviceProvider>().updateSet(
-        widget.index,
-        reps: _repsCtrl.text,
-      );
-    });
-    _rirCtrl.addListener(() {
-      if (_muteCtrls) return;
-      _slog(widget.index, 'rir → "${_rirCtrl.text}"');
-      context.read<DeviceProvider>().updateSet(
-        widget.index,
-        rir: _rirCtrl.text,
-      );
-    });
-    _dropWeightCtrl.addListener(() {
-      if (_muteCtrls) return;
-      _slog(widget.index, 'dropWeight → "${_dropWeightCtrl.text}"');
-      context.read<DeviceProvider>().updateSet(
-        widget.index,
-        dropWeight: _dropWeightCtrl.text,
-        dropReps: _dropRepsCtrl.text,
-      );
-    });
-    _dropRepsCtrl.addListener(() {
-      if (_muteCtrls) return;
-      _slog(widget.index, 'dropReps → "${_dropRepsCtrl.text}"');
-      context.read<DeviceProvider>().updateSet(
-        widget.index,
-        dropWeight: _dropWeightCtrl.text,
-        dropReps: _dropRepsCtrl.text,
-      );
-    });
+    if (!widget.readOnly) {
+      _weightCtrl.addListener(() {
+        if (_muteCtrls) return;
+        _slog(widget.index, 'weight → "${_weightCtrl.text}"');
+        context.read<DeviceProvider>().updateSet(
+          widget.index,
+          weight: _weightCtrl.text,
+        );
+      });
+      _repsCtrl.addListener(() {
+        if (_muteCtrls) return;
+        _slog(widget.index, 'reps → "${_repsCtrl.text}"');
+        context.read<DeviceProvider>().updateSet(
+          widget.index,
+          reps: _repsCtrl.text,
+        );
+      });
+      _rirCtrl.addListener(() {
+        if (_muteCtrls) return;
+        _slog(widget.index, 'rir → "${_rirCtrl.text}"');
+        context.read<DeviceProvider>().updateSet(
+          widget.index,
+          rir: _rirCtrl.text,
+        );
+      });
+      _dropWeightCtrl.addListener(() {
+        if (_muteCtrls) return;
+        _slog(widget.index, 'dropWeight → "${_dropWeightCtrl.text}"');
+        context.read<DeviceProvider>().updateSet(
+          widget.index,
+          dropWeight: _dropWeightCtrl.text,
+          dropReps: _dropRepsCtrl.text,
+        );
+      });
+      _dropRepsCtrl.addListener(() {
+        if (_muteCtrls) return;
+        _slog(widget.index, 'dropReps → "${_dropRepsCtrl.text}"');
+        context.read<DeviceProvider>().updateSet(
+          widget.index,
+          dropWeight: _dropWeightCtrl.text,
+          dropReps: _dropRepsCtrl.text,
+        );
+      });
+    }
   }
 
   @override
@@ -395,6 +399,7 @@ class SetCardState extends State<SetCard> {
                         labelText: loc.dropKgFieldLabel,
                         isDense: true,
                       ),
+                      enabled: !widget.readOnly,
                       readOnly: true,
                       keyboardType: TextInputType.none,
                       validator: _validateDrop,
@@ -412,6 +417,7 @@ class SetCardState extends State<SetCard> {
                         labelText: loc.dropRepsFieldLabel,
                         isDense: true,
                       ),
+                      enabled: !widget.readOnly,
                       readOnly: true,
                       keyboardType: TextInputType.none,
                       validator: _validateDrop,
@@ -434,6 +440,7 @@ class SetCardState extends State<SetCard> {
                         labelText: 'RIR',
                         isDense: true,
                       ),
+                      enabled: !widget.readOnly,
                       readOnly: true,
                       keyboardType: TextInputType.none,
                       onTap: done
@@ -445,7 +452,8 @@ class SetCardState extends State<SetCard> {
                   Expanded(
                     flex: 2,
                     child: TextFormField(
-                      readOnly: done,
+                      enabled: !widget.readOnly,
+                      readOnly: widget.readOnly || done,
                       initialValue: widget.set['note'] as String?,
                       decoration: InputDecoration(
                         labelText: loc.noteFieldLabel,
@@ -590,6 +598,7 @@ class _InputPill extends StatelessWidget {
         child: TextFormField(
           controller: controller,
           focusNode: focusNode,
+          enabled: !widget.readOnly,
           readOnly: true,
           onTap: readOnly ? null : onTap,
           keyboardType: TextInputType.none,

--- a/test/providers/device_provider_test.dart
+++ b/test/providers/device_provider_test.dart
@@ -30,6 +30,27 @@ class FakeDeviceRepository implements DeviceRepository {
   Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) => throw UnimplementedError();
   @override
   Future<void> setMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) => throw UnimplementedError();
+
+  @override
+  Future<void> writeSessionSnapshot(String gymId, DeviceSessionSnapshot snapshot) async {}
+
+  @override
+  Future<List<DeviceSessionSnapshot>> fetchSessionSnapshotsPaginated({
+    required String gymId,
+    required String deviceId,
+    required int limit,
+    DocumentSnapshot? startAfter,
+  }) async => <DeviceSessionSnapshot>[];
+
+  @override
+  Future<DeviceSessionSnapshot?> getSnapshotBySessionId({
+    required String gymId,
+    required String deviceId,
+    required String sessionId,
+  }) async => null;
+
+  @override
+  DocumentSnapshot? get lastSnapshotCursor => null;
 }
 
 class FakeXpRepository implements XpRepository {

--- a/test/ui/exercise_list_chips_update_test.dart
+++ b/test/ui/exercise_list_chips_update_test.dart
@@ -87,6 +87,27 @@ class _FakeDeviceRepo implements DeviceRepository {
   Future<void> setMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
   @override
   Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
+
+  @override
+  Future<void> writeSessionSnapshot(String gymId, DeviceSessionSnapshot snapshot) async {}
+
+  @override
+  Future<List<DeviceSessionSnapshot>> fetchSessionSnapshotsPaginated({
+    required String gymId,
+    required String deviceId,
+    required int limit,
+    DocumentSnapshot? startAfter,
+  }) async => <DeviceSessionSnapshot>[];
+
+  @override
+  Future<DeviceSessionSnapshot?> getSnapshotBySessionId({
+    required String gymId,
+    required String deviceId,
+    required String sessionId,
+  }) async => null;
+
+  @override
+  DocumentSnapshot? get lastSnapshotCursor => null;
 }
 
 class _FakeMuscleGroupProvider extends MuscleGroupProvider {

--- a/test/ui/gym/device_card_test.dart
+++ b/test/ui/gym/device_card_test.dart
@@ -59,6 +59,27 @@ class _DummyDeviceRepo implements DeviceRepository {
 
   @override
   Future<void> setMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
+
+  @override
+  Future<void> writeSessionSnapshot(String gymId, DeviceSessionSnapshot snapshot) async {}
+
+  @override
+  Future<List<DeviceSessionSnapshot>> fetchSessionSnapshotsPaginated({
+    required String gymId,
+    required String deviceId,
+    required int limit,
+    DocumentSnapshot? startAfter,
+  }) async => <DeviceSessionSnapshot>[];
+
+  @override
+  Future<DeviceSessionSnapshot?> getSnapshotBySessionId({
+    required String gymId,
+    required String deviceId,
+    required String sessionId,
+  }) async => null;
+
+  @override
+  DocumentSnapshot? get lastSnapshotCursor => null;
 }
 
 MuscleGroupProvider _makeProvider() {

--- a/test/ui/gym/search_and_filters_test.dart
+++ b/test/ui/gym/search_and_filters_test.dart
@@ -58,6 +58,27 @@ class _DummyDeviceRepo implements DeviceRepository {
 
   @override
   Future<void> setMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
+
+  @override
+  Future<void> writeSessionSnapshot(String gymId, DeviceSessionSnapshot snapshot) async {}
+
+  @override
+  Future<List<DeviceSessionSnapshot>> fetchSessionSnapshotsPaginated({
+    required String gymId,
+    required String deviceId,
+    required int limit,
+    DocumentSnapshot? startAfter,
+  }) async => <DeviceSessionSnapshot>[];
+
+  @override
+  Future<DeviceSessionSnapshot?> getSnapshotBySessionId({
+    required String gymId,
+    required String deviceId,
+    required String sessionId,
+  }) async => null;
+
+  @override
+  DocumentSnapshot? get lastSnapshotCursor => null;
 }
 
 class _TestMuscleGroupProvider extends MuscleGroupProvider {

--- a/test/widgets/dismissible_session_list_test.dart
+++ b/test/widgets/dismissible_session_list_test.dart
@@ -23,6 +23,27 @@ class _FakeRepo implements DeviceRepository {
   Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) => throw UnimplementedError();
   @override
   Future<void> setMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) => throw UnimplementedError();
+
+  @override
+  Future<void> writeSessionSnapshot(String gymId, DeviceSessionSnapshot snapshot) async {}
+
+  @override
+  Future<List<DeviceSessionSnapshot>> fetchSessionSnapshotsPaginated({
+    required String gymId,
+    required String deviceId,
+    required int limit,
+    DocumentSnapshot? startAfter,
+  }) async => <DeviceSessionSnapshot>[];
+
+  @override
+  Future<DeviceSessionSnapshot?> getSnapshotBySessionId({
+    required String gymId,
+    required String deviceId,
+    required String sessionId,
+  }) async => null;
+
+  @override
+  DocumentSnapshot? get lastSnapshotCursor => null;
 }
 
 class _TestList extends StatelessWidget {

--- a/test/widgets/exercise_bottom_sheet_selected_preview_test.dart
+++ b/test/widgets/exercise_bottom_sheet_selected_preview_test.dart
@@ -56,6 +56,27 @@ class _FakeDeviceRepo implements DeviceRepository {
   Future<void> setMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
   @override
   Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
+
+  @override
+  Future<void> writeSessionSnapshot(String gymId, DeviceSessionSnapshot snapshot) async {}
+
+  @override
+  Future<List<DeviceSessionSnapshot>> fetchSessionSnapshotsPaginated({
+    required String gymId,
+    required String deviceId,
+    required int limit,
+    DocumentSnapshot? startAfter,
+  }) async => <DeviceSessionSnapshot>[];
+
+  @override
+  Future<DeviceSessionSnapshot?> getSnapshotBySessionId({
+    required String gymId,
+    required String deviceId,
+    required String sessionId,
+  }) async => null;
+
+  @override
+  DocumentSnapshot? get lastSnapshotCursor => null;
 }
 
 class FakeMuscleGroupProvider extends MuscleGroupProvider {

--- a/test/widgets/muscle_group_list_selector_test.dart
+++ b/test/widgets/muscle_group_list_selector_test.dart
@@ -52,6 +52,27 @@ class _FakeDeviceRepo implements DeviceRepository {
   Future<void> setMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
   @override
   Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
+
+  @override
+  Future<void> writeSessionSnapshot(String gymId, DeviceSessionSnapshot snapshot) async {}
+
+  @override
+  Future<List<DeviceSessionSnapshot>> fetchSessionSnapshotsPaginated({
+    required String gymId,
+    required String deviceId,
+    required int limit,
+    DocumentSnapshot? startAfter,
+  }) async => <DeviceSessionSnapshot>[];
+
+  @override
+  Future<DeviceSessionSnapshot?> getSnapshotBySessionId({
+    required String gymId,
+    required String deviceId,
+    required String sessionId,
+  }) async => null;
+
+  @override
+  DocumentSnapshot? get lastSnapshotCursor => null;
 }
 
 class _FakeMuscleGroupProvider extends MuscleGroupProvider {

--- a/test/widgets/muscle_group_selector_test.dart
+++ b/test/widgets/muscle_group_selector_test.dart
@@ -54,6 +54,27 @@ class _FakeDeviceRepo implements DeviceRepository {
   Future<void> setMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
   @override
   Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) async {}
+
+  @override
+  Future<void> writeSessionSnapshot(String gymId, DeviceSessionSnapshot snapshot) async {}
+
+  @override
+  Future<List<DeviceSessionSnapshot>> fetchSessionSnapshotsPaginated({
+    required String gymId,
+    required String deviceId,
+    required int limit,
+    DocumentSnapshot? startAfter,
+  }) async => <DeviceSessionSnapshot>[];
+
+  @override
+  Future<DeviceSessionSnapshot?> getSnapshotBySessionId({
+    required String gymId,
+    required String deviceId,
+    required String sessionId,
+  }) async => null;
+
+  @override
+  DocumentSnapshot? get lastSnapshotCursor => null;
 }
 
 class FakeMuscleGroupProvider extends MuscleGroupProvider {

--- a/test/widgets/set_card_test.dart
+++ b/test/widgets/set_card_test.dart
@@ -23,6 +23,27 @@ class _FakeRepo implements DeviceRepository {
   Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) => throw UnimplementedError();
   @override
   Future<void> setMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) => throw UnimplementedError();
+
+  @override
+  Future<void> writeSessionSnapshot(String gymId, DeviceSessionSnapshot snapshot) async {}
+
+  @override
+  Future<List<DeviceSessionSnapshot>> fetchSessionSnapshotsPaginated({
+    required String gymId,
+    required String deviceId,
+    required int limit,
+    DocumentSnapshot? startAfter,
+  }) async => <DeviceSessionSnapshot>[];
+
+  @override
+  Future<DeviceSessionSnapshot?> getSnapshotBySessionId({
+    required String gymId,
+    required String deviceId,
+    required String sessionId,
+  }) async => null;
+
+  @override
+  DocumentSnapshot? get lastSnapshotCursor => null;
 }
 
 void main() {


### PR DESCRIPTION
## Summary
- replace meta import with foundation immutable annotation
- extend DeviceProvider with session snapshot pagination and snapshot writing
- expose pagination cursor in DeviceRepository and Firestore source
- add readOnly support in SetCard and scaffold DevicePager for history browsing

## Testing
- `flutter analyze` *(command not found)*
- `dart test test/features/device/domain/models/device_session_snapshot_test.dart` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a226080bb0832096259806427f8419