### PR TITLE
Handle nullable radio selections in profile screen

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -97,6 +97,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   value: true,
                   groupValue: current,
                   onChanged: (v) {
+                    if (v == null) return;
                     authProv.setShowInLeaderboard(v);
                     authProv.setPublicProfile(v);
                     Navigator.pop(context);
@@ -107,6 +108,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   value: false,
                   groupValue: current,
                   onChanged: (v) {
+                    if (v == null) return;
                     authProv.setShowInLeaderboard(v);
                     authProv.setPublicProfile(v);
                     Navigator.pop(context);


### PR DESCRIPTION
## Summary
- guard against null values in profile privacy settings so bool parameters receive non-null values

## Testing
- `flutter analyze lib/features/profile/presentation/screens/profile_screen.dart` *(command not found)*
- `dart analyze lib/features/profile/presentation/screens/profile_screen.dart` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afa7bb41ec8320a4fefeaa35323c9f