### PR TITLE
feat: flexible set completion with save warnings

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -320,11 +320,46 @@ class _DeviceScreenState extends State<DeviceScreen> {
                             );
                             return;
                           }
-                          if (prov.completedCount == 0) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(
-                                content: Text(loc.noCompletedSets),
+                          final counts = prov.getSetCounts();
+                          final totalFilled =
+                              counts.done + counts.filledNotDone;
+                          if (counts.filledNotDone > 0) {
+                            elogUi('SAVE_OPEN_SETS_DIALOG', {
+                              'doneCount': counts.done,
+                              'filledNotDoneCount': counts.filledNotDone,
+                              'emptyOrIncompleteCount': counts.emptyOrIncomplete,
+                            });
+                            final confirm = await showDialog<bool>(
+                              context: context,
+                              builder: (ctx) => AlertDialog(
+                                title: Text(loc.notAllSetsConfirmed),
+                                content: Text(loc.notAllSetsConfirmed),
+                                actions: [
+                                  TextButton(
+                                    onPressed: () => Navigator.pop(ctx, false),
+                                    child: Text(loc.cancelButton),
+                                  ),
+                                  TextButton(
+                                    onPressed: () => Navigator.pop(ctx, true),
+                                    child: Text(loc.confirmAllSets),
+                                  ),
+                                ],
                               ),
+                            );
+                            if (confirm != true) return;
+                            final added = prov.completeAllFilledNotDone();
+                            elogUi('CONFIRM_ALL_SETS', {
+                              'completedCount': added,
+                            });
+                            if (prov.completedCount == 0) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text(loc.noCompletedSets)),
+                              );
+                              return;
+                            }
+                          } else if (totalFilled == 0) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(content: Text(loc.noCompletedSets)),
                             );
                             return;
                           }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -311,6 +311,11 @@
     "description": "Snackbar, wenn keine Sätze abgeschlossen sind"
   },
 
+  "notAllSetsConfirmed": "Noch nicht alle Sätze bestätigt.",
+  "@notAllSetsConfirmed": {"description": "Dialogtitel bei offenen Sätzen"},
+  "confirmAllSets": "Alle Bestätigen",
+  "@confirmAllSets": {"description": "Button zum Bestätigen aller Sätze"},
+
   "todayAlreadySaved": "Heute bereits gespeichert.",
   "@todayAlreadySaved": {
     "description": "Fehler wenn bereits eine Session gespeichert wurde"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -311,6 +311,11 @@
     "description": "Snackbar when no sets are completed"
   },
 
+  "notAllSetsConfirmed": "Not all sets confirmed.",
+  "@notAllSetsConfirmed": {"description": "Dialog title when sets are unconfirmed"},
+  "confirmAllSets": "Confirm All",
+  "@confirmAllSets": {"description": "Button to confirm all sets"},
+
   "todayAlreadySaved": "Already saved today.",
   "@todayAlreadySaved": {
     "description": "Error when a session has already been saved today"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -479,6 +479,18 @@ abstract class AppLocalizations {
   /// **'No completed sets.'**
   String get noCompletedSets;
 
+  /// Dialog title when sets are unconfirmed
+  ///
+  /// In en, this message translates to:
+  /// **'Not all sets confirmed.'**
+  String get notAllSetsConfirmed;
+
+  /// Button to confirm all sets
+  ///
+  /// In en, this message translates to:
+  /// **'Confirm All'**
+  String get confirmAllSets;
+
   /// Error when a session has already been saved today
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -213,6 +213,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get noCompletedSets => 'Keine abgeschlossenen Sätze.';
 
   @override
+  String get notAllSetsConfirmed => 'Noch nicht alle Sätze bestätigt.';
+
+  @override
+  String get confirmAllSets => 'Alle Bestätigen';
+
+  @override
   String get todayAlreadySaved => 'Heute bereits gespeichert.';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -213,6 +213,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get noCompletedSets => 'No completed sets.';
 
   @override
+  String get notAllSetsConfirmed => 'Not all sets confirmed.';
+
+  @override
+  String get confirmAllSets => 'Confirm All';
+
+  @override
   String get todayAlreadySaved => 'Already saved today.';
 
   @override


### PR DESCRIPTION
## Summary
- validate and complete sets individually in DeviceProvider
- replace keypad copy with check-next action and log events
- warn on save when sets remain unconfirmed

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7488855a883209c5d5758d53a3cd6