### PR TITLE
fix nullable user access in auth provider

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -97,8 +97,8 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   value: true,
                   groupValue: current,
                   onChanged: (v) {
-                    authProv.setShowInLeaderboard(v!);
-                    authProv.setPublicProfile(v!);
+                    authProv.setShowInLeaderboard(v);
+                    authProv.setPublicProfile(v);
                     Navigator.pop(context);
                   },
                 ),
@@ -107,8 +107,8 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   value: false,
                   groupValue: current,
                   onChanged: (v) {
-                    authProv.setShowInLeaderboard(v!);
-                    authProv.setPublicProfile(v!);
+                    authProv.setShowInLeaderboard(v);
+                    authProv.setPublicProfile(v);
                     Navigator.pop(context);
                   },
                 ),


### PR DESCRIPTION
## Summary
- avoid nullability errors in `AuthProvider._loadCurrentUser`
- remove unnecessary non-null assertions in profile screen
- drop redundant `dispose` override

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afa6f1d00c832081497a48182c8b95