### PR TITLE
feat(training): persist and order sets

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -631,6 +631,7 @@ class DeviceProvider extends ChangeNotifier {
           'timestamp': ts,
           'weight': double.parse(set['weight']!.replaceAll(',', '.')),
           'reps': int.parse(set['reps']!),
+          'setNumber': int.parse(set['number']),
           'note': _note,
           'tz': tz,
         };

--- a/lib/features/history/presentation/screens/history_screen.dart
+++ b/lib/features/history/presentation/screens/history_screen.dart
@@ -350,11 +350,14 @@ class _HistoryScreenState extends State<HistoryScreen> {
                     .format(logs.first.timestamp);
 
                 final sets = logs
-                    .map((l) => SessionSet(
-                          weight: l.weight,
-                          reps: l.reps,
-                          dropWeightKg: l.dropWeightKg,
-                          dropReps: l.dropReps,
+                    .asMap()
+                    .entries
+                    .map((e) => SessionSet(
+                          weight: e.value.weight,
+                          reps: e.value.reps,
+                          setNumber: e.key + 1,
+                          dropWeightKg: e.value.dropWeightKg,
+                          dropReps: e.value.dropReps,
                         ))
                     .toList();
                 return Padding(

--- a/lib/features/training_details/data/dtos/session_dto.dart
+++ b/lib/features/training_details/data/dtos/session_dto.dart
@@ -11,6 +11,7 @@ class SessionDto {
   final DateTime timestamp;
   final double weight;
   final int reps;
+  final int setNumber;
   final double? dropWeightKg;
   final int? dropReps;
   final String note;
@@ -24,6 +25,7 @@ class SessionDto {
     required this.timestamp,
     required this.weight,
     required this.reps,
+    required this.setNumber,
     this.dropWeightKg,
     this.dropReps,
     required this.note,
@@ -46,6 +48,7 @@ class SessionDto {
       timestamp: (data['timestamp'] as Timestamp).toDate(),
       weight: (data['weight'] as num).toDouble(),
       reps: (data['reps'] as num).toInt(),
+      setNumber: (data['setNumber'] as num?)?.toInt() ?? 0,
       dropWeightKg: (data['dropWeightKg'] as num?)?.toDouble(),
       dropReps: (data['dropReps'] as num?)?.toInt(),
       note: data['note'] as String? ?? '',

--- a/lib/features/training_details/data/repositories/session_repository_impl.dart
+++ b/lib/features/training_details/data/repositories/session_repository_impl.dart
@@ -27,7 +27,7 @@ class SessionRepositoryImpl implements SessionRepository {
 
     // 2) Für jede Gruppe: sortieren, Sets mappen, Namen+Description holen
     for (var entry in grouped.entries) {
-      final list = entry.value..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+      final list = entry.value..sort((a, b) => a.setNumber.compareTo(b.setNumber));
       final first = list.first;
 
       // Referenz aufs Device-Dokument:
@@ -85,6 +85,7 @@ class SessionRepositoryImpl implements SessionRepository {
           .map((dto) => SessionSet(
                 weight: dto.weight,
                 reps: dto.reps,
+                setNumber: dto.setNumber,
                 dropWeightKg: dto.dropWeightKg,
                 dropReps: dto.dropReps,
               ))

--- a/lib/features/training_details/domain/models/session.dart
+++ b/lib/features/training_details/domain/models/session.dart
@@ -22,11 +22,13 @@ class Session {
 class SessionSet {
   final double weight;
   final int reps;
+  final int setNumber;
   final double? dropWeightKg;
   final int? dropReps;
   SessionSet({
     required this.weight,
     required this.reps,
+    required this.setNumber,
     this.dropWeightKg,
     this.dropReps,
   });

--- a/test/ui/brand_widgets_test.dart
+++ b/test/ui/brand_widgets_test.dart
@@ -118,7 +118,7 @@ void main() {
       home: SessionExerciseCard(
         title: 'Bench',
         subtitle: 'Chest',
-        sets: [SessionSet(weight: 10, reps: 5)],
+        sets: [SessionSet(weight: 10, reps: 5, setNumber: 1)],
       ),
     ));
 

--- a/test/widgets/day_sessions_overview_test.dart
+++ b/test/widgets/day_sessions_overview_test.dart
@@ -13,7 +13,7 @@ void main() {
       deviceDescription: '',
       timestamp: DateTime.now(),
       note: '',
-      sets: [SessionSet(weight: 10, reps: 5)],
+      sets: [SessionSet(weight: 10, reps: 5, setNumber: 1)],
     );
 
     await tester.pumpWidget(MaterialApp(


### PR DESCRIPTION
## Summary
- persist set order when saving workout sessions
- expose `setNumber` in session DTOs and domain models
- sort session sets by their set number

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b73ccc434083208e3bd2ac28750e26