### PR TITLE
fix: handle duplicate Firebase app initialization

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -96,10 +96,12 @@ const bool kEnablePush = false;
 @pragma('vm:entry-point')
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   // Falls der Prozess im Hintergrund startet, Firebase erneut initialisieren.
-  if (Firebase.apps.isEmpty) {
+  try {
     await Firebase.initializeApp(
       options: DefaultFirebaseOptions.currentPlatform,
     );
+  } on FirebaseException catch (e) {
+    if (e.code != 'duplicate-app') rethrow;
   }
   // Aktuell keine weitere Logik
 }
@@ -179,10 +181,12 @@ Future<void> main() async {
   await dotenv.load(fileName: '.env.dev').catchError((_) {});
 
   // Firebase init (einheitlich)
-  if (Firebase.apps.isEmpty) {
+  try {
     await Firebase.initializeApp(
       options: DefaultFirebaseOptions.currentPlatform,
     );
+  } on FirebaseException catch (e) {
+    if (e.code != 'duplicate-app') rethrow;
   }
   assert(() {
     debugPrint('[Firebase] projectId=' + Firebase.app().options.projectId);


### PR DESCRIPTION
## Summary
- avoid duplicate Firebase initialization in background handler and main

## Testing
- `flutter analyze` *(fails: command not found)*
- `git clone https://github.com/flutter/flutter.git -b stable --depth 1` *(fails: CONNECT tunnel failed)*
- `flutter build apk` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0eecc62608320a87969a4637954d7