### PR TITLE
refactor: defer UI state mutations to post-frame

### DIFF
--- a/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
+++ b/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
@@ -44,7 +44,12 @@ class _DeviceMuscleAssignmentSheetState
     super.initState();
     _selectedSecondaryIds = <String>{};
     _initialSecondaryIds = <String>{};
-    _searchCtr.addListener(() => setState(() {}));
+    _searchCtr.addListener(() {
+      if (!mounted) return;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) setState(() {});
+      });
+    });
   }
 
   @override

--- a/lib/ui/common/search_bar.dart
+++ b/lib/ui/common/search_bar.dart
@@ -32,7 +32,12 @@ class _SearchBarState extends State<SearchBar> {
     }
   }
 
-  void _onChanged() => setState(() {});
+  void _onChanged() {
+    if (!mounted) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) setState(() {});
+    });
+  }
 
   @override
   void dispose() {

--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -161,7 +161,12 @@ class _OverlayNumericKeypadHostState extends State<OverlayNumericKeypadHost>
     }
   }
 
-  void _rebuild() => setState(() {});
+  void _rebuild() {
+    if (!mounted) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) setState(() {});
+    });
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary
- schedule SearchBar rebuilds post-frame to avoid build-time setState
- defer DeviceMuscleAssignmentSheet search listener updates until after the frame
- add post-frame scheduling for OverlayNumericKeypadHost rebuilds

## Testing
- `npm test` (fails: Error: no test specified)
- `flutter test` (fails: command not found: flutter)


------
https://chatgpt.com/codex/tasks/task_e_68b4ca643b088320b51ec50d0510da96