### PR TITLE
Allow self-service gym membership

### DIFF
--- a/firestore-tests/security_rules.test.js
+++ b/firestore-tests/security_rules.test.js
@@ -71,10 +71,16 @@ describe('Security Rules v1', function () {
       await assertSucceeds(ref.get());
     });
 
-    it('prevents membership self-write (membership_admin_only)', async () => {
-      const db = userA().firestore();
-      const ref = db.collection('gyms').doc('G1').collection('users').doc('userA');
-      await assertFails(ref.set({ role: 'member' }));
+    it('allows user to create own membership', async () => {
+      const db = noMember().firestore();
+      const ref = db.collection('gyms').doc('G1').collection('users').doc('noMember');
+      await assertSucceeds(ref.set({ role: 'member' }));
+    });
+
+    it('blocks user from creating admin membership', async () => {
+      const db = testEnv.authenticatedContext('rogueUser', {}).firestore();
+      const ref = db.collection('gyms').doc('G1').collection('users').doc('rogueUser');
+      await assertFails(ref.set({ role: 'admin' }));
     });
 
     it('allows admin membership write', async () => {

--- a/firestore.rules
+++ b/firestore.rules
@@ -170,9 +170,11 @@ service cloud.firestore {
       // ---- Users subcollection ----
       // Users are referenced under their gym as well
       match /users/{userId} {
-        // v1 hardening: membership lifecycle admin-only (membership_admin_only)
         allow read: if inGym(gymId);
-        allow create, update, delete: if isAdmin(gymId);
+        allow create: if request.auth != null &&
+                       request.auth.uid == userId &&
+                       request.resource.data.role == 'member';
+        allow update, delete: if isAdmin(gymId);
       }
       match /users/{userId}/{doc=**} {
         allow read, write: if ownerOrAdmin(gymId, userId);

--- a/lib/features/auth/data/sources/firestore_auth_source.dart
+++ b/lib/features/auth/data/sources/firestore_auth_source.dart
@@ -52,8 +52,16 @@ class FirestoreAuthSource {
     );
     await _firestore.collection('users').doc(uid).set(dto.toJson());
 
-    // v1 hardening: membership creation is admin-only (membership_admin_only)
-    // Admins must add the user to a gym via server-side process.
+    // create gym membership so the user can access gym data
+    await _firestore
+        .collection('gyms')
+        .doc(gym.id)
+        .collection('users')
+        .doc(uid)
+        .set({
+      'role': 'member',
+      'createdAt': now,
+    });
 
     return dto;
   }


### PR DESCRIPTION
## Summary
- Create gym membership document automatically during registration
- Permit signed-in users to create their own gym membership in Firestore rules
- Update security rule tests for membership creation and restriction

## Testing
- `npm run rules-test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68a2fe52195c83208fb7c84fa4b0302f