### PR TITLE
Ensure black text on gradient cards

### DIFF
--- a/lib/core/widgets/brand_action_tile.dart
+++ b/lib/core/widgets/brand_action_tile.dart
@@ -34,8 +34,16 @@ class BrandActionTile extends StatelessWidget {
             (leadingIcon != null
                 ? Icon(leadingIcon, color: onGradient)
                 : null),
-        title: Text(title),
-        subtitle: subtitle != null ? Text(subtitle!) : null,
+        title: Text(
+          title,
+          style: const TextStyle(color: Colors.black),
+        ),
+        subtitle: subtitle != null
+            ? Text(
+                subtitle!,
+                style: const TextStyle(color: Colors.black),
+              )
+            : null,
         trailing: trailing ?? Icon(Icons.chevron_right, color: onGradient),
       ),
     );


### PR DESCRIPTION
## Summary
- enforce black text for titles and subtitles inside BrandActionTile

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b37d614b9c83209acbed0c176c1d6c