### PR TITLE
feat(theme): add contrast-aware brand on-colors

### DIFF
--- a/lib/core/theme/brand_on_colors.dart
+++ b/lib/core/theme/brand_on_colors.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+/// Theme extension exposing contrast-safe foreground colours for brand tokens.
+class BrandOnColors extends ThemeExtension<BrandOnColors> {
+  final Color onPrimary;
+  final Color onSecondary;
+  final Color onGradient;
+  final Color onCta;
+
+  const BrandOnColors({
+    required this.onPrimary,
+    required this.onSecondary,
+    required this.onGradient,
+    required this.onCta,
+  });
+
+  @override
+  BrandOnColors copyWith({
+    Color? onPrimary,
+    Color? onSecondary,
+    Color? onGradient,
+    Color? onCta,
+  }) {
+    return BrandOnColors(
+      onPrimary: onPrimary ?? this.onPrimary,
+      onSecondary: onSecondary ?? this.onSecondary,
+      onGradient: onGradient ?? this.onGradient,
+      onCta: onCta ?? this.onCta,
+    );
+  }
+
+  @override
+  BrandOnColors lerp(ThemeExtension<BrandOnColors>? other, double t) {
+    if (other is! BrandOnColors) return this;
+    return BrandOnColors(
+      onPrimary: Color.lerp(onPrimary, other.onPrimary, t) ?? onPrimary,
+      onSecondary: Color.lerp(onSecondary, other.onSecondary, t) ?? onSecondary,
+      onGradient: Color.lerp(onGradient, other.onGradient, t) ?? onGradient,
+      onCta: Color.lerp(onCta, other.onCta, t) ?? onCta,
+    );
+  }
+}

--- a/lib/core/theme/contrast.dart
+++ b/lib/core/theme/contrast.dart
@@ -1,0 +1,94 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+
+/// Calculates the WCAG contrast ratio between [a] and [b].
+/// Formula: (L1 + 0.05) / (L2 + 0.05) where L1 is lighter luminance.
+double contrastRatio(Color a, Color b) {
+  final l1 = a.computeLuminance();
+  final l2 = b.computeLuminance();
+  final bright = math.max(l1, l2);
+  final dark = math.min(l1, l2);
+  return (bright + 0.05) / (dark + 0.05);
+}
+
+class ColorContrast {
+  final Color background;
+  final Color foreground;
+  const ColorContrast(this.background, this.foreground);
+}
+
+/// Returns a foreground colour with maximum contrast on [background].
+/// If necessary, subtly darkens or lightens the background before
+/// finalising the foreground colour.  The returned [ColorContrast]
+/// contains the potentially adjusted background and the chosen foreground.
+ColorContrast ensureForeground(Color background, {double minRatio = 4.5}) {
+  final black = contrastRatio(background, Colors.black);
+  final white = contrastRatio(background, Colors.white);
+  Color fg = black > white ? Colors.black : Colors.white;
+  double contrast = math.max(black, white);
+  Color bg = background;
+  if (contrast < minRatio) {
+    final overlay = bg.computeLuminance() > 0.5 ? Colors.black : Colors.white;
+    double opacity = 0.05;
+    while (contrast < minRatio && opacity <= 0.4) {
+      bg = Color.alphaBlend(overlay.withOpacity(opacity), bg);
+      contrast = contrastRatio(bg, fg);
+      opacity += 0.05;
+    }
+  }
+  return ColorContrast(bg, fg);
+}
+
+class GradientContrast {
+  final Color start;
+  final Color end;
+  final Color foreground;
+  const GradientContrast(this.start, this.end, this.foreground);
+}
+
+/// Computes a foreground colour for a gradient defined by [start] and [end].
+/// Evaluates contrast at the start, end and midpoint colours and picks the
+/// foreground that maximises the minimum contrast across them.  If the
+/// resulting contrast falls below [minRatio], the gradient colours are
+/// subtly darkened or lightened until the threshold is met.
+GradientContrast ensureGradientForeground(Color start, Color end,
+    {double minRatio = 4.5}) {
+  Color s = start;
+  Color e = end;
+  Color mid = Color.lerp(s, e, 0.5)!;
+  Color bestFg = Colors.white;
+  double bestMin = 0;
+  for (final candidate in [Colors.black, Colors.white]) {
+    final ratios = [
+      contrastRatio(s, candidate),
+      contrastRatio(e, candidate),
+      contrastRatio(mid, candidate),
+    ];
+    final minContrast = ratios.reduce(math.min);
+    if (minContrast > bestMin) {
+      bestMin = minContrast;
+      bestFg = candidate;
+    }
+  }
+  if (bestMin < minRatio) {
+    final overlay =
+        (s.computeLuminance() + e.computeLuminance() + mid.computeLuminance()) /
+                    3 >
+                0.5
+            ? Colors.black
+            : Colors.white;
+    double opacity = 0.05;
+    while (bestMin < minRatio && opacity <= 0.4) {
+      s = Color.alphaBlend(overlay.withOpacity(opacity), s);
+      e = Color.alphaBlend(overlay.withOpacity(opacity), e);
+      mid = Color.lerp(s, e, 0.5)!;
+      bestMin = [
+        contrastRatio(s, bestFg),
+        contrastRatio(e, bestFg),
+        contrastRatio(mid, bestFg),
+      ].reduce(math.min);
+      opacity += 0.05;
+    }
+  }
+  return GradientContrast(s, e, bestFg);
+}

--- a/lib/core/theme/theme_loader.dart
+++ b/lib/core/theme/theme_loader.dart
@@ -4,6 +4,8 @@ import '../../features/gym/domain/models/branding.dart';
 import 'design_tokens.dart';
 import 'theme.dart';
 import 'app_brand_theme.dart';
+import 'brand_on_colors.dart';
+import 'contrast.dart';
 
 /// Lädt dynamisch Themes je nach Gym.
 class ThemeLoader extends ChangeNotifier {
@@ -12,15 +14,12 @@ class ThemeLoader extends ChangeNotifier {
 
   /// Setzt das Standard-Dark-Theme.
   void loadDefault() {
-    _currentTheme = AppTheme.mintDarkTheme;
-    AppGradients.setBrandGradient(
-      AppColors.accentMint,
-      AppColors.accentTurquoise,
-    );
-    AppGradients.setCtaGlow(AppColors.accentMint);
-    _attachBrandTheme(
+    _applyBrandColors(
+      primary: AppColors.accentMint,
+      secondary: AppColors.accentTurquoise,
+      gradStart: AppColors.accentMint,
+      gradEnd: AppColors.accentTurquoise,
       focus: AppColors.accentTurquoise,
-      foreground: AppColors.textPrimary,
     );
     notifyListeners();
   }
@@ -30,12 +29,6 @@ class ThemeLoader extends ChangeNotifier {
     if (gymId == 'gym_01') {
       if (branding == null) {
         _applyMagentaDefaults();
-        MagentaTones.normalizeFromGradient(AppGradients.brandGradient);
-        _attachBrandTheme(
-          focus: MagentaColors.focus,
-          foreground: MagentaColors.textPrimary,
-          useMagenta: true,
-        );
         notifyListeners();
         return;
       }
@@ -51,16 +44,12 @@ class ThemeLoader extends ChangeNotifier {
       final gradEnd = branding.gradientEnd != null
           ? _parseHex(branding.gradientEnd!)
           : MagentaColors.secondary;
-      _currentTheme = AppTheme.customTheme(
+      _applyBrandColors(
         primary: primary,
         secondary: secondary,
-      );
-      AppGradients.setBrandGradient(gradStart, gradEnd);
-      AppGradients.setCtaGlow(MagentaColors.focus);
-      MagentaTones.normalizeFromGradient(AppGradients.brandGradient);
-      _attachBrandTheme(
+        gradStart: gradStart,
+        gradEnd: gradEnd,
         focus: MagentaColors.focus,
-        foreground: MagentaColors.textPrimary,
         useMagenta: true,
       );
       notifyListeners();
@@ -70,12 +59,6 @@ class ThemeLoader extends ChangeNotifier {
     if (gymId == 'Club Aktiv') {
       if (branding == null) {
         _applyClubAktivDefaults();
-        ClubAktivTones.normalizeFromGradient(AppGradients.brandGradient);
-        _attachBrandTheme(
-          focus: ClubAktivColors.focus,
-          foreground: ClubAktivColors.textPrimary,
-          useClubAktiv: true,
-        );
         notifyListeners();
         return;
       }
@@ -91,16 +74,12 @@ class ThemeLoader extends ChangeNotifier {
       final gradEnd = branding.gradientEnd != null
           ? _parseHex(branding.gradientEnd!)
           : ClubAktivColors.primary600;
-      _currentTheme = AppTheme.customTheme(
+      _applyBrandColors(
         primary: primary,
         secondary: secondary,
-      );
-      AppGradients.setBrandGradient(gradStart, gradEnd);
-      AppGradients.setCtaGlow(ClubAktivColors.focus);
-      ClubAktivTones.normalizeFromGradient(AppGradients.brandGradient);
-      _attachBrandTheme(
+        gradStart: gradStart,
+        gradEnd: gradEnd,
         focus: ClubAktivColors.focus,
-        foreground: ClubAktivColors.textPrimary,
         useClubAktiv: true,
       );
       notifyListeners();
@@ -115,44 +94,44 @@ class ThemeLoader extends ChangeNotifier {
     }
     final primary = _parseHex(branding.primaryColor!);
     final accent = _parseHex(branding.secondaryColor!);
-    _currentTheme = AppTheme.customTheme(primary: primary, secondary: accent);
-    AppGradients.setBrandGradient(primary, accent);
-    AppGradients.setCtaGlow(primary);
-    _attachBrandTheme(
+    final gradStart = branding.gradientStart != null
+        ? _parseHex(branding.gradientStart!)
+        : primary;
+    final gradEnd = branding.gradientEnd != null
+        ? _parseHex(branding.gradientEnd!)
+        : accent;
+    _applyBrandColors(
+      primary: primary,
+      secondary: accent,
+      gradStart: gradStart,
+      gradEnd: gradEnd,
       focus: accent,
-      foreground: AppColors.textPrimary,
     );
     notifyListeners();
   }
 
   void _applyMagentaDefaults() {
-    _currentTheme = AppTheme.magentaDarkTheme;
-    AppGradients.setBrandGradient(
-      MagentaColors.primary500,
-      MagentaColors.secondary,
-    );
-    AppGradients.setCtaGlow(MagentaColors.focus);
-    MagentaTones.normalizeFromGradient(AppGradients.brandGradient);
-    _attachBrandTheme(
+    _applyBrandColors(
+      primary: MagentaColors.primary600,
+      secondary: MagentaColors.secondary,
+      gradStart: MagentaColors.primary500,
+      gradEnd: MagentaColors.secondary,
       focus: MagentaColors.focus,
-      foreground: MagentaColors.textPrimary,
       useMagenta: true,
     );
+    MagentaTones.normalizeFromGradient(AppGradients.brandGradient);
   }
 
   void _applyClubAktivDefaults() {
-    _currentTheme = AppTheme.clubAktivDarkTheme;
-    AppGradients.setBrandGradient(
-      ClubAktivColors.primary500,
-      ClubAktivColors.primary600,
-    );
-    AppGradients.setCtaGlow(ClubAktivColors.focus);
-    ClubAktivTones.normalizeFromGradient(AppGradients.brandGradient);
-    _attachBrandTheme(
+    _applyBrandColors(
+      primary: ClubAktivColors.primary600,
+      secondary: ClubAktivColors.secondary,
+      gradStart: ClubAktivColors.primary500,
+      gradEnd: ClubAktivColors.primary600,
       focus: ClubAktivColors.focus,
-      foreground: ClubAktivColors.textPrimary,
       useClubAktiv: true,
     );
+    ClubAktivTones.normalizeFromGradient(AppGradients.brandGradient);
   }
 
   Color _parseHex(String hex) {
@@ -161,9 +140,49 @@ class ThemeLoader extends ChangeNotifier {
     return Color(int.parse(hex, radix: 16));
   }
 
+  void _applyBrandColors({
+    required Color primary,
+    required Color secondary,
+    required Color gradStart,
+    required Color gradEnd,
+    required Color focus,
+    bool useMagenta = false,
+    bool useClubAktiv = false,
+  }) {
+    final p = ensureForeground(primary);
+    final s = ensureForeground(secondary);
+    final g = ensureGradientForeground(gradStart, gradEnd);
+
+    _currentTheme = AppTheme.customTheme(
+      primary: p.background,
+      secondary: s.background,
+    );
+    AppGradients.setBrandGradient(g.start, g.end);
+    AppGradients.setCtaGlow(focus);
+
+    final onColors = BrandOnColors(
+      onPrimary: p.foreground,
+      onSecondary: s.foreground,
+      onGradient: g.foreground,
+      onCta: g.foreground,
+    );
+
+    final scheme = _currentTheme.colorScheme.copyWith(
+      onPrimary: onColors.onPrimary,
+      onSecondary: onColors.onSecondary,
+    );
+    _currentTheme = _currentTheme.copyWith(colorScheme: scheme);
+    _attachBrandTheme(
+      focus: focus,
+      onColors: onColors,
+      useMagenta: useMagenta,
+      useClubAktiv: useClubAktiv,
+    );
+  }
+
   void _attachBrandTheme({
     required Color focus,
-    required Color foreground,
+    required BrandOnColors onColors,
     bool useMagenta = false,
     bool useClubAktiv = false,
   }) {
@@ -175,8 +194,8 @@ class ThemeLoader extends ChangeNotifier {
                 gradient: AppGradients.brandGradient,
                 outlineGradient: AppGradients.brandGradient,
                 focusRing: focus,
-                onBrand: foreground,
+                onBrand: onColors.onCta,
               );
-    _currentTheme = _currentTheme.copyWith(extensions: [ext]);
+    _currentTheme = _currentTheme.copyWith(extensions: [ext, onColors]);
   }
 }

--- a/lib/core/widgets/brand_gradient_card.dart
+++ b/lib/core/widgets/brand_gradient_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../theme/app_brand_theme.dart';
 import '../theme/design_tokens.dart';
+import '../theme/brand_on_colors.dart';
 
 /// Reusable card container with the brand gradient and rounded corners.
 class BrandGradientCard extends StatelessWidget {
@@ -27,7 +28,9 @@ class BrandGradientCard extends StatelessWidget {
     final gradient = surface?.gradient ?? AppGradients.brandGradient;
     final shadow = surface?.shadow;
     final overlay = surface?.pressedOverlay ?? Colors.black26;
-    final onBrand = surface?.onBrand ?? Colors.white;
+    final onBrand =
+        Theme.of(context).extension<BrandOnColors>()?.onGradient ??
+            Colors.white;
 
     Widget content = Container(
       decoration: BoxDecoration(

--- a/lib/core/widgets/brand_primary_button.dart
+++ b/lib/core/widgets/brand_primary_button.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../theme/app_brand_theme.dart';
 import '../theme/design_tokens.dart';
+import '../theme/brand_on_colors.dart';
 
 /// Primary call-to-action button using the global brand gradient.
 class BrandPrimaryButton extends StatelessWidget {
@@ -27,7 +28,8 @@ class BrandPrimaryButton extends StatelessWidget {
     final gradient = surface?.gradient ?? AppGradients.brandGradient;
     final shadow = surface?.shadow;
     final overlay = surface?.pressedOverlay ?? Colors.black26;
-    final onBrand = surface?.onBrand ?? Colors.white;
+    final onBrand =
+        Theme.of(context).extension<BrandOnColors>()?.onCta ?? Colors.white;
     final textStyle = surface?.textStyle;
     final height = surface?.height ?? 48;
     final padding = surface?.padding ?? const EdgeInsets.symmetric(horizontal: AppSpacing.sm);

--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/device_provider.dart';
 import 'package:tapem/core/theme/app_brand_theme.dart';
+import 'package:tapem/core/theme/brand_on_colors.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/ui/numeric_keypad/overlay_numeric_keypad.dart';
@@ -700,7 +701,7 @@ class _RoundButtonState extends State<_RoundButton> {
               widget.icon,
               color:
                   widget.filled
-                      ? Theme.of(context).extension<AppBrandTheme>()?.onBrand ?? Theme.of(context).colorScheme.onPrimary
+                      ? Theme.of(context).extension<BrandOnColors>()?.onCta ?? Theme.of(context).colorScheme.onPrimary
                       : widget.tokens.menuFg,
             ),
           ),

--- a/lib/features/training_details/presentation/widgets/session_exercise_card.dart
+++ b/lib/features/training_details/presentation/widgets/session_exercise_card.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
-import 'package:tapem/core/theme/app_brand_theme.dart';
+import 'package:tapem/core/theme/brand_on_colors.dart';
 import '../../domain/models/session.dart';
 
 /// A reusable card displaying a session's sets for a single device/exercise.
@@ -21,7 +21,7 @@ class SessionExerciseCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final onBrand =
-        Theme.of(context).extension<AppBrandTheme>()?.onBrand ?? Colors.white;
+        Theme.of(context).extension<BrandOnColors>()?.onGradient ?? Colors.white;
     return BrandGradientCard(
       padding: padding,
       child: Column(

--- a/test/theme/contrast_test.dart
+++ b/test/theme/contrast_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/core/theme/contrast.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
+
+void main() {
+  group('contrast', () {
+    test('mint/turquoise', () {
+      final r = ensureForeground(AppColors.accentMint);
+      expect(contrastRatio(r.background, r.foreground) >= 4.5, isTrue);
+    });
+    test('magenta', () {
+      final r = ensureForeground(MagentaColors.primary600);
+      expect(contrastRatio(r.background, r.foreground) >= 4.5, isTrue);
+    });
+    test('club aktiv', () {
+      final r = ensureForeground(ClubAktivColors.primary600);
+      expect(contrastRatio(r.background, r.foreground) >= 4.5, isTrue);
+    });
+    test('very light custom', () {
+      final r = ensureForeground(const Color(0xFFF5F5F5));
+      expect(contrastRatio(r.background, r.foreground) >= 4.5, isTrue);
+    });
+    test('gradient', () {
+      final g = ensureGradientForeground(
+        AppColors.accentMint,
+        AppColors.accentTurquoise,
+      );
+      final ratios = [
+        contrastRatio(g.start, g.foreground),
+        contrastRatio(g.end, g.foreground),
+        contrastRatio(Color.lerp(g.start, g.end, 0.5)!, g.foreground),
+      ];
+      expect(ratios.every((r) => r >= 4.5), isTrue);
+    });
+  });
+}

--- a/test/ui/brand_widgets_test.dart
+++ b/test/ui/brand_widgets_test.dart
@@ -2,24 +2,43 @@ import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tapem/core/theme/app_brand_theme.dart';
+import 'package:tapem/core/theme/brand_on_colors.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/core/theme/contrast.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
 import 'package:tapem/core/widgets/brand_primary_button.dart';
 import 'package:tapem/core/widgets/brand_outline.dart';
 
 void main() {
   testWidgets('BrandGradientCard uses onBrand text colour', (tester) async {
-    final theme = ThemeData(extensions: [AppBrandTheme.defaultTheme()]);
+    final theme = ThemeData(extensions: [
+      AppBrandTheme.defaultTheme(),
+      const BrandOnColors(
+        onPrimary: Colors.white,
+        onSecondary: Colors.white,
+        onGradient: Colors.white,
+        onCta: Colors.white,
+      ),
+    ]);
     await tester.pumpWidget(MaterialApp(
       theme: theme,
       home: const BrandGradientCard(child: Text('card')),
     ));
     final text = tester.widget<Text>(find.text('card'));
-    final brand = theme.extension<AppBrandTheme>()!;
-    expect(text.style?.color, brand.onBrand);
+    final brand = theme.extension<BrandOnColors>()!;
+    expect(text.style?.color, brand.onGradient);
   });
 
   testWidgets('BrandPrimaryButton exposes semantics and colours', (tester) async {
-    final theme = ThemeData(extensions: [AppBrandTheme.defaultTheme()]);
+    final theme = ThemeData(extensions: [
+      AppBrandTheme.defaultTheme(),
+      const BrandOnColors(
+        onPrimary: Colors.white,
+        onSecondary: Colors.white,
+        onGradient: Colors.white,
+        onCta: Colors.white,
+      ),
+    ]);
     await tester.pumpWidget(MaterialApp(
       theme: theme,
       home: BrandPrimaryButton(
@@ -31,13 +50,29 @@ void main() {
     final semantics = tester.getSemantics(find.byType(BrandPrimaryButton));
     expect(semantics.hasFlag(SemanticsFlag.isButton), isTrue);
     final text = tester.widget<Text>(find.text('tap'));
-    final brand = theme.extension<AppBrandTheme>()!;
-    expect(text.style?.color, brand.onBrand);
+    final brand = theme.extension<BrandOnColors>()!;
+    expect(text.style?.color, brand.onCta);
+    final grad = AppGradients.brandGradient;
+    final ratios = [
+      contrastRatio(grad.colors.first, brand.onCta),
+      contrastRatio(grad.colors.last, brand.onCta),
+      contrastRatio(Color.lerp(grad.colors.first, grad.colors.last, 0.5)!,
+          brand.onCta),
+    ];
+    expect(ratios.every((r) => r >= 4.5), isTrue);
   });
 
   testWidgets('BrandOutline uses gradient from theme and handles states',
       (tester) async {
-    final theme = ThemeData(extensions: [AppBrandTheme.defaultTheme()]);
+    final theme = ThemeData(extensions: [
+      AppBrandTheme.defaultTheme(),
+      const BrandOnColors(
+        onPrimary: Colors.white,
+        onSecondary: Colors.white,
+        onGradient: Colors.white,
+        onCta: Colors.white,
+      ),
+    ]);
     await tester.pumpWidget(MaterialApp(
       theme: theme,
       home: Center(


### PR DESCRIPTION
## Summary
- compute WCAG-compliant on-colors for primary, secondary, gradient and CTA surfaces
- expose new BrandOnColors theme extension and replace hardcoded whites
- add contrast utility tests and widget checks for gradient/CTA rendering

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b362891f608320983f22fbfdef0e81