### PR TITLE
fix(rules): erlauben gerätelesen für authentifizierte nutzer

### DIFF
--- a/firestore-tests/security_rules.test.js
+++ b/firestore-tests/security_rules.test.js
@@ -76,9 +76,15 @@ describe('Security Rules v1', function () {
   const p3 = () => testEnv.authenticatedContext('user3', {});
 
   describe('Firestore rules', () => {
-    it('blocks cross-gym device read (device_cross_gym)', async () => {
+    it('allows cross-gym device read when authenticated', async () => {
       const db = userA().firestore();
       const ref = db.collection('gyms').doc('G2').collection('devices').doc('D2');
+      await assertSucceeds(ref.get());
+    });
+
+    it('blocks device read when unauthenticated', async () => {
+      const db = testEnv.unauthenticatedContext().firestore();
+      const ref = db.collection('gyms').doc('G1').collection('devices').doc('D1');
       await assertFails(ref.get());
     });
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -189,7 +189,7 @@ service cloud.firestore {
 
       // Devices
       match /devices/{deviceId} {
-        allow read: if inGym(gymId);
+        allow read: if isAuthed();
         allow write: if isAdmin(gymId);
 
         // Device logs (immutable; owner append-only)


### PR DESCRIPTION
## Summary
- allow authenticated users to read device documents so friends can view session details
- adjust security rule tests for cross-gym device reads and unauthenticated access

## Testing
- `npx firebase emulators:exec --only firestore,storage "npm run rules-test"` *(failed: Error: download failed, status 403: Forbidden)*
- `flutter test` *(failed: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b452ff82ec83209c34428e055164bb