### PR TITLE
fix: enforce canonical set ordering across details and history

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -583,6 +583,14 @@ class DeviceProvider extends ChangeNotifier {
         return false;
       }
 
+      elogUi('SESSION_SAVE_SET_ORDER', {
+        'setsInputOrder': savedSets.map((s) => int.parse(s['number'])).toList(),
+        'reps': savedSets.map((s) => int.tryParse(s['reps'] ?? '0') ?? 0).toList(),
+        'weights': savedSets
+            .map((s) => double.tryParse(s['weight']?.replaceAll(',', '.') ?? '0') ?? 0)
+            .toList(),
+      });
+
       final now = DateTime.now();
       final startOfDay = DateTime(now.year, now.month, now.day);
       final endOfDay = startOfDay.add(const Duration(days: 1));

--- a/lib/core/providers/history_provider.dart
+++ b/lib/core/providers/history_provider.dart
@@ -75,8 +75,8 @@ class HistoryProvider extends ChangeNotifier {
   }
 
   void _computeStats() {
-    _logs.sort((a, b) => a.timestamp.compareTo(b.timestamp));
-    if (_logs.isEmpty) {
+    final logsSorted = [..._logs]..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    if (logsSorted.isEmpty) {
       _workoutCount = 0;
       _setsPerSessionAvg = 0;
       _heaviest = 0;
@@ -86,7 +86,7 @@ class HistoryProvider extends ChangeNotifier {
     }
 
     final sessions = <String, List<WorkoutLog>>{};
-    for (final log in _logs) {
+    for (final log in logsSorted) {
       sessions.putIfAbsent(log.sessionId, () => []).add(log);
     }
 
@@ -98,7 +98,7 @@ class HistoryProvider extends ChangeNotifier {
     _setsPerSessionAvg = double.parse(
         (_logs.length / (_workoutCount == 0 ? 1 : _workoutCount))
             .toStringAsFixed(1));
-    _heaviest = _logs.map((e) => e.weight).reduce((a, b) => a > b ? a : b);
+    _heaviest = logsSorted.map((e) => e.weight).reduce((a, b) => a > b ? a : b);
 
     _e1rmChart = sessionEntries.map((e) {
       final date = e.value.first.timestamp;

--- a/lib/features/history/data/dtos/workout_log_dto.dart
+++ b/lib/features/history/data/dtos/workout_log_dto.dart
@@ -10,6 +10,8 @@ part 'workout_log_dto.g.dart';
 class WorkoutLogDto {
   @JsonKey(ignore: true)
   late String id;
+  @JsonKey(ignore: true)
+  late DocumentReference<Map<String, dynamic>> reference;
 
   final String userId;
   final String sessionId;
@@ -24,6 +26,8 @@ class WorkoutLogDto {
   final String? note;
   final double? dropWeightKg;
   final int? dropReps;
+  @JsonKey(fromJson: _setNumberFromJson)
+  final int setNumber;
 
   WorkoutLogDto({
     required this.userId,
@@ -36,6 +40,7 @@ class WorkoutLogDto {
     this.note,
     this.dropWeightKg,
     this.dropReps,
+    required this.setNumber,
   });
 
   factory WorkoutLogDto.fromJson(Map<String, dynamic> json) =>
@@ -46,8 +51,10 @@ class WorkoutLogDto {
   /// Dokument → DTO
   factory WorkoutLogDto.fromDocument(DocumentSnapshot doc) {
     final data = doc.data()! as Map<String, dynamic>;
+    data['setNumber'] = data['setNumber'] ?? data['number'];
     final dto = WorkoutLogDto.fromJson(data);
     dto.id = doc.id;
+    dto.reference = doc.reference;
     return dto;
   }
 
@@ -64,8 +71,14 @@ class WorkoutLogDto {
     note: note,
     dropWeightKg: dropWeightKg,
     dropReps: dropReps,
+    setNumber: setNumber,
   );
 
   static DateTime _timestampToDate(Timestamp ts) => ts.toDate();
   static Timestamp _dateToTimestamp(DateTime date) => Timestamp.fromDate(date);
+  static int _setNumberFromJson(dynamic v) {
+    if (v is num) return v.toInt();
+    if (v is String) return int.tryParse(v) ?? 0;
+    return 0;
+  }
 }

--- a/lib/features/history/data/dtos/workout_log_dto.g.dart
+++ b/lib/features/history/data/dtos/workout_log_dto.g.dart
@@ -18,6 +18,7 @@ WorkoutLogDto _$WorkoutLogDtoFromJson(Map<String, dynamic> json) =>
       note: json['setNote'] as String?,
       dropWeightKg: (json['dropWeightKg'] as num?)?.toDouble(),
       dropReps: (json['dropReps'] as num?)?.toInt(),
+      setNumber: WorkoutLogDto._setNumberFromJson(json['setNumber']),
     );
 
 Map<String, dynamic> _$WorkoutLogDtoToJson(WorkoutLogDto instance) =>
@@ -32,4 +33,5 @@ Map<String, dynamic> _$WorkoutLogDtoToJson(WorkoutLogDto instance) =>
       if (instance.note != null) 'setNote': instance.note,
       if (instance.dropWeightKg != null) 'dropWeightKg': instance.dropWeightKg,
       if (instance.dropReps != null) 'dropReps': instance.dropReps,
+      'setNumber': instance.setNumber,
     };

--- a/lib/features/history/data/repositories/history_repository_impl.dart
+++ b/lib/features/history/data/repositories/history_repository_impl.dart
@@ -1,6 +1,8 @@
 // lib/features/history/data/repositories/history_repository_impl.dart
 
+import 'package:tapem/core/logging/elog.dart';
 import '../sources/firestore_history_source.dart';
+import '../dtos/workout_log_dto.dart';
 import '../../domain/models/workout_log.dart';
 import '../../domain/usecases/get_history_for_device.dart';
 
@@ -21,6 +23,47 @@ class HistoryRepositoryImpl implements GetHistoryForDeviceRepository {
       userId: userId,
       exerciseId: exerciseId,
     );
-    return dtos.map((d) => d.toModel()).toList();
+
+    final Map<String, List<WorkoutLogDto>> grouped = {};
+    for (var dto in dtos) {
+      grouped.putIfAbsent(dto.sessionId, () => []).add(dto);
+    }
+
+    final List<WorkoutLog> logs = [];
+    for (var entry in grouped.entries) {
+      final list = entry.value;
+      final raw = list.map((d) => d.setNumber).toList();
+      elogUi('SESSION_READ_RAW_SETS', {
+        'sessionId': entry.key,
+        'rawSetNumbers': raw,
+        'rawCount': list.length,
+      });
+
+      var usedKey = 'setNumber';
+      if (list.any((d) => d.setNumber <= 0)) {
+        usedKey = 'timestamp';
+        list.sort((a, b) => a.timestamp.compareTo(b.timestamp));
+        elogUi('ORDER_FALLBACK_USED', {
+          'sessionId': entry.key,
+          'reason': 'missing',
+        });
+        try {
+          await _source.backfillSetNumbers(list);
+        } catch (_) {}
+      } else {
+        list.sort((a, b) => a.setNumber.compareTo(b.setNumber));
+      }
+
+      elogUi('SESSION_SORT_APPLIED', {
+        'sessionId': entry.key,
+        'usedKey': usedKey,
+        'sortedSetNumbers': list.map((d) => d.setNumber).toList(),
+        'finalCount': list.length,
+      });
+
+      logs.addAll(list.map((d) => d.toModel()));
+    }
+
+    return logs;
   }
 }

--- a/lib/features/history/data/sources/firestore_history_source.dart
+++ b/lib/features/history/data/sources/firestore_history_source.dart
@@ -31,4 +31,15 @@ class FirestoreHistorySource {
 
     return snapshot.docs.map((doc) => WorkoutLogDto.fromDocument(doc)).toList();
   }
+
+  Future<void> backfillSetNumbers(List<WorkoutLogDto> dtos) async {
+    final batch = _firestore.batch();
+    for (var i = 0; i < dtos.length; i++) {
+      batch.update(dtos[i].reference, {
+        'setNumber': i + 1,
+        'backfilled': true,
+      });
+    }
+    await batch.commit();
+  }
 }

--- a/lib/features/history/domain/models/workout_log.dart
+++ b/lib/features/history/domain/models/workout_log.dart
@@ -13,6 +13,7 @@ class WorkoutLog {
   final String? note;
   final double? dropWeightKg;
   final int? dropReps;
+  final int setNumber;
 
   WorkoutLog({
     required this.id,
@@ -26,5 +27,6 @@ class WorkoutLog {
     this.note,
     this.dropWeightKg,
     this.dropReps,
+    required this.setNumber,
   });
 }

--- a/lib/features/history/presentation/screens/history_screen.dart
+++ b/lib/features/history/presentation/screens/history_screen.dart
@@ -12,6 +12,7 @@ import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
 import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/core/logging/elog.dart';
 
 class HistoryScreen extends StatefulWidget {
   final String deviceId;
@@ -344,22 +345,23 @@ class _HistoryScreenState extends State<HistoryScreen> {
           SliverList(
             delegate: SliverChildBuilderDelegate(
               (context, idx) {
-                final logs = [...sessionEntries[idx].value]
-                  ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+                final logs = sessionEntries[idx].value;
                 final titleDate = DateFormat.yMMMMd(localeString)
                     .format(logs.first.timestamp);
 
                 final sets = logs
-                    .asMap()
-                    .entries
                     .map((e) => SessionSet(
-                          weight: e.value.weight,
-                          reps: e.value.reps,
-                          setNumber: e.key + 1,
-                          dropWeightKg: e.value.dropWeightKg,
-                          dropReps: e.value.dropReps,
+                          weight: e.weight,
+                          reps: e.reps,
+                          setNumber: e.setNumber,
+                          dropWeightKg: e.dropWeightKg,
+                          dropReps: e.dropReps,
                         ))
                     .toList();
+                elogUi('HISTORY_CARD_RENDER', {
+                  'sessionId': sessionEntries[idx].key,
+                  'setNumbers': sets.take(10).map((s) => s.setNumber).toList(),
+                });
                 return Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
                   child: _HistoryExpansionTile(

--- a/lib/features/training_details/data/dtos/session_dto.dart
+++ b/lib/features/training_details/data/dtos/session_dto.dart
@@ -40,6 +40,16 @@ class SessionDto {
     final exerciseId = data['exerciseId'] as String? ?? '';
     final userId = data['userId'] as String? ?? '';
 
+    final rawNumber = data['setNumber'] ?? data['number'];
+    int setNumber;
+    if (rawNumber is num) {
+      setNumber = rawNumber.toInt();
+    } else if (rawNumber is String) {
+      setNumber = int.tryParse(rawNumber) ?? 0;
+    } else {
+      setNumber = 0;
+    }
+
     return SessionDto(
       sessionId: data['sessionId'] as String,
       deviceId: deviceId, // nicht mehr data['deviceId']
@@ -48,7 +58,7 @@ class SessionDto {
       timestamp: (data['timestamp'] as Timestamp).toDate(),
       weight: (data['weight'] as num).toDouble(),
       reps: (data['reps'] as num).toInt(),
-      setNumber: (data['setNumber'] as num?)?.toInt() ?? 0,
+      setNumber: setNumber,
       dropWeightKg: (data['dropWeightKg'] as num?)?.toDouble(),
       dropReps: (data['dropReps'] as num?)?.toInt(),
       note: data['note'] as String? ?? '',

--- a/lib/features/training_details/data/sources/firestore_session_source.dart
+++ b/lib/features/training_details/data/sources/firestore_session_source.dart
@@ -50,4 +50,15 @@ class FirestoreSessionSource {
       rethrow;
     }
   }
+
+  Future<void> backfillSetNumbers(List<SessionDto> dtos) async {
+    final batch = _firestore.batch();
+    for (var i = 0; i < dtos.length; i++) {
+      batch.update(dtos[i].reference, {
+        'setNumber': i + 1,
+        'backfilled': true,
+      });
+    }
+    await batch.commit();
+  }
 }

--- a/lib/features/training_details/presentation/widgets/day_sessions_overview.dart
+++ b/lib/features/training_details/presentation/widgets/day_sessions_overview.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../domain/models/session.dart';
 import 'session_exercise_card.dart';
+import 'package:tapem/core/logging/elog.dart';
 
 class DaySessionsOverview extends StatelessWidget {
   final List<Session> sessions;
@@ -20,14 +21,21 @@ class DaySessionsOverview extends StatelessWidget {
           runSpacing: 12,
           children: sessions
               .map(
-                (session) => SizedBox(
-                  width: cardWidth,
-                  child: SessionExerciseCard(
-                    title: session.deviceName,
-                    subtitle: session.deviceDescription,
-                    sets: session.sets,
-                  ),
-                ),
+                (session) {
+                  elogUi('DETAILS_RENDER', {
+                    'sessionId': session.sessionId,
+                    'setNumbers':
+                        session.sets.take(10).map((s) => s.setNumber).toList(),
+                  });
+                  return SizedBox(
+                    width: cardWidth,
+                    child: SessionExerciseCard(
+                      title: session.deviceName,
+                      subtitle: session.deviceDescription,
+                      sets: session.sets,
+                    ),
+                  );
+                },
               )
               .toList(),
         );


### PR DESCRIPTION
## Summary
- normalize and log set order on read, including fallback & backfill
- persist input set order and render without UI-side sorting
- support setNumber in history models and add render diagnostics

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b73fea44148320ac5caee3f124a3be