### PR TITLE
fix(device): sync planned table controllers post-frame

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -564,7 +564,9 @@ class _PlannedTableState extends State<_PlannedTable> {
       });
     }
 
-    _syncControllers(prov.sets);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _syncControllers(prov.sets);
+    });
 
     final weightHint = widget.entry.weight?.toString();
     final repsHint = widget.entry.reps?.toString();


### PR DESCRIPTION
## Summary
- avoid controller updates during build in planned table by syncing after frame

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c4b898848320a4b09ca9fba6b825