### PR TITLE
fix(history): type-safe reference for workout logs

### DIFF
--- a/lib/features/history/data/dtos/workout_log_dto.dart
+++ b/lib/features/history/data/dtos/workout_log_dto.dart
@@ -49,8 +49,9 @@ class WorkoutLogDto {
   Map<String, dynamic> toJson() => _$WorkoutLogDtoToJson(this);
 
   /// Dokument → DTO
-  factory WorkoutLogDto.fromDocument(DocumentSnapshot doc) {
-    final data = doc.data()! as Map<String, dynamic>;
+  factory WorkoutLogDto.fromDocument(
+      DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data()!;
     data['setNumber'] = data['setNumber'] ?? data['number'];
     final dto = WorkoutLogDto.fromJson(data);
     dto.id = doc.id;


### PR DESCRIPTION
## Summary
- ensure workout log DTO uses typed DocumentSnapshot for reference

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7420fcbd88320ba1c986b2d196ae6