### PR TITLE
fix: handle nullable bool in profile privacy dialog

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -97,9 +97,11 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   value: true,
                   groupValue: current,
                   onChanged: (v) {
-                    authProv.setShowInLeaderboard(v);
-                    authProv.setPublicProfile(v);
-                    Navigator.pop(context);
+                    if (v != null) {
+                      authProv.setShowInLeaderboard(v);
+                      authProv.setPublicProfile(v);
+                      Navigator.pop(context);
+                    }
                   },
                 ),
                 RadioListTile<bool>(
@@ -107,9 +109,11 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   value: false,
                   groupValue: current,
                   onChanged: (v) {
-                    authProv.setShowInLeaderboard(v);
-                    authProv.setPublicProfile(v);
-                    Navigator.pop(context);
+                    if (v != null) {
+                      authProv.setShowInLeaderboard(v);
+                      authProv.setPublicProfile(v);
+                      Navigator.pop(context);
+                    }
                   },
                 ),
               ],


### PR DESCRIPTION
## Summary
- guard against null values in profile privacy dialog radio buttons

## Testing
- `flutter analyze` *(command not found)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afa7bb41ec8320a4fefeaa35323c9f