### PR TITLE
Refactor username change to Firestore transaction

### DIFF
--- a/lib/core/providers/auth_provider.dart
+++ b/lib/core/providers/auth_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:firebase_auth/firebase_auth.dart' as fb_auth;
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tapem/features/auth/data/repositories/auth_repository_impl.dart';
 import 'package:tapem/features/auth/domain/models/user_data.dart';
@@ -161,12 +162,15 @@ class AuthProvider extends ChangeNotifier {
     try {
       final available = await _checkUsernameUC.execute(username);
       if (!available) {
-        _error = 'Username already taken';
+        _error = 'username_taken';
         return false;
       }
       await _setUsernameUC.execute(_user!.id, username);
       _user = _user!.copyWith(userName: username);
       return true;
+    } on FirebaseException catch (e) {
+      _error = e.code;
+      return false;
     } catch (e) {
       _error = e.toString();
       return false;

--- a/lib/features/auth/data/services/username_service.dart
+++ b/lib/features/auth/data/services/username_service.dart
@@ -1,0 +1,51 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+Future<void> changeUsernameTransaction({
+  required FirebaseFirestore firestore,
+  required String uid,
+  required String newUsername,
+}) async {
+  final newName = newUsername.trim().replaceAll(RegExp(' +'), ' ');
+  final newLower = newName.toLowerCase();
+  final userRef = firestore.collection('users').doc(uid);
+  final userDoc = await userRef.get();
+  if (!userDoc.exists) {
+    throw FirebaseException(plugin: 'tapem', code: 'user_not_found');
+  }
+  final currentLower = userDoc.data()?['usernameLower'] as String?;
+  if (currentLower == newLower) {
+    return;
+  }
+
+  await firestore.runTransaction((tx) async {
+    final newRef = firestore.collection('usernames').doc(newLower);
+    final newSnap = await tx.get(newRef);
+    if (newSnap.exists) {
+      final existing = newSnap.data()?['uid'];
+      if (existing != uid) {
+        throw FirebaseException(plugin: 'tapem', code: 'username_taken');
+      } else {
+        return; // self-same mapping
+      }
+    }
+
+    DocumentSnapshot<Map<String, dynamic>>? currentSnap;
+    DocumentReference<Map<String, dynamic>>? currentRef;
+    if (currentLower != null) {
+      currentRef = firestore.collection('usernames').doc(currentLower);
+      currentSnap = await tx.get(currentRef);
+    }
+
+    tx.set(newRef, {
+      'uid': uid,
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+    if (currentSnap != null && currentSnap.exists) {
+      tx.delete(currentRef!);
+    }
+    tx.update(userRef, {
+      'username': newName,
+      'usernameLower': newLower,
+    });
+  });
+}

--- a/lib/features/auth/data/sources/firestore_auth_source.dart
+++ b/lib/features/auth/data/sources/firestore_auth_source.dart
@@ -1,19 +1,16 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:cloud_functions/cloud_functions.dart';
-import 'package:tapem/core/providers/functions_provider.dart';
 import 'package:tapem/features/auth/data/dtos/user_data_dto.dart';
+import 'package:tapem/features/auth/data/services/username_service.dart';
 import 'package:tapem/features/gym/data/sources/firestore_gym_source.dart';
 
 class FirestoreAuthSource {
   final FirebaseAuth _auth;
   final FirebaseFirestore _firestore;
-  final FirebaseFunctions _functions;
 
-  FirestoreAuthSource({FirebaseAuth? auth, FirebaseFirestore? firestore, FirebaseFunctions? functions})
-    : _auth = auth ?? FirebaseAuth.instance,
-      _firestore = firestore ?? FirebaseFirestore.instance,
-      _functions = functions ?? FunctionsProvider.instance;
+  FirestoreAuthSource({FirebaseAuth? auth, FirebaseFirestore? firestore})
+      : _auth = auth ?? FirebaseAuth.instance,
+        _firestore = firestore ?? FirebaseFirestore.instance;
 
   Future<UserDataDto> login(String email, String password) async {
     final cred = await _auth.signInWithEmailAndPassword(
@@ -88,55 +85,20 @@ class FirestoreAuthSource {
   }
 
   Future<void> setUsername(String userId, String username) async {
+    Future<void> run() => changeUsernameTransaction(
+          firestore: _firestore,
+          uid: userId,
+          newUsername: username,
+        );
     try {
-      await _functions
-          .httpsCallable('changeUsername')
-          .call({'newUsername': username});
-    } on FirebaseFunctionsException catch (e) {
-      if (e.code == 'not-found' || e.code == 'unavailable') {
-        await _fallbackSetUsername(userId, username);
-      } else if (e.code == 'already-exists' || e.message == 'username_taken') {
-        throw Exception('Username already taken');
-      } else if (e.code == 'invalid-argument') {
-        throw Exception('Invalid username');
+      await run();
+    } on FirebaseException catch (e) {
+      if (e.code == 'aborted') {
+        await run();
       } else {
         rethrow;
       }
     }
-  }
-
-  Future<void> _fallbackSetUsername(String userId, String username) async {
-    final target = username.trim();
-    final regex = RegExp(r'^[A-Za-z0-9 ]{3,20}$');
-    if (!regex.hasMatch(target)) {
-      throw Exception('Invalid username');
-    }
-    final lower = target.toLowerCase();
-    final userRef = _firestore.collection('users').doc(userId);
-    await _firestore.runTransaction((tx) async {
-      final userSnap = await tx.get(userRef);
-      if (!userSnap.exists) {
-        throw Exception('User not found');
-      }
-      final oldLower = userSnap.data()?['usernameLower'];
-      if (oldLower == lower) return;
-      final mappingRef = _firestore.collection('usernames').doc(lower);
-      final mappingSnap = await tx.get(mappingRef);
-      if (mappingSnap.exists && mappingSnap.data()?['uid'] != userId) {
-        throw Exception('Username already taken');
-      }
-      if (oldLower != null) {
-        tx.delete(_firestore.collection('usernames').doc(oldLower));
-      }
-      tx.set(mappingRef, {
-        'uid': userId,
-        'createdAt': FieldValue.serverTimestamp(),
-      });
-      tx.update(userRef, {
-        'username': target,
-        'usernameLower': lower,
-      });
-    });
   }
 
   Future<void> setShowInLeaderboard(String userId, bool value) async {

--- a/lib/features/profile/presentation/widgets/change_username_sheet.dart
+++ b/lib/features/profile/presentation/widgets/change_username_sheet.dart
@@ -147,7 +147,7 @@ Future<void> showChangeUsernameSheet(BuildContext context) async {
                             } else {
                               setState(() {
                                 loading = false;
-                                if (auth.error == 'Username already taken') {
+                                if (auth.error == 'username_taken') {
                                   error = loc.usernameTaken;
                                   availability = UsernameAvailability.taken;
                                 } else {

--- a/test/features/auth/username_service_test.dart
+++ b/test/features/auth/username_service_test.dart
@@ -1,0 +1,93 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/features/auth/data/services/username_service.dart';
+
+void main() {
+  group('changeUsernameTransaction', () {
+    test('successfully changes to free name', () async {
+      final fs = FakeFirebaseFirestore();
+      await fs.collection('users').doc('u1').set({
+        'username': 'Old',
+        'usernameLower': 'old',
+      });
+      await fs.collection('usernames').doc('old').set({
+        'uid': 'u1',
+        'createdAt': Timestamp.now(),
+      });
+
+      await changeUsernameTransaction(
+        firestore: fs,
+        uid: 'u1',
+        newUsername: 'Alice',
+      );
+
+      final user = await fs.collection('users').doc('u1').get();
+      expect(user.data()!['username'], 'Alice');
+      expect(user.data()!['usernameLower'], 'alice');
+      final mapping = await fs.collection('usernames').doc('alice').get();
+      expect(mapping.data()!['uid'], 'u1');
+      expect(mapping.data()!.keys, unorderedEquals(['uid', 'createdAt']));
+      final old = await fs.collection('usernames').doc('old').get();
+      expect(old.exists, isFalse);
+    });
+
+    test('throws when name taken by another uid', () async {
+      final fs = FakeFirebaseFirestore();
+      await fs.collection('users').doc('u1').set({
+        'username': 'Old',
+        'usernameLower': 'old',
+      });
+      await fs.collection('usernames').doc('old').set({
+        'uid': 'u1',
+        'createdAt': Timestamp.now(),
+      });
+      await fs.collection('usernames').doc('alice').set({
+        'uid': 'other',
+        'createdAt': Timestamp.now(),
+      });
+
+      expect(
+        () => changeUsernameTransaction(
+          firestore: fs,
+          uid: 'u1',
+          newUsername: 'Alice',
+        ),
+        throwsA(isA<FirebaseException>().having((e) => e.code, 'code', 'username_taken')),
+      );
+      final user = await fs.collection('users').doc('u1').get();
+      expect(user.data()!['usernameLower'], 'old');
+      final mapping = await fs.collection('usernames').doc('alice').get();
+      expect(mapping.data()!['uid'], 'other');
+    });
+
+    test('self-same mapping is no-op', () async {
+      final fs = FakeFirebaseFirestore();
+      await fs.collection('users').doc('u1').set({
+        'username': 'Old',
+        'usernameLower': 'old',
+      });
+      await fs.collection('usernames').doc('old').set({
+        'uid': 'u1',
+        'createdAt': Timestamp.fromMillisecondsSinceEpoch(1),
+      });
+      await fs.collection('usernames').doc('alice').set({
+        'uid': 'u1',
+        'createdAt': Timestamp.fromMillisecondsSinceEpoch(2),
+      });
+
+      await changeUsernameTransaction(
+        firestore: fs,
+        uid: 'u1',
+        newUsername: 'Alice',
+      );
+
+      final user = await fs.collection('users').doc('u1').get();
+      expect(user.data()!['usernameLower'], 'old');
+      final newDoc = await fs.collection('usernames').doc('alice').get();
+      expect(newDoc.data()!['createdAt'], Timestamp.fromMillisecondsSinceEpoch(2));
+      final oldDoc = await fs.collection('usernames').doc('old').get();
+      expect(oldDoc.exists, isTrue);
+    });
+  });
+}

--- a/test/features/profile/change_username_sheet_test.dart
+++ b/test/features/profile/change_username_sheet_test.dart
@@ -38,7 +38,8 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  testWidgets('typing a valid new username enables save', (tester) async {
+  testWidgets('typing a valid new username enables save and completes flow',
+      (tester) async {
     final auth = MockAuthProvider();
     when(() => auth.userName).thenReturn('current');
     when(() => auth.checkUsernameAvailable(any())).thenAnswer((_) async => true);
@@ -51,8 +52,11 @@ void main() {
     await tester.pump(const Duration(milliseconds: 600));
 
     final saveFinder = find.widgetWithText(ElevatedButton, 'Speichern');
-    final button = tester.widget<ElevatedButton>(saveFinder);
-    expect(button.onPressed, isNotNull);
+    await tester.tap(saveFinder);
+    await tester.pumpAndSettle();
+
+    expect(saveFinder, findsNothing);
+    verify(() => auth.setUsername('new name')).called(1);
   });
 
   testWidgets('same username keeps save disabled', (tester) async {


### PR DESCRIPTION
## Summary
- add `changeUsernameTransaction` to perform atomic username swap in Firestore
- replace function call with transactional write and propagate `username_taken`
- adjust provider, UI, and tests for new flow

## Testing
- `flutter test` *(fails: command not found)*
- `npm run rules-test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_68b44faa6c3c8320a40de18fca07a1e5