### PR TITLE
fix: defer search field sync to avoid build-time setState

### DIFF
--- a/lib/ui/common/search_and_filters.dart
+++ b/lib/ui/common/search_and_filters.dart
@@ -40,7 +40,10 @@ class _SearchAndFiltersState extends State<SearchAndFilters> {
   void didUpdateWidget(covariant SearchAndFilters oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.query != widget.query && _controller.text != widget.query) {
-      _controller.text = widget.query;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _controller.text = widget.query;
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- Defer query controller updates with `addPostFrameCallback` to avoid triggering setState during build

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c834a72c8320b98d14ed47f05a8e