### PR TITLE
fix: ensure last session date is non-null

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -245,7 +245,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                         ),
                       ),
                     ],
-                    if (lastSets.isNotEmpty) ...[
+                    if (lastDate != null && lastSets.isNotEmpty) ...[
                       const SizedBox(height: 16),
                       const Divider(),
                       Builder(
@@ -263,7 +263,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                                 }
                               },
                               child: LastSessionCard(
-                                date: lastDate,
+                                date: lastDate!,
                                 sets: lastSets,
                                 note: lastNote,
                               ),


### PR DESCRIPTION
## Summary
- avoid passing a nullable `lastDate` to `LastSessionCard`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2e840e7748320b90530e57383fcef