### PR TITLE
fix: remove unsupported select call

### DIFF
--- a/lib/core/providers/profile_provider.dart
+++ b/lib/core/providers/profile_provider.dart
@@ -33,7 +33,6 @@ class ProfileProvider extends ChangeNotifier {
       final snapshot = await FirebaseFirestore.instance
           .collectionGroup('logs')
           .where('userId', isEqualTo: userId)
-          .select(['timestamp'])
           .get();
 
       final datesSet = <String>{};


### PR DESCRIPTION
## Summary
- fix profile provider by removing unsupported query select call

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b769628788832089887ceb3913f9f7