### PR TITLE
fix(device): resolve analyzer errors

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -11,6 +11,7 @@ import 'package:tapem/features/device/data/repositories/device_repository_impl.d
 import 'package:tapem/features/device/data/sources/firestore_device_source.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
+import 'package:tapem/features/device/domain/repositories/device_repository.dart';
 import 'package:tapem/features/device/domain/usecases/get_devices_for_gym.dart';
 import 'package:uuid/uuid.dart';
 import 'package:tapem/features/rank/domain/models/level_info.dart';

--- a/lib/features/device/data/repositories/device_repository_impl.dart
+++ b/lib/features/device/data/repositories/device_repository_impl.dart
@@ -13,6 +13,7 @@ class DeviceRepositoryImpl implements DeviceRepository {
 
   DocumentSnapshot? _lastSnapshotCursor;
 
+  @override
   DocumentSnapshot? get lastSnapshotCursor => _lastSnapshotCursor;
 
   @override

--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -598,7 +598,7 @@ class _InputPill extends StatelessWidget {
         child: TextFormField(
           controller: controller,
           focusNode: focusNode,
-          enabled: !widget.readOnly,
+          enabled: !readOnly,
           readOnly: true,
           onTap: readOnly ? null : onTap,
           keyboardType: TextInputType.none,

--- a/test/providers/device_provider_test.dart
+++ b/test/providers/device_provider_test.dart
@@ -8,6 +8,7 @@ import 'package:tapem/core/providers/challenge_provider.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/features/device/domain/repositories/device_repository.dart';
 import 'package:tapem/features/device/domain/usecases/get_devices_for_gym.dart';
+import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
 import 'package:tapem/features/xp/domain/xp_repository.dart';
 import 'package:tapem/features/challenges/domain/repositories/challenge_repository.dart';
 import 'package:tapem/features/challenges/domain/models/challenge.dart';

--- a/test/ui/exercise_list_chips_update_test.dart
+++ b/test/ui/exercise_list_chips_update_test.dart
@@ -20,6 +20,8 @@ import 'package:tapem/features/history/domain/usecases/get_history_for_device.da
 import 'package:tapem/features/device/domain/usecases/update_device_muscle_groups_usecase.dart';
 import 'package:tapem/features/device/domain/usecases/set_device_muscle_groups_usecase.dart';
 import 'package:tapem/features/device/domain/repositories/device_repository.dart';
+import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:tapem/features/history/domain/models/workout_log.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/features/device/presentation/screens/exercise_list_screen.dart';

--- a/test/ui/gym/device_card_test.dart
+++ b/test/ui/gym/device_card_test.dart
@@ -15,6 +15,8 @@ import 'package:tapem/features/history/domain/models/workout_log.dart';
 import 'package:tapem/features/device/domain/repositories/device_repository.dart';
 import 'package:tapem/features/device/domain/usecases/update_device_muscle_groups_usecase.dart';
 import 'package:tapem/features/device/domain/usecases/set_device_muscle_groups_usecase.dart';
+import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class _DummyMuscleGroupRepo implements MuscleGroupRepository {
   @override

--- a/test/ui/gym/search_and_filters_test.dart
+++ b/test/ui/gym/search_and_filters_test.dart
@@ -14,6 +14,8 @@ import 'package:tapem/features/device/domain/repositories/device_repository.dart
 import 'package:tapem/features/device/domain/usecases/update_device_muscle_groups_usecase.dart';
 import 'package:tapem/features/device/domain/usecases/set_device_muscle_groups_usecase.dart';
 import 'package:tapem/ui/common/search_and_filters.dart';
+import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class _DummyMuscleGroupRepo implements MuscleGroupRepository {
   @override

--- a/test/widgets/dismissible_session_list_test.dart
+++ b/test/widgets/dismissible_session_list_test.dart
@@ -9,6 +9,8 @@ import 'package:tapem/features/device/domain/usecases/get_devices_for_gym.dart';
 import 'package:tapem/features/device/domain/repositories/device_repository.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/ui/numeric_keypad/overlay_numeric_keypad.dart';
+import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class _FakeRepo implements DeviceRepository {
   @override

--- a/test/widgets/exercise_bottom_sheet_selected_preview_test.dart
+++ b/test/widgets/exercise_bottom_sheet_selected_preview_test.dart
@@ -17,6 +17,8 @@ import 'package:tapem/features/device/domain/usecases/set_device_muscle_groups_u
 import 'package:tapem/features/device/domain/repositories/device_repository.dart';
 import 'package:tapem/features/history/domain/models/workout_log.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
+import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class _FakeMuscleGroupRepo implements MuscleGroupRepository {
   final List<MuscleGroup> groups;

--- a/test/widgets/muscle_group_list_selector_test.dart
+++ b/test/widgets/muscle_group_list_selector_test.dart
@@ -15,6 +15,8 @@ import 'package:tapem/features/history/domain/models/workout_log.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/ui/muscles/muscle_group_list_selector.dart';
 import 'package:tapem/l10n/app_localizations.dart';
+import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class _FakeMuscleGroupRepo implements MuscleGroupRepository {
   final List<MuscleGroup> groups;

--- a/test/widgets/muscle_group_selector_test.dart
+++ b/test/widgets/muscle_group_selector_test.dart
@@ -15,6 +15,8 @@ import 'package:tapem/features/device/domain/repositories/device_repository.dart
 import 'package:tapem/features/history/domain/models/workout_log.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/l10n/app_localizations.dart';
+import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class _FakeMuscleGroupRepo implements MuscleGroupRepository {
   final List<MuscleGroup> groups;

--- a/test/widgets/set_card_test.dart
+++ b/test/widgets/set_card_test.dart
@@ -9,6 +9,8 @@ import 'package:tapem/features/device/domain/repositories/device_repository.dart
 import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/ui/numeric_keypad/overlay_numeric_keypad.dart';
+import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class _FakeRepo implements DeviceRepository {
   @override


### PR DESCRIPTION
## Summary
- import DeviceRepository in DeviceProvider
- mark lastSnapshotCursor override in DeviceRepositoryImpl
- fix set card read-only check and add missing test imports

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a22a433a6c83208d936b941fa95323