### PR TITLE
feat: align rank cards with gym card styling

### DIFF
--- a/lib/core/widgets/brand_action_tile.dart
+++ b/lib/core/widgets/brand_action_tile.dart
@@ -1,9 +1,20 @@
 import 'package:flutter/material.dart';
 
 import 'brand_gradient_card.dart';
+import 'brand_outline.dart';
 import '../theme/brand_on_colors.dart';
+import '../theme/design_tokens.dart';
 
-/// Navigable tile using the brand gradient background.
+/// Visual styles for [BrandActionTile].
+enum BrandActionTileVariant {
+  /// Filled card using the brand gradient.
+  gradient,
+
+  /// Outlined surface using the brand outline style.
+  outlined,
+}
+
+/// Navigable tile using the brand gradient background or outlined surface.
 class BrandActionTile extends StatelessWidget {
   final Widget? leading;
   final IconData? leadingIcon;
@@ -14,6 +25,13 @@ class BrandActionTile extends StatelessWidget {
   final bool centerTitle;
   final bool showChevron;
   final EdgeInsetsGeometry? margin;
+
+  /// Visual variant of the tile.
+  ///
+  /// Defaults to [BrandActionTileVariant.gradient] to preserve existing
+  /// behaviour. Use [BrandActionTileVariant.outlined] for a surface styled like
+  /// the gym device cards.
+  final BrandActionTileVariant variant;
 
   const BrandActionTile({
     super.key,
@@ -26,37 +44,49 @@ class BrandActionTile extends StatelessWidget {
     this.centerTitle = false,
     this.showChevron = true,
     this.margin,
+    this.variant = BrandActionTileVariant.gradient,
   });
 
   @override
   Widget build(BuildContext context) {
     final onGradient =
         Theme.of(context).extension<BrandOnColors>()?.onGradient ?? Colors.black;
+    final titleStyle =
+        variant == BrandActionTileVariant.gradient ? TextStyle(color: onGradient) : null;
+    final subtitleStyle =
+        variant == BrandActionTileVariant.gradient ? TextStyle(color: onGradient) : null;
+
+    final tile = ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: leading ??
+          (leadingIcon != null ? Icon(leadingIcon, color: onGradient) : null),
+      title: Text(
+        title,
+        textAlign: centerTitle ? TextAlign.center : TextAlign.start,
+        style: titleStyle,
+      ),
+      subtitle: subtitle != null
+          ? Text(
+              subtitle!,
+              style: subtitleStyle,
+            )
+          : null,
+      trailing: showChevron
+          ? (trailing ?? Icon(Icons.chevron_right, color: onGradient))
+          : null,
+    );
+
+    final Widget card = variant == BrandActionTileVariant.gradient
+        ? BrandGradientCard(onTap: onTap, child: tile)
+        : BrandOutline(
+            onTap: onTap,
+            padding: const EdgeInsets.all(AppSpacing.sm),
+            child: tile,
+          );
+
     return Container(
       margin: margin,
-      child: BrandGradientCard(
-        onTap: onTap,
-        child: ListTile(
-          contentPadding: EdgeInsets.zero,
-          leading: leading ??
-              (leadingIcon != null
-                  ? Icon(leadingIcon, color: onGradient)
-                  : null),
-          title: Text(
-            title,
-            textAlign: centerTitle ? TextAlign.center : TextAlign.start,
-            style: const TextStyle(color: Colors.black),
-          ),
-          subtitle: subtitle != null
-              ? Text(
-                  subtitle!,
-                  style: const TextStyle(color: Colors.black),
-                )
-              : null,
-          trailing:
-              showChevron ? (trailing ?? Icon(Icons.chevron_right, color: onGradient)) : null,
-        ),
-      ),
+      child: card,
     );
   }
 }

--- a/lib/features/rank/presentation/screens/rank_screen.dart
+++ b/lib/features/rank/presentation/screens/rank_screen.dart
@@ -61,6 +61,7 @@ class _RankScreenState extends State<RankScreen>
                         Navigator.of(context).pushNamed(AppRouter.dayXp),
                     centerTitle: true,
                     showChevron: false,
+                    variant: BrandActionTileVariant.outlined,
                     margin: const EdgeInsets.symmetric(
                         horizontal: AppSpacing.sm),
                   ),
@@ -71,6 +72,7 @@ class _RankScreenState extends State<RankScreen>
                         Navigator.of(context).pushNamed(AppRouter.deviceXp),
                     centerTitle: true,
                     showChevron: false,
+                    variant: BrandActionTileVariant.outlined,
                     margin: const EdgeInsets.symmetric(
                         horizontal: AppSpacing.sm),
                   ),
@@ -81,6 +83,7 @@ class _RankScreenState extends State<RankScreen>
                         Navigator.of(context).pushNamed(AppRouter.xpOverview),
                     centerTitle: true,
                     showChevron: false,
+                    variant: BrandActionTileVariant.outlined,
                     margin: const EdgeInsets.symmetric(
                         horizontal: AppSpacing.sm),
                   ),

--- a/test/ui/rank_tiles_test.dart
+++ b/test/ui/rank_tiles_test.dart
@@ -28,4 +28,20 @@ void main() {
     final icon = tester.widget<Icon>(find.byIcon(Icons.chevron_right));
     expect(icon.color, onGrad);
   });
+
+  testWidgets('Outlined variant uses default text colour', (tester) async {
+    final theme = ThemeData(extensions: [AppBrandTheme.defaultTheme()]);
+
+    await tester.pumpWidget(MaterialApp(
+      theme: theme,
+      home: const BrandActionTile(
+        title: 'tile',
+        variant: BrandActionTileVariant.outlined,
+        showChevron: false,
+      ),
+    ));
+
+    final text = tester.widget<Text>(find.text('tile'));
+    expect(text.style, isNull);
+  });
 }


### PR DESCRIPTION
## Summary
- add reusable outlined variant to `BrandActionTile`
- style rank landing cards with gym-like outline
- cover outlined variant with widget test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b89023a7cc8320890a6bad8cafc282