### PR TITLE
feat: extend club aktiv theme to bronze daniel

### DIFF
--- a/lib/core/theme/theme_loader.dart
+++ b/lib/core/theme/theme_loader.dart
@@ -55,7 +55,7 @@ class ThemeLoader extends ChangeNotifier {
       return;
     }
 
-    if (gymId == 'Club Aktiv') {
+    if (gymId == 'Club Aktiv' || gymId == 'BronzeDaniel') {
       if (branding == null) {
         _applyClubAktivDefaults();
         notifyListeners();

--- a/test/theme/theme_loader_test.dart
+++ b/test/theme/theme_loader_test.dart
@@ -44,6 +44,12 @@ void main() {
           equals(const Color(0xFF654321)));
     });
 
+    test('BronzeDaniel without branding uses red/orange theme', () {
+      final loader = ThemeLoader()..loadDefault();
+      loader.applyBranding('BronzeDaniel', null);
+      expect(loader.theme.colorScheme.primary, ClubAktivColors.primary600);
+    });
+
     test('other gyms keep default theme', () {
       final loader = ThemeLoader()..loadDefault();
       loader.applyBranding('other', null);


### PR DESCRIPTION
## Summary
- treat BronzeDaniel gym same as Club Aktiv to use red/orange theme
- cover BronzeDaniel in theme loader tests

## Testing
- `flutter test test/theme/theme_loader_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4705553848320b659d49d6c877b6d