### PR TITLE
feat(rank): revamp rank landing tiles

### DIFF
--- a/lib/core/widgets/brand_action_tile.dart
+++ b/lib/core/widgets/brand_action_tile.dart
@@ -11,6 +11,9 @@ class BrandActionTile extends StatelessWidget {
   final String? subtitle;
   final Widget? trailing;
   final VoidCallback? onTap;
+  final bool centerTitle;
+  final bool showChevron;
+  final EdgeInsetsGeometry? margin;
 
   const BrandActionTile({
     super.key,
@@ -20,31 +23,39 @@ class BrandActionTile extends StatelessWidget {
     this.subtitle,
     this.trailing,
     this.onTap,
+    this.centerTitle = false,
+    this.showChevron = true,
+    this.margin,
   });
 
   @override
   Widget build(BuildContext context) {
     final onGradient =
         Theme.of(context).extension<BrandOnColors>()?.onGradient ?? Colors.black;
-    return BrandGradientCard(
-      onTap: onTap,
-      child: ListTile(
-        contentPadding: EdgeInsets.zero,
-        leading: leading ??
-            (leadingIcon != null
-                ? Icon(leadingIcon, color: onGradient)
-                : null),
-        title: Text(
-          title,
-          style: const TextStyle(color: Colors.black),
+    return Container(
+      margin: margin,
+      child: BrandGradientCard(
+        onTap: onTap,
+        child: ListTile(
+          contentPadding: EdgeInsets.zero,
+          leading: leading ??
+              (leadingIcon != null
+                  ? Icon(leadingIcon, color: onGradient)
+                  : null),
+          title: Text(
+            title,
+            textAlign: centerTitle ? TextAlign.center : TextAlign.start,
+            style: const TextStyle(color: Colors.black),
+          ),
+          subtitle: subtitle != null
+              ? Text(
+                  subtitle!,
+                  style: const TextStyle(color: Colors.black),
+                )
+              : null,
+          trailing:
+              showChevron ? (trailing ?? Icon(Icons.chevron_right, color: onGradient)) : null,
         ),
-        subtitle: subtitle != null
-            ? Text(
-                subtitle!,
-                style: const TextStyle(color: Colors.black),
-              )
-            : null,
-        trailing: trailing ?? Icon(Icons.chevron_right, color: onGradient),
       ),
     );
   }

--- a/lib/features/rank/presentation/screens/rank_screen.dart
+++ b/lib/features/rank/presentation/screens/rank_screen.dart
@@ -5,7 +5,9 @@ import 'package:tapem/app_router.dart';
 import 'package:tapem/features/challenges/presentation/screens/challenge_tab.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/widgets/brand_action_tile.dart';
+import 'package:tapem/l10n/app_localizations.dart';
 
+/// Rank landing displayed in the "Rank" tab of the leaderboard.
 class RankScreen extends StatefulWidget {
   final String gymId;
   final String deviceId;
@@ -54,21 +56,33 @@ class _RankScreenState extends State<RankScreen>
                 padding: const EdgeInsets.all(AppSpacing.sm),
                 children: [
                   BrandActionTile(
-                    title: 'XP je Muskelgruppe',
-                    onTap: () =>
-                        Navigator.of(context).pushNamed(AppRouter.xpOverview),
-                  ),
-                  const SizedBox(height: AppSpacing.sm),
-                  BrandActionTile(
-                    title: 'XP je Trainingstag',
+                    title: AppLocalizations.of(context)!.rankExperience,
                     onTap: () =>
                         Navigator.of(context).pushNamed(AppRouter.dayXp),
+                    centerTitle: true,
+                    showChevron: false,
+                    margin: const EdgeInsets.symmetric(
+                        horizontal: AppSpacing.sm),
                   ),
                   const SizedBox(height: AppSpacing.sm),
                   BrandActionTile(
-                    title: 'XP je Gerät',
+                    title: AppLocalizations.of(context)!.rankDeviceLevel,
                     onTap: () =>
                         Navigator.of(context).pushNamed(AppRouter.deviceXp),
+                    centerTitle: true,
+                    showChevron: false,
+                    margin: const EdgeInsets.symmetric(
+                        horizontal: AppSpacing.sm),
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  BrandActionTile(
+                    title: AppLocalizations.of(context)!.rankMuscleLevel,
+                    onTap: () =>
+                        Navigator.of(context).pushNamed(AppRouter.xpOverview),
+                    centerTitle: true,
+                    showChevron: false,
+                    margin: const EdgeInsets.symmetric(
+                        horizontal: AppSpacing.sm),
                   ),
                 ],
               ),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -67,6 +67,21 @@
     "description": "Fallback-Anzeige für unbekannten Benutzer"
   },
 
+  "rankExperience": "Erfahrung",
+  "@rankExperience": {
+    "description": "Titelkarte für Tageserfahrung im Rank-Tab"
+  },
+
+  "rankDeviceLevel": "Geräte level",
+  "@rankDeviceLevel": {
+    "description": "Titelkarte für Gerätestatistik im Rank-Tab"
+  },
+
+  "rankMuscleLevel": "Mucki level",
+  "@rankMuscleLevel": {
+    "description": "Titelkarte für Muskelgruppenstatistik im Rank-Tab"
+  },
+
   "gymCodeFieldLabel": "Gym-Code",
   "@gymCodeFieldLabel": {
     "description": "Beschriftung für das Gym-Code-Feld"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -67,6 +67,21 @@
     "description": "Fallback display for unknown user"
   },
 
+  "rankExperience": "Experience",
+  "@rankExperience": {
+    "description": "Title card for daily experience on rank tab"
+  },
+
+  "rankDeviceLevel": "Device level",
+  "@rankDeviceLevel": {
+    "description": "Title card for device stats on rank tab"
+  },
+
+  "rankMuscleLevel": "Muscle level",
+  "@rankMuscleLevel": {
+    "description": "Title card for muscle group stats on rank tab"
+  },
+
   "gymCodeFieldLabel": "Gym Code",
   "@gymCodeFieldLabel": {
     "description": "Label for the gym code input"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1139,6 +1139,24 @@ abstract class AppLocalizations {
   /// **'Lower body'**
   String get muscleCatLower;
 
+  /// Title card for daily experience on rank tab
+  ///
+  /// In en, this message translates to:
+  /// **'Experience'**
+  String get rankExperience;
+
+  /// Title card for device stats on rank tab
+  ///
+  /// In en, this message translates to:
+  /// **'Device level'**
+  String get rankDeviceLevel;
+
+  /// Title card for muscle group stats on rank tab
+  ///
+  /// In en, this message translates to:
+  /// **'Muscle level'**
+  String get rankMuscleLevel;
+
   /// No description provided for @friends_title.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -549,6 +549,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get muscleCatLower => 'Unterkörper';
 
   @override
+  String get rankExperience => 'Erfahrung';
+
+  @override
+  String get rankDeviceLevel => 'Geräte level';
+
+  @override
+  String get rankMuscleLevel => 'Mucki level';
+
+  @override
   String get friends_title => 'Freunde';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -549,6 +549,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get muscleCatLower => 'Lower body';
 
   @override
+  String get rankExperience => 'Experience';
+
+  @override
+  String get rankDeviceLevel => 'Device level';
+
+  @override
+  String get rankMuscleLevel => 'Muscle level';
+
+  @override
   String get friends_title => 'Friends';
 
   @override


### PR DESCRIPTION
## Summary
- reorder rank landing cards and rename to Experience, Device level, Mucki level
- add localization entries for new rank labels (de/en)
- extend BrandActionTile with centerTitle, showChevron, and margin options and use them on rank landing

`RankScreen` in `lib/features/rank/presentation/screens/rank_screen.dart` renders the Rank landing.

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b88db99b648320bf0429f6314f89d5