### PR TITLE
Ensure membership before gym reads

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,3 +2,7 @@
 
 - Create a Firestore composite index for `gyms/{gymId}/devices/{deviceId}/sessions` on `userId` equality and `createdAt` descending order.
 - Optionally backfill legacy session snapshots that lack a `userId` by setting the field based on the owning user when first read.
+
+- Neue Nutzer werden beim ersten Zugriff automatisch unter `gyms/{gymId}/users/{uid}` mit `role: 'member'` registriert.
+- Bei `permission-denied` gibt es einen einmaligen Retry nach Membership-Sicherung.
+- Sessions sind owner-basiert geregelt; Abfragen scopen auf `userId`.

--- a/firestore.rules
+++ b/firestore.rules
@@ -100,6 +100,13 @@ service cloud.firestore {
           allow update, delete: if false;
         }
 
+        // Session snapshots per user
+        match /sessions/{sessionId} {
+          allow create: if requestOwnerInGym(gymId);
+          allow read: if resourceOwnerOrAdmin(gymId);
+          allow update, delete: if false;
+        }
+
         // Each user manages their own notes for the device.
         match /userNotes/{userId} {
           allow read, write: if ownerOrAdmin(gymId, userId);

--- a/lib/core/providers/branding_provider.dart
+++ b/lib/core/providers/branding_provider.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/foundation.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:tapem/features/gym/data/sources/firestore_gym_source.dart';
 import 'package:tapem/features/gym/domain/models/branding.dart';
+import 'package:tapem/services/membership_service.dart';
 
 typedef LogFn = void Function(String message, [StackTrace? stack]);
 
@@ -16,10 +18,15 @@ void _defaultLog(String message, [StackTrace? stack]) {
 class BrandingProvider extends ChangeNotifier {
   final FirestoreGymSource _source;
   final LogFn _log;
+  final MembershipService _membership;
 
-  BrandingProvider({required FirestoreGymSource source, LogFn? log})
-    : _source = source,
-      _log = log ?? _defaultLog;
+  BrandingProvider({
+    required FirestoreGymSource source,
+    required MembershipService membership,
+    LogFn? log,
+  })  : _source = source,
+        _membership = membership,
+        _log = log ?? _defaultLog;
 
   Branding? _branding;
   bool _isLoading = false;
@@ -31,13 +38,26 @@ class BrandingProvider extends ChangeNotifier {
   String? get error => _error;
   String? get gymId => _gymId;
 
-  Future<void> loadBranding(String gymId) async {
+  Future<void> loadBranding(String gymId, String uid) async {
     _isLoading = true;
     _error = null;
     _gymId = gymId;
     notifyListeners();
     try {
-      _branding = await _source.getBranding(gymId);
+      await _membership.ensureMembership(gymId, uid);
+      try {
+        _branding = await _source.getBranding(gymId);
+      } on FirebaseException catch (e) {
+        if (e.code == 'permission-denied') {
+          _log('RULES_DENIED path=gyms/$gymId/config/branding op=read');
+          await _membership.ensureMembership(gymId, uid);
+          _log(
+              'RETRY_AFTER_ENSURE_MEMBERSHIP path=gyms/$gymId/config/branding op=read');
+          _branding = await _source.getBranding(gymId);
+        } else {
+          rethrow;
+        }
+      }
     } catch (e, st) {
       _error = 'Fehler beim Laden: ${e.toString()}';
       _log('BrandingProvider.loadBranding error: $e', st);
@@ -48,13 +68,13 @@ class BrandingProvider extends ChangeNotifier {
     }
   }
 
-  void loadBrandingWithGym(String? gymId) {
-    if (gymId == null || gymId.isEmpty) {
+  void loadBrandingWithGym(String? gymId, String? uid) {
+    if (gymId == null || gymId.isEmpty || uid == null) {
       _branding = null;
       _gymId = null;
       notifyListeners();
       return;
     }
-    loadBranding(gymId);
+    loadBranding(gymId, uid);
   }
 }

--- a/lib/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_admin_screen.dart
@@ -34,7 +34,7 @@ class _MuscleGroupAdminScreenState extends State<MuscleGroupAdminScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final auth = context.read<AuthProvider>();
       final gymId = auth.gymCode ?? '';
-      context.read<DeviceProvider>().loadDevices(gymId);
+      context.read<DeviceProvider>().loadDevices(gymId, auth.userId!);
       context.read<MuscleGroupProvider>().loadGroups(context);
     });
   }

--- a/lib/features/nfc/widgets/nfc_scan_button.dart
+++ b/lib/features/nfc/widgets/nfc_scan_button.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/features/device/domain/usecases/get_device_by_nfc_code.dart';
+import 'package:tapem/services/membership_service.dart';
 
 class NfcScanButton extends StatelessWidget {
   const NfcScanButton({super.key});
@@ -13,6 +14,7 @@ class NfcScanButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final authProv = context.read<AuthProvider>();
     final getDeviceUC = context.read<GetDeviceByNfcCode>();
+    final membership = context.read<MembershipService>();
 
     return IconButton(
       icon: const Icon(Icons.nfc),
@@ -62,6 +64,8 @@ class NfcScanButton extends StatelessWidget {
                 );
                 return;
               }
+
+              await membership.ensureMembership(gymId, authProv.userId!);
 
               // Navigation basierend auf dev.isMulti
               if (dev.isMulti) {

--- a/lib/features/training_plan/presentation/widgets/device_selection_dialog.dart
+++ b/lib/features/training_plan/presentation/widgets/device_selection_dialog.dart
@@ -15,7 +15,7 @@ Future<ExerciseEntry?> showDeviceSelectionDialog(
   final gymId = context.read<AuthProvider>().gymCode!;
   final userId = context.read<AuthProvider>().userId!;
   final deviceProv = context.read<DeviceProvider>();
-  await deviceProv.loadDevices(gymId);
+  await deviceProv.loadDevices(gymId, userId);
   final devices = deviceProv.devices;
   final exProv = context.read<ExerciseProvider>();
 

--- a/lib/services/membership_service.dart
+++ b/lib/services/membership_service.dart
@@ -1,0 +1,46 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+
+typedef LogFn = void Function(String message, [StackTrace? stack]);
+
+void _defaultLog(String message, [StackTrace? stack]) {
+  if (stack != null) {
+    debugPrintStack(label: message, stackTrace: stack);
+  } else {
+    debugPrint(message);
+  }
+}
+
+abstract class MembershipService {
+  Future<void> ensureMembership(String gymId, String uid);
+}
+
+class FirestoreMembershipService implements MembershipService {
+  final FirebaseFirestore _firestore;
+  final LogFn _log;
+  final Set<String> _ensured = {};
+
+  FirestoreMembershipService({FirebaseFirestore? firestore, LogFn? log})
+      : _firestore = firestore ?? FirebaseFirestore.instance,
+        _log = log ?? _defaultLog;
+
+  @override
+  Future<void> ensureMembership(String gymId, String uid) async {
+    final key = '$gymId|$uid';
+    if (_ensured.contains(key)) return;
+    _log('ENSURE_MEMBERSHIP start gymId=$gymId uid=$uid');
+    try {
+      await _firestore
+          .collection('gyms')
+          .doc(gymId)
+          .collection('users')
+          .doc(uid)
+          .set({'role': 'member'}, SetOptions(merge: true));
+      _ensured.add(key);
+      _log('ENSURE_MEMBERSHIP success gymId=$gymId uid=$uid');
+    } catch (e, st) {
+      _log('ENSURE_MEMBERSHIP fail gymId=$gymId uid=$uid error=$e', st);
+      rethrow;
+    }
+  }
+}

--- a/test/providers/branding_provider_test.dart
+++ b/test/providers/branding_provider_test.dart
@@ -3,6 +3,7 @@ import 'package:tapem/core/providers/branding_provider.dart';
 import 'package:tapem/features/gym/data/sources/firestore_gym_source.dart';
 import 'package:tapem/features/gym/domain/models/branding.dart';
 import 'package:tapem/features/gym/domain/models/gym_config.dart';
+import 'package:tapem/services/membership_service.dart';
 
 class FakeGymSource implements FirestoreGymSource {
   FakeGymSource({this.branding, this.throwError});
@@ -22,6 +23,11 @@ class FakeGymSource implements FirestoreGymSource {
   }
 }
 
+class FakeMembershipService implements MembershipService {
+  @override
+  Future<void> ensureMembership(String gymId, String uid) async {}
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -30,9 +36,10 @@ void main() {
       final source = FakeGymSource(branding: Branding(logoUrl: 'x'));
       final provider = BrandingProvider(
         source: source,
+        membership: FakeMembershipService(),
         log: (_, [__]) {},
       );
-      await provider.loadBranding('g1');
+      await provider.loadBranding('g1', 'u1');
       expect(provider.branding?.logoUrl, 'x');
       expect(provider.error, isNull);
     });
@@ -41,9 +48,10 @@ void main() {
       final source = FakeGymSource(branding: null);
       final provider = BrandingProvider(
         source: source,
+        membership: FakeMembershipService(),
         log: (_, [__]) {},
       );
-      await provider.loadBranding('g1');
+      await provider.loadBranding('g1', 'u1');
       expect(provider.branding, isNull);
     });
 
@@ -51,9 +59,10 @@ void main() {
       final source = FakeGymSource(throwError: true);
       final provider = BrandingProvider(
         source: source,
+        membership: FakeMembershipService(),
         log: (_, [__]) {},
       );
-      await provider.loadBranding('g1');
+      await provider.loadBranding('g1', 'u1');
       expect(provider.branding, isNull);
       expect(provider.error, isNotNull);
     });

--- a/test/providers/device_provider_test.dart
+++ b/test/providers/device_provider_test.dart
@@ -15,6 +15,7 @@ import 'package:tapem/features/challenges/domain/models/challenge.dart';
 import 'package:tapem/features/challenges/domain/models/badge.dart';
 import 'package:tapem/features/challenges/domain/models/completed_challenge.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tapem/services/membership_service.dart';
 
 class FakeDeviceRepository implements DeviceRepository {
   FakeDeviceRepository(this.devices);
@@ -53,6 +54,11 @@ class FakeDeviceRepository implements DeviceRepository {
 
   @override
   DocumentSnapshot? get lastSnapshotCursor => null;
+}
+
+class FakeMembershipService implements MembershipService {
+  @override
+  Future<void> ensureMembership(String gymId, String uid) async {}
 }
 
 class FakeXpRepository implements XpRepository {
@@ -154,6 +160,7 @@ void main() {
         getDevicesForGym: GetDevicesForGym(FakeDeviceRepository([device])),
         firestore: firestore,
         log: (_, [__]) {},
+        membership: FakeMembershipService(),
       );
 
       await provider.loadDevice(
@@ -183,6 +190,7 @@ void main() {
         getDevicesForGym: GetDevicesForGym(FakeDeviceRepository([device])),
         firestore: firestore,
         log: (_, [__]) {},
+        membership: FakeMembershipService(),
       );
       await provider.loadDevice(
         gymId: 'g1',
@@ -244,6 +252,7 @@ void main() {
         getDevicesForGym: GetDevicesForGym(FakeDeviceRepository([device])),
         firestore: firestore,
         log: (_, [__]) {},
+        membership: FakeMembershipService(),
       );
       await provider.loadDevice(
         gymId: 'g1',
@@ -285,6 +294,7 @@ void main() {
         firestore: FakeFirebaseFirestore(),
         getDevicesForGym: GetDevicesForGym(FakeDeviceRepository([])),
         log: (_, [__]) {},
+        membership: FakeMembershipService(),
       );
       provider.addSet();
       provider.updateSet(0, weight: '10');
@@ -309,6 +319,7 @@ void main() {
         getDevicesForGym: GetDevicesForGym(FakeDeviceRepository([device])),
         firestore: firestore,
         log: (_, [__]) {},
+        membership: FakeMembershipService(),
       );
       await provider.loadDevice(
         gymId: 'g1',
@@ -364,8 +375,9 @@ void main() {
           ]),
         ),
         log: (_, [__]) {},
+        membership: FakeMembershipService(),
       );
-      await provider.loadDevices('g1');
+      await provider.loadDevices('g1', 'u1');
       var calls = 0;
       provider.addListener(() => calls++);
       provider.patchDeviceGroups('d1', ['p'], ['s']);

--- a/test/ui/muscle_groups/admin_list_filters_test.dart
+++ b/test/ui/muscle_groups/admin_list_filters_test.dart
@@ -24,7 +24,7 @@ class FakeDeviceProvider extends ChangeNotifier implements DeviceProvider {
   @override
   bool get isLoading => false;
   @override
-  Future<void> loadDevices(String gymId) async {}
+  Future<void> loadDevices(String gymId, String uid) async {}
   @override
   void applyMuscleAssignments(String deviceId, List<String> primary,
       List<String> secondary) {

--- a/test/widgets/device_pager_test.dart
+++ b/test/widgets/device_pager_test.dart
@@ -6,6 +6,7 @@ import 'package:tapem/core/providers/device_provider.dart';
 import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
 import 'package:tapem/features/device/domain/repositories/device_repository.dart';
 import 'package:tapem/features/device/presentation/widgets/device_pager.dart';
+import 'package:tapem/services/membership_service.dart';
 
 class _FakeDeviceRepository implements DeviceRepository {
   final List<DeviceSessionSnapshot> snaps;
@@ -27,6 +28,11 @@ class _FakeDeviceRepository implements DeviceRepository {
   noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+class FakeMembershipService implements MembershipService {
+  @override
+  Future<void> ensureMembership(String gymId, String uid) async {}
+}
+
 void main() {
   testWidgets('pager direction and swipe handlers', (tester) async {
     final snapshot = DeviceSessionSnapshot(
@@ -41,6 +47,7 @@ void main() {
     final prov = DeviceProvider(
       firestore: FakeFirebaseFirestore(),
       deviceRepository: repo,
+      membership: FakeMembershipService(),
     );
     await prov.loadMoreSnapshots(gymId: 'g', deviceId: 'd', userId: 'u1');
 

--- a/test/widgets/dismissible_session_list_test.dart
+++ b/test/widgets/dismissible_session_list_test.dart
@@ -11,6 +11,7 @@ import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/ui/numeric_keypad/overlay_numeric_keypad.dart';
 import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tapem/services/membership_service.dart';
 
 class _FakeRepo implements DeviceRepository {
   @override
@@ -47,6 +48,11 @@ class _FakeRepo implements DeviceRepository {
 
   @override
   DocumentSnapshot? get lastSnapshotCursor => null;
+}
+
+class FakeMembershipService implements MembershipService {
+  @override
+  Future<void> ensureMembership(String gymId, String uid) async {}
 }
 
 class _TestList extends StatelessWidget {
@@ -100,6 +106,7 @@ void main() {
       firestore: FakeFirebaseFirestore(),
       getDevicesForGym: GetDevicesForGym(_FakeRepo()),
       log: (_, [__]) {},
+      membership: FakeMembershipService(),
     );
     provider.addSet();
     provider.addSet();

--- a/test/widgets/set_card_test.dart
+++ b/test/widgets/set_card_test.dart
@@ -11,6 +11,7 @@ import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/ui/numeric_keypad/overlay_numeric_keypad.dart';
 import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tapem/services/membership_service.dart';
 
 class _FakeRepo implements DeviceRepository {
   @override
@@ -49,12 +50,18 @@ class _FakeRepo implements DeviceRepository {
   DocumentSnapshot? get lastSnapshotCursor => null;
 }
 
+class FakeMembershipService implements MembershipService {
+  @override
+  Future<void> ensureMembership(String gymId, String uid) async {}
+}
+
 void main() {
   testWidgets('SetCard toggle locks fields', (tester) async {
     final provider = DeviceProvider(
       firestore: FakeFirebaseFirestore(),
       getDevicesForGym: GetDevicesForGym(_FakeRepo()),
       log: (_, [__]) {},
+      membership: FakeMembershipService(),
     );
     provider.addSet();
 


### PR DESCRIPTION
## Summary
- add FirestoreMembershipService to auto-create `gyms/{gymId}/users/{uid}`
- guard branding, muscle group, and device loads with membership and retry logic
- allow device session writes via owner-based security rule

## Testing
- `flutter test test/providers/branding_provider_test.dart test/providers/device_provider_test.dart test/widgets/device_pager_test.dart test/widgets/dismissible_session_list_test.dart test/widgets/set_card_test.dart` *(command failed: flutter: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a308af8da08320a25995f8aca0e0bf