### PR TITLE
fix: avoid constant pattern name conflict in AppRouter

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -75,8 +75,9 @@ class AppRouter {
   };
 
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
-    final auth = navigatorKey.currentContext?.read<AuthProvider>();
-    final isRestricted = FF.limitTabsForMembers && !(auth?.isAdmin ?? false) &&
+    final authProvider = navigatorKey.currentContext?.read<AuthProvider>();
+    final isRestricted = FF.limitTabsForMembers &&
+        !(authProvider?.isAdmin ?? false) &&
         restrictedRoutesForMembers.contains(settings.name);
     if (isRestricted) {
       return MaterialPageRoute(builder: (_) => const HomeScreen());


### PR DESCRIPTION
## Summary
- rename local `auth` variable to `authProvider` to avoid conflicting with `auth` route constant

## Testing
- `dart format lib/app_router.dart` (fails: command not found)
- `flutter analyze` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b0769776248320ac84cdef486f220f