### PR TITLE
Allow username mapping updates

### DIFF
--- a/firestore-tests/security_rules.test.js
+++ b/firestore-tests/security_rules.test.js
@@ -217,9 +217,27 @@ describe('Security Rules v1', function () {
       await assertSucceeds(
         db1.collection('usernames').doc('alice').set({ uid: 'user1', createdAt: new Date() })
       );
+      await assertSucceeds(
+        db1
+          .collection('usernames')
+          .doc('alice')
+          .set({ createdAt: new Date(Date.now() + 1000) }, { merge: true })
+      );
+      await assertFails(
+        db1
+          .collection('usernames')
+          .doc('alice')
+          .set({ uid: 'user2' }, { merge: true })
+      );
       const db2 = p2().firestore();
       await assertFails(
         db2.collection('usernames').doc('alice').set({ uid: 'user2', createdAt: new Date() })
+      );
+      await assertFails(
+        db2
+          .collection('usernames')
+          .doc('alice')
+          .set({ createdAt: new Date() }, { merge: true })
       );
       await testEnv.withSecurityRulesDisabled(async (ctx) => {
         await ctx.firestore().collection('usernames').doc('bob').set({ uid: 'user2' });

--- a/firestore.rules
+++ b/firestore.rules
@@ -114,7 +114,10 @@ service cloud.firestore {
         request.auth.uid == request.resource.data.uid &&
         !exists(/databases/$(database)/documents/usernames/$(name));
       allow delete: if request.auth != null && request.auth.uid == resource.data.uid;
-      allow update: if false;
+      allow update: if request.auth != null &&
+        request.auth.uid == resource.data.uid &&
+        (!('uid' in request.resource.data) ||
+          request.resource.data.uid == resource.data.uid);
     }
 
     // ─────────────────────────


### PR DESCRIPTION
## Summary
- permit authenticated users to update their own `usernames` mapping without changing ownership
- expand Firestore security rules tests for username mapping updates

## Testing
- `npm --prefix functions test` *(fails: jest not found)*
- `npm run rules-test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_68b446923d708320b97abc55fd942fec