### PR TITLE
feat(rules): allow cross-gym friend reads

### DIFF
--- a/firestore-tests/security_rules.test.js
+++ b/firestore-tests/security_rules.test.js
@@ -102,6 +102,22 @@ describe('Security Rules v1', function () {
       await db
         .collection('gyms')
         .doc('G2')
+        .collection('devices')
+        .doc('D2')
+        .collection('sessions')
+        .doc('sFriend')
+        .set({ userId: 'user1' });
+      await db
+        .collection('gyms')
+        .doc('G2')
+        .collection('devices')
+        .doc('D2')
+        .collection('sessions')
+        .doc('sNF')
+        .set({ userId: 'user3' });
+      await db
+        .collection('gyms')
+        .doc('G2')
         .collection('users')
         .doc('adminB')
         .set({ role: 'admin' });
@@ -188,6 +204,54 @@ describe('Security Rules v1', function () {
         .collection('exercises')
         .doc('exPublic');
       await assertSucceeds(ref.get());
+    });
+
+    it('allows cross-gym friend to read session snapshot', async () => {
+      const db = friend().firestore();
+      const ref = db
+        .collection('gyms')
+        .doc('G2')
+        .collection('devices')
+        .doc('D2')
+        .collection('sessions')
+        .doc('sFriend');
+      await assertSucceeds(ref.get());
+    });
+
+    it('blocks non-friend cross-gym from reading session snapshot', async () => {
+      const db = stranger().firestore();
+      const ref = db
+        .collection('gyms')
+        .doc('G2')
+        .collection('devices')
+        .doc('D2')
+        .collection('sessions')
+        .doc('sNF');
+      await assertFails(ref.get());
+    });
+
+    it('allows admin to read session snapshot', async () => {
+      const db = adminB().firestore();
+      const ref = db
+        .collection('gyms')
+        .doc('G2')
+        .collection('devices')
+        .doc('D2')
+        .collection('sessions')
+        .doc('sFriend');
+      await assertSucceeds(ref.get());
+    });
+
+    it('denies friend from writing session snapshot', async () => {
+      const db = friend().firestore();
+      const ref = db
+        .collection('gyms')
+        .doc('G2')
+        .collection('devices')
+        .doc('D2')
+        .collection('sessions')
+        .doc('newSession');
+      await assertFails(ref.set({ userId: 'user2' }));
     });
 
     it('allows user to create own membership', async () => {

--- a/firestore.rules
+++ b/firestore.rules
@@ -63,13 +63,6 @@ service cloud.firestore {
       return !("userId" in resource.data) || resource.data.userId == null || resource.data.userId == "";
     }
 
-    // Can view exercise when in gym or friend of owner and relation allows
-    function canViewExercise(gymId) {
-      let friend = isFriend(resource.data.userId, request.auth.uid);
-      return (inGym(gymId) || friend) &&
-             (isOwner(resource.data.userId) || friend || isPublicExercise());
-    }
-
     // ─────────────────────────
     // Global logs read (owner-only)
     // ─────────────────────────
@@ -209,7 +202,8 @@ service cloud.firestore {
         // Session snapshots per user (read owner/admin; write owner-only)
         match /sessions/{sessionId} {
           allow create: if requestOwnerInGym(gymId);
-          allow read: if resourceOwnerOrAdmin(gymId);
+          allow read: if resourceOwnerOrAdmin(gymId) ||
+                       isFriend(resource.data.userId, request.auth.uid);
           allow update, delete: if false;
         }
 
@@ -226,7 +220,12 @@ service cloud.firestore {
 
         // Custom exercises (public, owner or friends; admin override)
         match /exercises/{exerciseId} {
-          allow read: if isAdmin(gymId) || canViewExercise(gymId);
+          let canSeeByRelation =
+            (request.auth.uid == resource.data.userId) ||
+            isFriend(resource.data.userId, request.auth.uid) ||
+            isPublicExercise();
+
+          allow read: if isAdmin(gymId) || canSeeByRelation;
           allow write: if inGym(gymId) && (
                           request.auth.uid == request.resource.data.userId ||
                           request.auth.uid == resource.data.userId


### PR DESCRIPTION
## Summary
- allow friends to read exercise docs across gyms without gym membership
- permit cross-gym friend reads of session snapshots while keeping writes locked down
- test coverage for cross-gym session access and write denial

## Testing
- `npx firebase emulators:exec --only firestore,storage "npm run rules-test"` *(failed: Error: download failed, status 403: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b459935844832091f708438811a02f