### PR TITLE
feat: enable friend search via public profiles

### DIFF
--- a/docs/friend_search.md
+++ b/docs/friend_search.md
@@ -1,0 +1,35 @@
+# Friend Username Search
+
+The app searches in the `publicProfiles` collection. Documents mirror a subset of `users/*` fields via Cloud Functions (`mirrorPublicProfile`) and contain:
+
+- `username`
+- `usernameLower` (lower‑cased)
+- `primaryGymCode`
+- `avatarUrl`
+- `createdAt`
+
+## Query
+
+```dart
+orderBy('usernameLower')
+  .startAt([prefix])
+  .endAt([prefix + '\u{f8ff}'])
+```
+
+- Input is trimmed and lower‑cased.
+- Queries fire only for inputs with at least **2 characters**.
+- Results are limited to 20 items.
+
+## Testing
+
+1. Ensure users have public profiles (Function + backfill).
+2. Run the app, open the Friends tab → Search.
+3. Enter a prefix like `ad` or `the` (lowercase). Matching users should appear.
+4. Try full usernames to verify exact matches.
+
+Look out for:
+
+- Case insensitivity (always lowercase).
+- Prefix behaviour (`the` matches `themain`).
+- Debounce delay (~400 ms) before the query fires.
+

--- a/functions/__tests__/public_profile_mirror.test.js
+++ b/functions/__tests__/public_profile_mirror.test.js
@@ -1,0 +1,53 @@
+process.env.FIRESTORE_EMULATOR_HOST = '127.0.0.1:8080';
+const fft = require('firebase-functions-test')({ projectId: 'demo-friends' });
+const admin = require('firebase-admin');
+const myFuncs = require('..');
+
+describe('public profile mirror', () => {
+  afterAll(() => {
+    fft.cleanup();
+  });
+
+  it('mirrors user writes to publicProfiles', async () => {
+    const wrapped = fft.wrap(myFuncs.mirrorPublicProfile);
+    const after = fft.firestore.makeDocumentSnapshot(
+      { username: 'Alice' },
+      'users/A1'
+    );
+    await wrapped({ before: null, after }, { params: { uid: 'A1' } });
+    let snap = await admin.firestore().collection('publicProfiles').doc('A1').get();
+    expect(snap.data().usernameLower).toBe('alice');
+
+    const after2 = fft.firestore.makeDocumentSnapshot(
+      { username: 'Alicia', usernameLower: 'alicia' },
+      'users/A1'
+    );
+    await wrapped({ before: after, after: after2 }, { params: { uid: 'A1' } });
+    snap = await admin.firestore().collection('publicProfiles').doc('A1').get();
+    expect(snap.data().username).toBe('Alicia');
+  });
+
+  it('backfills existing users', async () => {
+    await admin
+      .firestore()
+      .collection('users')
+      .doc('B1')
+      .set({ username: 'Bob' });
+    await admin
+      .firestore()
+      .collection('users')
+      .doc('C1')
+      .set({ username: 'Carol', usernameLower: 'carol' });
+    const wrapped = fft.wrap(myFuncs.backfillPublicProfiles);
+    const res = await wrapped({}, { auth: { uid: 'admin' } });
+    expect(res.processed).toBe(2);
+    const snap = await admin.firestore().collection('publicProfiles').get();
+    expect(snap.size).toBeGreaterThanOrEqual(2);
+    const doc = await admin
+      .firestore()
+      .collection('publicProfiles')
+      .doc('B1')
+      .get();
+    expect(doc.data().usernameLower).toBe('bob');
+  });
+});

--- a/lib/features/friends/data/public_profile_source.dart
+++ b/lib/features/friends/data/public_profile_source.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
 import '../domain/models/public_profile.dart';
 
 class PublicProfileSource {
@@ -16,14 +17,25 @@ class PublicProfileSource {
 
   Stream<List<PublicProfile>> searchByUsernamePrefix(String prefixLower,
       {int limit = 20}) {
+    final end = prefixLower + '\\uf8ff';
+    if (kDebugMode) {
+      debugPrint(
+          '[FriendSearch] query collection=publicProfiles orderBy=usernameLower startAt=$prefixLower endAt=$end limit=$limit');
+    }
     return _firestore
         .collection('publicProfiles')
-        .where('usernameLower', isGreaterThanOrEqualTo: prefixLower)
-        .where('usernameLower', isLessThan: prefixLower + '\uf8ff')
         .orderBy('usernameLower')
+        .startAt([prefixLower])
+        .endAt([end])
         .limit(limit)
         .snapshots()
-        .map((snap) =>
-            snap.docs.map((d) => PublicProfile.fromMap(d.id, d.data())).toList());
+        .map((snap) {
+      if (kDebugMode) {
+        debugPrint('[FriendSearch] results=${snap.docs.length}');
+      }
+      return snap.docs
+          .map((d) => PublicProfile.fromMap(d.id, d.data()))
+          .toList();
+    });
   }
 }

--- a/lib/features/friends/presentation/screens/friends_home_screen.dart
+++ b/lib/features/friends/presentation/screens/friends_home_screen.dart
@@ -27,8 +27,6 @@ class _FriendsHomeScreenState extends State<FriendsHomeScreen>
         context.read<FriendsProvider>().markIncomingSeen();
       }
     });
-    _searchCtrl.addListener(
-        () => context.read<FriendSearchProvider>().updateQuery(_searchCtrl.text));
   }
 
   @override
@@ -164,6 +162,8 @@ class _FriendsHomeScreenState extends State<FriendsHomeScreen>
           padding: const EdgeInsets.all(8.0),
           child: TextField(
             controller: _searchCtrl,
+            onChanged: (v) =>
+                context.read<FriendSearchProvider>().updateQuery(v),
             decoration: InputDecoration(labelText: loc.friends_tab_search),
           ),
         ),

--- a/lib/features/friends/providers/friend_search_provider.dart
+++ b/lib/features/friends/providers/friend_search_provider.dart
@@ -25,6 +25,9 @@ class FriendSearchProvider extends ChangeNotifier {
   void _startSearch() {
     _sub?.cancel();
     final q = query.trim().toLowerCase();
+    if (kDebugMode) {
+      debugPrint('[FriendSearch] search start "$q"');
+    }
     if (q.length < 2) {
       results = [];
       loading = false;
@@ -41,6 +44,9 @@ class FriendSearchProvider extends ChangeNotifier {
       notifyListeners();
     }, onError: (e) {
       error = e.toString();
+      if (kDebugMode) {
+        debugPrint('[FriendSearch] error $e');
+      }
       loading = false;
       notifyListeners();
     });

--- a/lib/features/friends/providers/friends_provider.dart
+++ b/lib/features/friends/providers/friends_provider.dart
@@ -84,7 +84,10 @@ class FriendsProvider extends ChangeNotifier {
   }
 
   Future<void> markIncomingSeen() async {
-    await _guard(() => _api.markIncomingSeen());
+    await _guard(() async {
+      await _api.markIncomingSeen();
+      pendingCount = 0;
+    });
   }
 
   Set<String> friendsUids = {};

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -185,6 +185,10 @@ Future<void> main() async {
       options: DefaultFirebaseOptions.currentPlatform,
     );
   }
+  assert(() {
+    debugPrint('[Firebase] projectId=' + Firebase.app().options.projectId);
+    return true;
+  }());
 
   // App Check (iOS: DeviceCheck für TestFlight/Prod)
   await FirebaseAppCheck.instance.activate(


### PR DESCRIPTION
## Summary
- mirror user docs into publicProfiles and add backfill
- query publicProfiles with prefix and log results
- add projectId log and friend search/provider tweaks

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af89f490508320b9ccd8245f9543b3