### PR TITLE
feat: add creatine intake calendar

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -178,6 +178,10 @@ service cloud.firestore {
         allow read, write: if isOwner(uid);
       }
 
+      match /creatine_intakes/{date} {
+        allow read, write: if isOwner(uid);
+      }
+
       // Fallback for other user subcollections (owner-only)
       match /{document=**} {
         allow read, write: if isOwner(uid);

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -29,6 +29,7 @@ import 'package:tapem/features/survey/presentation/screens/survey_vote_screen.da
 import 'package:tapem/features/friends/presentation/screens/friends_home_screen.dart';
 import 'package:tapem/features/friends/presentation/screens/friend_detail_screen.dart';
 import 'package:tapem/features/friends/presentation/screens/friend_training_calendar_screen.dart';
+import 'package:tapem/features/creatine/presentation/screens/creatine_screen.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/core/config/feature_flags.dart';
@@ -65,6 +66,7 @@ class AppRouter {
   static const friendsHome = '/friends';
   static const friendDetail = '/friend_detail';
   static const friendTrainingCalendar = '/friend_training_calendar';
+  static const creatine = '/creatine';
 
   static const restrictedRoutesForMembers = {
     report,
@@ -232,6 +234,9 @@ class AppRouter {
             friendName: args['name'] ?? '',
           ),
         );
+
+      case creatine:
+        return MaterialPageRoute(builder: (_) => const CreatineScreen());
 
       default:
         return MaterialPageRoute(

--- a/lib/features/creatine/data/creatine_repository.dart
+++ b/lib/features/creatine/data/creatine_repository.dart
@@ -1,0 +1,34 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class CreatineRepository {
+  final FirebaseFirestore _firestore;
+  CreatineRepository({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  CollectionReference<Map<String, dynamic>> _col(String uid) {
+    return _firestore.collection('users').doc(uid).collection('creatine_intakes');
+  }
+
+  Future<Set<String>> fetchDatesForYear(String uid, int year) async {
+    final start = '$year-01-01';
+    final end = '$year-12-31';
+    final snap = await _col(uid)
+        .where('dateKey', isGreaterThanOrEqualTo: start)
+        .where('dateKey', isLessThanOrEqualTo: end)
+        .get();
+    return snap.docs.map((d) => d.id).toSet();
+  }
+
+  Future<void> setIntake(String uid, String dateKey) async {
+    await _col(uid).doc(dateKey).set({
+      'uid': uid,
+      'dateKey': dateKey,
+      'ts': FieldValue.serverTimestamp(),
+      'source': 'manual',
+    });
+  }
+
+  Future<void> deleteIntake(String uid, String dateKey) async {
+    await _col(uid).doc(dateKey).delete();
+  }
+}

--- a/lib/features/creatine/presentation/screens/creatine_screen.dart
+++ b/lib/features/creatine/presentation/screens/creatine_screen.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/logging/elog.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+import 'package:tapem/features/profile/presentation/widgets/calendar.dart';
+import '../../providers/creatine_provider.dart';
+
+class CreatineScreen extends StatefulWidget {
+  final String? userId;
+  const CreatineScreen({super.key, this.userId});
+
+  @override
+  State<CreatineScreen> createState() => _CreatineScreenState();
+}
+
+class _CreatineScreenState extends State<CreatineScreen> {
+  late final String _uid;
+
+  @override
+  void initState() {
+    super.initState();
+    final auth = widget.userId;
+    _uid = auth ?? '';
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context
+          .read<CreatineProvider>()
+          .loadIntakeDates(_uid, DateTime.now().year);
+      elogUi('creatine_open_screen', {});
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final prov = context.watch<CreatineProvider>();
+    final loc = AppLocalizations.of(context)!;
+    final year = DateTime.now().year;
+    final selected = prov.selectedDate;
+    final dateKey = CreatineProvider.dateKeyFrom(selected);
+    final isTaken = prov.intakeDates.contains(dateKey);
+    final today = DateTime.now();
+    final isToday = selected.year == today.year &&
+        selected.month == today.month &&
+        selected.day == today.day;
+    final formatted = DateFormat('dd.MM.yyyy').format(selected);
+    String label;
+    if (isTaken) {
+      label = loc.creatineRemoveMarking;
+    } else {
+      label = isToday
+          ? loc.creatineTakenToday
+          : loc.creatineConfirmForDate(formatted);
+    }
+
+    Widget body;
+    if (prov.isLoading) {
+      body = const Center(child: CircularProgressIndicator());
+    } else if (prov.error != null) {
+      body = Center(child: Text('${loc.errorPrefix}: ${prov.error}'));
+    } else {
+      body = Padding(
+        padding: const EdgeInsets.all(AppSpacing.sm),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Expanded(
+              child: Stack(
+                children: [
+                  Calendar(
+                    trainingDates: prov.intakeDates.toList(),
+                    showNavigation: false,
+                    year: year,
+                    onDayTap: (d) => prov.setSelectedDate(d),
+                  ),
+                  _SelectionOverlay(date: selected, year: year),
+                ],
+              ),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            ElevatedButton.icon(
+              onPressed: () async {
+                try {
+                  final added = await prov.toggleIntake(_uid, dateKey);
+                  final snack = added
+                      ? loc.creatineSaved(formatted)
+                      : loc.creatineRemoved(formatted);
+                  ScaffoldMessenger.of(context)
+                      .showSnackBar(SnackBar(content: Text(snack)));
+                } catch (e) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('${loc.errorPrefix}: $e')),
+                  );
+                }
+              },
+              icon: const Icon(Icons.check),
+              label: Text(label),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: Text(loc.creatineTitle)),
+      body: body,
+    );
+  }
+}
+
+class _SelectionOverlay extends StatelessWidget {
+  final DateTime date;
+  final int year;
+  const _SelectionOverlay({required this.date, required this.year});
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: LayoutBuilder(
+        builder: (ctx, constraints) {
+          const hPad = 16.0;
+          const margin = 1.0;
+          final firstOfYear = DateTime(year, 1, 1);
+          final lastOfYear = DateTime(year, 12, 31);
+          final startOffset = (firstOfYear.weekday + 6) % 7;
+          final gridStart = firstOfYear.subtract(Duration(days: startOffset));
+          final endOffset = 6 - ((lastOfYear.weekday + 6) % 7);
+          final gridEnd = lastOfYear.add(Duration(days: endOffset));
+          final totalDays = gridEnd.difference(gridStart).inDays + 1;
+          final weekCount = (totalDays / 7).ceil();
+
+          final usable = constraints.maxWidth - hPad * 2;
+          final rawSize = (usable - weekCount * margin * 2) / weekCount;
+          final cellSize = rawSize.clamp(4.0, usable);
+
+          final diff = date.difference(gridStart).inDays;
+          if (diff < 0 || diff >= totalDays) {
+            return const SizedBox.shrink();
+          }
+          final w = diff ~/ 7;
+          final d = diff % 7;
+          final left = hPad + w * (cellSize + margin * 2);
+          final top = 20 + 4 + d * (cellSize + margin * 2);
+
+          final today = DateTime.now();
+          final isToday = today.year == date.year &&
+              today.month == date.month &&
+              today.day == date.day;
+          final color = isToday
+              ? Theme.of(context).colorScheme.primary
+              : Theme.of(context).colorScheme.error;
+          final width = isToday ? 3.0 : 2.0;
+
+          return Positioned(
+            left: left,
+            top: top,
+            child: Container(
+              width: cellSize,
+              height: cellSize,
+              decoration: BoxDecoration(
+                border: Border.all(color: color, width: width),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/creatine/providers/creatine_provider.dart
+++ b/lib/features/creatine/providers/creatine_provider.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/foundation.dart';
+import 'package:intl/intl.dart';
+import 'package:tapem/core/logging/elog.dart';
+import '../data/creatine_repository.dart';
+
+class CreatineProvider extends ChangeNotifier {
+  final CreatineRepository _repo;
+  CreatineProvider({required CreatineRepository repository}) : _repo = repository;
+
+  final Set<String> _intakeDates = {};
+  DateTime _selectedDate = DateTime.now();
+  bool _isLoading = false;
+  Object? _error;
+
+  Set<String> get intakeDates => _intakeDates;
+  DateTime get selectedDate => _selectedDate;
+  bool get isLoading => _isLoading;
+  Object? get error => _error;
+
+  Future<void> loadIntakeDates(String uid, int year) async {
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+    try {
+      final data = await _repo.fetchDatesForYear(uid, year);
+      _intakeDates
+        ..clear()
+        ..addAll(data);
+    } catch (e) {
+      _error = e;
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  void setSelectedDate(DateTime d) {
+    _selectedDate = DateTime(d.year, d.month, d.day);
+    notifyListeners();
+  }
+
+  Future<bool> toggleIntake(String uid, String dateKey) async {
+    final exists = _intakeDates.contains(dateKey);
+    try {
+      if (exists) {
+        await _repo.deleteIntake(uid, dateKey);
+        _intakeDates.remove(dateKey);
+      } else {
+        await _repo.setIntake(uid, dateKey);
+        _intakeDates.add(dateKey);
+      }
+      elogUi('creatine_mark', {'dateKey': dateKey, 'mode': exists ? 'delete' : 'create'});
+      notifyListeners();
+      return !exists;
+    } catch (e) {
+      _error = e;
+      notifyListeners();
+      rethrow;
+    }
+  }
+
+  static String dateKeyFrom(DateTime d) => DateFormat('yyyy-MM-dd').format(d);
+}

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -17,6 +17,7 @@ import '../widgets/calendar_popup.dart';
 import '../../../survey/presentation/screens/survey_vote_screen.dart';
 import 'package:tapem/features/friends/presentation/screens/friends_home_screen.dart';
 import '../widgets/change_username_sheet.dart';
+import 'package:tapem/app_router.dart';
 
 const bool enableFriends = true;
 
@@ -211,6 +212,13 @@ class _ProfileScreenState extends State<ProfileScreen> {
                 );
               },
             ),
+          IconButton(
+            icon: const Icon(Icons.medication),
+            tooltip: loc.creatineTitle,
+            onPressed: () {
+              Navigator.pushNamed(context, AppRouter.creatine);
+            },
+          ),
           IconButton(
             icon: const Icon(Icons.settings),
             tooltip: loc.settingsIconTooltip,

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -52,6 +52,16 @@
     "placeholders": {"hour": {}}
   },
 
+  "creatineTitle": "Kreatin",
+  "creatineTakenToday": "Heute genommen",
+  "creatineConfirmForDate": "Für {date} bestätigen",
+  "@creatineConfirmForDate": {"placeholders": {"date": {}}},
+  "creatineRemoveMarking": "Markierung entfernen",
+  "creatineSaved": "Kreatin für {date} gespeichert",
+  "@creatineSaved": {"placeholders": {"date": {}}},
+  "creatineRemoved": "Kreatin für {date} entfernt",
+  "@creatineRemoved": {"placeholders": {"date": {}}},
+
   "invalidEmailError": "Ungültige E-Mail-Adresse.",
   "@invalidEmailError": {
     "description": "Fehlermeldung bei ungültiger E-Mail-Adresse"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -52,6 +52,16 @@
     "placeholders": {"hour": {}}
   },
 
+  "creatineTitle": "Creatine",
+  "creatineTakenToday": "Taken today",
+  "creatineConfirmForDate": "Confirm for {date}",
+  "@creatineConfirmForDate": {"placeholders": {"date": {}}},
+  "creatineRemoveMarking": "Remove mark",
+  "creatineSaved": "Creatine for {date} saved",
+  "@creatineSaved": {"placeholders": {"date": {}}},
+  "creatineRemoved": "Creatine for {date} removed",
+  "@creatineRemoved": {"placeholders": {"date": {}}},
+
   "invalidEmailError": "Invalid e-mail address.",
   "@invalidEmailError": {
     "description": "Error when e-mail address is malformed"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -155,6 +155,42 @@ abstract class AppLocalizations {
   /// **'Late workouts count toward previous day (rollover {hour}:00)'**
   String lateWorkoutsCountPrevDay(Object hour);
 
+  /// Title for creatine screen
+  ///
+  /// In en, this message translates to:
+  /// **'Creatine'**
+  String get creatineTitle;
+
+  /// Button label when creatine taken today
+  ///
+  /// In en, this message translates to:
+  /// **'Taken today'**
+  String get creatineTakenToday;
+
+  /// Button label to confirm intake for a date
+  ///
+  /// In en, this message translates to:
+  /// **'Confirm for {date}'**
+  String creatineConfirmForDate(Object date);
+
+  /// Button label to remove intake marking
+  ///
+  /// In en, this message translates to:
+  /// **'Remove mark'**
+  String get creatineRemoveMarking;
+
+  /// Snackbar when intake saved
+  ///
+  /// In en, this message translates to:
+  /// **'Creatine for {date} saved'**
+  String creatineSaved(Object date);
+
+  /// Snackbar when intake removed
+  ///
+  /// In en, this message translates to:
+  /// **'Creatine for {date} removed'**
+  String creatineRemoved(Object date);
+
   /// Error when e-mail address is malformed
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -45,6 +45,30 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get creatineTitle => 'Kreatin';
+
+  @override
+  String get creatineTakenToday => 'Heute genommen';
+
+  @override
+  String creatineConfirmForDate(Object date) {
+    return 'Für $date bestätigen';
+  }
+
+  @override
+  String get creatineRemoveMarking => 'Markierung entfernen';
+
+  @override
+  String creatineSaved(Object date) {
+    return 'Kreatin für $date gespeichert';
+  }
+
+  @override
+  String creatineRemoved(Object date) {
+    return 'Kreatin für $date entfernt';
+  }
+
+  @override
   String get invalidEmailError => 'Ungültige E-Mail-Adresse.';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -45,6 +45,30 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get creatineTitle => 'Creatine';
+
+  @override
+  String get creatineTakenToday => 'Taken today';
+
+  @override
+  String creatineConfirmForDate(Object date) {
+    return 'Confirm for $date';
+    }
+
+  @override
+  String get creatineRemoveMarking => 'Remove mark';
+
+  @override
+  String creatineSaved(Object date) {
+    return 'Creatine for $date saved';
+  }
+
+  @override
+  String creatineRemoved(Object date) {
+    return 'Creatine for $date removed';
+  }
+
+  @override
   String get invalidEmailError => 'Invalid e-mail address.';
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,6 +45,8 @@ import 'package:tapem/features/friends/data/friends_source.dart';
 import 'package:tapem/features/friends/data/user_search_source.dart';
 import 'package:tapem/features/friends/providers/friends_provider.dart';
 import 'package:tapem/features/friends/providers/friend_calendar_provider.dart';
+import 'package:tapem/features/creatine/data/creatine_repository.dart';
+import 'package:tapem/features/creatine/providers/creatine_provider.dart';
 import 'package:tapem/features/friends/providers/friend_search_provider.dart';
 import 'features/gym/data/sources/firestore_gym_source.dart';
 import 'ui/numeric_keypad/overlay_numeric_keypad.dart';
@@ -356,6 +358,9 @@ Future<void> main() async {
         ChangeNotifierProvider(create: (_) => TrainingPlanProvider()),
         ChangeNotifierProvider(create: (_) => HistoryProvider()),
         ChangeNotifierProvider(create: (_) => ProfileProvider()),
+        ChangeNotifierProvider(
+          create: (_) => CreatineProvider(repository: CreatineRepository()),
+        ),
         ChangeNotifierProvider(
           create: (c) =>
               MuscleGroupProvider(membership: c.read<MembershipService>()),

--- a/test/features/creatine/creatine_screen_test.dart
+++ b/test/features/creatine/creatine_screen_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/features/creatine/presentation/screens/creatine_screen.dart';
+import 'package:tapem/features/creatine/providers/creatine_provider.dart';
+import 'package:tapem/features/creatine/data/creatine_repository.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
+class FakeRepo implements CreatineRepository {
+  Set<String> dates;
+  FakeRepo(this.dates);
+  @override
+  Future<Set<String>> fetchDatesForYear(String uid, int year) async => dates;
+  @override
+  Future<void> setIntake(String uid, String dateKey) async {
+    dates.add(dateKey);
+  }
+  @override
+  Future<void> deleteIntake(String uid, String dateKey) async {
+    dates.remove(dateKey);
+  }
+}
+
+Future<void> pumpScreen(WidgetTester tester, CreatineProvider prov) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: ChangeNotifierProvider.value(
+        value: prov,
+        child: const CreatineScreen(userId: 'u1'),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('shows taken today when not marked', (tester) async {
+    final repo = FakeRepo({});
+    final prov = CreatineProvider(repository: repo);
+    await prov.loadIntakeDates('u1', DateTime.now().year);
+    await pumpScreen(tester, prov);
+    expect(find.text('Taken today'), findsOneWidget);
+  });
+
+  testWidgets('shows remove when marked', (tester) async {
+    final dateKey = CreatineProvider.dateKeyFrom(DateTime.now());
+    final repo = FakeRepo({dateKey});
+    final prov = CreatineProvider(repository: repo);
+    await prov.loadIntakeDates('u1', DateTime.now().year);
+    await pumpScreen(tester, prov);
+    expect(find.text('Remove mark'), findsOneWidget);
+  });
+}

--- a/test/providers/creatine_provider_test.dart
+++ b/test/providers/creatine_provider_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/features/creatine/providers/creatine_provider.dart';
+import 'package:tapem/features/creatine/data/creatine_repository.dart';
+
+class FakeRepo implements CreatineRepository {
+  Set<String> dates = {};
+  @override
+  Future<Set<String>> fetchDatesForYear(String uid, int year) async => dates;
+  @override
+  Future<void> setIntake(String uid, String dateKey) async {
+    dates.add(dateKey);
+  }
+  @override
+  Future<void> deleteIntake(String uid, String dateKey) async {
+    dates.remove(dateKey);
+  }
+}
+
+class ErrorRepo implements CreatineRepository {
+  @override
+  Future<Set<String>> fetchDatesForYear(String uid, int year) async => {};
+  @override
+  Future<void> setIntake(String uid, String dateKey) async => throw Exception('fail');
+  @override
+  Future<void> deleteIntake(String uid, String dateKey) async => throw Exception('fail');
+}
+
+void main() {
+  test('toggleIntake adds and removes date', () async {
+    final repo = FakeRepo();
+    final prov = CreatineProvider(repository: repo);
+    await prov.loadIntakeDates('u1', 2024);
+    expect(prov.intakeDates, isEmpty);
+    final key = CreatineProvider.dateKeyFrom(DateTime(2024, 1, 1));
+    await prov.toggleIntake('u1', key);
+    expect(prov.intakeDates.contains(key), true);
+    await prov.toggleIntake('u1', key);
+    expect(prov.intakeDates.contains(key), false);
+  });
+
+  test('toggleIntake surfaces errors', () async {
+    final prov = CreatineProvider(repository: ErrorRepo());
+    await prov.loadIntakeDates('u1', 2024);
+    expect(prov.intakeDates, isEmpty);
+    final key = CreatineProvider.dateKeyFrom(DateTime(2024, 1, 1));
+    expect(() => prov.toggleIntake('u1', key), throwsException);
+  });
+}


### PR DESCRIPTION
## Summary
- add creatine intake tracking with calendar UI
- wire creatine screen, routing, l10n, and security rules
- add provider and repository with tests

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ee04f7ec8320b5785b986b3c6891