### PR TITLE
fix: resolve analysis errors

### DIFF
--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -78,7 +78,7 @@ enum SetCardSize { regular, dense }
 class SetCard extends StatefulWidget {
   final int index;
   final Map<String, dynamic> set;
-  final Map<String, String>? previous;
+  final Map<String, dynamic>? previous;
   final SetCardSize size;
   final bool readOnly;
   const SetCard({
@@ -280,8 +280,6 @@ class SetCardState extends State<SetCard> {
       final delta = surface.luminanceRef - lum;
       gradient = Tone.gradient(gradient, delta);
     }
-
-    final prov = context.watch<DeviceProvider>();
     final doneVal = widget.set['done'];
     final done = doneVal == true || doneVal == 'true';
     final dropActive =

--- a/test/features/creatine/creatine_screen_test.dart
+++ b/test/features/creatine/creatine_screen_test.dart
@@ -87,7 +87,10 @@ void main() {
 class _FakeLauncher extends UrlLauncherPlatform {
   bool launched = false;
   @override
-  Future<bool> launchUrl(Uri url, LaunchOptions options) async {
+  LinkDelegate? linkDelegate;
+
+  @override
+  Future<bool> launchUrl(String url, LaunchOptions options) async {
     launched = true;
     return true;
   }


### PR DESCRIPTION
## Summary
- allow SetCard to accept dynamic maps for previous set data
- avoid duplicate `DeviceProvider` watch in `SetCard`
- update test launcher stub to implement required interface

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb672f0ca88320b971d43344220f06