### PR TITLE
feat: allow users to change their username

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -108,17 +108,20 @@ service cloud.firestore {
     // ─────────────────────────
     // Usernames mapping
     // ─────────────────────────
-    match /usernames/{name} {
-      allow read: if isAuthed();
-      allow create: if request.auth != null &&
-        request.auth.uid == request.resource.data.uid &&
-        !exists(/databases/$(database)/documents/usernames/$(name));
-      allow delete: if request.auth != null && request.auth.uid == resource.data.uid;
-      allow update: if request.auth != null &&
-        request.auth.uid == resource.data.uid &&
-        (!('uid' in request.resource.data) ||
-          request.resource.data.uid == resource.data.uid);
-    }
+      match /usernames/{name} {
+        allow read: if isAuthed();
+        allow create: if isOwner(request.resource.data.uid) &&
+          !exists(/databases/$(database)/documents/usernames/$(name)) &&
+          request.resource.data.keys().hasOnly(['uid','createdAt']) &&
+          request.resource.data.createdAt is timestamp;
+        allow update: if isOwner(resource.data.uid) &&
+          request.resource.data.keys().hasOnly(['uid','createdAt']) &&
+          (!('uid' in request.resource.data) ||
+            request.resource.data.uid == resource.data.uid) &&
+          (!('createdAt' in request.resource.data) ||
+            request.resource.data.createdAt is timestamp);
+        allow delete: if isOwner(resource.data.uid);
+      }
 
     // ─────────────────────────
     // Users (top-level)


### PR DESCRIPTION
## Summary
- refine `/usernames` rules so authenticated users can create, update, or delete their own username mapping

## Testing
- `npx firebase emulators:exec --only firestore "npm run rules-test"` *(fails: download failed, status 403: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b44a66e2808320b03ed4ccf27a97ff