### PR TITLE
feat: allow friends to view cross-gym training details

### DIFF
--- a/firestore-tests/training_details_rules.test.js
+++ b/firestore-tests/training_details_rules.test.js
@@ -1,0 +1,128 @@
+const path = require('path');
+const fs = require('fs');
+const {
+  initializeTestEnvironment,
+  assertFails,
+  assertSucceeds,
+} = require('@firebase/rules-unit-testing');
+
+const rules = fs.readFileSync(
+  path.resolve(__dirname, '../firestore.rules'),
+  'utf8'
+);
+
+describe('Training details rules', () => {
+  let testEnv;
+  before(async () => {
+    testEnv = await initializeTestEnvironment({
+      projectId: 'tap-em',
+      firestore: {
+        rules,
+        host: '127.0.0.1',
+        port: 8080,
+      },
+    });
+
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const db = context.firestore();
+      const gym = 'Club Aktiv';
+      await db.collection('gyms').doc(gym).set({});
+      await db.collection('gyms').doc(gym).collection('devices').doc('dev1').set({});
+      await db
+        .collection('gyms')
+        .doc(gym)
+        .collection('devices')
+        .doc('dev1')
+        .collection('exercises')
+        .doc('ex1')
+        .set({ userId: 'owner' });
+      await db
+        .collection('gyms')
+        .doc(gym)
+        .collection('devices')
+        .doc('dev1')
+        .collection('sessions')
+        .doc('s1')
+        .set({ userId: 'owner' });
+      await db.collection('users').doc('owner').set({});
+      await db.collection('users').doc('friend').set({});
+      await db.collection('users').doc('owner').collection('friends').doc('friend').set({});
+      await db.collection('users').doc('friend').collection('friends').doc('owner').set({});
+    });
+  });
+
+  after(async () => {
+    await testEnv.cleanup();
+  });
+
+  const friendCtx = () => testEnv.authenticatedContext('friend');
+  const strangerCtx = () => testEnv.authenticatedContext('stranger');
+
+  it('allows friend to read device', async () => {
+    const db = friendCtx().firestore();
+    const ref = db
+      .collection('gyms')
+      .doc('Club Aktiv')
+      .collection('devices')
+      .doc('dev1');
+    await assertSucceeds(ref.get());
+  });
+
+  it('denies unauthenticated device read', async () => {
+    const db = testEnv.unauthenticatedContext().firestore();
+    const ref = db
+      .collection('gyms')
+      .doc('Club Aktiv')
+      .collection('devices')
+      .doc('dev1');
+    await assertFails(ref.get());
+  });
+
+  it('allows friend to read exercise', async () => {
+    const db = friendCtx().firestore();
+    const ref = db
+      .collection('gyms')
+      .doc('Club Aktiv')
+      .collection('devices')
+      .doc('dev1')
+      .collection('exercises')
+      .doc('ex1');
+    await assertSucceeds(ref.get());
+  });
+
+  it('allows friend to read session', async () => {
+    const db = friendCtx().firestore();
+    const ref = db
+      .collection('gyms')
+      .doc('Club Aktiv')
+      .collection('devices')
+      .doc('dev1')
+      .collection('sessions')
+      .doc('s1');
+    await assertSucceeds(ref.get());
+  });
+
+  it('denies non-friend exercise read', async () => {
+    const db = strangerCtx().firestore();
+    const ref = db
+      .collection('gyms')
+      .doc('Club Aktiv')
+      .collection('devices')
+      .doc('dev1')
+      .collection('exercises')
+      .doc('ex1');
+    await assertFails(ref.get());
+  });
+
+  it('denies friend from writing session', async () => {
+    const db = friendCtx().firestore();
+    const ref = db
+      .collection('gyms')
+      .doc('Club Aktiv')
+      .collection('devices')
+      .doc('dev1')
+      .collection('sessions')
+      .doc('newSession');
+    await assertFails(ref.set({ userId: 'friend' }));
+  });
+});

--- a/firestore.rules
+++ b/firestore.rules
@@ -58,9 +58,20 @@ service cloud.firestore {
       return (inGym(gymId) && resource.data.userId == request.auth.uid) || isAdmin(gymId);
     }
 
-    // Public exercise if no userId set or empty (READ context uses resource)
+    // Owner or friend based on a given field
+    function isOwnerOrFriend(field) {
+      return (field in resource.data) &&
+        (resource.data[field] == request.auth.uid ||
+         isFriend(resource.data[field], request.auth.uid));
+    }
+
+    function fieldEmpty(field) {
+      return !(field in resource.data) || resource.data[field] == null || resource.data[field] == '';
+    }
+
+    // Public exercise if none of the owner fields are set (READ context uses resource)
     function isPublicExercise() {
-      return !("userId" in resource.data) || resource.data.userId == null || resource.data.userId == "";
+      return fieldEmpty('userId') && fieldEmpty('ownerId') && fieldEmpty('createdBy');
     }
 
     // ─────────────────────────
@@ -220,12 +231,11 @@ service cloud.firestore {
 
         // Custom exercises (public, owner or friends; admin override)
         match /exercises/{exerciseId} {
-          let canSeeByRelation =
-            (request.auth.uid == resource.data.userId) ||
-            isFriend(resource.data.userId, request.auth.uid) ||
+          allow read: if isAdmin(gymId) ||
+            isOwnerOrFriend('userId') ||
+            isOwnerOrFriend('ownerId') ||
+            isOwnerOrFriend('createdBy') ||
             isPublicExercise();
-
-          allow read: if isAdmin(gymId) || canSeeByRelation;
           allow write: if inGym(gymId) && (
                           request.auth.uid == request.resource.data.userId ||
                           request.auth.uid == resource.data.userId

--- a/lib/features/training_details/data/sources/firestore_session_source.dart
+++ b/lib/features/training_details/data/sources/firestore_session_source.dart
@@ -18,25 +18,36 @@ class FirestoreSessionSource {
         .add(const Duration(days: 1))
         .subtract(const Duration(milliseconds: 1));
 
-    debugPrint(
-      '📥 FirestoreSessionSource: query logs user=$userId start=$start end=$end',
-    );
+    debugPrint('FirestoreSessionSource: read path=collectionGroup/logs owner=' +
+        userId +
+        ' start=' +
+        start.toString() +
+        ' end=' +
+        end.toString());
 
-    final snap =
-        await _firestore
-            .collectionGroup('logs')
-            .where('userId', isEqualTo: userId)
-            .where(
-              'timestamp',
-              isGreaterThanOrEqualTo: Timestamp.fromDate(start),
-            )
-            .where('timestamp', isLessThanOrEqualTo: Timestamp.fromDate(end))
-            .get();
+    try {
+      final snap = await _firestore
+          .collectionGroup('logs')
+          .where('userId', isEqualTo: userId)
+          .where(
+            'timestamp',
+            isGreaterThanOrEqualTo: Timestamp.fromDate(start),
+          )
+          .where('timestamp', isLessThanOrEqualTo: Timestamp.fromDate(end))
+          .get();
 
-    debugPrint(
-      '📥 FirestoreSessionSource: fetched ${snap.docs.length} log docs',
-    );
+      debugPrint('FirestoreSessionSource: success path=collectionGroup/logs owner=' +
+          userId +
+          ' docs=' +
+          snap.docs.length.toString());
 
-    return snap.docs.map((doc) => SessionDto.fromFirestore(doc)).toList();
+      return snap.docs.map((doc) => SessionDto.fromFirestore(doc)).toList();
+    } on FirebaseException catch (e) {
+      debugPrint('FirestoreSessionSource: failure path=collectionGroup/logs owner=' +
+          userId +
+          ' code=' +
+          e.code);
+      rethrow;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- log Firestore reads in session data layer with path, owner and result
- relax exercise read rules to accept friends regardless of owner field naming
- add Firestore rule tests for friend access to devices, exercises and sessions

## Testing
- `dart format lib/features/training_details/data/repositories/session_repository_impl.dart lib/features/training_details/data/sources/firestore_session_source.dart` *(fails: command not found)*
- `npm run --silent rules-test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*
- `npx firebase emulators:exec "npx mocha --timeout 120000 firestore-tests/security_rules.test.js firestore-tests/training_details_rules.test.js"` *(fails: download failed, status 403: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b45cef4820832090f420eac1d712de