### PR TITLE
fix(training-details): make training details page scrollable

### DIFF
--- a/lib/features/training_details/presentation/screens/training_details_screen.dart
+++ b/lib/features/training_details/presentation/screens/training_details_screen.dart
@@ -43,13 +43,14 @@ class TrainingDetailsScreen extends StatelessWidget {
           final sessions = prov.sessions;
           return Scaffold(
             appBar: _AppBar(titleDate: date),
-            body: Padding(
-              padding: const EdgeInsets.all(16),
-              child:
-                  sessions.isEmpty
-                      ? const Center(child: Text('Keine Trainingseinheiten'))
-                      : DaySessionsOverview(sessions: sessions),
-            ),
+            body: sessions.isEmpty
+                ? const Center(child: Text('Keine Trainingseinheiten'))
+                : Scrollbar(
+                    child: SingleChildScrollView(
+                      padding: const EdgeInsets.all(16),
+                      child: DaySessionsOverview(sessions: sessions),
+                    ),
+                  ),
           );
         },
       ),


### PR DESCRIPTION
## Summary
- wrap session overview in `Scrollbar` + `SingleChildScrollView` so overflowed sessions can be scrolled

## Testing
- `dart format features/training_details/presentation/screens/training_details_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4611f26a4832099372da0e1b3017b