### PR TITLE
Allow spaces in username validation

### DIFF
--- a/lib/features/profile/presentation/widgets/change_username_sheet.dart
+++ b/lib/features/profile/presentation/widgets/change_username_sheet.dart
@@ -8,7 +8,7 @@ Future<void> showChangeUsernameSheet(BuildContext context) async {
   final loc = AppLocalizations.of(context)!;
   final auth = context.read<AuthProvider>();
   final ctr = TextEditingController(text: auth.userName ?? '');
-  final regex = RegExp(r'^(?!_)(?!.*__)[A-Za-z0-9_]{3,20}(?<!_)$');
+  final regex = RegExp(r'^(?!_)(?!.*__)[A-Za-z0-9 _]{3,20}(?<!_)$');
   String? error;
   bool available = false;
   bool isValid(String v) => regex.hasMatch(v);

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -471,7 +471,7 @@
   "@usernameTaken": {"description": "Fehler wenn Nutzername existiert"},
   "usernameInvalid": "Ungültiger Nutzername.",
   "@usernameInvalid": {"description": "Fehler bei ungültigem Nutzernamen"},
-  "usernameHelper": "3–20 Zeichen, Buchstaben, Zahlen, Unterstrich. Nicht mit _ starten/enden, keine doppelten Unterstriche.",
+  "usernameHelper": "3–20 Zeichen, Buchstaben, Zahlen, Leerzeichen, Unterstrich. Nicht mit _ starten/enden, keine doppelten Unterstriche.",
   "@usernameHelper": {"description": "Hinweistext für Nutzernamen-Regeln"},
   "usernameLowerPreview": "Klein: {lower}",
   "@usernameLowerPreview": {"description": "Vorschau des kleingeschriebenen Nutzernamens", "placeholders": {"lower": {}}},

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -469,7 +469,7 @@
   "@usernameTaken": {"description": "Error when username exists"},
   "usernameInvalid": "Invalid username.",
   "@usernameInvalid": {"description": "Error for invalid username"},
-  "usernameHelper": "3–20 chars, letters, numbers, underscores. Can't start or end with underscore, no double underscores.",
+  "usernameHelper": "3–20 chars, letters, numbers, spaces, underscores. Can't start or end with underscore, no double underscores.",
   "@usernameHelper": {"description": "Helper text for username rules"},
   "usernameLowerPreview": "Lowercase: {lower}",
   "@usernameLowerPreview": {"description": "Preview of lowercased username", "placeholders": {"lower": {}}},

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -692,7 +692,7 @@ abstract class AppLocalizations {
   /// Helper text for username rules
   ///
   /// In en, this message translates to:
-  /// **'3–20 chars, letters, numbers, underscores. Can't start or end with underscore, no double underscores.'**
+  /// **'3–20 chars, letters, numbers, spaces, underscores. Can't start or end with underscore, no double underscores.'**
   String get usernameHelper;
 
   /// Preview of lowercased username

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -319,7 +319,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get usernameHelper =>
-      '3–20 Zeichen, Buchstaben, Zahlen, Unterstrich. Nicht mit _ starten/enden, keine doppelten Unterstriche.';
+      '3–20 Zeichen, Buchstaben, Zahlen, Leerzeichen, Unterstrich. Nicht mit _ starten/enden, keine doppelten Unterstriche.';
 
   @override
   String usernameLowerPreview(Object lower) {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -319,7 +319,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get usernameHelper =>
-      '3–20 chars, letters, numbers, underscores. Can't start or end with underscore, no double underscores.';
+      '3–20 chars, letters, numbers, spaces, underscores. Can't start or end with underscore, no double underscores.';
 
   @override
   String usernameLowerPreview(Object lower) {


### PR DESCRIPTION
## Summary
- allow spaces in username regex
- document new username rules in localizations

## Testing
- `flutter test` *(fails: command not found)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b3999f9e3883209418f7b82788010b