### PR TITLE
fix(friends): handle profile fetch errors

### DIFF
--- a/lib/features/friends/presentation/screens/friends_home_screen.dart
+++ b/lib/features/friends/presentation/screens/friends_home_screen.dart
@@ -23,7 +23,8 @@ class _FriendsHomeScreenState extends State<FriendsHomeScreen>
 
   Future<PublicProfile?> _fetchProfile(String uid) {
     return _profileCache[uid] ??=
-        context.read<UserSearchSource>().getProfile(uid).catchError((_) => null);
+        context.read<UserSearchSource>().getProfile(uid).then<PublicProfile?>
+            ((value) => value, onError: (_, __) => null);
   }
 
   @override


### PR DESCRIPTION
## Summary
- ensure profile fetch returns nullable after errors in FriendsHomeScreen

## Testing
- `flutter analyze lib/features/friends/presentation/screens/friends_home_screen.dart` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b045dd053883208d118745d5c87175