### PR TITLE
feat: unify action cards with gym outline style

### DIFF
--- a/lib/core/widgets/brand_action_tile.dart
+++ b/lib/core/widgets/brand_action_tile.dart
@@ -4,6 +4,7 @@ import 'brand_gradient_card.dart';
 import 'brand_outline.dart';
 import '../theme/brand_on_colors.dart';
 import '../theme/design_tokens.dart';
+import '../logging/elog.dart';
 
 /// Visual styles for [BrandActionTile].
 enum BrandActionTileVariant {
@@ -25,6 +26,7 @@ class BrandActionTile extends StatelessWidget {
   final bool centerTitle;
   final bool showChevron;
   final EdgeInsetsGeometry? margin;
+  final String? uiLogEvent;
 
   /// Visual variant of the tile.
   ///
@@ -45,10 +47,14 @@ class BrandActionTile extends StatelessWidget {
     this.showChevron = true,
     this.margin,
     this.variant = BrandActionTileVariant.gradient,
+    this.uiLogEvent,
   });
 
   @override
   Widget build(BuildContext context) {
+    if (uiLogEvent != null) {
+      elogUi(uiLogEvent!, {'title': title});
+    }
     final onGradient =
         Theme.of(context).extension<BrandOnColors>()?.onGradient ?? Colors.black;
     final titleStyle =

--- a/lib/features/admin/presentation/screens/admin_dashboard_screen.dart
+++ b/lib/features/admin/presentation/screens/admin_dashboard_screen.dart
@@ -15,6 +15,8 @@ import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/widgets/brand_primary_button.dart';
+import 'package:tapem/core/widgets/brand_action_tile.dart';
+import 'package:tapem/core/logging/elog.dart';
 
 class AdminDashboardScreen extends StatefulWidget {
   const AdminDashboardScreen({Key? key}) : super(key: key);
@@ -201,60 +203,48 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen> {
                 padding: const EdgeInsets.all(AppSpacing.sm),
                 child: Column(
                   children: [
-                    BrandPrimaryButton(
-                      onPressed: _showCreateDialog,
-                      child: const Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(Icons.add),
-                          SizedBox(width: AppSpacing.xs),
-                          Text('Gerät anlegen'),
-                        ],
-                      ),
+                    BrandActionTile(
+                      leadingIcon: Icons.add,
+                      title: 'Gerät anlegen',
+                      onTap: _showCreateDialog,
+                      variant: BrandActionTileVariant.outlined,
+                      showChevron: false,
+                      uiLogEvent: 'ADMIN_CARD_RENDER',
                     ),
                     const SizedBox(height: AppSpacing.sm),
-                    BrandPrimaryButton(
-                      onPressed: () {
+                    BrandActionTile(
+                      leadingIcon: Icons.fitness_center,
+                      title: 'Muskelgruppen',
+                      onTap: () {
                         Navigator.of(context)
                             .pushNamed(AppRouter.manageMuscleGroups);
                       },
-                      child: const Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(Icons.fitness_center),
-                          SizedBox(width: AppSpacing.xs),
-                          Text('Muskelgruppen'),
-                        ],
-                      ),
+                      variant: BrandActionTileVariant.outlined,
+                      showChevron: false,
+                      uiLogEvent: 'ADMIN_CARD_RENDER',
                     ),
                     const SizedBox(height: AppSpacing.sm),
-                    BrandPrimaryButton(
-                      onPressed: () {
+                    BrandActionTile(
+                      leadingIcon: Icons.brush,
+                      title: 'Branding',
+                      onTap: () {
                         Navigator.of(context).pushNamed(AppRouter.branding);
                       },
-                      child: const Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(Icons.brush),
-                          SizedBox(width: AppSpacing.xs),
-                          Text('Branding'),
-                        ],
-                      ),
+                      variant: BrandActionTileVariant.outlined,
+                      showChevron: false,
+                      uiLogEvent: 'ADMIN_CARD_RENDER',
                     ),
                     const SizedBox(height: AppSpacing.sm),
-                    BrandPrimaryButton(
-                      onPressed: () {
+                    BrandActionTile(
+                      leadingIcon: Icons.flag,
+                      title: 'Challenges verwalten',
+                      onTap: () {
                         Navigator.of(context)
                             .pushNamed(AppRouter.manageChallenges);
                       },
-                      child: const Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(Icons.flag),
-                          SizedBox(width: AppSpacing.xs),
-                          Text('Challenges verwalten'),
-                        ],
-                      ),
+                      variant: BrandActionTileVariant.outlined,
+                      showChevron: false,
+                      uiLogEvent: 'ADMIN_CARD_RENDER',
                     ),
                     const SizedBox(height: AppSpacing.md),
                     Expanded(

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -10,7 +10,8 @@ import 'package:tapem/features/friends/providers/friends_provider.dart';
 import 'package:tapem/features/nfc/widgets/nfc_scan_button.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
-import 'package:tapem/core/widgets/brand_primary_button.dart';
+import 'package:tapem/core/widgets/brand_action_tile.dart';
+import 'package:tapem/core/logging/elog.dart';
 import '../widgets/calendar.dart';
 import '../widgets/calendar_popup.dart';
 import '../../../survey/presentation/screens/survey_vote_screen.dart';
@@ -254,9 +255,9 @@ class _ProfileScreenState extends State<ProfileScreen> {
           padding: const EdgeInsets.all(AppSpacing.sm),
           child: SizedBox(
             width: double.infinity,
-            child: BrandPrimaryButton(
-              semanticsLabel: 'Umfragen',
-              onPressed: () {
+            child: BrandActionTile(
+              title: 'Umfragen',
+              onTap: () {
                 final gymId = context.read<GymProvider>().currentGymId;
                 final userId = context.read<AuthProvider>().userId ?? '';
                 Navigator.push(
@@ -269,7 +270,9 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   ),
                 );
               },
-              child: const Text('Umfragen'),
+              variant: BrandActionTileVariant.outlined,
+              showChevron: false,
+              uiLogEvent: 'PROFILE_CARD_RENDER',
             ),
           ),
         ),

--- a/lib/features/rank/presentation/screens/rank_screen.dart
+++ b/lib/features/rank/presentation/screens/rank_screen.dart
@@ -6,6 +6,7 @@ import 'package:tapem/features/challenges/presentation/screens/challenge_tab.dar
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/widgets/brand_action_tile.dart';
 import 'package:tapem/l10n/app_localizations.dart';
+import 'package:tapem/core/logging/elog.dart';
 
 /// Rank landing displayed in the "Rank" tab of the leaderboard.
 class RankScreen extends StatefulWidget {
@@ -64,6 +65,7 @@ class _RankScreenState extends State<RankScreen>
                     variant: BrandActionTileVariant.outlined,
                     margin: const EdgeInsets.symmetric(
                         horizontal: AppSpacing.sm),
+                    uiLogEvent: 'RANK_CARD_RENDER',
                   ),
                   const SizedBox(height: AppSpacing.sm),
                   BrandActionTile(
@@ -75,6 +77,7 @@ class _RankScreenState extends State<RankScreen>
                     variant: BrandActionTileVariant.outlined,
                     margin: const EdgeInsets.symmetric(
                         horizontal: AppSpacing.sm),
+                    uiLogEvent: 'RANK_CARD_RENDER',
                   ),
                   const SizedBox(height: AppSpacing.sm),
                   BrandActionTile(
@@ -86,6 +89,7 @@ class _RankScreenState extends State<RankScreen>
                     variant: BrandActionTileVariant.outlined,
                     margin: const EdgeInsets.symmetric(
                         horizontal: AppSpacing.sm),
+                    uiLogEvent: 'RANK_CARD_RENDER',
                   ),
                 ],
               ),

--- a/lib/features/report/presentation/screens/report_screen_new.dart
+++ b/lib/features/report/presentation/screens/report_screen_new.dart
@@ -11,6 +11,7 @@ import '../../../survey/presentation/widgets/create_survey_sheet.dart';
 import '../../../../core/providers/report_provider.dart';
 import '../../../../core/theme/design_tokens.dart';
 import '../../../../core/widgets/brand_action_tile.dart';
+import '../../../../core/logging/elog.dart';
 
 class ReportScreenNew extends StatelessWidget {
   final String gymId;
@@ -51,12 +52,16 @@ class ReportScreenNew extends StatelessWidget {
                   ),
                 );
               },
+              variant: BrandActionTileVariant.outlined,
+              uiLogEvent: 'REPORT_CARD_RENDER',
             ),
             const SizedBox(height: AppSpacing.sm),
             BrandActionTile(
               leadingIcon: Icons.add_circle_outline,
               title: 'Umfrage erstellen',
               onTap: () => _showCreateSurveyDialog(context),
+              variant: BrandActionTileVariant.outlined,
+              uiLogEvent: 'REPORT_CARD_RENDER',
             ),
             const SizedBox(height: AppSpacing.sm),
             BrandActionTile(
@@ -70,6 +75,8 @@ class ReportScreenNew extends StatelessWidget {
                   ),
                 );
               },
+              variant: BrandActionTileVariant.outlined,
+              uiLogEvent: 'REPORT_CARD_RENDER',
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- add reusable logging-aware BrandActionTile variant for gym-style outline cards
- update rank, report, profile and admin screens to use gradient outline action tiles
- log card renders for rank, report, profile and admin screens

## Testing
- `dart format lib/core/widgets/brand_action_tile.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8946be4888320b9fe7dfe5231b6ed