### PR TITLE
feat: switch friends feature to client-side Firestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Eine Übersicht über die Steuerung des Pausen-Timers findet sich in [docs/devic
    Ohne die Indexe schlagen bestimmte Abfragen fehl (z. B. "Heute bereits gespeichert?").
    Für die Freundes-Suche ist ein zusammengesetzter Index auf `users(publicProfile ASC, usernameLower ASC)` erforderlich.
 
+---
+
+## Freundes-Suche & Requests (Spark)
+
+Alle Aktionen rund um Freundschaften laufen vollständig clientseitig über Firestore. Anfragen werden unter `users/{toUid}/friendRequests/{fromUid_toUid}` gespeichert, die Freundschaft als symmetrische Kante unter `users/{uid}/friends/{friendUid}`. Die Suche filtert nur öffentliche Profile (`publicProfile == true`) und arbeitet prefix-basiert auf `usernameLower`.
+
 Hinweis: `.gitignore` schützt diese Dateien. Weitere Regeln stehen in [docs/secrets-policy.md](docs/secrets-policy.md).
 
 Die Dateien `pubspec.lock` und – sobald vorhanden – `ios/Podfile.lock` werden versioniert, um reproduzierbare Builds zu gewährleisten.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -68,6 +68,14 @@
       ]
     },
     {
+      "collectionGroup": "friendRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "users",
       "queryScope": "COLLECTION",
       "fields": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -79,18 +79,47 @@ service cloud.firestore {
       allow read: if isAuthed();
       allow update: if isOwner(uid);
 
-      // Friend Requests (server-managed)
+      // Friend Requests (client-managed)
       match /friendRequests/{reqId} {
-        // Recipient can read all their requests; Sender can read only their own request at recipient
+        // Recipient can read all; sender only their own request at recipient
         allow read: if isOwner(uid) ||
-                    (isAuthed() && resource.data.fromUserId == request.auth.uid);
-        allow write: if false; // only via Cloud Functions
+                      (isAuthed() && resource.data.fromUserId == request.auth.uid);
+
+        allow create: if request.auth.uid == request.resource.data.fromUserId &&
+                        uid == request.resource.data.toUserId &&
+                        request.resource.data.fromUserId != request.resource.data.toUserId &&
+                        request.resource.data.status == 'pending' &&
+                        request.resource.data.keys().hasOnly(['fromUserId','toUserId','status','createdAt','updatedAt','message']) &&
+                        request.resource.data.createdAt is timestamp &&
+                        request.resource.data.updatedAt is timestamp &&
+                        (!('message' in request.resource.data) ||
+                         (request.resource.data.message is string &&
+                          request.resource.data.message.size() <= 280));
+
+        // accept/decline by recipient; cancel by sender
+        allow update: if request.resource.data.keys().hasOnly(['fromUserId','toUserId','status','createdAt','updatedAt','message']) &&
+                        request.resource.data.fromUserId == resource.data.fromUserId &&
+                        request.resource.data.toUserId == resource.data.toUserId && (
+                          (request.auth.uid == uid && resource.data.status == 'pending' &&
+                            (request.resource.data.status == 'accepted' || request.resource.data.status == 'declined')) ||
+                          (request.auth.uid == resource.data.fromUserId && resource.data.status == 'pending' &&
+                            request.resource.data.status == 'canceled')
+                        );
       }
 
-      // Friends list (owner-only read; server writes)
+      // Friends list (symmetrische Kante)
       match /friends/{fid} {
         allow read: if isOwner(uid);
-        allow write: if false; // only via Cloud Functions
+        allow create: if (request.auth.uid == uid || request.auth.uid == fid) &&
+                        request.resource.data.friendUid == fid &&
+                        request.resource.data.keys().hasOnly(['friendUid','since','createdAt','updatedAt','gymCodesAtAcceptance']) &&
+                        (
+                          exists(/databases/$(database)/documents/users/$(uid)/friendRequests/$(fid + '_' + uid)) &&
+                          get(/databases/$(database)/documents/users/$(uid)/friendRequests/$(fid + '_' + uid)).data.status == 'accepted' ||
+                          exists(/databases/$(database)/documents/users/$(fid)/friendRequests/$(uid + '_' + fid)) &&
+                          get(/databases/$(database)/documents/users/$(fid)/friendRequests/$(uid + '_' + fid)).data.status == 'accepted'
+                        );
+        allow delete: if request.auth.uid == uid || request.auth.uid == fid;
       }
 
       // Privacy-aware public calendar (server writes)
@@ -132,6 +161,12 @@ service cloud.firestore {
       // Public gym doc (non-sensitive fields only)
       allow read: if true;
       allow write: if isAdmin(gymId);
+
+      // Branding / config
+      match /config/{docId} {
+        allow read: if isAuthed();
+        allow write: if isAdmin(gymId);
+      }
 
       // Devices
       match /devices/{deviceId} {

--- a/lib/features/friends/data/friends_source.dart
+++ b/lib/features/friends/data/friends_source.dart
@@ -41,20 +41,4 @@ class FriendsSource {
             .map((d) => FriendRequest.fromMap(d.id, d.data()))
             .toList());
   }
-
-  Stream<int> watchPendingCount(String meUid) {
-    final metaRef = _firestore
-        .collection('users')
-        .doc(meUid)
-        .collection('friendMeta')
-        .doc('meta');
-    return metaRef.snapshots().map((snap) {
-      final data = snap.data();
-      if (data == null) {
-        return -1;
-      }
-      final val = data['pendingCountCache'] as int?;
-      return val ?? -1;
-    });
-  }
 }

--- a/lib/features/friends/presentation/screens/friends_home_screen.dart
+++ b/lib/features/friends/presentation/screens/friends_home_screen.dart
@@ -105,7 +105,7 @@ class _FriendsHomeScreenState extends State<FriendsHomeScreen>
                           IconButton(
                             icon: const Icon(Icons.check),
                             onPressed: () async {
-                              await prov.accept(r.requestId, r.toUserId);
+                              await prov.accept(r.fromUserId);
                               ScaffoldMessenger.of(context).showSnackBar(
                                 SnackBar(content: Text(loc.friends_snackbar_accepted)),
                               );
@@ -114,7 +114,7 @@ class _FriendsHomeScreenState extends State<FriendsHomeScreen>
                           IconButton(
                             icon: const Icon(Icons.close),
                             onPressed: () async {
-                              await prov.decline(r.requestId, r.toUserId);
+                              await prov.decline(r.fromUserId);
                               ScaffoldMessenger.of(context).showSnackBar(
                                 SnackBar(content: Text(loc.friends_snackbar_declined)),
                               );
@@ -140,7 +140,7 @@ class _FriendsHomeScreenState extends State<FriendsHomeScreen>
                       trailing: IconButton(
                         icon: const Icon(Icons.cancel),
                         onPressed: () async {
-                          await prov.cancel(r.requestId, r.toUserId);
+                          await prov.cancel(r.toUserId);
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(content: Text(loc.friends_snackbar_canceled)),
                           );

--- a/lib/features/friends/providers/friend_search_provider.dart
+++ b/lib/features/friends/providers/friend_search_provider.dart
@@ -19,7 +19,7 @@ class FriendSearchProvider extends ChangeNotifier {
   void updateQuery(String value) {
     query = value;
     _debounce?.cancel();
-    _debounce = Timer(const Duration(milliseconds: 500), _startSearch);
+    _debounce = Timer(const Duration(milliseconds: 400), _startSearch);
   }
 
   void _startSearch() {


### PR DESCRIPTION
## Summary
- move friends API from Cloud Functions to direct Firestore writes
- add Firestore security rules and index for friend requests and friendships
- streamline providers and debounce and document friend search

## Testing
- `npm run rules-test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afabe6a3cc832087df1b34f08b26d9