### PR TITLE
Refactor friends feature for Firestore two-phase accept

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -76,6 +76,14 @@
       ]
     },
     {
+      "collectionGroup": "friendRequests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "fromUserId", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "users",
       "queryScope": "COLLECTION",
       "fields": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -110,7 +110,7 @@ service cloud.firestore {
       // Friends list (symmetrische Kante)
       match /friends/{fid} {
         allow read: if isOwner(uid);
-        allow create: if (request.auth.uid == uid || request.auth.uid == fid) &&
+        allow create: if isOwner(uid) &&
                         request.resource.data.friendUid == fid &&
                         request.resource.data.keys().hasOnly(['friendUid','since','createdAt','updatedAt','gymCodesAtAcceptance']) &&
                         (
@@ -119,7 +119,7 @@ service cloud.firestore {
                           exists(/databases/$(database)/documents/users/$(fid)/friendRequests/$(uid + '_' + fid)) &&
                           get(/databases/$(database)/documents/users/$(fid)/friendRequests/$(uid + '_' + fid)).data.status == 'accepted'
                         );
-        allow delete: if request.auth.uid == uid || request.auth.uid == fid;
+        allow delete: if isOwner(uid);
       }
 
       // Privacy-aware public calendar (server writes)

--- a/lib/features/friends/data/friends_source.dart
+++ b/lib/features/friends/data/friends_source.dart
@@ -41,4 +41,15 @@ class FriendsSource {
             .map((d) => FriendRequest.fromMap(d.id, d.data()))
             .toList());
   }
+
+  Stream<List<FriendRequest>> watchOutgoingAccepted(String meUid) {
+    return _firestore
+        .collectionGroup('friendRequests')
+        .where('fromUserId', isEqualTo: meUid)
+        .where('status', isEqualTo: 'accepted')
+        .snapshots()
+        .map((snap) => snap.docs
+            .map((d) => FriendRequest.fromMap(d.id, d.data()))
+            .toList());
+  }
 }

--- a/lib/features/friends/data/user_search_source.dart
+++ b/lib/features/friends/data/user_search_source.dart
@@ -29,14 +29,15 @@ class UserSearchSource {
     final end = '$prefix\uf8ff';
     if (kDebugMode) {
       debugPrint(
-          '[FriendSearch] query collection=users where publicProfile=true orderBy=usernameLower startAt=$prefix endAt=$end limit=$limit');
+          '[FriendSearch] query collection=users orderBy=publicProfile,usernameLower where publicProfile=true startAt=[true,$prefix] endAt=[true,$end] limit=$limit');
     }
     return _firestore
         .collection('users')
+        .orderBy('publicProfile')
         .where('publicProfile', isEqualTo: true)
         .orderBy('usernameLower')
-        .startAt([prefix])
-        .endAt([end])
+        .startAt([true, prefix])
+        .endAt([true, end])
         .limit(limit)
         .snapshots()
         .map((snap) {


### PR DESCRIPTION
## Summary
- shift friend acceptance to two-phase Firestore workflow
- add outgoing-accepted watcher to sync friend edges
- restrict friend edge writes to owner and adjust indexes

## Testing
- ⚠️ `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afb00e85688320bd5b07f3dce31c1d