### PR TITLE
fix(profile): remove verbose logs and cache device data

### DIFF
--- a/lib/core/logging/elog.dart
+++ b/lib/core/logging/elog.dart
@@ -1,7 +1,10 @@
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
 
+const bool _enableLogging = false;
+
 void _log(String tag, String event, Map<String, Object?> data) {
+  if (!_enableLogging) return;
   final payload = jsonEncode(data);
   debugPrint('$tag $event $payload');
 }

--- a/lib/features/history/data/repositories/history_repository_impl.dart
+++ b/lib/features/history/data/repositories/history_repository_impl.dart
@@ -1,6 +1,5 @@
 // lib/features/history/data/repositories/history_repository_impl.dart
 
-import 'package:tapem/core/logging/elog.dart';
 import '../sources/firestore_history_source.dart';
 import '../dtos/workout_log_dto.dart';
 import '../../domain/models/workout_log.dart';
@@ -32,34 +31,14 @@ class HistoryRepositoryImpl implements GetHistoryForDeviceRepository {
     final List<WorkoutLog> logs = [];
     for (var entry in grouped.entries) {
       final list = entry.value;
-      final raw = list.map((d) => d.setNumber).toList();
-      elogUi('SESSION_READ_RAW_SETS', {
-        'sessionId': entry.key,
-        'rawSetNumbers': raw,
-        'rawCount': list.length,
-      });
-
-      var usedKey = 'setNumber';
       if (list.any((d) => d.setNumber <= 0)) {
-        usedKey = 'timestamp';
         list.sort((a, b) => a.timestamp.compareTo(b.timestamp));
-        elogUi('ORDER_FALLBACK_USED', {
-          'sessionId': entry.key,
-          'reason': 'missing',
-        });
         try {
           await _source.backfillSetNumbers(list);
         } catch (_) {}
       } else {
         list.sort((a, b) => a.setNumber.compareTo(b.setNumber));
       }
-
-      elogUi('SESSION_SORT_APPLIED', {
-        'sessionId': entry.key,
-        'usedKey': usedKey,
-        'sortedSetNumbers': list.map((d) => d.setNumber).toList(),
-        'finalCount': list.length,
-      });
 
       logs.addAll(list.map((d) => d.toModel()));
     }

--- a/lib/features/training_details/data/repositories/session_repository_impl.dart
+++ b/lib/features/training_details/data/repositories/session_repository_impl.dart
@@ -1,6 +1,4 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter/foundation.dart';
-import 'package:tapem/core/logging/elog.dart';
 import 'package:tapem/features/training_details/data/dtos/session_dto.dart';
 import 'package:tapem/features/training_details/data/sources/firestore_session_source.dart';
 import 'package:tapem/features/training_details/domain/models/session.dart';
@@ -16,7 +14,6 @@ class SessionRepositoryImpl implements SessionRepository {
     required DateTime date,
   }) async {
     final dtos = await _source.getSessionsForDate(userId: userId, date: date);
-    debugPrint('SessionRepositoryImpl: processing ' + dtos.length.toString() + ' log dtos');
 
     // 1) Gruppieren
     final Map<String, List<SessionDto>> grouped = {};
@@ -27,23 +24,14 @@ class SessionRepositoryImpl implements SessionRepository {
     final List<Session> sessions = [];
 
     // 2) Für jede Gruppe: sortieren, Sets mappen, Namen+Description holen
+    final deviceCache =
+        <String, DocumentSnapshot<Map<String, dynamic>>>{};
+    final exerciseCache =
+        <String, DocumentSnapshot<Map<String, dynamic>>>{};
     for (var entry in grouped.entries) {
       final list = entry.value;
-      final rawNums = list.map((d) => d.setNumber).toList();
-      elogUi('SESSION_READ_RAW_SETS', {
-        'sessionId': entry.key,
-        'rawSetNumbers': rawNums,
-        'rawCount': list.length,
-      });
-
-      var usedKey = 'setNumber';
       if (list.any((d) => d.setNumber <= 0)) {
-        usedKey = 'timestamp';
         list.sort((a, b) => a.timestamp.compareTo(b.timestamp));
-        elogUi('ORDER_FALLBACK_USED', {
-          'sessionId': entry.key,
-          'reason': 'missing',
-        });
         try {
           await _source.backfillSetNumbers(list);
         } catch (_) {}
@@ -51,63 +39,45 @@ class SessionRepositoryImpl implements SessionRepository {
         list.sort((a, b) => a.setNumber.compareTo(b.setNumber));
       }
 
-      elogUi('SESSION_SORT_APPLIED', {
-        'sessionId': entry.key,
-        'usedKey': usedKey,
-        'sortedSetNumbers': list.map((e) => e.setNumber).toList(),
-        'finalCount': list.length,
-      });
-
       final first = list.first;
-
-      // Referenz aufs Device-Dokument:
       final deviceRef = first.reference.parent.parent!;
-      debugPrint('SessionRepositoryImpl: read path=' +
-          deviceRef.path +
-          ' owner=' +
-          first.userId);
-
       var deviceName = first.deviceId;
       var deviceDescription = '';
       var isMulti = false;
-      try {
-        final deviceSnap = await deviceRef.get();
-        debugPrint('SessionRepositoryImpl: success path=' + deviceRef.path);
-        final data = deviceSnap.data();
-        if (data != null) {
-          deviceName = (data['name'] as String?) ?? first.deviceId;
-          deviceDescription = (data['description'] as String?) ?? '';
-          isMulti = (data['isMulti'] as bool?) ?? false;
+
+      DocumentSnapshot<Map<String, dynamic>>? deviceSnap =
+          deviceCache[deviceRef.path];
+      if (deviceSnap == null) {
+        try {
+          deviceSnap = await deviceRef.get();
+          deviceCache[deviceRef.path] = deviceSnap;
+        } on FirebaseException {
+          deviceSnap = null;
         }
-      } on FirebaseException catch (e) {
-        debugPrint('SessionRepositoryImpl: failure path=' +
-            deviceRef.path +
-            ' code=' +
-            e.code);
       }
-      debugPrint('SessionRepositoryImpl: deviceName=' +
-          deviceName +
-          ' isMulti=' +
-          isMulti.toString());
+
+      final data = deviceSnap?.data();
+      if (data != null) {
+        deviceName = (data['name'] as String?) ?? first.deviceId;
+        deviceDescription = (data['description'] as String?) ?? '';
+        isMulti = (data['isMulti'] as bool?) ?? false;
+      }
 
       if (isMulti && first.exerciseId.isNotEmpty) {
         final exRef = deviceRef.collection('exercises').doc(first.exerciseId);
-        debugPrint('SessionRepositoryImpl: read path=' +
-            exRef.path +
-            ' owner=' +
-            first.userId);
-        try {
-          final exSnap = await exRef.get();
-          debugPrint('SessionRepositoryImpl: success path=' + exRef.path);
-          if (exSnap.exists) {
-            final exName = (exSnap.data()?['name'] as String?) ?? '';
-            if (exName.isNotEmpty) deviceName = exName;
+        DocumentSnapshot<Map<String, dynamic>>? exSnap =
+            exerciseCache[exRef.path];
+        if (exSnap == null) {
+          try {
+            exSnap = await exRef.get();
+            exerciseCache[exRef.path] = exSnap;
+          } on FirebaseException {
+            exSnap = null;
           }
-        } on FirebaseException catch (e) {
-          debugPrint('SessionRepositoryImpl: failure path=' +
-              exRef.path +
-              ' code=' +
-              e.code);
+        }
+        if (exSnap != null && exSnap.exists) {
+          final exName = (exSnap.data()?['name'] as String?) ?? '';
+          if (exName.isNotEmpty) deviceName = exName;
         }
       }
 
@@ -134,7 +104,6 @@ class SessionRepositoryImpl implements SessionRepository {
       );
     }
 
-    // 3) Neueste zuerst
     sessions.sort((a, b) => b.timestamp.compareTo(a.timestamp));
     return sessions;
   }


### PR DESCRIPTION
## Summary
- silence debug event logging by default
- drop heavy UI logging from history and session repositories
- cache device and exercise lookups to reduce profile load time

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b765c83b648320b7ce1f906eebe379