### PR TITLE
Guard creatine paths and fix overlay

### DIFF
--- a/lib/features/creatine/data/creatine_repository.dart
+++ b/lib/features/creatine/data/creatine_repository.dart
@@ -1,4 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:intl/intl.dart';
 
 class CreatineRepository {
   final FirebaseFirestore _firestore;
@@ -6,29 +8,59 @@ class CreatineRepository {
       : _firestore = firestore ?? FirebaseFirestore.instance;
 
   CollectionReference<Map<String, dynamic>> _col(String uid) {
-    return _firestore.collection('users').doc(uid).collection('creatine_intakes');
+    final u = uid.trim();
+    if (u.isEmpty) {
+      throw StateError('Anmeldung erforderlich');
+    }
+    return _firestore.collection('users').doc(u).collection('creatine_intakes');
   }
 
   Future<Set<String>> fetchDatesForYear(String uid, int year) async {
     final start = '$year-01-01';
     final end = '$year-12-31';
-    final snap = await _col(uid)
-        .where('dateKey', isGreaterThanOrEqualTo: start)
-        .where('dateKey', isLessThanOrEqualTo: end)
+    final col = _col(uid);
+    final snap = await col
+        .where(FieldPath.documentId, isGreaterThanOrEqualTo: start)
+        .where(FieldPath.documentId, isLessThanOrEqualTo: end)
         .get();
     return snap.docs.map((d) => d.id).toSet();
   }
 
   Future<void> setIntake(String uid, String dateKey) async {
-    await _col(uid).doc(dateKey).set({
+    final key = _requireDateKey(dateKey);
+    await _col(uid).doc(key).set({
       'uid': uid,
-      'dateKey': dateKey,
+      'dateKey': key,
       'ts': FieldValue.serverTimestamp(),
       'source': 'manual',
     });
   }
 
   Future<void> deleteIntake(String uid, String dateKey) async {
-    await _col(uid).doc(dateKey).delete();
+    final key = _requireDateKey(dateKey);
+    await _col(uid).doc(key).delete();
   }
+
+  String _requireDateKey(String dateKey) {
+    final key = dateKey.trim();
+    final regex = RegExp(r'^\d{4}-\d{2}-\d{2}$');
+    if (!regex.hasMatch(key)) {
+      throw StateError('Ungültiges Datum');
+    }
+    return key;
+  }
+}
+
+String currentUidOrFail() {
+  final uid = FirebaseAuth.instance.currentUser?.uid.trim() ?? '';
+  if (uid.isEmpty) {
+    throw StateError('Anmeldung erforderlich');
+  }
+  return uid;
+}
+
+String toDateKeyLocal(DateTime d) {
+  final local = d.toLocal();
+  final normalized = DateTime(local.year, local.month, local.day);
+  return DateFormat('yyyy-MM-dd').format(normalized);
 }

--- a/test/features/creatine/creatine_screen_test.dart
+++ b/test/features/creatine/creatine_screen_test.dart
@@ -45,7 +45,7 @@ void main() {
   });
 
   testWidgets('shows remove when marked', (tester) async {
-    final dateKey = CreatineProvider.dateKeyFrom(DateTime.now());
+    final dateKey = toDateKeyLocal(DateTime.now());
     final repo = FakeRepo({dateKey});
     final prov = CreatineProvider(repository: repo);
     await prov.loadIntakeDates('u1', DateTime.now().year);

--- a/test/providers/creatine_provider_test.dart
+++ b/test/providers/creatine_provider_test.dart
@@ -26,12 +26,19 @@ class ErrorRepo implements CreatineRepository {
 }
 
 void main() {
+  test('setSelectedDate sets key', () {
+    final prov = CreatineProvider(repository: FakeRepo());
+    final d = DateTime(2024, 1, 1);
+    prov.setSelectedDate(d);
+    expect(prov.selectedDateKey, toDateKeyLocal(d));
+  });
+
   test('toggleIntake adds and removes date', () async {
     final repo = FakeRepo();
     final prov = CreatineProvider(repository: repo);
     await prov.loadIntakeDates('u1', 2024);
     expect(prov.intakeDates, isEmpty);
-    final key = CreatineProvider.dateKeyFrom(DateTime(2024, 1, 1));
+    final key = toDateKeyLocal(DateTime(2024, 1, 1));
     await prov.toggleIntake('u1', key);
     expect(prov.intakeDates.contains(key), true);
     await prov.toggleIntake('u1', key);
@@ -42,7 +49,7 @@ void main() {
     final prov = CreatineProvider(repository: ErrorRepo());
     await prov.loadIntakeDates('u1', 2024);
     expect(prov.intakeDates, isEmpty);
-    final key = CreatineProvider.dateKeyFrom(DateTime(2024, 1, 1));
+    final key = toDateKeyLocal(DateTime(2024, 1, 1));
     expect(() => prov.toggleIntake('u1', key), throwsException);
   });
 }


### PR DESCRIPTION
## Summary
- validate uid/dateKey before building Firestore refs
- add toggle busy state and expose selected date key
- fix selection overlay layout and disable button when busy

## Testing
- ⚠️ `flutter test` *(flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fa1c372c832090093accdea4ec24