### PR TITLE
fix: handle nullable onTap in set card

### DIFF
--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -583,7 +583,7 @@ class _InputPill extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: readOnly ? null : () => onTap(),
+      onTap: readOnly ? null : () => onTap?.call(),
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 150),
         decoration: BoxDecoration(


### PR DESCRIPTION
## Summary
- handle nullable onTap in `_InputPill`'s `GestureDetector`

## Testing
- `dart format lib/features/device/presentation/widgets/set_card.dart` *(fails: command not found)*
- `flutter format lib/features/device/presentation/widgets/set_card.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2bd15bbc08320903b43365d48102d