### PR TITLE
fix chart intervals and gradient foregrounds

### DIFF
--- a/lib/core/theme/contrast.dart
+++ b/lib/core/theme/contrast.dart
@@ -90,5 +90,13 @@ GradientContrast ensureGradientForeground(Color start, Color end,
       opacity += 0.05;
     }
   }
+  final finalMin = [
+    contrastRatio(s, bestFg),
+    contrastRatio(e, bestFg),
+    contrastRatio(mid, bestFg),
+  ].reduce(math.min);
+  if (!finalMin.isFinite || finalMin < minRatio) {
+    return GradientContrast(start, end, Colors.black);
+  }
   return GradientContrast(s, e, bestFg);
 }

--- a/lib/core/utils/chart_interval.dart
+++ b/lib/core/utils/chart_interval.dart
@@ -1,0 +1,34 @@
+import 'dart:math' as math;
+
+/// Result of resolving a safe axis interval.
+class AxisInterval {
+  final double interval;
+  final bool showTitles;
+  const AxisInterval(this.interval, this.showTitles);
+}
+
+/// Computes a positive interval for chart axes.
+///
+/// Returns [AxisInterval] with [showTitles] set to false if the range
+/// is invalid or zero. The [interval] will always be > 0 to satisfy
+/// fl_chart's assertions. The number of labels is clamped by
+/// [maxLabels] to avoid overcrowding.
+AxisInterval resolveAxisInterval(double min, double max,
+    {int targetLabels = 5, int maxLabels = 10, double fallback = 1}) {
+  final range = max - min;
+  if (!range.isFinite || range <= 0) {
+    return AxisInterval(fallback, false);
+  }
+  double interval = range / math.max(1, targetLabels);
+  if (!interval.isFinite || interval <= 0) {
+    return AxisInterval(fallback, false);
+  }
+  final labelCount = (range / interval).ceil();
+  if (labelCount > maxLabels) {
+    interval = range / maxLabels;
+  }
+  if (interval <= 0 || !interval.isFinite) {
+    interval = fallback;
+  }
+  return AxisInterval(interval, true);
+}

--- a/lib/core/widgets/brand_action_tile.dart
+++ b/lib/core/widgets/brand_action_tile.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'brand_gradient_card.dart';
+import '../theme/brand_on_colors.dart';
 
 /// Navigable tile using the brand gradient background.
 class BrandActionTile extends StatelessWidget {
@@ -23,14 +24,19 @@ class BrandActionTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final onGradient =
+        Theme.of(context).extension<BrandOnColors>()?.onGradient;
     return BrandGradientCard(
       onTap: onTap,
       child: ListTile(
         contentPadding: EdgeInsets.zero,
-        leading: leading ?? (leadingIcon != null ? Icon(leadingIcon) : null),
+        leading: leading ??
+            (leadingIcon != null
+                ? Icon(leadingIcon, color: onGradient)
+                : null),
         title: Text(title),
         subtitle: subtitle != null ? Text(subtitle!) : null,
-        trailing: trailing ?? const Icon(Icons.chevron_right),
+        trailing: trailing ?? Icon(Icons.chevron_right, color: onGradient),
       ),
     );
   }

--- a/lib/features/report/presentation/screens/report_screen_new.dart
+++ b/lib/features/report/presentation/screens/report_screen_new.dart
@@ -20,7 +20,6 @@ class ReportScreenNew extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final usageData = context.watch<ReportProvider>().usageCounts;
-    final data = usageData.isEmpty ? _exampleUsageData(context) : usageData;
     final feedbackProvider = context.watch<FeedbackProvider>();
     if (!feedbackProvider.isLoading && feedbackProvider.entries.isEmpty) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -36,7 +35,7 @@ class ReportScreenNew extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            DeviceUsageChart(usageData: data),
+            DeviceUsageChart(usageData: usageData),
             const SizedBox(height: AppSpacing.md),
             BrandActionTile(
               leadingIcon: Icons.feedback_outlined,
@@ -76,27 +75,6 @@ class ReportScreenNew extends StatelessWidget {
         ),
       ),
     );
-  }
-
-  Map<String, int> _exampleUsageData(BuildContext context) {
-    return {
-      'Gerät A': 120,
-      'Gerät B': 95,
-      'Gerät C': 80,
-      'Gerät D': 75,
-      'Gerät E': 60,
-      'Gerät F': 55,
-      'Gerät G': 50,
-      'Gerät H': 45,
-      'Gerät I': 40,
-      'Gerät J': 35,
-      'Gerät K': 30,
-      'Gerät L': 25,
-      'Gerät M': 20,
-      'Gerät N': 15,
-      'Gerät O': 10,
-      'Gerät P': 5,
-    };
   }
 
   void _showCreateSurveyDialog(BuildContext context) {

--- a/lib/features/report/presentation/widgets/device_usage_chart.dart
+++ b/lib/features/report/presentation/widgets/device_usage_chart.dart
@@ -1,6 +1,8 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
+import '../../../../core/utils/chart_interval.dart';
+
 class DeviceUsageChart extends StatefulWidget {
   final Map<String, int> usageData;
 
@@ -33,6 +35,13 @@ class _DeviceUsageChartState extends State<DeviceUsageChart> {
       display.add(MapEntry('Other', otherSum));
     }
 
+    if (display.isEmpty) {
+      return const SizedBox(
+        height: 220,
+        child: Center(child: Text('Keine Daten')),
+      );
+    }
+
     final bars = <BarChartGroupData>[];
     final gradient = [Colors.tealAccent, Colors.cyan, Colors.amber];
     for (var i = 0; i < display.length; i++) {
@@ -54,6 +63,10 @@ class _DeviceUsageChartState extends State<DeviceUsageChart> {
 
     final maxY =
         display.map((e) => e.value).reduce((a, b) => a > b ? a : b).toDouble();
+    final yInterval = resolveAxisInterval(0, maxY, targetLabels: 5);
+    final xMax = (display.length - 1).toDouble();
+    final xInterval =
+        resolveAxisInterval(0, xMax, targetLabels: 6, maxLabels: 10);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -75,7 +88,8 @@ class _DeviceUsageChartState extends State<DeviceUsageChart> {
               titlesData: FlTitlesData(
                 bottomTitles: AxisTitles(
                   sideTitles: SideTitles(
-                    showTitles: true,
+                    showTitles: xInterval.showTitles,
+                    interval: xInterval.interval,
                     getTitlesWidget: (value, meta) {
                       final i = value.toInt();
                       if (i < 0 || i >= display.length) return const SizedBox();
@@ -91,7 +105,9 @@ class _DeviceUsageChartState extends State<DeviceUsageChart> {
                   ),
                 ),
                 leftTitles: AxisTitles(
-                  sideTitles: SideTitles(showTitles: true, interval: maxY / 5),
+                  sideTitles: SideTitles(
+                      showTitles: yInterval.showTitles,
+                      interval: yInterval.interval),
                 ),
                 topTitles: AxisTitles(
                   sideTitles: SideTitles(showTitles: false),

--- a/test/core/theme/contrast_utils_test.dart
+++ b/test/core/theme/contrast_utils_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/core/theme/contrast.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
+
+void main() {
+  test('mint/turquoise gradient picks black foreground', () {
+    final grad = ensureGradientForeground(
+      AppColors.accentMint,
+      AppColors.accentTurquoise,
+    );
+    expect(grad.foreground, Colors.black);
+  });
+}

--- a/test/core/utils/chart_interval_test.dart
+++ b/test/core/utils/chart_interval_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/core/utils/chart_interval.dart';
+
+void main() {
+  test('zero range disables titles and uses fallback interval', () {
+    final res = resolveAxisInterval(0, 0);
+    expect(res.showTitles, isFalse);
+    expect(res.interval, greaterThan(0));
+  });
+
+  test('tiny range still yields positive interval', () {
+    final res = resolveAxisInterval(0, 0.001);
+    expect(res.showTitles, isTrue);
+    expect(res.interval, greaterThan(0));
+  });
+
+  test('normal range computes expected interval', () {
+    final res = resolveAxisInterval(0, 100, targetLabels: 5);
+    expect(res.showTitles, isTrue);
+    expect(res.interval, closeTo(20, 0.0001));
+  });
+}

--- a/test/ui/rank_tiles_test.dart
+++ b/test/ui/rank_tiles_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
+import 'package:tapem/core/theme/brand_on_colors.dart';
+import 'package:tapem/core/widgets/brand_action_tile.dart';
+
+void main() {
+  testWidgets('Rank tile text and chevron use onGradient colour', (tester) async {
+    const onGrad = Colors.black;
+    final theme = ThemeData(extensions: [
+      AppBrandTheme.defaultTheme(),
+      const BrandOnColors(
+        onPrimary: Colors.white,
+        onSecondary: Colors.white,
+        onGradient: onGrad,
+        onCta: Colors.white,
+      ),
+    ]);
+
+    await tester.pumpWidget(MaterialApp(
+      theme: theme,
+      home: const BrandActionTile(title: 'tile'),
+    ));
+
+    final text = tester.widget<Text>(find.text('tile'));
+    expect(text.style?.color, onGrad);
+
+    final icon = tester.widget<Icon>(find.byIcon(Icons.chevron_right));
+    expect(icon.color, onGrad);
+  });
+}


### PR DESCRIPTION
## Summary
- add centralized axis interval resolver to avoid zero tick spacing and render placeholder when no device usage data
- apply BrandOnColors.onGradient to gradient tiles and add contrast fallback to black
- expand tests for axis interval, gradient contrast, and rank tiles

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b36d66f4288320baac63e03909cb9c