### PR TITLE
Refactor rank landing card layout

### DIFF
--- a/lib/core/widgets/brand_action_tile.dart
+++ b/lib/core/widgets/brand_action_tile.dart
@@ -11,6 +11,9 @@ class BrandActionTile extends StatelessWidget {
   final String? subtitle;
   final Widget? trailing;
   final VoidCallback? onTap;
+  final bool centerTitle;
+  final bool showChevron;
+  final EdgeInsetsGeometry? margin;
 
   const BrandActionTile({
     super.key,
@@ -20,31 +23,55 @@ class BrandActionTile extends StatelessWidget {
     this.subtitle,
     this.trailing,
     this.onTap,
+    this.centerTitle = false,
+    this.showChevron = true,
+    this.margin,
   });
 
   @override
   Widget build(BuildContext context) {
     final onGradient =
         Theme.of(context).extension<BrandOnColors>()?.onGradient ?? Colors.black;
-    return BrandGradientCard(
-      onTap: onTap,
-      child: ListTile(
-        contentPadding: EdgeInsets.zero,
-        leading: leading ??
-            (leadingIcon != null
-                ? Icon(leadingIcon, color: onGradient)
-                : null),
-        title: Text(
-          title,
-          style: const TextStyle(color: Colors.black),
+    return Padding(
+      padding: margin ?? EdgeInsets.zero,
+      child: BrandGradientCard(
+        onTap: onTap,
+        child: ListTile(
+          contentPadding: EdgeInsets.zero,
+          leading: leading ??
+              (leadingIcon != null
+                  ? Icon(leadingIcon, color: onGradient)
+                  : null),
+          title: centerTitle
+              ? Center(
+                  child: Text(
+                    title,
+                    textAlign: TextAlign.center,
+                    style: const TextStyle(color: Colors.black),
+                  ),
+                )
+              : Text(
+                  title,
+                  style: const TextStyle(color: Colors.black),
+                ),
+          subtitle: subtitle != null
+              ? (centerTitle
+                  ? Center(
+                      child: Text(
+                        subtitle!,
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(color: Colors.black),
+                      ),
+                    )
+                  : Text(
+                      subtitle!,
+                      style: const TextStyle(color: Colors.black),
+                    ))
+              : null,
+          trailing: showChevron
+              ? (trailing ?? Icon(Icons.chevron_right, color: onGradient))
+              : null,
         ),
-        subtitle: subtitle != null
-            ? Text(
-                subtitle!,
-                style: const TextStyle(color: Colors.black),
-              )
-            : null,
-        trailing: trailing ?? Icon(Icons.chevron_right, color: onGradient),
       ),
     );
   }

--- a/lib/features/rank/presentation/screens/rank_screen.dart
+++ b/lib/features/rank/presentation/screens/rank_screen.dart
@@ -5,6 +5,7 @@ import 'package:tapem/app_router.dart';
 import 'package:tapem/features/challenges/presentation/screens/challenge_tab.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/widgets/brand_action_tile.dart';
+import 'package:tapem/l10n/app_localizations.dart';
 
 class RankScreen extends StatefulWidget {
   final String gymId;
@@ -47,6 +48,7 @@ class _RankScreenState extends State<RankScreen>
       ),
       body: Consumer<RankProvider>(
         builder: (context, prov, _) {
+          final loc = AppLocalizations.of(context)!;
           return TabBarView(
             controller: _tabController,
             children: [
@@ -54,21 +56,33 @@ class _RankScreenState extends State<RankScreen>
                 padding: const EdgeInsets.all(AppSpacing.sm),
                 children: [
                   BrandActionTile(
-                    title: 'XP je Muskelgruppe',
-                    onTap: () =>
-                        Navigator.of(context).pushNamed(AppRouter.xpOverview),
-                  ),
-                  const SizedBox(height: AppSpacing.sm),
-                  BrandActionTile(
-                    title: 'XP je Trainingstag',
+                    title: loc.rank_experience,
                     onTap: () =>
                         Navigator.of(context).pushNamed(AppRouter.dayXp),
+                    centerTitle: true,
+                    showChevron: false,
+                    margin:
+                        const EdgeInsets.symmetric(horizontal: AppSpacing.md),
                   ),
                   const SizedBox(height: AppSpacing.sm),
                   BrandActionTile(
-                    title: 'XP je Gerät',
+                    title: loc.rank_device_level,
                     onTap: () =>
                         Navigator.of(context).pushNamed(AppRouter.deviceXp),
+                    centerTitle: true,
+                    showChevron: false,
+                    margin:
+                        const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  BrandActionTile(
+                    title: loc.rank_muscle_level,
+                    onTap: () =>
+                        Navigator.of(context).pushNamed(AppRouter.xpOverview),
+                    centerTitle: true,
+                    showChevron: false,
+                    margin:
+                        const EdgeInsets.symmetric(horizontal: AppSpacing.md),
                   ),
                 ],
               ),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -657,5 +657,17 @@
   "friends_cta_friend": "Freund",
   "friends_cta_pending": "Ausstehend",
   "friends_action_send": "Anfrage senden",
-  "friends_search_min_chars": "Mindestens 2 Zeichen eingeben"
+  "friends_search_min_chars": "Mindestens 2 Zeichen eingeben",
+  "rank_experience": "Erfahrung",
+  "@rank_experience": {
+    "description": "Tile auf der Rangliste für Erfahrung je Trainingstag"
+  },
+  "rank_device_level": "Geräte level",
+  "@rank_device_level": {
+    "description": "Tile auf der Rangliste für Gerätelevel"
+  },
+  "rank_muscle_level": "Mucki level",
+  "@rank_muscle_level": {
+    "description": "Tile auf der Rangliste für Muskellevel"
+  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -655,5 +655,17 @@
   "friends_cta_friend": "Friend",
   "friends_cta_pending": "Pending",
   "friends_action_send": "Send request",
-  "friends_search_min_chars": "Enter at least 2 characters"
+  "friends_search_min_chars": "Enter at least 2 characters",
+  "rank_experience": "Experience",
+  "@rank_experience": {
+    "description": "Rank landing tile for experience per training day"
+  },
+  "rank_device_level": "Device level",
+  "@rank_device_level": {
+    "description": "Rank landing tile for device level"
+  },
+  "rank_muscle_level": "Muscle level",
+  "@rank_muscle_level": {
+    "description": "Rank landing tile for muscle level"
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1318,6 +1318,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Enter at least 2 characters'**
   String get friends_search_min_chars;
+
+  /// No description provided for @rank_experience.
+  ///
+  /// In en, this message translates to:
+  /// **'Experience'**
+  String get rank_experience;
+
+  /// No description provided for @rank_device_level.
+  ///
+  /// In en, this message translates to:
+  /// **'Device level'**
+  String get rank_device_level;
+
+  /// No description provided for @rank_muscle_level.
+  ///
+  /// In en, this message translates to:
+  /// **'Muscle level'**
+  String get rank_muscle_level;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -639,4 +639,13 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get friends_search_min_chars => 'Mindestens 2 Zeichen eingeben';
+
+  @override
+  String get rank_experience => 'Erfahrung';
+
+  @override
+  String get rank_device_level => 'Geräte level';
+
+  @override
+  String get rank_muscle_level => 'Mucki level';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -639,4 +639,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get friends_search_min_chars => 'Enter at least 2 characters';
+
+  @override
+  String get rank_experience => 'Experience';
+
+  @override
+  String get rank_device_level => 'Device level';
+
+  @override
+  String get rank_muscle_level => 'Muscle level';
 }


### PR DESCRIPTION
## Summary
- center Rank tiles and hide chevrons with optional parameters
- reorder Rank page cards and add localized labels
- add localization entries for experience, device level, and muscle level

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b889dc980c8320942873d5fa53db14