### PR TITLE
feat: improve friend search and request flow

### DIFF
--- a/lib/features/friends/data/friends_source.dart
+++ b/lib/features/friends/data/friends_source.dart
@@ -50,7 +50,11 @@ class FriendsSource {
         .doc('meta');
     return metaRef.snapshots().map((snap) {
       final data = snap.data();
-      return (data?['pendingCountCache'] as int?) ?? 0;
+      if (data == null) {
+        return -1;
+      }
+      final val = data['pendingCountCache'] as int?;
+      return val ?? -1;
     });
   }
 }

--- a/lib/features/friends/presentation/screens/friends_home_screen.dart
+++ b/lib/features/friends/presentation/screens/friends_home_screen.dart
@@ -1,8 +1,8 @@
-import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:tapem/l10n/app_localizations.dart';
 import '../../providers/friends_provider.dart';
-import '../../domain/models/public_profile.dart';
+import '../../providers/friend_search_provider.dart';
 import 'friend_detail_screen.dart';
 
 class FriendsHomeScreen extends StatefulWidget {
@@ -16,10 +16,7 @@ class FriendsHomeScreen extends StatefulWidget {
 class _FriendsHomeScreenState extends State<FriendsHomeScreen>
     with TickerProviderStateMixin {
   late TabController _tabController;
-  StreamSubscription? _incomingSeen;
   final _searchCtrl = TextEditingController();
-  Timer? _debounce;
-  List<PublicProfile> _results = [];
 
   @override
   void initState() {
@@ -30,62 +27,48 @@ class _FriendsHomeScreenState extends State<FriendsHomeScreen>
         context.read<FriendsProvider>().markIncomingSeen();
       }
     });
-    _searchCtrl.addListener(_onSearchChanged);
-  }
-
-  void _onSearchChanged() {
-    _debounce?.cancel();
-    _debounce = Timer(const Duration(milliseconds: 400), () async {
-      final text = _searchCtrl.text.trim().toLowerCase();
-      if (text.length < 2) {
-        setState(() => _results = []);
-        return;
-      }
-      final prov = context.read<FriendsProvider>();
-      final res = await prov.search(text);
-      setState(() => _results = res);
-    });
+    _searchCtrl.addListener(
+        () => context.read<FriendSearchProvider>().updateQuery(_searchCtrl.text));
   }
 
   @override
   void dispose() {
     _tabController.dispose();
-    _searchCtrl.removeListener(_onSearchChanged);
     _searchCtrl.dispose();
-    _debounce?.cancel();
-    _incomingSeen?.cancel();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     final prov = context.watch<FriendsProvider>();
+    final searchProv = context.watch<FriendSearchProvider>();
+    final loc = AppLocalizations.of(context)!;
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Freunde'),
+        title: Text(loc.friends_title),
         bottom: TabBar(
           controller: _tabController,
-          tabs: const [
-            Tab(text: 'Meine Freunde'),
-            Tab(text: 'Anfragen'),
-            Tab(text: 'Suchen'),
+          tabs: [
+            Tab(text: loc.friends_tab_my_friends),
+            Tab(text: loc.friends_tab_requests),
+            Tab(text: loc.friends_tab_search),
           ],
         ),
       ),
       body: TabBarView(
         controller: _tabController,
         children: [
-          _friendsTab(prov),
-          _requestsTab(prov),
-          _searchTab(prov),
+          _friendsTab(prov, loc),
+          _requestsTab(prov, loc),
+          _searchTab(prov, searchProv, loc),
         ],
       ),
     );
   }
 
-  Widget _friendsTab(FriendsProvider prov) {
+  Widget _friendsTab(FriendsProvider prov, AppLocalizations loc) {
     if (prov.friends.isEmpty) {
-      return const Center(child: Text('Keine Freunde'));
+      return Center(child: Text(loc.friends_empty_friends));
     }
     return ListView.builder(
       itemCount: prov.friends.length,
@@ -103,79 +86,144 @@ class _FriendsHomeScreenState extends State<FriendsHomeScreen>
         );
       },
     );
-  }
+    }
 
-  Widget _requestsTab(FriendsProvider prov) {
+  Widget _requestsTab(FriendsProvider prov, AppLocalizations loc) {
     return Column(
       children: [
         Expanded(
-          child: ListView.builder(
-            itemCount: prov.incomingPending.length,
-            itemBuilder: (_, i) {
-              final r = prov.incomingPending[i];
-              return ListTile(
-                title: Text(r.fromUserId),
-                subtitle: Text(r.message ?? ''),
-                trailing: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    IconButton(
-                      icon: const Icon(Icons.check),
-                      onPressed: () => prov.accept(r.requestId, r.toUserId),
-                    ),
-                    IconButton(
-                      icon: const Icon(Icons.close),
-                      onPressed: () => prov.decline(r.requestId, r.toUserId),
-                    ),
-                  ],
+          child: prov.incomingPending.isEmpty
+              ? Center(child: Text(loc.friends_empty_incoming))
+              : ListView.builder(
+                  itemCount: prov.incomingPending.length,
+                  itemBuilder: (_, i) {
+                    final r = prov.incomingPending[i];
+                    return ListTile(
+                      title: Text(r.fromUserId),
+                      subtitle: Text(r.message ?? ''),
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          IconButton(
+                            icon: const Icon(Icons.check),
+                            onPressed: () async {
+                              await prov.accept(r.requestId, r.toUserId);
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text(loc.friends_snackbar_accepted)),
+                              );
+                            },
+                          ),
+                          IconButton(
+                            icon: const Icon(Icons.close),
+                            onPressed: () async {
+                              await prov.decline(r.requestId, r.toUserId);
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text(loc.friends_snackbar_declined)),
+                              );
+                            },
+                          ),
+                        ],
+                      ),
+                    );
+                  },
                 ),
-              );
-            },
-          ),
         ),
         const Divider(),
         Expanded(
-          child: ListView.builder(
-            itemCount: prov.outgoingPending.length,
-            itemBuilder: (_, i) {
-              final r = prov.outgoingPending[i];
-              return ListTile(
-                title: Text(r.toUserId),
-                subtitle: Text(r.message ?? ''),
-                trailing: IconButton(
-                  icon: const Icon(Icons.cancel),
-                  onPressed: () => prov.cancel(r.requestId, r.toUserId),
+          child: prov.outgoingPending.isEmpty
+              ? Center(child: Text(loc.friends_empty_outgoing))
+              : ListView.builder(
+                  itemCount: prov.outgoingPending.length,
+                  itemBuilder: (_, i) {
+                    final r = prov.outgoingPending[i];
+                    return ListTile(
+                      title: Text(r.toUserId),
+                      subtitle: Text(r.message ?? ''),
+                      trailing: IconButton(
+                        icon: const Icon(Icons.cancel),
+                        onPressed: () async {
+                          await prov.cancel(r.requestId, r.toUserId);
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(content: Text(loc.friends_snackbar_canceled)),
+                          );
+                        },
+                      ),
+                    );
+                  },
                 ),
-              );
-            },
-          ),
         ),
       ],
     );
   }
 
-  Widget _searchTab(FriendsProvider prov) {
+  Widget _searchTab(
+      FriendsProvider prov, FriendSearchProvider searchProv, AppLocalizations loc) {
     return Column(
       children: [
         Padding(
           padding: const EdgeInsets.all(8.0),
           child: TextField(
             controller: _searchCtrl,
-            decoration: const InputDecoration(labelText: 'Suche'),
+            decoration: InputDecoration(labelText: loc.friends_tab_search),
           ),
         ),
         Expanded(
-          child: ListView.builder(
-            itemCount: _results.length,
-            itemBuilder: (_, i) {
-              final p = _results[i];
-              return ListTile(
-                title: Text(p.username),
-                subtitle: Text(p.primaryGymCode ?? ''),
-                trailing: IconButton(
-                  icon: const Icon(Icons.person_add),
-                  onPressed: () => prov.sendRequest(p.uid),
-                ),
+          child: Builder(
+            builder: (_) {
+              if (searchProv.loading) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              if (_searchCtrl.text.trim().length < 2) {
+                return Center(child: Text(loc.friends_search_min_chars));
+              }
+              if (searchProv.error != null) {
+                return Center(child: Text(searchProv.error!));
+              }
+              if (searchProv.results.isEmpty) {
+                return Center(child: Text(loc.friends_empty_search));
+              }
+              return ListView.builder(
+                itemCount: searchProv.results.length,
+                itemBuilder: (_, i) {
+                  final p = searchProv.results[i];
+                  Widget trailing;
+                  if (prov.isSelf(p.uid)) {
+                    trailing = Text(loc.friends_cta_self);
+                  } else if (prov.isFriend(p.uid)) {
+                    trailing = Text(loc.friends_cta_friend);
+                  } else if (prov.isOutgoing(p.uid)) {
+                    trailing = Text(loc.friends_cta_pending);
+                  } else {
+                    trailing = TextButton(
+                      onPressed: () async {
+                        try {
+                          await prov.sendRequest(p.uid);
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(content: Text(loc.friends_snackbar_sent)),
+                          );
+                        } catch (_) {
+                          final msg = prov.error ?? 'Error';
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(content: Text(msg)),
+                          );
+                        }
+                      },
+                      child: Text(loc.friends_action_send),
+                    );
+                  }
+                  return ListTile(
+                    leading: p.avatarUrl != null
+                        ? CircleAvatar(
+                            backgroundImage: NetworkImage(p.avatarUrl!),
+                          )
+                        : const CircleAvatar(child: Icon(Icons.person)),
+                    title: Text(p.username),
+                    subtitle: p.primaryGymCode != null
+                        ? Text(p.primaryGymCode!)
+                        : null,
+                    trailing: trailing,
+                  );
+                },
               );
             },
           ),

--- a/lib/features/friends/providers/friend_search_provider.dart
+++ b/lib/features/friends/providers/friend_search_provider.dart
@@ -1,0 +1,56 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import '../data/public_profile_source.dart';
+import '../domain/models/public_profile.dart';
+
+class FriendSearchProvider extends ChangeNotifier {
+  FriendSearchProvider(this._source);
+
+  final PublicProfileSource _source;
+
+  String query = '';
+  List<PublicProfile> results = [];
+  bool loading = false;
+  String? error;
+
+  Timer? _debounce;
+  StreamSubscription? _sub;
+
+  void updateQuery(String value) {
+    query = value;
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 400), _startSearch);
+  }
+
+  void _startSearch() {
+    _sub?.cancel();
+    final q = query.trim().toLowerCase();
+    if (q.length < 2) {
+      results = [];
+      loading = false;
+      error = null;
+      notifyListeners();
+      return;
+    }
+    loading = true;
+    error = null;
+    notifyListeners();
+    _sub = _source.searchByUsernamePrefix(q).listen((res) {
+      results = res;
+      loading = false;
+      notifyListeners();
+    }, onError: (e) {
+      error = e.toString();
+      loading = false;
+      notifyListeners();
+    });
+  }
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _sub?.cancel();
+    super.dispose();
+  }
+}
+

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -165,10 +165,11 @@ class _ProfileScreenState extends State<ProfileScreen> {
   @override
   Widget build(BuildContext context) {
     final prov = context.watch<ProfileProvider>();
+    final loc = AppLocalizations.of(context)!;
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(AppLocalizations.of(context)!.profileTitle),
+        title: Text(loc.profileTitle),
         actions: [
           const NfcScanButton(),
           if (enableFriends)
@@ -188,7 +189,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                         ),
                     ],
                   ),
-                  tooltip: 'Freundesliste',
+                  tooltip: loc.friends_title,
                   onPressed: () {
                     Navigator.push(context, FriendsHomeScreen.route());
                   },
@@ -197,7 +198,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
             ),
           IconButton(
             icon: const Icon(Icons.settings),
-            tooltip: AppLocalizations.of(context)!.settingsIconTooltip,
+            tooltip: loc.settingsIconTooltip,
             onPressed: _showSettingsDialog,
           ),
         ],

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -633,5 +633,10 @@
   "friends_empty_outgoing": "Keine ausgehenden Anfragen",
   "friends_empty_friends": "Noch keine Freunde",
   "friends_empty_search": "Keine Nutzer gefunden",
-  "friends_privacy_no_access": "Dieser Nutzer teilt seinen Kalender nicht."
+  "friends_privacy_no_access": "Dieser Nutzer teilt seinen Kalender nicht.",
+  "friends_cta_self": "Du selbst",
+  "friends_cta_friend": "Freund",
+  "friends_cta_pending": "Ausstehend",
+  "friends_action_send": "Anfrage senden",
+  "friends_search_min_chars": "Mindestens 2 Zeichen eingeben"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -631,5 +631,10 @@
   "friends_empty_outgoing": "No outgoing requests",
   "friends_empty_friends": "No friends yet",
   "friends_empty_search": "No users found",
-  "friends_privacy_no_access": "This user does not share their calendar"
+  "friends_privacy_no_access": "This user does not share their calendar",
+  "friends_cta_self": "You",
+  "friends_cta_friend": "Friend",
+  "friends_cta_pending": "Pending",
+  "friends_action_send": "Send request",
+  "friends_search_min_chars": "Enter at least 2 characters"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1216,6 +1216,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'This user does not share their calendar'**
   String get friends_privacy_no_access;
+
+  /// No description provided for @friends_cta_self.
+  ///
+  /// In en, this message translates to:
+  /// **'You'**
+  String get friends_cta_self;
+
+  /// No description provided for @friends_cta_friend.
+  ///
+  /// In en, this message translates to:
+  /// **'Friend'**
+  String get friends_cta_friend;
+
+  /// No description provided for @friends_cta_pending.
+  ///
+  /// In en, this message translates to:
+  /// **'Pending'**
+  String get friends_cta_pending;
+
+  /// No description provided for @friends_action_send.
+  ///
+  /// In en, this message translates to:
+  /// **'Send request'**
+  String get friends_action_send;
+
+  /// No description provided for @friends_search_min_chars.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter at least 2 characters'**
+  String get friends_search_min_chars;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -584,4 +584,19 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get friends_privacy_no_access => 'Dieser Nutzer teilt seinen Kalender nicht.';
+
+  @override
+  String get friends_cta_self => 'Du selbst';
+
+  @override
+  String get friends_cta_friend => 'Freund';
+
+  @override
+  String get friends_cta_pending => 'Ausstehend';
+
+  @override
+  String get friends_action_send => 'Anfrage senden';
+
+  @override
+  String get friends_search_min_chars => 'Mindestens 2 Zeichen eingeben';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -584,4 +584,19 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get friends_privacy_no_access => 'This user does not share their calendar';
+
+  @override
+  String get friends_cta_self => 'You';
+
+  @override
+  String get friends_cta_friend => 'Friend';
+
+  @override
+  String get friends_cta_pending => 'Pending';
+
+  @override
+  String get friends_action_send => 'Send request';
+
+  @override
+  String get friends_search_min_chars => 'Enter at least 2 characters';
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,6 +46,7 @@ import 'package:tapem/features/friends/data/public_profile_source.dart';
 import 'package:tapem/features/friends/data/public_calendar_source.dart';
 import 'package:tapem/features/friends/providers/friends_provider.dart';
 import 'package:tapem/features/friends/providers/friend_calendar_provider.dart';
+import 'package:tapem/features/friends/providers/friend_search_provider.dart';
 import 'features/gym/data/sources/firestore_gym_source.dart';
 import 'ui/numeric_keypad/overlay_numeric_keypad.dart';
 import 'core/drafts/session_draft_repository_impl.dart';
@@ -290,8 +291,10 @@ Future<void> main() async {
           create: (c) => FriendsProvider(
             c.read<FriendsSource>(),
             c.read<FriendsApi>(),
-            c.read<PublicProfileSource>(),
           ),
+        ),
+        ChangeNotifierProvider(
+          create: (c) => FriendSearchProvider(c.read<PublicProfileSource>()),
         ),
         ChangeNotifierProvider(
           create: (c) => FriendCalendarProvider(c.read<PublicCalendarSource>()),


### PR DESCRIPTION
## Summary
- add FriendSearchProvider with debounced usernameLower prefix search
- track friends/outgoing/self in FriendsProvider and improve pending count
- localize friend screens and integrate request handling

## Testing
- `flutter test` *(fails: command not found)*
- `dart format lib/main.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af768115c083209938fcc11be0cf55