### PR TITLE
feat: improve set completion behaviour

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -421,14 +421,13 @@ class DeviceProvider extends ChangeNotifier {
   bool toggleSetDone(int index) {
     final s = _sets[index];
     if (!_isFilled(s)) {
-      _error = 'Bitte gültiges Gewicht und Wiederholungen angeben.';
       _log(
         '⚠️ [Provider] toggleSetDone($index) blocked: invalid',
       );
-      notifyListeners();
       return false;
     }
 
+    _error = null;
     final before = Map<String, dynamic>.from(s);
     final current = (s['done'] == true || s['done'] == 'true');
     s['done'] = !current;

--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -303,6 +303,12 @@ class SetCardState extends State<SetCard> {
     final dropActive =
         (widget.set['dropWeight'] ?? '').toString().isNotEmpty &&
             (widget.set['dropReps'] ?? '').toString().isNotEmpty;
+    final weight = (widget.set['weight'] ?? '').toString().trim();
+    final reps = (widget.set['reps'] ?? '').toString().trim();
+    final filled = weight.isNotEmpty &&
+        double.tryParse(weight.replaceAll(',', '.')) != null &&
+        reps.isNotEmpty &&
+        int.tryParse(reps) != null;
 
     return Semantics(
       label: 'Set ${widget.index + 1}',
@@ -378,7 +384,7 @@ class SetCardState extends State<SetCard> {
                   semantics:
                       done ? loc.setReopenTooltip : loc.setCompleteTooltip,
                   dense: dense,
-                  onTap: widget.readOnly
+                  onTap: widget.readOnly || !filled
                       ? null
                       : () {
                           _slog(
@@ -390,7 +396,7 @@ class SetCardState extends State<SetCard> {
                           elogUi('SET_DONE_TAP', {
                             'index': widget.index,
                             'wasValid': ok,
-                            if (!ok) 'reasonIfBlocked': prov.error ?? 'invalid',
+                            if (!ok) 'reasonIfBlocked': 'invalid',
                           });
                           HapticFeedback.lightImpact();
                           if (ok) {

--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -385,14 +385,12 @@ class OverlayNumericKeypad extends StatelessWidget {
       'setIndexFocused': prov.focusedIndex,
       'nextToComplete': next,
     });
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      final idx = prov.completeNextFilledSet();
-      if (idx != null) {
-        elogUi('AUTO_CHECK_NEXT_OK', {'completedIndex': idx});
-      } else {
-        elogUi('AUTO_CHECK_NEXT_SKIP', {'reason': 'none'});
-      }
-    });
+    final idx = prov.completeNextFilledSet();
+    if (idx != null) {
+      elogUi('AUTO_CHECK_NEXT_OK', {'completedIndex': idx});
+    } else {
+      elogUi('AUTO_CHECK_NEXT_SKIP', {'reason': 'none'});
+    }
     _haptic(context);
   }
 


### PR DESCRIPTION
## Summary
- avoid error page when toggling incomplete sets
- disable checkmark until set fields are valid
- refresh device page immediately when checking sets via overlay keypad

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b74f3968b083208f1486b7e0284ae3