### PR TITLE
feat: hide last session by flag and scope snapshots to user

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,4 +1,4 @@
 # Migration Notes
 
 - Create a Firestore composite index for `gyms/{gymId}/devices/{deviceId}/sessions` on `userId` equality and `createdAt` descending order.
-- Backfill existing session snapshots without `userId` by setting the field based on owning user when first read.
+- Optionally backfill legacy session snapshots that lack a `userId` by setting the field based on the owning user when first read.

--- a/lib/core/config/feature_flags.dart
+++ b/lib/core/config/feature_flags.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/foundation.dart';
+
+class FF {
+  // Standard auf false: „Letzte Session“-Card wird NICHT angezeigt.
+  static const bool showLastSessionOnDevicePage = false;
+
+  // Optional: für lokale Tests aktivierbar via dart-define
+  // siehe: FF.runtimeShowLastSessionOnDevicePage
+  static bool get runtimeShowLastSessionOnDevicePage {
+    const v = String.fromEnvironment('SHOW_LAST_SESSION_CARD', defaultValue: 'false');
+    return v.toLowerCase() == 'true';
+  }
+
+  @visibleForTesting
+  static bool get isLastSessionVisible => showLastSessionOnDevicePage || runtimeShowLastSessionOnDevicePage;
+}

--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -23,6 +23,7 @@ import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:tapem/core/drafts/session_draft.dart';
 import 'package:tapem/core/drafts/session_draft_repository.dart';
 import 'package:tapem/core/drafts/session_draft_repository_impl.dart';
+import 'package:tapem/core/config/feature_flags.dart';
 
 typedef LogFn = void Function(String message, [StackTrace? stack]);
 
@@ -244,7 +245,9 @@ class DeviceProvider extends ChangeNotifier {
         userId: userId,
       );
 
-      await _loadLastSession(gymId, deviceId, exerciseId, userId);
+      if (FF.isLastSessionVisible) {
+        await _loadLastSession(gymId, deviceId, exerciseId, userId);
+      }
       await _loadUserNote(gymId, deviceId, userId);
       if (!_device!.isMulti) {
         await _loadUserXp(gymId, deviceId, userId);

--- a/lib/features/device/data/repositories/device_repository_impl.dart
+++ b/lib/features/device/data/repositories/device_repository_impl.dart
@@ -87,7 +87,7 @@ class DeviceRepositoryImpl implements DeviceRepository {
     required int limit,
     DocumentSnapshot? startAfter,
   }) async {
-    var snap = await _source.fetchSessionSnapshotsPage(
+    final snap = await _source.fetchSessionSnapshotsPage(
       gymId: gymId,
       deviceId: deviceId,
       userId: userId,
@@ -96,7 +96,7 @@ class DeviceRepositoryImpl implements DeviceRepository {
     );
 
     if (snap.docs.isEmpty && startAfter == null) {
-      snap = await _source.fetchSessionSnapshotsPage(
+      final legacy = await _source.fetchSessionSnapshotsPage(
         gymId: gymId,
         deviceId: deviceId,
         userId: null,
@@ -104,7 +104,7 @@ class DeviceRepositoryImpl implements DeviceRepository {
         startAfter: startAfter,
       );
       bool backfilled = false;
-      for (final d in snap.docs) {
+      for (final d in legacy.docs) {
         final data = d.data();
         if (data['userId'] == null) {
           backfilled = true;

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -9,6 +9,7 @@ import 'package:tapem/core/widgets/brand_primary_button.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
 import 'package:tapem/l10n/app_localizations.dart';
+import 'package:tapem/core/config/feature_flags.dart';
 
 import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
@@ -245,9 +246,10 @@ class _DeviceScreenState extends State<DeviceScreen> {
                         ),
                       ),
                     ],
-                    if (lastDate != null && lastSets.isNotEmpty) ...[
+                    if (FF.isLastSessionVisible &&
+                        lastDate != null &&
+                        lastSets.isNotEmpty) ...[
                       const SizedBox(height: 16),
-                      const Divider(),
                       Builder(
                         builder: (context) {
                           return Padding(
@@ -271,6 +273,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                           );
                         },
                       ),
+                      const SizedBox(height: 12),
                     ],
                   ],
                 );

--- a/test/device_screen_no_last_session_test.dart
+++ b/test/device_screen_no_last_session_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/core/config/feature_flags.dart';
+import 'package:tapem/features/device/presentation/widgets/last_session_card.dart';
+
+void main() {
+  testWidgets('hides last session when flag is false', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              if (FF.isLastSessionVisible) ...[
+                const SizedBox(height: 16),
+                LastSessionCard(
+                  date: DateTime(2000),
+                  sets: const [],
+                  note: null,
+                ),
+                const SizedBox(height: 12),
+              ]
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(LastSessionCard), findsNothing);
+    expect(find.text('Letzte Session'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- add feature flag to toggle last session card
- hide last session card & skip loading when flag disabled
- ensure snapshot queries filter by userId and backfill legacy docs
- add migration note for sessions index and optional backfill
- add widget test confirming card hidden by default

## Testing
- `flutter test test/device_screen_no_last_session_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ec049e448320873aedc12b4af381