### PR TITLE
feat: show global NFC button and move logout to profile

### DIFF
--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -17,6 +17,7 @@ import 'package:tapem/features/training_plan/presentation/screens/plan_overview_
 import 'package:tapem/features/auth/presentation/widgets/username_dialog.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/config/feature_flags.dart';
+import 'package:tapem/features/nfc/widgets/nfc_scan_button.dart';
 
 class HomeScreen extends StatefulWidget {
   final int initialIndex;
@@ -120,14 +121,8 @@ class _HomeScreenState extends State<HomeScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text(userDisplay),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.logout),
-            onPressed: () {
-              context.read<AuthProvider>().logout();
-              Navigator.of(context).pushReplacementNamed(AppRouter.auth);
-            },
-          ),
+        actions: const [
+          NfcScanButton(),
         ],
       ),
       body: tabs[_currentIndex].page,

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -7,7 +7,6 @@ import 'package:tapem/core/providers/profile_provider.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/core/providers/gym_provider.dart';
 import 'package:tapem/features/friends/providers/friends_provider.dart';
-import 'package:tapem/features/nfc/widgets/nfc_scan_button.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/widgets/brand_action_tile.dart';
@@ -187,7 +186,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
       appBar: AppBar(
         title: Text(loc.profileTitle),
         actions: [
-          const NfcScanButton(),
           if (enableFriends)
             Consumer<FriendsProvider>(
               builder: (context, friends, _) {
@@ -223,6 +221,14 @@ class _ProfileScreenState extends State<ProfileScreen> {
             icon: const Icon(Icons.settings),
             tooltip: loc.settingsIconTooltip,
             onPressed: _showSettingsDialog,
+          ),
+          IconButton(
+            icon: const Icon(Icons.logout),
+            tooltip: loc.logoutTooltip,
+            onPressed: () {
+              context.read<AuthProvider>().logout();
+              Navigator.of(context).pushReplacementNamed(AppRouter.auth);
+            },
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- expose the NFC scan action in the global app bar
- relocate logout to the profile screen next to settings

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1690c0d883208ee7a4d39de315dc