### PR TITLE
Allow optimistic username save

### DIFF
--- a/lib/features/profile/presentation/widgets/change_username_sheet.dart
+++ b/lib/features/profile/presentation/widgets/change_username_sheet.dart
@@ -4,14 +4,38 @@ import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 
+enum UsernameAvailability { idle, loading, available, taken, error }
+
+String normalizeUsername(String v) {
+  final collapsed = v.replaceAll(RegExp(' +'), ' ');
+  return collapsed.trim();
+}
+
+bool isValidUsername(String v) {
+  final n = normalizeUsername(v);
+  if (n.length < 3 || n.length > 20) return false;
+  return RegExp(r'^[A-Za-z0-9 ]+$').hasMatch(n);
+}
+
+bool canSubmitUsername({
+  required String input,
+  required String current,
+  required UsernameAvailability availability,
+  required bool submitting,
+}) {
+  final normalized = normalizeUsername(input);
+  final currentNorm = normalizeUsername(current);
+  return !submitting &&
+      isValidUsername(normalized) &&
+      normalized.toLowerCase() != currentNorm.toLowerCase() &&
+      availability != UsernameAvailability.taken;
+}
 Future<void> showChangeUsernameSheet(BuildContext context) async {
   final loc = AppLocalizations.of(context)!;
   final auth = context.read<AuthProvider>();
   final ctr = TextEditingController();
-  final regex = RegExp(r'^[A-Za-z0-9 ]{3,20}$');
   String? error;
-  bool available = false;
-  bool isValid(String v) => regex.hasMatch(v.trim());
+  UsernameAvailability availability = UsernameAvailability.idle;
   Timer? debouncer;
   bool loading = false;
 
@@ -21,22 +45,38 @@ Future<void> showChangeUsernameSheet(BuildContext context) async {
     builder: (_) => StatefulBuilder(
       builder: (ctx, setState) {
         Future<void> check(String value) async {
-          final name = value.trim();
-          if (!isValid(name)) {
+          final name = normalizeUsername(value);
+          if (!isValidUsername(name)) {
             setState(() {
               error = name.isEmpty ? null : loc.usernameInvalid;
-              available = false;
+              availability = UsernameAvailability.idle;
+            });
+            return;
+          }
+          final current = auth.userName ?? '';
+          if (name.toLowerCase() == normalizeUsername(current).toLowerCase()) {
+            setState(() {
+              error = null;
+              availability = UsernameAvailability.idle;
             });
             return;
           }
           setState(() {
             error = null;
+            availability = UsernameAvailability.loading;
           });
-          final free = await auth.checkUsernameAvailable(name);
-          setState(() {
-            available = free;
-            if (!free) error = loc.usernameTaken;
-          });
+          try {
+            final free = await auth.checkUsernameAvailable(name.toLowerCase());
+            setState(() {
+              availability =
+                  free ? UsernameAvailability.available : UsernameAvailability.taken;
+              if (!free) error = loc.usernameTaken;
+            });
+          } catch (_) {
+            setState(() {
+              availability = UsernameAvailability.error;
+            });
+          }
         }
 
         return Padding(
@@ -55,9 +95,18 @@ Future<void> showChangeUsernameSheet(BuildContext context) async {
               TextField(
                 controller: ctr,
                 autofocus: true,
+                enabled: !loading,
                 onChanged: (v) {
+                  final normalized = normalizeUsername(v);
+                  if (v != normalized) {
+                    ctr.value = TextEditingValue(
+                      text: normalized,
+                      selection: TextSelection.collapsed(offset: normalized.length),
+                    );
+                  }
                   debouncer?.cancel();
-                  debouncer = Timer(const Duration(milliseconds: 300), () => check(v));
+                  debouncer =
+                      Timer(const Duration(milliseconds: 300), () => check(normalized));
                   setState(() {});
                 },
                 decoration: InputDecoration(
@@ -67,8 +116,9 @@ Future<void> showChangeUsernameSheet(BuildContext context) async {
                 ),
               ),
               const SizedBox(height: 8),
-              if (ctr.text.trim().isNotEmpty)
-                Text(loc.usernameLowerPreview(ctr.text.trim().toLowerCase())),
+              if (normalizeUsername(ctr.text).isNotEmpty)
+                Text(loc
+                    .usernameLowerPreview(normalizeUsername(ctr.text).toLowerCase())),
               const SizedBox(height: 16),
               Row(
                 mainAxisAlignment: MainAxisAlignment.end,
@@ -79,27 +129,40 @@ Future<void> showChangeUsernameSheet(BuildContext context) async {
                   ),
                   const SizedBox(width: 8),
                   ElevatedButton(
-                    onPressed: (!loading && available && isValid(ctr.text.trim()))
+                    onPressed: canSubmitUsername(
+                            input: ctr.text,
+                            current: auth.userName ?? '',
+                            availability: availability,
+                            submitting: loading)
                         ? () async {
+                            final username = normalizeUsername(ctr.text);
                             setState(() => loading = true);
-                            final success = await auth.setUsername(ctr.text.trim());
+                            final success = await auth.setUsername(username);
                             if (success) {
                               // ignore: use_build_context_synchronously
                               Navigator.pop(ctx);
                               // ignore: use_build_context_synchronously
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(content: Text(loc.saveSuccess)),
-                              );
+                              ScaffoldMessenger.of(context)
+                                  .showSnackBar(SnackBar(content: Text(loc.saveSuccess)));
                             } else {
                               setState(() {
                                 loading = false;
-                                error = auth.error ?? loc.usernameTaken;
+                                if (auth.error == 'Username already taken') {
+                                  error = loc.usernameTaken;
+                                  availability = UsernameAvailability.taken;
+                                } else {
+                                  error = auth.error;
+                                  availability = UsernameAvailability.error;
+                                }
                               });
                             }
                           }
                         : null,
                     child: loading
-                        ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator(strokeWidth: 2))
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2))
                         : Text(loc.saveButton),
                   ),
                 ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,6 +84,7 @@ dev_dependencies:
   json_serializable: ^6.7.0
   flutter_launcher_icons: ^0.14.3
   fake_cloud_firestore: ^3.1.0
+  mocktail: ^1.0.0
 
 # Overrides (behalten, damit nfc_manager konsistent aus Git kommt;
 # value_layout_builder ist erforderlich für aktuelle Abhängigkeiten)

--- a/test/features/profile/change_username_sheet_test.dart
+++ b/test/features/profile/change_username_sheet_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/features/profile/presentation/widgets/change_username_sheet.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
+class MockAuthProvider extends Mock implements AuthProvider {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue('');
+  });
+
+  Future<void> _openSheet(WidgetTester tester, AuthProvider auth) async {
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AuthProvider>.value(
+        value: auth,
+        child: MaterialApp(
+          locale: const Locale('de'),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () => showChangeUsernameSheet(context),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('typing a valid new username enables save', (tester) async {
+    final auth = MockAuthProvider();
+    when(() => auth.userName).thenReturn('current');
+    when(() => auth.checkUsernameAvailable(any())).thenAnswer((_) async => true);
+    when(() => auth.setUsername(any())).thenAnswer((_) async => true);
+    when(() => auth.error).thenReturn(null);
+
+    await _openSheet(tester, auth);
+
+    await tester.enterText(find.byType(TextField), 'new name');
+    await tester.pump(const Duration(milliseconds: 600));
+
+    final saveFinder = find.widgetWithText(ElevatedButton, 'Speichern');
+    final button = tester.widget<ElevatedButton>(saveFinder);
+    expect(button.onPressed, isNotNull);
+  });
+
+  testWidgets('same username keeps save disabled', (tester) async {
+    final auth = MockAuthProvider();
+    when(() => auth.userName).thenReturn('current');
+    when(() => auth.checkUsernameAvailable(any())).thenAnswer((_) async => true);
+    when(() => auth.setUsername(any())).thenAnswer((_) async => true);
+    when(() => auth.error).thenReturn(null);
+
+    await _openSheet(tester, auth);
+
+    await tester.enterText(find.byType(TextField), 'Current');
+    await tester.pump(const Duration(milliseconds: 600));
+
+    final saveFinder = find.widgetWithText(ElevatedButton, 'Speichern');
+    final button = tester.widget<ElevatedButton>(saveFinder);
+    expect(button.onPressed, isNull);
+  });
+}

--- a/test/features/profile/change_username_validator_test.dart
+++ b/test/features/profile/change_username_validator_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/features/profile/presentation/widgets/change_username_sheet.dart';
+
+void main() {
+  group('username normalization and validation', () {
+    test('collapses spaces and trims', () {
+      expect(normalizeUsername('  foo  bar  '), 'foo bar');
+    });
+
+    test('allows spaces and enforces length', () {
+      expect(isValidUsername('foo bar'), isTrue);
+      expect(isValidUsername('fo'), isFalse);
+      expect(isValidUsername('a' * 21), isFalse);
+    });
+
+    test('normalizes double spaces', () {
+      expect(normalizeUsername('foo  bar'), 'foo bar');
+    });
+  });
+
+  group('canSubmitUsername', () {
+    const current = 'current';
+
+    test('enables for non-taken states', () {
+      for (final state in [
+        UsernameAvailability.idle,
+        UsernameAvailability.loading,
+        UsernameAvailability.available,
+        UsernameAvailability.error,
+      ]) {
+        expect(
+          canSubmitUsername(
+            input: 'new name',
+            current: current,
+            availability: state,
+            submitting: false,
+          ),
+          isTrue,
+          reason: 'state: $state',
+        );
+      }
+    });
+
+    test('disables when taken or same as current', () {
+      expect(
+        canSubmitUsername(
+          input: 'new name',
+          current: current,
+          availability: UsernameAvailability.taken,
+          submitting: false,
+        ),
+        isFalse,
+      );
+      expect(
+        canSubmitUsername(
+          input: 'Current',
+          current: current,
+          availability: UsernameAvailability.available,
+          submitting: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- allow saving of new usernames while availability check is pending
- validate usernames with spaces and length limits and collapse spaces
- add tests for validator and save button enabling

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test test/features/profile/change_username_validator_test.dart test/features/profile/change_username_sheet_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a1505bac8320987c973a44994063