### PR TITLE
Reduce Umfragen card height and center text

### DIFF
--- a/lib/core/widgets/brand_action_tile.dart
+++ b/lib/core/widgets/brand_action_tile.dart
@@ -26,6 +26,9 @@ class BrandActionTile extends StatelessWidget {
   final bool centerTitle;
   final bool showChevron;
   final EdgeInsetsGeometry? margin;
+  final EdgeInsetsGeometry? padding;
+  final bool dense;
+  final double? minVerticalPadding;
   final String? uiLogEvent;
 
   /// Visual variant of the tile.
@@ -46,6 +49,9 @@ class BrandActionTile extends StatelessWidget {
     this.centerTitle = false,
     this.showChevron = true,
     this.margin,
+    this.padding,
+    this.dense = false,
+    this.minVerticalPadding,
     this.variant = BrandActionTileVariant.gradient,
     this.uiLogEvent,
   });
@@ -64,6 +70,8 @@ class BrandActionTile extends StatelessWidget {
 
     final tile = ListTile(
       contentPadding: EdgeInsets.zero,
+      dense: dense,
+      minVerticalPadding: minVerticalPadding,
       leading: leading ??
           (leadingIcon != null ? Icon(leadingIcon, color: onGradient) : null),
       title: Text(
@@ -83,10 +91,10 @@ class BrandActionTile extends StatelessWidget {
     );
 
     final Widget card = variant == BrandActionTileVariant.gradient
-        ? BrandGradientCard(onTap: onTap, child: tile)
+        ? BrandGradientCard(onTap: onTap, padding: padding, child: tile)
         : BrandOutline(
             onTap: onTap,
-            padding: const EdgeInsets.all(AppSpacing.sm),
+            padding: padding ?? const EdgeInsets.all(AppSpacing.sm),
             child: tile,
           );
 

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -257,6 +257,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
             width: double.infinity,
             child: BrandActionTile(
               title: 'Umfragen',
+              centerTitle: true,
+              dense: true,
+              minVerticalPadding: 0,
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
               onTap: () {
                 final gymId = context.read<GymProvider>().currentGymId;
                 final userId = context.read<AuthProvider>().userId ?? '';


### PR DESCRIPTION
## Summary
- make BrandActionTile support custom padding and dense layout
- shrink and center the "Umfragen" tile on the profile screen

## Testing
- `flutter analyze` *(command not found)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ab74db60832084bd1be5c5f6832b