### PR TITLE
fix: resolve lint warnings

### DIFF
--- a/lib/features/friends/presentation/screens/friend_detail_screen.dart
+++ b/lib/features/friends/presentation/screens/friend_detail_screen.dart
@@ -24,8 +24,12 @@ class _FriendDetailScreenState extends State<FriendDetailScreen> {
 
   Future<void> _loadProfile() async {
     final src = context.read<PublicProfileSource>();
-    final p = await src.getProfile(widget.uid).catchError((_) => null);
-    setState(() => _profile = p);
+    try {
+      final p = await src.getProfile(widget.uid);
+      setState(() => _profile = p);
+    } catch (_) {
+      setState(() => _profile = null);
+    }
   }
 
   @override

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -32,7 +32,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       context.read<ProfileProvider>().loadTrainingDates(context);
       final uid = context.read<AuthProvider>().userId;
-      if (uid != null && context.read<FriendsProvider>() != null) {
+      if (uid != null) {
         context.read<FriendsProvider>().listen(uid);
       }
     });

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,7 @@
 
 import 'dart:async';
 import 'package:flutter/foundation.dart'
-    show defaultTargetPlatform, TargetPlatform, kIsWeb, kReleaseMode;
+    show defaultTargetPlatform, TargetPlatform, kIsWeb;
 
 import 'package:firebase_auth/firebase_auth.dart' as fb_auth;
 import 'package:firebase_core/firebase_core.dart';

--- a/lib/ui/muscles/muscle_group_card.dart
+++ b/lib/ui/muscles/muscle_group_card.dart
@@ -18,7 +18,6 @@ class MuscleGroupCard extends StatelessWidget {
       orElse: () => MuscleGroup(id: '', name: '', region: MuscleRegion.rectusAbdominis),
     );
     if (group.id.isEmpty) return const SizedBox.shrink();
-    final theme = Theme.of(context);
     final loc = AppLocalizations.of(context)!;
     return Semantics(
       label: loc.a11yMgSelected(group.name),


### PR DESCRIPTION
## Summary
- handle profile load errors gracefully in FriendDetailScreen
- drop redundant null check in ProfileScreen
- remove unused kReleaseMode import and theme variable

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af5961e2c08320b1cc5d0598618c5e