### PR TITLE
feat: reverse pager navigation and swipe gestures

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -252,66 +252,77 @@ class _DeviceScreenState extends State<DeviceScreen> {
                         builder: (context) {
                           return Padding(
                             padding: const EdgeInsets.symmetric(vertical: 8),
-                            child: BrandGradientCard(
-                              padding: const EdgeInsets.all(AppSpacing.sm),
-                              child: Column(
-                                crossAxisAlignment:
-                                    CrossAxisAlignment.stretch,
-                                children: [
-                                  Text(
-                                    'Letzte Session: ${DateFormat.yMd(locale).add_Hm().format(prov.lastSessionDate!)}',
-                                    style: const TextStyle(
-                                      fontWeight: FontWeight.w600,
+                            child: GestureDetector(
+                              behavior: HitTestBehavior.opaque,
+                              onHorizontalDragEnd: (d) {
+                                final v = d.primaryVelocity ?? 0;
+                                if (v > 250) {
+                                  _pagerKey.currentState?.goToPreviousSession();
+                                } else if (v < -250) {
+                                  _pagerKey.currentState?.goToNextSession();
+                                }
+                              },
+                              child: BrandGradientCard(
+                                padding: const EdgeInsets.all(AppSpacing.sm),
+                                child: Column(
+                                  crossAxisAlignment:
+                                      CrossAxisAlignment.stretch,
+                                  children: [
+                                    Text(
+                                      'Letzte Session: ${DateFormat.yMd(locale).add_Hm().format(prov.lastSessionDate!)}',
+                                      style: const TextStyle(
+                                        fontWeight: FontWeight.w600,
+                                      ),
                                     ),
-                                  ),
-                                  const SizedBox(height: 8),
-                                  for (final set in prov.lastSessionSets)
-                                    Row(
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.start,
-                                      children: [
-                                        Text('${set['number']}. '),
-                                        const SizedBox(width: 12),
-                                        BrandGradientCard(
-                                          padding: const EdgeInsets.symmetric(
-                                            horizontal: AppSpacing.sm,
-                                            vertical: AppSpacing.xs,
-                                          ),
-                                          child: Text(
-                                            '${set['weight']} kg',
-                                          ),
-                                        ),
-                                        const SizedBox(width: 16),
-                                        Text('${set['reps']} x'),
-                                        if (set['dropWeight'] != null &&
-                                            set['dropWeight']!.isNotEmpty) ...[
-                                          const SizedBox(width: 16),
-                                          Text(
-                                            '↘︎ ${set['dropWeight']} kg × ${set['dropReps']}',
-                                            style: Theme.of(context)
-                                                .textTheme
-                                                .bodySmall,
-                                          ),
-                                        ],
-                                        if (set['rir'] != null &&
-                                            set['rir']!.isNotEmpty) ...[
-                                          const SizedBox(width: 16),
-                                          Text('RIR ${set['rir']}'),
-                                        ],
-                                        if (set['note'] != null &&
-                                            set['note']!.isNotEmpty) ...[
-                                          const SizedBox(width: 16),
-                                          Expanded(
-                                            child: Text(set['note']!),
-                                          ),
-                                        ],
-                                      ],
-                                    ),
-                                  if (prov.lastSessionNote.isNotEmpty) ...[
                                     const SizedBox(height: 8),
-                                    Text('Notiz: ${prov.lastSessionNote}'),
+                                    for (final set in prov.lastSessionSets)
+                                      Row(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        children: [
+                                          Text('${set['number']}. '),
+                                          const SizedBox(width: 12),
+                                          BrandGradientCard(
+                                            padding: const EdgeInsets.symmetric(
+                                              horizontal: AppSpacing.sm,
+                                              vertical: AppSpacing.xs,
+                                            ),
+                                            child: Text(
+                                              '${set['weight']} kg',
+                                            ),
+                                          ),
+                                          const SizedBox(width: 16),
+                                          Text('${set['reps']} x'),
+                                          if (set['dropWeight'] != null &&
+                                              set['dropWeight']!.isNotEmpty) ...[
+                                            const SizedBox(width: 16),
+                                            Text(
+                                              '↘︎ ${set['dropWeight']} kg × ${set['dropReps']}',
+                                              style: Theme.of(context)
+                                                  .textTheme
+                                                  .bodySmall,
+                                            ),
+                                          ],
+                                          if (set['rir'] != null &&
+                                              set['rir']!.isNotEmpty) ...[
+                                            const SizedBox(width: 16),
+                                            Text('RIR ${set['rir']}'),
+                                          ],
+                                          if (set['note'] != null &&
+                                              set['note']!.isNotEmpty) ...[
+                                            const SizedBox(width: 16),
+                                            Expanded(
+                                              child: Text(set['note']!),
+                                            ),
+                                          ],
+                                        ],
+                                      ),
+                                    if (prov.lastSessionNote.isNotEmpty) ...[
+                                      const SizedBox(height: 8),
+                                      Text('Notiz: ${prov.lastSessionNote}'),
+                                    ],
                                   ],
-                                ],
+                                ),
                               ),
                             ),
                           );

--- a/lib/features/device/presentation/widgets/device_pager.dart
+++ b/lib/features/device/presentation/widgets/device_pager.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 import 'package:tapem/core/providers/device_provider.dart';
 import 'read_only_snapshot_page.dart';
@@ -21,82 +22,78 @@ class DevicePager extends StatefulWidget {
 }
 
 class DevicePagerState extends State<DevicePager> {
-  late final PageController _controller;
+  late final PageController _pc;
   int _currentIndex = 0;
 
   @override
   void initState() {
     super.initState();
-    _controller = PageController();
+    _pc = PageController(initialPage: 0);
   }
 
   @override
   void dispose() {
-    _controller.dispose();
+    _pc.dispose();
     super.dispose();
   }
 
   void animateToPage(int page) {
-    _controller.animateToPage(
+    _pc.animateToPage(
       page,
       duration: const Duration(milliseconds: 300),
       curve: Curves.easeInOut,
     );
   }
 
+  void _goToPreviousSession() {
+    _pc.nextPage(
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  void _goToNextSession() {
+    _pc.previousPage(
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  void goToPreviousSession() => _goToPreviousSession();
+  void goToNextSession() => _goToNextSession();
+
   @override
   Widget build(BuildContext context) {
     final prov = widget.provider;
     final itemCount = 1 + prov.sessionSnapshots.length;
+
+    final pageView = PageView.builder(
+      controller: _pc,
+      reverse: true,
+      physics: const PageScrollPhysics(),
+      itemCount: itemCount,
+      onPageChanged: (index) {
+        setState(() => _currentIndex = index);
+        HapticFeedback.lightImpact();
+        if (index >= itemCount - 2 && prov.hasMoreSnapshots) {
+          prov.loadMoreSnapshots(
+            gymId: widget.gymId,
+            deviceId: widget.deviceId,
+          );
+        }
+      },
+      itemBuilder: (context, index) {
+        if (index == 0) return widget.editablePage;
+        final snap = prov.sessionSnapshots[index - 1];
+        return ReadOnlySnapshotPage(snapshot: snap);
+      },
+    );
+
+    final isEditor = _pc.hasClients ? _pc.page?.round() == 0 : true;
+
     return Stack(
       children: [
-        PageView.builder(
-          controller: _controller,
-          physics: const PageScrollPhysics(),
-          itemCount: itemCount,
-          onPageChanged: (index) {
-            setState(() => _currentIndex = index);
-            if (index >= itemCount - 2 && prov.hasMoreSnapshots) {
-              prov.loadMoreSnapshots(
-                gymId: widget.gymId,
-                deviceId: widget.deviceId,
-              );
-            }
-          },
-          itemBuilder: (context, index) {
-            if (index == 0) return widget.editablePage;
-            final snap = prov.sessionSnapshots[index - 1];
-            return ReadOnlySnapshotPage(snapshot: snap);
-          },
-        ),
-        Positioned(
-          left: 0,
-          top: 0,
-          bottom: 0,
-          child: IconButton(
-            icon: const Icon(Icons.chevron_left),
-            onPressed: _currentIndex == 0
-                ? null
-                : () => _controller.previousPage(
-                      duration: const Duration(milliseconds: 300),
-                      curve: Curves.easeInOut,
-                    ),
-          ),
-        ),
-        Positioned(
-          right: 0,
-          top: 0,
-          bottom: 0,
-          child: IconButton(
-            icon: const Icon(Icons.chevron_right),
-            onPressed: _currentIndex == itemCount - 1
-                ? null
-                : () => _controller.nextPage(
-                      duration: const Duration(milliseconds: 300),
-                      curve: Curves.easeInOut,
-                    ),
-          ),
-        ),
+        pageView,
         if (prov.sessionSnapshots.isEmpty && !prov.isLoadingSnapshots)
           Positioned.fill(
             child: IgnorePointer(
@@ -108,20 +105,108 @@ class DevicePagerState extends State<DevicePager> {
               ),
             ),
           ),
-        Positioned(
-          bottom: 8,
-          left: 0,
-          right: 0,
-          child: Center(
-            child: _currentIndex == 0
-                ? const SizedBox.shrink()
-                : Text(
-                    DateFormat('dd.MM.yyyy')
-                        .format(prov.sessionSnapshots[_currentIndex - 1].createdAt),
-                  ),
-          ),
+        EdgeGestureOverlay(
+          enabled: isEditor,
+          onLeftEdgeSwipe: _goToPreviousSession,
+          onRightEdgeSwipe: _goToNextSession,
         ),
+        _buildChevrons(itemCount),
+        _buildBottomDate(prov),
       ],
+    );
+  }
+
+  Widget _buildChevrons(int itemCount) {
+    return Positioned.fill(
+      child: Row(
+        children: [
+          IconButton(
+            icon: const Icon(Icons.chevron_left),
+            tooltip: 'Vorherige Session',
+            onPressed:
+                _currentIndex == itemCount - 1 ? null : _goToPreviousSession,
+          ),
+          const Spacer(),
+          IconButton(
+            icon: const Icon(Icons.chevron_right),
+            tooltip: 'Neuere / Aktuelle',
+            onPressed: _currentIndex == 0 ? null : _goToNextSession,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBottomDate(DeviceProvider prov) {
+    return Positioned(
+      bottom: 8,
+      left: 0,
+      right: 0,
+      child: Center(
+        child: _currentIndex == 0
+            ? const SizedBox.shrink()
+            : Text(
+                DateFormat('dd.MM.yyyy')
+                    .format(prov.sessionSnapshots[_currentIndex - 1].createdAt),
+              ),
+      ),
+    );
+  }
+}
+
+class EdgeGestureOverlay extends StatelessWidget {
+  const EdgeGestureOverlay({
+    super.key,
+    required this.onLeftEdgeSwipe,
+    required this.onRightEdgeSwipe,
+    required this.enabled,
+  });
+
+  final VoidCallback onLeftEdgeSwipe;
+  final VoidCallback onRightEdgeSwipe;
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!enabled) return const SizedBox.shrink();
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        const edge = 28.0;
+        return IgnorePointer(
+          ignoring: false,
+          child: Row(
+            children: [
+              SizedBox(
+                width: edge,
+                height: double.infinity,
+                child: GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+                  onHorizontalDragEnd: (details) {
+                    if (details.primaryVelocity != null &&
+                        details.primaryVelocity! > 250) {
+                      onLeftEdgeSwipe();
+                    }
+                  },
+                ),
+              ),
+              const Expanded(child: SizedBox()),
+              SizedBox(
+                width: edge,
+                height: double.infinity,
+                child: GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+                  onHorizontalDragEnd: (details) {
+                    if (details.primaryVelocity != null &&
+                        details.primaryVelocity! < -250) {
+                      onRightEdgeSwipe();
+                    }
+                  },
+                ),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }

--- a/test/widgets/device_pager_test.dart
+++ b/test/widgets/device_pager_test.dart
@@ -1,0 +1,72 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/core/providers/device_provider.dart';
+import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
+import 'package:tapem/features/device/domain/repositories/device_repository.dart';
+import 'package:tapem/features/device/presentation/widgets/device_pager.dart';
+
+class _FakeDeviceRepository implements DeviceRepository {
+  final List<DeviceSessionSnapshot> snaps;
+  _FakeDeviceRepository(this.snaps);
+
+  @override
+  Future<List<DeviceSessionSnapshot>> fetchSessionSnapshotsPaginated({
+    required String gymId,
+    required String deviceId,
+    required int limit,
+    DocumentSnapshot? startAfter,
+  }) async => snaps;
+
+  @override
+  DocumentSnapshot? get lastSnapshotCursor => null;
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  testWidgets('pager direction and swipe handlers', (tester) async {
+    final snapshot = DeviceSessionSnapshot(
+      sessionId: 's1',
+      deviceId: 'd1',
+      createdAt: DateTime(2023, 1, 1),
+      note: 'snapnote',
+      sets: const [SetEntry(kg: 10, reps: 5)],
+    );
+    final repo = _FakeDeviceRepository([snapshot]);
+    final prov = DeviceProvider(
+      firestore: FakeFirebaseFirestore(),
+      deviceRepository: repo,
+    );
+    await prov.loadMoreSnapshots(gymId: 'g', deviceId: 'd');
+
+    await tester.pumpWidget(MaterialApp(
+      home: DevicePager(
+        editablePage: const Text('edit'),
+        provider: prov,
+        gymId: 'g',
+        deviceId: 'd',
+      ),
+    ));
+
+    expect(find.text('edit'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Vorherige Session'));
+    await tester.pumpAndSettle();
+    expect(find.text('snapnote'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Neuere / Aktuelle'));
+    await tester.pumpAndSettle();
+    expect(find.text('edit'), findsOneWidget);
+
+    await tester.dragFrom(const Offset(5, 300), const Offset(300, 0));
+    await tester.pumpAndSettle();
+    expect(find.text('snapnote'), findsOneWidget);
+
+    await tester.dragFrom(const Offset(300, 300), const Offset(-300, 0));
+    await tester.pumpAndSettle();
+    expect(find.text('edit'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- reverse session pager so previous sessions sit to the left and swap chevron controls
- add edge swipe overlay and swipable last-session card to avoid editor conflicts
- refine chevron labels, add light haptic feedback, and cover pager navigation in widget test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d2c3d67483209212c5d3e56e5567