### PR TITLE
feat: add snapshot pager to device screen

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -229,6 +229,10 @@ class DeviceProvider extends ChangeNotifier {
       _log(
         '🧩 [Provider] loadDevice initialized sets=${_sets.length} ${_setsBrief(_sets)}',
       );
+      _sessionSnapshots.clear();
+      _lastSnapshotCursor = null;
+      _snapshotsHasMore = true;
+      _snapshotsLoading = false;
       notifyListeners();
 
       await _loadLastSession(gymId, deviceId, exerciseId, userId);
@@ -237,11 +241,6 @@ class DeviceProvider extends ChangeNotifier {
         await _loadUserXp(gymId, deviceId, userId);
       }
       await _restoreDraft();
-      unawaited(loadMoreSnapshots(
-        gymId: gymId,
-        deviceId: deviceId,
-        pageSize: 10,
-      ));
       _log(
         '✅ [Provider] loadDevice done device=${_device!.name} exerciseId=$exerciseId',
       );

--- a/lib/features/device/presentation/widgets/read_only_snapshot_page.dart
+++ b/lib/features/device/presentation/widgets/read_only_snapshot_page.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
+import 'set_card.dart';
+import 'package:tapem/core/widgets/brand_gradient_card.dart';
+
+class ReadOnlySnapshotPage extends StatelessWidget {
+  final DeviceSessionSnapshot snapshot;
+  const ReadOnlySnapshotPage({super.key, required this.snapshot});
+
+  @override
+  Widget build(BuildContext context) {
+    final dateStr = DateFormat('dd.MM.yyyy HH:mm').format(snapshot.createdAt);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              Text(dateStr, style: const TextStyle(fontWeight: FontWeight.bold)),
+              if (snapshot.note != null && snapshot.note!.isNotEmpty)
+                const Padding(
+                  padding: EdgeInsets.only(left: 8),
+                  child: Icon(Icons.note, size: 16),
+                ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: ListView.separated(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            itemCount: snapshot.sets.length,
+            itemBuilder: (context, i) {
+              final s = snapshot.sets[i];
+              return SetCard(
+                index: i,
+                set: {
+                  'number': '${i + 1}',
+                  'weight': s.kg.toString(),
+                  'reps': s.reps.toString(),
+                  'rir': s.rir?.toString() ?? '',
+                  'note': s.note,
+                  'dropWeight': s.drops.isNotEmpty
+                      ? s.drops.first.kg.toString()
+                      : '',
+                  'dropReps': s.drops.isNotEmpty
+                      ? s.drops.first.reps.toString()
+                      : '',
+                  'done': s.done,
+                },
+                readOnly: true,
+                size: SetCardSize.dense,
+              );
+            },
+            separatorBuilder: (_, __) => const SizedBox(height: 8),
+          ),
+        ),
+        if (snapshot.note != null && snapshot.note!.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: BrandGradientCard(
+              padding: const EdgeInsets.all(12),
+              child: Text(snapshot.note!),
+            ),
+          ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add DevicePager with swipeable history and navigation controls
- render read-only session snapshots with proper headers and notes
- ensure SetCard disables editing when readOnly

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b958ebd083208f89790b2781634e