### PR TITLE
feat: mirror public profiles and searchable friend lookup

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -71,11 +71,31 @@ service cloud.firestore {
     }
 
     // ─────────────────────────
-    // Public Profiles (read-only for authed users)
+    // Public Profiles (owner-managed mirror of basic user info)
     // ─────────────────────────
     match /publicProfiles/{uid} {
       allow read: if isAuthed();
-      allow write: if false;
+      allow create, update, delete: if isOwner(uid) && isValidPublicProfile();
+
+      function isValidPublicProfile() {
+        let allowed = ['username', 'usernameLower', 'primaryGymCode', 'avatarUrl', 'createdAt'];
+        return request.resource.data.keys().hasOnly(allowed)
+          && request.resource.data.usernameLower is string
+          && request.resource.data.usernameLower.size() >= 1
+          && request.resource.data.usernameLower.size() <= 32
+          && (!('username' in request.resource.data) ||
+              (request.resource.data.username is string &&
+               request.resource.data.username.size() <= 32))
+          && (!('primaryGymCode' in request.resource.data) ||
+              (request.resource.data.primaryGymCode is string &&
+               request.resource.data.primaryGymCode.size() <= 32))
+          && (!('avatarUrl' in request.resource.data) ||
+              (request.resource.data.avatarUrl is string &&
+               request.resource.data.avatarUrl.size() <= 1024))
+          && (request.method == 'create'
+              ? ('createdAt' in request.resource.data && request.resource.data.createdAt is timestamp)
+              : request.resource.data.createdAt == resource.data.createdAt);
+      }
     }
 
     // ─────────────────────────

--- a/lib/features/friends/data/public_profile_source.dart
+++ b/lib/features/friends/data/public_profile_source.dart
@@ -15,17 +15,18 @@ class PublicProfileSource {
     return PublicProfile.fromMap(doc.id, data);
   }
 
-  Stream<List<PublicProfile>> searchByUsernamePrefix(String prefixLower,
+  Stream<List<PublicProfile>> searchByUsernamePrefix(String prefix,
       {int limit = 20}) {
-    final end = prefixLower + '\\uf8ff';
+    final q = prefix.trim().toLowerCase();
+    final end = q + '\\uf8ff';
     if (kDebugMode) {
       debugPrint(
-          '[FriendSearch] query collection=publicProfiles orderBy=usernameLower startAt=$prefixLower endAt=$end limit=$limit');
+          '[FriendSearch] query collection=publicProfiles orderBy=usernameLower startAt=$q endAt=$end limit=$limit');
     }
     return _firestore
         .collection('publicProfiles')
         .orderBy('usernameLower')
-        .startAt([prefixLower])
+        .startAt([q])
         .endAt([end])
         .limit(limit)
         .snapshots()

--- a/lib/features/friends/data/public_profile_sync_service.dart
+++ b/lib/features/friends/data/public_profile_sync_service.dart
@@ -1,0 +1,96 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+
+/// Syncs a subset of the user profile into `publicProfiles/{uid}`.
+///
+/// Only mirrors when the user opted in to a public profile
+/// (`showInLeaderboard == true`). Otherwise the mirror document is
+/// removed.
+class PublicProfileSyncService {
+  PublicProfileSyncService(this._firestore);
+
+  final FirebaseFirestore _firestore;
+  StreamSubscription<DocumentSnapshot<Map<String, dynamic>>>? _sub;
+
+  /// Ensures that a mirror document exists in `publicProfiles/{uid}`.
+  ///
+  /// If the user profile is marked as private the mirror will be
+  /// removed instead. The [primaryGymCode] is optional and can be used
+  /// to store the currently selected gym of the user.
+  Future<void> ensurePublicProfile(String uid, {String? primaryGymCode}) async {
+    try {
+      final userSnap = await _firestore.collection('users').doc(uid).get();
+      final user = userSnap.data();
+      if (user == null) return;
+
+      final isPublic = user['showInLeaderboard'] != false;
+      if (!isPublic) {
+        await removePublicProfileIfPrivate(uid);
+        return;
+      }
+
+      final ref = _firestore.collection('publicProfiles').doc(uid);
+      final profileSnap = await ref.get();
+      final data = <String, dynamic>{
+        'username': user['userName'] ?? '',
+        'usernameLower': (user['userName'] as String? ?? '').toLowerCase(),
+        if (primaryGymCode != null) 'primaryGymCode': primaryGymCode,
+        if (user['avatarUrl'] != null) 'avatarUrl': user['avatarUrl'],
+      };
+      if (!profileSnap.exists) {
+        data['createdAt'] = user['createdAt'] ?? FieldValue.serverTimestamp();
+      }
+      await ref.set(data, SetOptions(merge: true));
+    } catch (e, st) {
+      if (kDebugMode) {
+        debugPrint('PublicProfileSyncService.ensure error: $e');
+        debugPrintStack(stackTrace: st);
+      }
+      rethrow;
+    }
+  }
+
+  /// Deletes the public profile mirror for [uid].
+  Future<void> removePublicProfileIfPrivate(String uid) async {
+    try {
+      await _firestore.collection('publicProfiles').doc(uid).delete();
+    } catch (e, st) {
+      if (kDebugMode) {
+        debugPrint('PublicProfileSyncService.remove error: $e');
+        debugPrintStack(stackTrace: st);
+      }
+      rethrow;
+    }
+  }
+
+  /// Listens to `users/{uid}` and mirrors changes to `publicProfiles`.
+  ///
+  /// The optional [primaryGymCodeProvider] is invoked whenever a sync
+  /// happens to obtain the latest gym code.
+  void syncOnProfileChanges(String uid,
+      {String? Function()? primaryGymCodeProvider}) {
+    _sub?.cancel();
+    _sub = _firestore
+        .collection('users')
+        .doc(uid)
+        .snapshots()
+        .listen((snap) async {
+      final data = snap.data();
+      if (data == null) return;
+      final gym = primaryGymCodeProvider?.call();
+      final isPublic = data['showInLeaderboard'] != false;
+      if (isPublic) {
+        await ensurePublicProfile(uid, primaryGymCode: gym);
+      } else {
+        await removePublicProfileIfPrivate(uid);
+      }
+    });
+  }
+
+  void dispose() {
+    _sub?.cancel();
+  }
+}
+


### PR DESCRIPTION
## Summary
- mirror a user's profile into publicProfiles when visibility is public and remove when private
- allow authenticated owners to manage their public profile via Firestore rules
- normalize friend search to query publicProfiles.usernameLower with a lowercase prefix

## Testing
- `npm run rules-test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*
- `flutter analyze` *(command not found)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af922b2fc083208c0ad2183e7c7dea