### PR TITLE
Allow spaces in usernames

### DIFF
--- a/functions/__tests__/change_username.test.js
+++ b/functions/__tests__/change_username.test.js
@@ -29,6 +29,16 @@ describe('changeUsername', () => {
     await expect(wrapped({ newUsername: 'Bob' }, { auth: { uid: 'user2' } })).rejects.toThrow();
   });
 
+  it('allows spaces', async () => {
+    const uid = 'userSpace';
+    await admin.firestore().collection('users').doc(uid).set({});
+    const wrapped = fft.wrap(myFuncs.changeUsername);
+    const res = await wrapped({ newUsername: 'Alice Smith' }, { auth: { uid } });
+    expect(res.username).toBe('Alice Smith');
+    const userDoc = await admin.firestore().collection('users').doc(uid).get();
+    expect(userDoc.data().usernameLower).toBe('alice smith');
+  });
+
   it('normalizes case', async () => {
     const uid = 'user3';
     await admin.firestore().collection('users').doc(uid).set({});

--- a/functions/index.js
+++ b/functions/index.js
@@ -629,7 +629,7 @@ exports.changeUsername = functions.https.onCall(async (data, context) => {
     throw new functions.https.HttpsError('invalid-argument', 'Missing username');
   }
   const target = newUsername.trim();
-  const regex = /^(?!_)(?!.*__)[A-Za-z0-9_]{3,20}(?<!_)$/;
+  const regex = /^[A-Za-z0-9 ]{3,20}$/;
   if (!regex.test(target)) {
     throw new functions.https.HttpsError('invalid-argument', 'username_invalid');
   }

--- a/lib/features/profile/presentation/widgets/change_username_sheet.dart
+++ b/lib/features/profile/presentation/widgets/change_username_sheet.dart
@@ -7,11 +7,11 @@ import 'package:tapem/l10n/app_localizations.dart';
 Future<void> showChangeUsernameSheet(BuildContext context) async {
   final loc = AppLocalizations.of(context)!;
   final auth = context.read<AuthProvider>();
-  final ctr = TextEditingController(text: auth.userName ?? '');
-  final regex = RegExp(r'^(?!_)(?!.*__)[A-Za-z0-9 _]{3,20}(?<!_)$');
+  final ctr = TextEditingController();
+  final regex = RegExp(r'^[A-Za-z0-9 ]{3,20}$');
   String? error;
   bool available = false;
-  bool isValid(String v) => regex.hasMatch(v);
+  bool isValid(String v) => regex.hasMatch(v.trim());
   Timer? debouncer;
   bool loading = false;
 
@@ -67,8 +67,8 @@ Future<void> showChangeUsernameSheet(BuildContext context) async {
                 ),
               ),
               const SizedBox(height: 8),
-              if (ctr.text.isNotEmpty)
-                Text(loc.usernameLowerPreview(ctr.text.toLowerCase())),
+              if (ctr.text.trim().isNotEmpty)
+                Text(loc.usernameLowerPreview(ctr.text.trim().toLowerCase())),
               const SizedBox(height: 16),
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,
@@ -79,7 +79,7 @@ Future<void> showChangeUsernameSheet(BuildContext context) async {
                   ),
                   const SizedBox(width: 8),
                   ElevatedButton(
-                    onPressed: (!loading && available && isValid(ctr.text))
+                    onPressed: (!loading && available && isValid(ctr.text.trim()))
                         ? () async {
                             setState(() => loading = true);
                             final success = await auth.setUsername(ctr.text.trim());

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -471,7 +471,7 @@
   "@usernameTaken": {"description": "Fehler wenn Nutzername existiert"},
   "usernameInvalid": "Ungültiger Nutzername.",
   "@usernameInvalid": {"description": "Fehler bei ungültigem Nutzernamen"},
-  "usernameHelper": "3–20 Zeichen, Buchstaben, Zahlen, Leerzeichen, Unterstrich. Nicht mit _ starten/enden, keine doppelten Unterstriche.",
+  "usernameHelper": "3–20 Zeichen, Buchstaben, Zahlen, Leerzeichen.",
   "@usernameHelper": {"description": "Hinweistext für Nutzernamen-Regeln"},
   "usernameLowerPreview": "Klein: {lower}",
   "@usernameLowerPreview": {"description": "Vorschau des kleingeschriebenen Nutzernamens", "placeholders": {"lower": {}}},

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -469,7 +469,7 @@
   "@usernameTaken": {"description": "Error when username exists"},
   "usernameInvalid": "Invalid username.",
   "@usernameInvalid": {"description": "Error for invalid username"},
-  "usernameHelper": "3–20 chars, letters, numbers, spaces, underscores. Can't start or end with underscore, no double underscores.",
+  "usernameHelper": "3–20 chars, letters, numbers, spaces.",
   "@usernameHelper": {"description": "Helper text for username rules"},
   "usernameLowerPreview": "Lowercase: {lower}",
   "@usernameLowerPreview": {"description": "Preview of lowercased username", "placeholders": {"lower": {}}},

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -319,7 +319,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get usernameHelper =>
-      '3–20 Zeichen, Buchstaben, Zahlen, Leerzeichen, Unterstrich. Nicht mit _ starten/enden, keine doppelten Unterstriche.';
+      '3–20 Zeichen, Buchstaben, Zahlen, Leerzeichen.';
 
   @override
   String usernameLowerPreview(Object lower) {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -319,7 +319,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get usernameHelper =>
-      '3–20 chars, letters, numbers, spaces, underscores. Can't start or end with underscore, no double underscores.';
+      '3–20 chars, letters, numbers, spaces.';
 
   @override
   String usernameLowerPreview(Object lower) {


### PR DESCRIPTION
## Summary
- empty username change field and validate letters, numbers, spaces only
- allow spaces in Cloud Function username change
- update localization hints and add test for usernames with spaces

## Testing
- `npm --prefix functions test` *(fails: jest: not found)*
- `npm --prefix functions install` *(fails: 403 Forbidden for firebase-functions-test)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b39ce3e4e883208abd85884c0aa3cb