### PR TITLE
Force black foreground on brand surfaces

### DIFF
--- a/lib/core/theme/theme_loader.dart
+++ b/lib/core/theme/theme_loader.dart
@@ -5,7 +5,6 @@ import 'design_tokens.dart';
 import 'theme.dart';
 import 'app_brand_theme.dart';
 import 'brand_on_colors.dart';
-import 'contrast.dart';
 
 /// Lädt dynamisch Themes je nach Gym.
 class ThemeLoader extends ChangeNotifier {
@@ -149,22 +148,18 @@ class ThemeLoader extends ChangeNotifier {
     bool useMagenta = false,
     bool useClubAktiv = false,
   }) {
-    final p = ensureForeground(primary);
-    final s = ensureForeground(secondary);
-    final g = ensureGradientForeground(gradStart, gradEnd);
-
     _currentTheme = AppTheme.customTheme(
-      primary: p.background,
-      secondary: s.background,
+      primary: primary,
+      secondary: secondary,
     );
-    AppGradients.setBrandGradient(g.start, g.end);
+    AppGradients.setBrandGradient(gradStart, gradEnd);
     AppGradients.setCtaGlow(focus);
 
-    final onColors = BrandOnColors(
-      onPrimary: p.foreground,
-      onSecondary: s.foreground,
-      onGradient: g.foreground,
-      onCta: g.foreground,
+    const onColors = BrandOnColors(
+      onPrimary: Colors.black,
+      onSecondary: Colors.black,
+      onGradient: Colors.black,
+      onCta: Colors.black,
     );
 
     final scheme = _currentTheme.colorScheme.copyWith(

--- a/lib/core/widgets/brand_action_tile.dart
+++ b/lib/core/widgets/brand_action_tile.dart
@@ -25,7 +25,7 @@ class BrandActionTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final onGradient =
-        Theme.of(context).extension<BrandOnColors>()?.onGradient;
+        Theme.of(context).extension<BrandOnColors>()?.onGradient ?? Colors.black;
     return BrandGradientCard(
       onTap: onTap,
       child: ListTile(

--- a/lib/core/widgets/brand_gradient_card.dart
+++ b/lib/core/widgets/brand_gradient_card.dart
@@ -30,7 +30,7 @@ class BrandGradientCard extends StatelessWidget {
     final overlay = surface?.pressedOverlay ?? Colors.black26;
     final onBrand =
         Theme.of(context).extension<BrandOnColors>()?.onGradient ??
-            Colors.white;
+            Colors.black;
 
     Widget content = Container(
       decoration: BoxDecoration(

--- a/lib/core/widgets/brand_primary_button.dart
+++ b/lib/core/widgets/brand_primary_button.dart
@@ -29,7 +29,7 @@ class BrandPrimaryButton extends StatelessWidget {
     final shadow = surface?.shadow;
     final overlay = surface?.pressedOverlay ?? Colors.black26;
     final onBrand =
-        Theme.of(context).extension<BrandOnColors>()?.onCta ?? Colors.white;
+        Theme.of(context).extension<BrandOnColors>()?.onCta ?? Colors.black;
     final textStyle = surface?.textStyle;
     final height = surface?.height ?? 48;
     final padding = surface?.padding ?? const EdgeInsets.symmetric(horizontal: AppSpacing.sm);

--- a/lib/features/device/presentation/widgets/last_session_card.dart
+++ b/lib/features/device/presentation/widgets/last_session_card.dart
@@ -99,9 +99,9 @@ class _DropChip extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
       decoration: BoxDecoration(
-        color: Colors.white.withOpacity(0.06),
+        color: Colors.black.withOpacity(0.06),
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: Colors.white24, width: 0.5),
+        border: Border.all(color: Colors.black.withOpacity(0.24), width: 0.5),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,

--- a/lib/features/gym/presentation/widgets/device_card.dart
+++ b/lib/features/gym/presentation/widgets/device_card.dart
@@ -4,6 +4,7 @@ import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/core/utils/context_extensions.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/widgets/brand_outline.dart';
+import 'package:tapem/core/theme/brand_on_colors.dart';
 
 class DeviceCard extends StatefulWidget {
   final Device device;
@@ -28,6 +29,7 @@ class _DeviceCardState extends State<DeviceCard> {
     final initial = device.name.isNotEmpty ? device.name[0].toUpperCase() : '?';
     final subtitle = device.description;
     final idText = device.id > 0 ? device.id.toString() : '–';
+    final onBrand = Theme.of(context).extension<BrandOnColors>()?.onGradient ?? Colors.black;
     return Hero(
       tag: 'device-${device.uid}',
       child: AnimatedScale(
@@ -56,7 +58,10 @@ class _DeviceCardState extends State<DeviceCard> {
                           gradient: AppGradients.brandGradient,
                         ),
                         child: Center(
-                          child: Text(initial, style: theme.textTheme.titleLarge),
+                          child: Text(
+                            initial,
+                            style: theme.textTheme.titleLarge?.copyWith(color: onBrand),
+                          ),
                         ),
                       ),
                     ),

--- a/lib/features/training_details/presentation/widgets/session_exercise_card.dart
+++ b/lib/features/training_details/presentation/widgets/session_exercise_card.dart
@@ -21,7 +21,7 @@ class SessionExerciseCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final onBrand =
-        Theme.of(context).extension<BrandOnColors>()?.onGradient ?? Colors.white;
+        Theme.of(context).extension<BrandOnColors>()?.onGradient ?? Colors.black;
     return BrandGradientCard(
       padding: padding,
       child: Column(
@@ -39,7 +39,7 @@ class SessionExerciseCard extends StatelessWidget {
             Text(
               subtitle!,
               style: TextStyle(
-                color: onBrand.withOpacity(0.7),
+                color: onBrand,
                 fontSize: 14,
               ),
             ),
@@ -61,7 +61,7 @@ class SessionExerciseCard extends StatelessWidget {
                       Text(
                         '${set.weight.toStringAsFixed(1)} kg',
                         style: TextStyle(
-                          color: onBrand.withOpacity(0.7),
+                          color: onBrand,
                           fontSize: 14,
                         ),
                       ),
@@ -74,7 +74,7 @@ class SessionExerciseCard extends StatelessWidget {
                       Text(
                         '${set.reps} Wdh',
                         style: TextStyle(
-                          color: onBrand.withOpacity(0.7),
+                          color: onBrand,
                           fontSize: 14,
                         ),
                       ),
@@ -86,7 +86,7 @@ class SessionExerciseCard extends StatelessWidget {
                       child: Text(
                         '↘︎ ${set.dropWeightKg!.toStringAsFixed(1)} kg × ${set.dropReps}',
                         style: TextStyle(
-                          color: onBrand.withOpacity(0.6),
+                          color: onBrand,
                           fontSize: 12,
                         ),
                       ),

--- a/lib/features/xp/presentation/widgets/xp_gauge.dart
+++ b/lib/features/xp/presentation/widgets/xp_gauge.dart
@@ -88,20 +88,14 @@ class XpGauge extends StatelessWidget {
                   '$currentXp XP',
                   style: TextStyle(
                     fontSize: size * 0.14,
-                    color: Theme.of(context)
-                        .colorScheme
-                        .onPrimary
-                        .withOpacity(0.6),
+                    color: Theme.of(context).colorScheme.onPrimary,
                   ),
                 ),
                 Text(
                   label,
                   style: TextStyle(
                     fontSize: size * 0.12,
-                    color: Theme.of(context)
-                        .colorScheme
-                        .onPrimary
-                        .withOpacity(0.5),
+                    color: Theme.of(context).colorScheme.onPrimary,
                   ),
                 ),
               ],

--- a/test/theme/theme_loader_test.dart
+++ b/test/theme/theme_loader_test.dart
@@ -4,6 +4,7 @@ import 'package:tapem/core/theme/theme_loader.dart';
 import 'package:tapem/features/gym/domain/models/branding.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/theme/theme.dart';
+import 'package:tapem/core/theme/brand_on_colors.dart';
 
 void main() {
   group('ThemeLoader', () {
@@ -47,6 +48,15 @@ void main() {
       final loader = ThemeLoader()..loadDefault();
       loader.applyBranding('other', null);
       expect(loader.theme.colorScheme.primary, AppColors.accentMint);
+    });
+
+    test('BrandOnColors tokens are black', () {
+      final loader = ThemeLoader()..loadDefault();
+      final on = loader.theme.extension<BrandOnColors>()!;
+      expect(on.onPrimary, Colors.black);
+      expect(on.onSecondary, Colors.black);
+      expect(on.onGradient, Colors.black);
+      expect(on.onCta, Colors.black);
     });
 
     test('gym_01 surfaces are normalised to reference luminance', () {

--- a/test/ui/brand_widgets_test.dart
+++ b/test/ui/brand_widgets_test.dart
@@ -4,20 +4,21 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/core/theme/brand_on_colors.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
-import 'package:tapem/core/theme/contrast.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
 import 'package:tapem/core/widgets/brand_primary_button.dart';
 import 'package:tapem/core/widgets/brand_outline.dart';
+import 'package:tapem/features/training_details/presentation/widgets/session_exercise_card.dart';
+import 'package:tapem/features/training_details/domain/models/session.dart';
 
 void main() {
   testWidgets('BrandGradientCard uses onBrand text colour', (tester) async {
     final theme = ThemeData(extensions: [
       AppBrandTheme.defaultTheme(),
       const BrandOnColors(
-        onPrimary: Colors.white,
-        onSecondary: Colors.white,
-        onGradient: Colors.white,
-        onCta: Colors.white,
+        onPrimary: Colors.black,
+        onSecondary: Colors.black,
+        onGradient: Colors.black,
+        onCta: Colors.black,
       ),
     ]);
     await tester.pumpWidget(MaterialApp(
@@ -33,10 +34,10 @@ void main() {
     final theme = ThemeData(extensions: [
       AppBrandTheme.defaultTheme(),
       const BrandOnColors(
-        onPrimary: Colors.white,
-        onSecondary: Colors.white,
-        onGradient: Colors.white,
-        onCta: Colors.white,
+        onPrimary: Colors.black,
+        onSecondary: Colors.black,
+        onGradient: Colors.black,
+        onCta: Colors.black,
       ),
     ]);
     await tester.pumpWidget(MaterialApp(
@@ -52,14 +53,6 @@ void main() {
     final text = tester.widget<Text>(find.text('tap'));
     final brand = theme.extension<BrandOnColors>()!;
     expect(text.style?.color, brand.onCta);
-    final grad = AppGradients.brandGradient;
-    final ratios = [
-      contrastRatio(grad.colors.first, brand.onCta),
-      contrastRatio(grad.colors.last, brand.onCta),
-      contrastRatio(Color.lerp(grad.colors.first, grad.colors.last, 0.5)!,
-          brand.onCta),
-    ];
-    expect(ratios.every((r) => r >= 4.5), isTrue);
   });
 
   testWidgets('BrandOutline uses gradient from theme and handles states',
@@ -67,10 +60,10 @@ void main() {
     final theme = ThemeData(extensions: [
       AppBrandTheme.defaultTheme(),
       const BrandOnColors(
-        onPrimary: Colors.white,
-        onSecondary: Colors.white,
-        onGradient: Colors.white,
-        onCta: Colors.white,
+        onPrimary: Colors.black,
+        onSecondary: Colors.black,
+        onGradient: Colors.black,
+        onCta: Colors.black,
       ),
     ]);
     await tester.pumpWidget(MaterialApp(
@@ -107,5 +100,32 @@ void main() {
     );
     final brand = theme.extension<AppBrandTheme>()!;
     expect(opacity.opacity, brand.outlineDisabledOpacity);
+  });
+
+  testWidgets('SessionExerciseCard uses black foreground', (tester) async {
+    final theme = ThemeData(extensions: [
+      AppBrandTheme.defaultTheme(),
+      const BrandOnColors(
+        onPrimary: Colors.black,
+        onSecondary: Colors.black,
+        onGradient: Colors.black,
+        onCta: Colors.black,
+      ),
+    ]);
+
+    await tester.pumpWidget(MaterialApp(
+      theme: theme,
+      home: SessionExerciseCard(
+        title: 'Bench',
+        subtitle: 'Chest',
+        sets: const [SessionSet(weight: 10, reps: 5)],
+      ),
+    ));
+
+    final rich = tester.widget<RichText>(find.text('Bench'));
+    expect(rich.text.style?.color, Colors.black);
+    final iconColor =
+        IconTheme.of(tester.element(find.byIcon(Icons.fitness_center))).color;
+    expect(iconColor, Colors.black);
   });
 }

--- a/test/ui/rank_tiles_test.dart
+++ b/test/ui/rank_tiles_test.dart
@@ -10,10 +10,10 @@ void main() {
     final theme = ThemeData(extensions: [
       AppBrandTheme.defaultTheme(),
       const BrandOnColors(
-        onPrimary: Colors.white,
-        onSecondary: Colors.white,
+        onPrimary: Colors.black,
+        onSecondary: Colors.black,
         onGradient: onGrad,
-        onCta: Colors.white,
+        onCta: Colors.black,
       ),
     ]);
 


### PR DESCRIPTION
## Summary
- Remove contrast heuristics and map brand on-colors to constant black
- Centralize black foreground usage in brand widgets and gradients
- Update tests for black BrandOnColors tokens and brand components

## Testing
- `flutter format lib/core/theme/theme_loader.dart ... test/theme/theme_loader_test.dart` *(command not found: flutter)*
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b375f15a4c832095b17ee5f0cf913c