### PR TITLE
Fix provider setup and resolve analysis warnings

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -25,7 +25,6 @@ import 'package:tapem/core/drafts/session_draft_repository.dart';
 import 'package:tapem/core/drafts/session_draft_repository_impl.dart';
 import 'package:tapem/core/config/feature_flags.dart';
 import 'package:tapem/services/membership_service.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 
 typedef LogFn = void Function(String message, [StackTrace? stack]);
 
@@ -293,7 +292,8 @@ class DeviceProvider extends ChangeNotifier {
         userId: userId,
       );
 
-      if (FF.isLastSessionVisible) {
+      if (FF.showLastSessionOnDevicePage ||
+          FF.runtimeShowLastSessionOnDevicePage) {
         await _loadLastSession(gymId, deviceId, exerciseId, userId);
       }
       await _loadUserNote(gymId, deviceId, userId);

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -246,7 +246,8 @@ class _DeviceScreenState extends State<DeviceScreen> {
                         ),
                       ),
                     ],
-                    if (FF.isLastSessionVisible &&
+                    if ((FF.showLastSessionOnDevicePage ||
+                            FF.runtimeShowLastSessionOnDevicePage) &&
                         lastDate != null &&
                         lastSets.isNotEmpty) ...[
                       const SizedBox(height: 16),
@@ -265,7 +266,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                                 }
                               },
                               child: LastSessionCard(
-                                date: lastDate!,
+                                date: lastDate,
                                 sets: lastSets,
                                 note: lastNote,
                               ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -176,11 +176,11 @@ Future<void> main() async {
         ),
         ChangeNotifierProxyProvider2<AuthProvider, MembershipService,
             BrandingProvider>(
-          create: (c, auth, m) => BrandingProvider(
+          create: (c) => BrandingProvider(
             source: FirestoreGymSource(
               firestore: FirebaseFirestore.instance,
             ),
-            membership: m,
+            membership: c.read<MembershipService>(),
           ),
           update: (_, auth, m, prov) {
             final p = prov ??


### PR DESCRIPTION
## Summary
- create `BrandingProvider` without extra parameters
- drop duplicate imports and rely on public feature flag fields
- clean up last-session card logic in device screen

## Testing
- `flutter analyze` *(command failed: command not found)*
- `apt-get update` *(failed: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3102eec248320ac44adf1c40b09f1