### PR TITLE
feat: add bodyweight mode and remove rir fields

### DIFF
--- a/lib/core/drafts/session_draft.dart
+++ b/lib/core/drafts/session_draft.dart
@@ -18,47 +18,43 @@ class SetDraft {
   final int index;
   final String weight;
   final String reps;
-  final String? rir;
   final String? tempo;
-  final String? note;
   final String? dropWeight;
   final String? dropReps;
   final bool done;
+  final bool isBodyweight;
 
   SetDraft({
     required this.index,
     this.weight = '',
     this.reps = '',
-    this.rir,
     this.tempo,
-    this.note,
     this.dropWeight,
     this.dropReps,
     this.done = false,
+    this.isBodyweight = false,
   });
 
   factory SetDraft.fromJson(Map<String, dynamic> json) => SetDraft(
         index: json['index'] as int,
         weight: json['weight'] as String? ?? '',
         reps: json['reps'] as String? ?? '',
-        rir: json['rir'] as String?,
         tempo: json['tempo'] as String?,
-        note: json['note'] as String?,
         dropWeight: json['dropWeight'] as String?,
         dropReps: json['dropReps'] as String?,
         done: json['done'] as bool? ?? false,
+        isBodyweight: json['isBodyweight'] as bool? ?? false,
       );
 
   Map<String, dynamic> toJson() => {
         'index': index,
         'weight': weight,
         'reps': reps,
-        if (rir != null) 'rir': rir,
         if (tempo != null) 'tempo': tempo,
-        if (note != null) 'note': note,
         if (dropWeight != null) 'dropWeight': dropWeight,
         if (dropReps != null) 'dropReps': dropReps,
         'done': done,
+        if (isBodyweight) 'isBodyweight': true,
       };
 }
 

--- a/lib/features/device/domain/models/device_session_snapshot.dart
+++ b/lib/features/device/domain/models/device_session_snapshot.dart
@@ -58,38 +58,34 @@ class DeviceSessionSnapshot {
 class SetEntry {
   final num kg;
   final int reps;
-  final int? rir;
   final bool done;
-  final String? note;
   final List<DropEntry> drops;
+  final bool isBodyweight;
 
   const SetEntry({
     required this.kg,
     required this.reps,
-    this.rir,
     this.done = false,
-    this.note,
     this.drops = const [],
+    this.isBodyweight = false,
   });
 
   factory SetEntry.fromJson(Map<String, dynamic> j) => SetEntry(
         kg: j['kg'] as num,
         reps: j['reps'] as int,
-        rir: j['rir'] as int?,
         done: j['done'] as bool? ?? false,
-        note: j['note'] as String?,
         drops: (j['drops'] as List<dynamic>? ?? [])
             .map((e) => DropEntry.fromJson(Map<String, dynamic>.from(e)))
             .toList(),
+        isBodyweight: j['isBodyweight'] as bool? ?? false,
       );
 
   Map<String, dynamic> toJson() => {
         'kg': kg,
         'reps': reps,
-        'rir': rir,
         'done': done,
-        'note': note,
         'drops': drops.map((d) => d.toJson()).toList(),
+        'isBodyweight': isBodyweight,
       };
 }
 

--- a/lib/features/device/presentation/models/session_set_vm.dart
+++ b/lib/features/device/presentation/models/session_set_vm.dart
@@ -4,16 +4,14 @@ class SessionSetVM {
   final int ordinal; // 1,2,3… only for main sets
   final num kg;
   final int reps;
-  final int? rir;
-  final String? note;
   final List<DropEntry> drops;
+  final bool isBodyweight;
   const SessionSetVM({
     required this.ordinal,
     required this.kg,
     required this.reps,
-    this.rir,
-    this.note,
     this.drops = const [],
+    this.isBodyweight = false,
   });
 }
 
@@ -25,15 +23,14 @@ List<SessionSetVM> mapSnapshotToVM(DeviceSessionSnapshot snap) {
       ordinal: ordinal++,
       kg: s.kg,
       reps: s.reps,
-      rir: s.rir,
-      note: s.note,
       drops: s.drops,
+      isBodyweight: s.isBodyweight,
     ));
   }
   return vm;
 }
 
-List<SessionSetVM> mapLegacySetsToVM(List<Map<String, String>> sets) {
+List<SessionSetVM> mapLegacySetsToVM(List<Map<String, dynamic>> sets) {
   final vm = <SessionSetVM>[];
   var ordinal = 1;
   for (final s in sets) {
@@ -49,11 +46,10 @@ List<SessionSetVM> mapLegacySetsToVM(List<Map<String, String>> sets) {
             : <DropEntry>[];
     vm.add(SessionSetVM(
       ordinal: ordinal++,
-      kg: num.tryParse(s['weight'] ?? '0') ?? 0,
-      reps: int.tryParse(s['reps'] ?? '0') ?? 0,
-      rir: int.tryParse(s['rir'] ?? ''),
-      note: s['note'],
+      kg: num.tryParse(s['weight']?.toString() ?? '0') ?? 0,
+      reps: int.tryParse(s['reps']?.toString() ?? '0') ?? 0,
       drops: drops,
+      isBodyweight: (s['isBodyweight'] ?? 'false') == 'true',
     ));
   }
   return vm;

--- a/lib/features/device/presentation/widgets/last_session_card.dart
+++ b/lib/features/device/presentation/widgets/last_session_card.dart
@@ -4,6 +4,7 @@ import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
 import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
 import '../models/session_set_vm.dart';
+import 'package:tapem/l10n/app_localizations.dart';
 
 class LastSessionCard extends StatelessWidget {
   final DateTime date;
@@ -44,6 +45,10 @@ class _MainSetRow extends StatelessWidget {
   const _MainSetRow({required this.s});
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    final weightText = s.isBodyweight
+        ? (s.kg == 0 ? loc.bodyweight : loc.bodyweightPlus(s.kg))
+        : '${s.kg} kg';
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -54,18 +59,10 @@ class _MainSetRow extends StatelessWidget {
             horizontal: AppSpacing.sm,
             vertical: AppSpacing.xs,
           ),
-          child: Text('${s.kg} kg'),
+          child: Text(weightText),
         ),
         const SizedBox(width: 16),
         Text('${s.reps} x'),
-        if (s.rir != null) ...[
-          const SizedBox(width: 16),
-          Text('RIR ${s.rir}'),
-        ],
-        if (s.note != null && s.note!.isNotEmpty) ...[
-          const SizedBox(width: 16),
-          Expanded(child: Text(s.note!)),
-        ],
       ],
     );
   }

--- a/lib/features/device/presentation/widgets/read_only_snapshot_page.dart
+++ b/lib/features/device/presentation/widgets/read_only_snapshot_page.dart
@@ -3,6 +3,7 @@ import 'package:intl/intl.dart';
 import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
 import 'set_card.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
+import 'package:tapem/l10n/app_localizations.dart';
 
 class ReadOnlySnapshotPage extends StatelessWidget {
   final DeviceSessionSnapshot snapshot;
@@ -34,6 +35,12 @@ class ReadOnlySnapshotPage extends StatelessWidget {
             itemBuilder: (context, i) {
               final s = snapshot.sets[i];
               final drops = s.drops.isNotEmpty ? s.drops : _legacyDrops(snapshot, i);
+              final loc = AppLocalizations.of(context)!;
+              final weightText = s.isBodyweight
+                  ? (s.kg == 0
+                      ? loc.bodyweight
+                      : loc.bodyweightPlus(s.kg))
+                  : s.kg.toString();
               return Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
@@ -41,13 +48,12 @@ class ReadOnlySnapshotPage extends StatelessWidget {
                     index: i,
                     set: {
                       'number': '${i + 1}',
-                      'weight': s.kg.toString(),
+                      'weight': weightText,
                       'reps': s.reps.toString(),
-                      'rir': s.rir?.toString() ?? '',
-                      'note': s.note,
                       'dropWeight': '',
                       'dropReps': '',
                       'done': s.done,
+                      'isBodyweight': s.isBodyweight,
                     },
                     readOnly: true,
                     size: SetCardSize.dense,

--- a/lib/features/history/data/dtos/workout_log_dto.dart
+++ b/lib/features/history/data/dtos/workout_log_dto.dart
@@ -22,12 +22,11 @@ class WorkoutLogDto {
 
   final double weight;
   final int reps;
-  final int? rir;
-  final String? note;
   final double? dropWeightKg;
   final int? dropReps;
   @JsonKey(fromJson: _setNumberFromJson)
   final int setNumber;
+  final bool isBodyweight;
 
   WorkoutLogDto({
     required this.userId,
@@ -36,11 +35,10 @@ class WorkoutLogDto {
     required this.timestamp,
     required this.weight,
     required this.reps,
-    this.rir,
-    this.note,
     this.dropWeightKg,
     this.dropReps,
     required this.setNumber,
+    this.isBodyweight = false,
   });
 
   factory WorkoutLogDto.fromJson(Map<String, dynamic> json) =>
@@ -68,11 +66,10 @@ class WorkoutLogDto {
     timestamp: timestamp,
     weight: weight,
     reps: reps,
-    rir: rir,
-    note: note,
     dropWeightKg: dropWeightKg,
     dropReps: dropReps,
     setNumber: setNumber,
+    isBodyweight: isBodyweight,
   );
 
   static DateTime _timestampToDate(Timestamp ts) => ts.toDate();

--- a/lib/features/history/data/dtos/workout_log_dto.g.dart
+++ b/lib/features/history/data/dtos/workout_log_dto.g.dart
@@ -14,11 +14,10 @@ WorkoutLogDto _$WorkoutLogDtoFromJson(Map<String, dynamic> json) =>
       timestamp: WorkoutLogDto._timestampToDate(json['timestamp'] as Timestamp),
       weight: (json['weight'] as num).toDouble(),
       reps: (json['reps'] as num).toInt(),
-      rir: json['rir'] as int?,
-      note: json['setNote'] as String?,
       dropWeightKg: (json['dropWeightKg'] as num?)?.toDouble(),
       dropReps: (json['dropReps'] as num?)?.toInt(),
       setNumber: WorkoutLogDto._setNumberFromJson(json['setNumber']),
+      isBodyweight: json['isBodyweight'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$WorkoutLogDtoToJson(WorkoutLogDto instance) =>
@@ -29,9 +28,8 @@ Map<String, dynamic> _$WorkoutLogDtoToJson(WorkoutLogDto instance) =>
       'timestamp': WorkoutLogDto._dateToTimestamp(instance.timestamp),
       'weight': instance.weight,
       'reps': instance.reps,
-      if (instance.rir != null) 'rir': instance.rir,
-      if (instance.note != null) 'setNote': instance.note,
       if (instance.dropWeightKg != null) 'dropWeightKg': instance.dropWeightKg,
       if (instance.dropReps != null) 'dropReps': instance.dropReps,
       'setNumber': instance.setNumber,
+      if (instance.isBodyweight) 'isBodyweight': true,
     };

--- a/lib/features/history/domain/models/workout_log.dart
+++ b/lib/features/history/domain/models/workout_log.dart
@@ -9,11 +9,10 @@ class WorkoutLog {
   final DateTime timestamp;
   final double weight;
   final int reps;
-  final int? rir;
-  final String? note;
   final double? dropWeightKg;
   final int? dropReps;
   final int setNumber;
+  final bool isBodyweight;
 
   WorkoutLog({
     required this.id,
@@ -23,10 +22,9 @@ class WorkoutLog {
     required this.timestamp,
     required this.weight,
     required this.reps,
-    this.rir,
-    this.note,
     this.dropWeightKg,
     this.dropReps,
     required this.setNumber,
+    this.isBodyweight = false,
   });
 }

--- a/lib/features/history/presentation/screens/history_screen.dart
+++ b/lib/features/history/presentation/screens/history_screen.dart
@@ -356,6 +356,7 @@ class _HistoryScreenState extends State<HistoryScreen> {
                           setNumber: e.setNumber,
                           dropWeightKg: e.dropWeightKg,
                           dropReps: e.dropReps,
+                          isBodyweight: e.isBodyweight,
                         ))
                     .toList();
                 elogUi('HISTORY_CARD_RENDER', {

--- a/lib/features/training_details/data/dtos/session_dto.dart
+++ b/lib/features/training_details/data/dtos/session_dto.dart
@@ -16,6 +16,7 @@ class SessionDto {
   final int? dropReps;
   final String note;
   final DocumentReference<Map<String, dynamic>> reference;
+  final bool isBodyweight;
 
   SessionDto({
     required this.sessionId,
@@ -30,6 +31,7 @@ class SessionDto {
     this.dropReps,
     required this.note,
     required this.reference,
+    this.isBodyweight = false,
   });
 
   factory SessionDto.fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
@@ -63,6 +65,7 @@ class SessionDto {
       dropReps: (data['dropReps'] as num?)?.toInt(),
       note: data['note'] as String? ?? '',
       reference: doc.reference,
+      isBodyweight: data['isBodyweight'] as bool? ?? false,
     );
   }
 }

--- a/lib/features/training_details/data/repositories/session_repository_impl.dart
+++ b/lib/features/training_details/data/repositories/session_repository_impl.dart
@@ -88,6 +88,7 @@ class SessionRepositoryImpl implements SessionRepository {
                 setNumber: dto.setNumber,
                 dropWeightKg: dto.dropWeightKg,
                 dropReps: dto.dropReps,
+                isBodyweight: dto.isBodyweight,
               ))
           .toList();
 

--- a/lib/features/training_details/domain/models/session.dart
+++ b/lib/features/training_details/domain/models/session.dart
@@ -25,11 +25,13 @@ class SessionSet {
   final int setNumber;
   final double? dropWeightKg;
   final int? dropReps;
+  final bool isBodyweight;
   SessionSet({
     required this.weight,
     required this.reps,
     required this.setNumber,
     this.dropWeightKg,
     this.dropReps,
+    this.isBodyweight = false,
   });
 }

--- a/lib/features/training_details/presentation/widgets/session_exercise_card.dart
+++ b/lib/features/training_details/presentation/widgets/session_exercise_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
 import 'package:tapem/core/theme/brand_on_colors.dart';
 import '../../domain/models/session.dart';
+import 'package:tapem/l10n/app_localizations.dart';
 
 /// A reusable card displaying a session's sets for a single device/exercise.
 class SessionExerciseCard extends StatelessWidget {
@@ -58,13 +59,22 @@ class SessionExerciseCard extends StatelessWidget {
                         size: 16,
                       ),
                       const SizedBox(width: 4),
-                      Text(
-                        '${set.weight.toStringAsFixed(1)} kg',
-                        style: TextStyle(
-                          color: onBrand,
-                          fontSize: 14,
-                        ),
-                      ),
+                      Builder(builder: (context) {
+                        final loc = AppLocalizations.of(context)!;
+                        final wt = set.isBodyweight
+                            ? (set.weight == 0
+                                ? loc.bodyweight
+                                : loc.bodyweightPlus(
+                                    set.weight.toStringAsFixed(1)))
+                            : '${set.weight.toStringAsFixed(1)} kg';
+                        return Text(
+                          wt,
+                          style: TextStyle(
+                            color: onBrand,
+                            fontSize: 14,
+                          ),
+                        );
+                      }),
                       const SizedBox(width: 8),
                       const Icon(
                         Icons.repeat,

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -703,4 +703,10 @@
   "friends_cta_pending": "Ausstehend",
   "friends_action_send": "Anfrage senden",
   "friends_search_min_chars": "Mindestens 2 Zeichen eingeben"
+  ,"bodyweight": "Körpergewicht"
+  ,"@bodyweight": {"description": "Label für Körpergewicht"}
+  ,"bodyweightPlus": "Körpergewicht + {kg} kg"
+  ,"@bodyweightPlus": {"description": "Körpergewicht plus Zusatzgewicht","placeholders": {"kg": {}}}
+  ,"bodyweightToggleTooltip": "Körpergewicht umschalten"
+  ,"@bodyweightToggleTooltip": {"description": "Tooltip für Bodyweight-Toggle"}
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -701,4 +701,10 @@
   "friends_cta_pending": "Pending",
   "friends_action_send": "Send request",
   "friends_search_min_chars": "Enter at least 2 characters"
+  ,"bodyweight": "Bodyweight"
+  ,"@bodyweight": {"description": "Label for bodyweight"}
+  ,"bodyweightPlus": "Bodyweight + {kg} kg"
+  ,"@bodyweightPlus": {"description": "Bodyweight plus additional weight","placeholders": {"kg": {}}}
+  ,"bodyweightToggleTooltip": "Toggle bodyweight"
+  ,"@bodyweightToggleTooltip": {"description": "Tooltip for bodyweight toggle"}
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1450,6 +1450,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Enter at least 2 characters'**
   String get friends_search_min_chars;
+
+  /// No description provided for @bodyweight.
+  ///
+  /// In en, this message translates to:
+  /// **'Bodyweight'**
+  String get bodyweight;
+
+  /// No description provided for @bodyweightPlus.
+  ///
+  /// In en, this message translates to:
+  /// **'Bodyweight + {kg} kg'**
+  String bodyweightPlus(Object kg);
+
+  /// No description provided for @bodyweightToggleTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Toggle bodyweight'**
+  String get bodyweightToggleTooltip;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -711,4 +711,15 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get friends_search_min_chars => 'Mindestens 2 Zeichen eingeben';
+
+  @override
+  String get bodyweight => 'Körpergewicht';
+
+  @override
+  String bodyweightPlus(Object kg) {
+    return 'Körpergewicht + $kg kg';
+  }
+
+  @override
+  String get bodyweightToggleTooltip => 'Körpergewicht umschalten';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -711,4 +711,15 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get friends_search_min_chars => 'Enter at least 2 characters';
+
+  @override
+  String get bodyweight => 'Bodyweight';
+
+  @override
+  String bodyweightPlus(Object kg) {
+    return 'Bodyweight + $kg kg';
+  }
+
+  @override
+  String get bodyweightToggleTooltip => 'Toggle bodyweight';
 }

--- a/test/features/device/domain/models/device_session_snapshot_test.dart
+++ b/test/features/device/domain/models/device_session_snapshot_test.dart
@@ -15,11 +15,10 @@ void main() {
         SetEntry(
           kg: 20,
           reps: 10,
-          rir: 2,
           done: true,
-          note: 'set',
           drops: [DropEntry(kg: 10, reps: 5)],
         ),
+        SetEntry(kg: 0, reps: 5, isBodyweight: true),
       ],
     );
 
@@ -32,5 +31,7 @@ void main() {
     final decoded = DeviceSessionSnapshot.fromJson(json);
     expect(decoded.sessionId, snapshot.sessionId);
     expect(decoded.sets.first.drops.first.kg, 10);
+    expect(decoded.sets[1].isBodyweight, true);
+    expect(decoded.sets[1].kg, 0);
   });
 }


### PR DESCRIPTION
## Summary
- remove RIR and per-set notes from workout sets and UI
- add optional bodyweight mode with toggle and persistence
- display bodyweight sessions correctly across history and last session views

## Testing
- `flutter format lib/core/drafts/session_draft.dart lib/core/providers/device_provider.dart lib/features/device/domain/models/device_session_snapshot.dart lib/features/device/presentation/models/session_set_vm.dart lib/features/device/presentation/screens/device_screen.dart lib/features/device/presentation/widgets/last_session_card.dart lib/features/device/presentation/widgets/read_only_snapshot_page.dart lib/features/device/presentation/widgets/set_card.dart lib/features/history/data/dtos/workout_log_dto.dart lib/features/history/data/dtos/workout_log_dto.g.dart lib/features/history/domain/models/workout_log.dart lib/features/history/presentation/screens/history_screen.dart lib/features/training_details/data/dtos/session_dto.dart lib/features/training_details/data/repositories/session_repository_impl.dart lib/features/training_details/domain/models/session.dart lib/features/training_details/presentation/widgets/session_exercise_card.dart lib/l10n/app_de.arb lib/l10n/app_en.arb lib/l10n/app_localizations.dart lib/l10n/app_localizations_de.dart lib/l10n/app_localizations_en.dart test/features/device/domain/models/device_session_snapshot_test.dart` *(failed: command not found)*
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5a5b19388320973524ea2371435c