### PR TITLE
feat(theme): add Club Aktiv red-orange branding

### DIFF
--- a/lib/core/theme/app_brand_theme.dart
+++ b/lib/core/theme/app_brand_theme.dart
@@ -221,4 +221,34 @@ class AppBrandTheme extends ThemeExtension<AppBrandTheme> {
       outlineDisabledOpacity: 0.4,
     );
   }
+
+  /// Red/orange CTA preset used for "Club Aktiv".
+  static AppBrandTheme clubAktiv() {
+    final gradient = AppGradients.brandGradient;
+    final lums = gradient.colors.map((c) => c.computeLuminance());
+    final lum = lums.reduce((a, b) => a + b) / gradient.colors.length;
+    final outlineColor = gradient.colors.first;
+    return AppBrandTheme(
+      gradient: gradient,
+      radius: BorderRadius.circular(AppRadius.button),
+      shadow:
+          const [BoxShadow(color: Colors.black54, blurRadius: 8, offset: Offset(0, 4))],
+      pressedOverlay: ClubAktivColors.pressedTint.withOpacity(0.3),
+      focusRing: ClubAktivColors.focus,
+      textStyle: const TextStyle(fontWeight: FontWeight.bold),
+      height: 48,
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+      luminanceRef: lum,
+      onBrand: ClubAktivColors.textPrimary,
+      outline: outlineColor,
+      outlineGradient: gradient,
+      outlineColorFallback: outlineColor,
+      outlineWidth: 2,
+      outlineRadius: BorderRadius.circular(AppRadius.card),
+      outlineShadow: [
+        BoxShadow(color: gradient.colors.last.withOpacity(0.5), blurRadius: 8),
+      ],
+      outlineDisabledOpacity: 0.4,
+    );
+  }
 }

--- a/lib/core/theme/design_tokens.dart
+++ b/lib/core/theme/design_tokens.dart
@@ -103,6 +103,60 @@ class MagentaTones {
   }
 }
 
+/// Color palette for the red/orange themed gym "Club Aktiv".
+class ClubAktivColors {
+  static const Color primary500 = Color(0xFFFF6A00);
+  static const Color primary600 = Color(0xFFD32F2F);
+  static const Color secondary = Color(0xFFF57C00);
+  static const Color focus = Color(0xFFFF6A00);
+  static const Color pressedTint = Color(0xFF7F1D1D);
+  static const Color bg = Color(0xFF0B0F12);
+  static const Color surface1 = Color(0xFF12161C);
+  static const Color surface2 = Color(0xFF1A1F26);
+  static const Color textPrimary = Color(0xFFF6F7FA);
+  static const Color textSecondary = Color(0xFFC6CBD2);
+  static const Color textTertiary = Color(0xFF8C93A1);
+}
+
+/// Dynamic tone tokens used for brightness normalisation in "Club Aktiv".
+class ClubAktivTones {
+  /// Reference luminance derived from the "Letzte Session" card.
+  static double brightnessAnchor =
+      ClubAktivColors.surface1.computeLuminance();
+
+  /// Tone for cards and sheets.
+  static Color surface1 = ClubAktivColors.surface1;
+
+  /// Tone for inputs and key tiles.
+  static Color surface2 = ClubAktivColors.surface2;
+
+  /// Tone for control tiles and icon backgrounds.
+  static Color control = ClubAktivColors.surface2;
+
+  /// Re-computes tone values based on [gradient].
+  static void normalizeFromGradient(LinearGradient gradient) {
+    // Current gradient luminance and required delta to match anchor.
+    final lums = gradient.colors.map((c) => c.computeLuminance());
+    final origLum = lums.reduce((a, b) => a + b) / gradient.colors.length;
+    final delta = brightnessAnchor - origLum;
+    AppGradients.brandGradient = Tone.gradient(gradient, delta);
+
+    // Derive surface tones relative to anchor.
+    surface1 = Tone.color(
+      ClubAktivColors.surface1,
+      brightnessAnchor - ClubAktivColors.surface1.computeLuminance(),
+    );
+    surface2 = Tone.color(
+      ClubAktivColors.surface2,
+      brightnessAnchor + 0.025 - ClubAktivColors.surface2.computeLuminance(),
+    );
+    control = Tone.color(
+      ClubAktivColors.surface2,
+      brightnessAnchor + 0.01 - ClubAktivColors.surface2.computeLuminance(),
+    );
+  }
+}
+
 /// Standard spacing values based on an 8px grid.
 class AppSpacing {
   static const double xs = 8.0;

--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -148,4 +148,17 @@ class AppTheme {
     focus: MagentaColors.focus,
     buttonColor: MagentaColors.primary600,
   );
+
+  /// Red/orange dark theme for the "Club Aktiv" gym.
+  static final ThemeData clubAktivDarkTheme = _buildTheme(
+    primary: ClubAktivColors.primary600,
+    secondary: ClubAktivColors.secondary,
+    background: ClubAktivColors.bg,
+    surface: ClubAktivColors.surface1,
+    surface2: ClubAktivColors.surface2,
+    textPrimary: ClubAktivColors.textPrimary,
+    textSecondary: ClubAktivColors.textSecondary,
+    focus: ClubAktivColors.focus,
+    buttonColor: ClubAktivColors.primary600,
+  );
 }

--- a/lib/core/theme/theme_loader.dart
+++ b/lib/core/theme/theme_loader.dart
@@ -67,6 +67,46 @@ class ThemeLoader extends ChangeNotifier {
       return;
     }
 
+    if (gymId == 'Club Aktiv') {
+      if (branding == null) {
+        _applyClubAktivDefaults();
+        ClubAktivTones.normalizeFromGradient(AppGradients.brandGradient);
+        _attachBrandTheme(
+          focus: ClubAktivColors.focus,
+          foreground: ClubAktivColors.textPrimary,
+          useClubAktiv: true,
+        );
+        notifyListeners();
+        return;
+      }
+      final primary = branding.primaryColor != null
+          ? _parseHex(branding.primaryColor!)
+          : ClubAktivColors.primary600;
+      final secondary = branding.secondaryColor != null
+          ? _parseHex(branding.secondaryColor!)
+          : ClubAktivColors.secondary;
+      final gradStart = branding.gradientStart != null
+          ? _parseHex(branding.gradientStart!)
+          : ClubAktivColors.primary500;
+      final gradEnd = branding.gradientEnd != null
+          ? _parseHex(branding.gradientEnd!)
+          : ClubAktivColors.primary600;
+      _currentTheme = AppTheme.customTheme(
+        primary: primary,
+        secondary: secondary,
+      );
+      AppGradients.setBrandGradient(gradStart, gradEnd);
+      AppGradients.setCtaGlow(ClubAktivColors.focus);
+      ClubAktivTones.normalizeFromGradient(AppGradients.brandGradient);
+      _attachBrandTheme(
+        focus: ClubAktivColors.focus,
+        foreground: ClubAktivColors.textPrimary,
+        useClubAktiv: true,
+      );
+      notifyListeners();
+      return;
+    }
+
     if (branding == null ||
         branding.primaryColor == null ||
         branding.secondaryColor == null) {
@@ -100,6 +140,21 @@ class ThemeLoader extends ChangeNotifier {
     );
   }
 
+  void _applyClubAktivDefaults() {
+    _currentTheme = AppTheme.clubAktivDarkTheme;
+    AppGradients.setBrandGradient(
+      ClubAktivColors.primary500,
+      ClubAktivColors.primary600,
+    );
+    AppGradients.setCtaGlow(ClubAktivColors.focus);
+    ClubAktivTones.normalizeFromGradient(AppGradients.brandGradient);
+    _attachBrandTheme(
+      focus: ClubAktivColors.focus,
+      foreground: ClubAktivColors.textPrimary,
+      useClubAktiv: true,
+    );
+  }
+
   Color _parseHex(String hex) {
     hex = hex.replaceFirst('#', '');
     if (hex.length == 6) hex = 'FF$hex';
@@ -110,15 +165,18 @@ class ThemeLoader extends ChangeNotifier {
     required Color focus,
     required Color foreground,
     bool useMagenta = false,
+    bool useClubAktiv = false,
   }) {
     final ext = useMagenta
         ? AppBrandTheme.magenta()
-        : AppBrandTheme.defaultTheme().copyWith(
-            gradient: AppGradients.brandGradient,
-            outlineGradient: AppGradients.brandGradient,
-            focusRing: focus,
-            onBrand: foreground,
-          );
+        : useClubAktiv
+            ? AppBrandTheme.clubAktiv()
+            : AppBrandTheme.defaultTheme().copyWith(
+                gradient: AppGradients.brandGradient,
+                outlineGradient: AppGradients.brandGradient,
+                focusRing: focus,
+                onBrand: foreground,
+              );
     _currentTheme = _currentTheme.copyWith(extensions: [ext]);
   }
 }

--- a/test/theme/theme_loader_test.dart
+++ b/test/theme/theme_loader_test.dart
@@ -25,6 +25,24 @@ void main() {
           equals(const Color(0xFF654321)));
     });
 
+    test('Club Aktiv without branding uses red/orange theme', () {
+      final loader = ThemeLoader()..loadDefault();
+      loader.applyBranding('Club Aktiv', null);
+      expect(loader.theme.colorScheme.primary, ClubAktivColors.primary600);
+    });
+
+    test('Club Aktiv with branding applies custom colors', () {
+      final loader = ThemeLoader()..loadDefault();
+      loader.applyBranding(
+        'Club Aktiv',
+        Branding(primaryColor: '#123456', secondaryColor: '#654321'),
+      );
+      expect(loader.theme.colorScheme.primary,
+          equals(const Color(0xFF123456)));
+      expect(loader.theme.colorScheme.secondary,
+          equals(const Color(0xFF654321)));
+    });
+
     test('other gyms keep default theme', () {
       final loader = ThemeLoader()..loadDefault();
       loader.applyBranding('other', null);
@@ -49,6 +67,30 @@ void main() {
           lessThanOrEqualTo(0.02));
       expect(
           (MagentaTones.control.computeLuminance() - (anchor + 0.01)).abs(),
+          lessThanOrEqualTo(0.02));
+    });
+
+    test('Club Aktiv surfaces are normalised to reference luminance', () {
+      final loader = ThemeLoader()..loadDefault();
+      loader.applyBranding('Club Aktiv', null);
+
+      final anchor = ClubAktivTones.brightnessAnchor;
+      final grad = AppGradients.brandGradient;
+      final gradLum =
+          grad.colors.map((c) => c.computeLuminance()).reduce((a, b) => a + b) /
+              grad.colors.length;
+      expect((gradLum - anchor).abs(), lessThanOrEqualTo(0.02));
+      expect(
+          (ClubAktivTones.surface1.computeLuminance() - anchor).abs(),
+          lessThanOrEqualTo(0.02));
+      expect(
+          (ClubAktivTones.surface2.computeLuminance() -
+                  (anchor + 0.025))
+              .abs(),
+          lessThanOrEqualTo(0.02));
+      expect(
+          (ClubAktivTones.control.computeLuminance() - (anchor + 0.01))
+              .abs(),
           lessThanOrEqualTo(0.02));
     });
   });


### PR DESCRIPTION
## Summary
- add Club Aktiv special-case theme with red/orange defaults
- extend ThemeLoader to apply Club Aktiv branding and CTA glow
- cover red/orange branding behaviour with new tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b23164d54c83209caa07d1f20fadf0