### PR TITLE
refactor: overhaul friends feature

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -76,23 +76,25 @@
       ]
     },
     {
-      "collectionGroup": "friendRequests",
+      "collectionId": "friendRequests",
       "queryScope": "COLLECTION",
       "fields": [
+        { "fieldPath": "fromUserId", "order": "ASCENDING" },
         { "fieldPath": "status", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
     },
     {
-      "collectionGroup": "friendRequests",
+      "collectionId": "friendRequests",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "fromUserId", "order": "ASCENDING" },
-        { "fieldPath": "status", "order": "ASCENDING" }
+        { "fieldPath": "toUserId", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
     },
     {
-      "collectionGroup": "users",
+      "collectionId": "users",
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "publicProfile", "order": "ASCENDING" },

--- a/firestore.rules
+++ b/firestore.rules
@@ -73,6 +73,39 @@ service cloud.firestore {
     }
 
     // ─────────────────────────
+    // Friend Requests (top-level)
+    // ─────────────────────────
+    match /friendRequests/{reqId} {
+      allow read: if isAuthed() &&
+        (request.auth.uid == resource.data.fromUserId ||
+         request.auth.uid == resource.data.toUserId);
+
+      allow create: if request.auth.uid == request.resource.data.fromUserId &&
+        request.resource.data.fromUserId != request.resource.data.toUserId &&
+        request.resource.data.status == 'pending' &&
+        reqId == request.resource.data.fromUserId + '_' + request.resource.data.toUserId &&
+        request.resource.data.keys().hasOnly(['fromUserId','toUserId','status','createdAt','updatedAt','message']) &&
+        request.resource.data.createdAt is timestamp &&
+        request.resource.data.updatedAt is timestamp &&
+        (!('message' in request.resource.data) ||
+          (request.resource.data.message is string &&
+           request.resource.data.message.size() <= 280));
+
+      allow update: if request.resource.data.keys().hasOnly(['fromUserId','toUserId','status','createdAt','updatedAt','message']) &&
+        request.resource.data.fromUserId == resource.data.fromUserId &&
+        request.resource.data.toUserId == resource.data.toUserId &&
+        request.resource.data.createdAt == resource.data.createdAt &&
+        request.resource.data.updatedAt is timestamp && (
+          (request.auth.uid == resource.data.fromUserId && resource.data.status == 'pending' &&
+            request.resource.data.status == 'canceled') ||
+          (request.auth.uid == resource.data.toUserId && resource.data.status == 'pending' &&
+            (request.resource.data.status == 'accepted' || request.resource.data.status == 'declined'))
+        );
+
+      allow delete: if false;
+    }
+
+    // ─────────────────────────
     // Users (top-level)
     // ─────────────────────────
     match /users/{uid} {
@@ -81,46 +114,12 @@ service cloud.firestore {
       allow read: if isAuthed();
       allow update: if isOwner(uid);
 
-      // Friend Requests (client-managed)
-      match /friendRequests/{reqId} {
-        // Recipient can read all; sender only their own request at recipient
-        allow read: if isOwner(uid) ||
-                      (isAuthed() && resource.data.fromUserId == request.auth.uid);
-
-        allow create: if request.auth.uid == request.resource.data.fromUserId &&
-                        uid == request.resource.data.toUserId &&
-                        request.resource.data.fromUserId != request.resource.data.toUserId &&
-                        request.resource.data.status == 'pending' &&
-                        request.resource.data.keys().hasOnly(['fromUserId','toUserId','status','createdAt','updatedAt','message']) &&
-                        request.resource.data.createdAt is timestamp &&
-                        request.resource.data.updatedAt is timestamp &&
-                        (!('message' in request.resource.data) ||
-                         (request.resource.data.message is string &&
-                          request.resource.data.message.size() <= 280));
-
-        // accept/decline by recipient; cancel by sender
-        allow update: if request.resource.data.keys().hasOnly(['fromUserId','toUserId','status','createdAt','updatedAt','message']) &&
-                        request.resource.data.fromUserId == resource.data.fromUserId &&
-                        request.resource.data.toUserId == resource.data.toUserId && (
-                          (request.auth.uid == uid && resource.data.status == 'pending' &&
-                            (request.resource.data.status == 'accepted' || request.resource.data.status == 'declined')) ||
-                          (request.auth.uid == resource.data.fromUserId && resource.data.status == 'pending' &&
-                            request.resource.data.status == 'canceled')
-                        );
-      }
-
       // Friends list (symmetrische Kante)
       match /friends/{fid} {
         allow read: if isOwner(uid);
-        allow create: if isOwner(uid) &&
-                        request.resource.data.friendUid == fid &&
-                        request.resource.data.keys().hasOnly(['friendUid','since','createdAt','updatedAt','gymCodesAtAcceptance']) &&
-                        (
-                          exists(/databases/$(database)/documents/users/$(uid)/friendRequests/$(fid + '_' + uid)) &&
-                          get(/databases/$(database)/documents/users/$(uid)/friendRequests/$(fid + '_' + uid)).data.status == 'accepted' ||
-                          exists(/databases/$(database)/documents/users/$(fid)/friendRequests/$(uid + '_' + fid)) &&
-                          get(/databases/$(database)/documents/users/$(fid)/friendRequests/$(uid + '_' + fid)).data.status == 'accepted'
-                        );
+        allow create: if isOwner(uid) && uid != fid &&
+          request.resource.data.keys().hasOnly(['createdAt']) &&
+          request.resource.data.createdAt is timestamp;
         allow delete: if isOwner(uid);
       }
 

--- a/lib/features/friends/data/friends_source.dart
+++ b/lib/features/friends/data/friends_source.dart
@@ -11,7 +11,7 @@ class FriendsSource {
         .collection('users')
         .doc(meUid)
         .collection('friends')
-        .orderBy('since', descending: true)
+        .orderBy('createdAt', descending: true)
         .snapshots()
         .map((snap) =>
             snap.docs.map((d) => Friend.fromMap(d.id, d.data())).toList());
@@ -19,37 +19,33 @@ class FriendsSource {
 
   Stream<List<FriendRequest>> watchIncoming(String meUid) {
     return _firestore
-        .collection('users')
-        .doc(meUid)
         .collection('friendRequests')
+        .where('toUserId', isEqualTo: meUid)
         .where('status', isEqualTo: 'pending')
         .orderBy('createdAt', descending: true)
         .snapshots()
-        .map((snap) => snap.docs
-            .map((d) => FriendRequest.fromMap(d.id, d.data()))
-            .toList());
+        .map((snap) =>
+            snap.docs.map((d) => FriendRequest.fromMap(d.id, d.data())).toList());
   }
 
   Stream<List<FriendRequest>> watchOutgoing(String meUid) {
     return _firestore
-        .collectionGroup('friendRequests')
+        .collection('friendRequests')
         .where('fromUserId', isEqualTo: meUid)
         .where('status', isEqualTo: 'pending')
         .orderBy('createdAt', descending: true)
         .snapshots()
-        .map((snap) => snap.docs
-            .map((d) => FriendRequest.fromMap(d.id, d.data()))
-            .toList());
+        .map((snap) =>
+            snap.docs.map((d) => FriendRequest.fromMap(d.id, d.data())).toList());
   }
 
   Stream<List<FriendRequest>> watchOutgoingAccepted(String meUid) {
     return _firestore
-        .collectionGroup('friendRequests')
+        .collection('friendRequests')
         .where('fromUserId', isEqualTo: meUid)
         .where('status', isEqualTo: 'accepted')
         .snapshots()
-        .map((snap) => snap.docs
-            .map((d) => FriendRequest.fromMap(d.id, d.data()))
-            .toList());
+        .map((snap) =>
+            snap.docs.map((d) => FriendRequest.fromMap(d.id, d.data())).toList());
   }
 }

--- a/lib/features/friends/domain/models/friend.dart
+++ b/lib/features/friends/domain/models/friend.dart
@@ -1,19 +1,15 @@
-import "package:cloud_firestore/cloud_firestore.dart";
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class Friend {
-  Friend({required this.friendUid, required this.since, this.createdAt, this.updatedAt});
+  Friend({required this.friendUid, this.createdAt});
 
   final String friendUid;
-  final DateTime since;
   final DateTime? createdAt;
-  final DateTime? updatedAt;
 
   factory Friend.fromMap(String id, Map<String, dynamic> data) {
     return Friend(
       friendUid: id,
-      since: (data['since'] as Timestamp?)?.toDate() ?? DateTime.now(),
       createdAt: (data['createdAt'] as Timestamp?)?.toDate(),
-      updatedAt: (data['updatedAt'] as Timestamp?)?.toDate(),
     );
   }
 }

--- a/lib/features/friends/presentation/screens/friends_home_screen.dart
+++ b/lib/features/friends/presentation/screens/friends_home_screen.dart
@@ -250,30 +250,75 @@ class _FriendsHomeScreenState extends State<FriendsHomeScreen>
                 itemCount: searchProv.results.length,
                 itemBuilder: (_, i) {
                   final p = searchProv.results[i];
+                  final cta = searchProv.ctaFor(p.uid, prov);
                   Widget trailing;
-                  if (prov.isSelf(p.uid)) {
-                    trailing = Text(loc.friends_cta_self);
-                  } else if (prov.isFriend(p.uid)) {
-                    trailing = Text(loc.friends_cta_friend);
-                  } else if (prov.isOutgoing(p.uid)) {
-                    trailing = Text(loc.friends_cta_pending);
-                  } else {
-                    trailing = TextButton(
-                      onPressed: () async {
-                        try {
-                          await prov.sendRequest(p.uid);
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(content: Text(loc.friends_snackbar_sent)),
-                          );
-                        } catch (_) {
-                          final msg = prov.error ?? 'Error';
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(content: Text(msg)),
-                          );
-                        }
-                      },
-                      child: Text(loc.friends_action_send),
-                    );
+                  switch (cta) {
+                    case FriendSearchCta.self:
+                      trailing = Text(loc.friends_cta_self);
+                      break;
+                    case FriendSearchCta.friend:
+                      trailing = Text(loc.friends_cta_friend);
+                      break;
+                    case FriendSearchCta.outgoingPending:
+                      trailing = Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(loc.friends_cta_pending),
+                          TextButton(
+                            onPressed: () async {
+                              await prov.cancel(p.uid);
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text(loc.friends_snackbar_canceled)),
+                              );
+                            },
+                            child: Text(loc.friends_action_cancel),
+                          ),
+                        ],
+                      );
+                      break;
+                    case FriendSearchCta.incomingPending:
+                      trailing = Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          TextButton(
+                            onPressed: () async {
+                              await prov.accept(p.uid);
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text(loc.friends_snackbar_accepted)),
+                              );
+                            },
+                            child: Text(loc.friends_action_accept),
+                          ),
+                          TextButton(
+                            onPressed: () async {
+                              await prov.decline(p.uid);
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text(loc.friends_snackbar_declined)),
+                              );
+                            },
+                            child: Text(loc.friends_action_decline),
+                          ),
+                        ],
+                      );
+                      break;
+                    case FriendSearchCta.none:
+                      trailing = TextButton(
+                        onPressed: () async {
+                          try {
+                            await prov.sendRequest(p.uid);
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(content: Text(loc.friends_snackbar_sent)),
+                            );
+                          } catch (_) {
+                            final msg = prov.error ?? 'Error';
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(content: Text(msg)),
+                            );
+                          }
+                        },
+                        child: Text(loc.friends_action_send),
+                      );
+                      break;
                   }
                   return ListTile(
                     leading: p.avatarUrl != null

--- a/lib/features/friends/providers/friend_search_provider.dart
+++ b/lib/features/friends/providers/friend_search_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import '../data/user_search_source.dart';
 import '../domain/models/public_profile.dart';
+import 'friends_provider.dart';
 
 class FriendSearchProvider extends ChangeNotifier {
   FriendSearchProvider(this._source);
@@ -52,11 +53,31 @@ class FriendSearchProvider extends ChangeNotifier {
     });
   }
 
+  FriendSearchCta ctaFor(String uid, FriendsProvider friends) {
+    if (friends.isSelf(uid)) return FriendSearchCta.self;
+    if (friends.isFriend(uid)) return FriendSearchCta.friend;
+    if (friends.hasIncomingPending(uid)) {
+      return FriendSearchCta.incomingPending;
+    }
+    if (friends.hasOutgoingPending(uid)) {
+      return FriendSearchCta.outgoingPending;
+    }
+    return FriendSearchCta.none;
+  }
+
   @override
   void dispose() {
     _debounce?.cancel();
     _sub?.cancel();
     super.dispose();
   }
+}
+
+enum FriendSearchCta {
+  self,
+  friend,
+  incomingPending,
+  outgoingPending,
+  none,
 }
 


### PR DESCRIPTION
## Summary
- enforce top-level `friendRequests` rules and owner-only friend edges
- migrate friends API and providers to new request/edge workflow
- update search UI with send/accept/decline/cancel actions

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b08172895c8320a79ee1860fe58dba