### PR TITLE
feat: add avatar selection and friend activity status

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -141,7 +141,16 @@ service cloud.firestore {
       // Keep profile readable for authed users (e.g., username checks)
       allow create: if isOwner(uid);
       allow read: if isAuthed();
-      allow update: if isOwner(uid);
+      allow update: if isOwner(uid) &&
+        request.resource.data.keys().hasOnly([
+          'username',
+          'usernameLower',
+          'showInLeaderboard',
+          'publicProfile',
+          'avatarUrl',
+          'avatarKey',
+          'avatarUpdatedAt'
+        ]);
 
       // Friends list (symmetrische Kante)
       match /friends/{fid} {

--- a/lib/core/providers/auth_provider.dart
+++ b/lib/core/providers/auth_provider.dart
@@ -13,6 +13,7 @@ import 'package:tapem/features/auth/domain/usecases/check_username_available.dar
 import 'package:tapem/features/auth/domain/usecases/reset_password.dart';
 import 'package:tapem/features/auth/domain/usecases/set_show_in_leaderboard.dart';
 import 'package:tapem/features/auth/domain/usecases/set_public_profile.dart';
+import 'package:tapem/features/auth/domain/usecases/set_avatar_key.dart';
 import 'package:tapem/core/drafts/session_draft_repository_impl.dart';
 
 class AuthProvider extends ChangeNotifier {
@@ -23,6 +24,7 @@ class AuthProvider extends ChangeNotifier {
   final SetUsernameUseCase _setUsernameUC;
   final SetShowInLeaderboardUseCase _setShowInLbUC;
   final SetPublicProfileUseCase _setPublicProfileUC;
+  final SetAvatarKeyUseCase _setAvatarKeyUC;
   final CheckUsernameAvailable _checkUsernameUC;
   final ResetPasswordUseCase _resetPasswordUC;
 
@@ -39,6 +41,7 @@ class AuthProvider extends ChangeNotifier {
       _setUsernameUC = SetUsernameUseCase(repo),
       _setShowInLbUC = SetShowInLeaderboardUseCase(repo),
       _setPublicProfileUC = SetPublicProfileUseCase(repo),
+      _setAvatarKeyUC = SetAvatarKeyUseCase(repo),
       _checkUsernameUC = CheckUsernameAvailable(repo),
       _resetPasswordUC = ResetPasswordUseCase(repo) {
     _loadCurrentUser();
@@ -48,6 +51,7 @@ class AuthProvider extends ChangeNotifier {
   bool get isLoggedIn => _user != null;
   String? get userEmail => _user?.email;
   String? get userName => _user?.userName;
+  String get avatarKey => _user?.avatarKey ?? 'default';
 
   /// Liste der Gym-Codes, die diesem Nutzer zugeordnet sind
   List<String>? get gymCodes => _user?.gymCodes;
@@ -206,6 +210,23 @@ class AuthProvider extends ChangeNotifier {
       _user = _user!.copyWith(publicProfile: value);
     } catch (e) {
       _error = e.toString();
+    } finally {
+      _setLoading(false);
+    }
+  }
+
+  Future<void> setAvatarKey(String key) async {
+    if (_user == null) return;
+    _setLoading(true);
+    _error = null;
+    final previous = _user!.avatarKey;
+    try {
+      await _setAvatarKeyUC.execute(_user!.id, key);
+      _user = _user!.copyWith(avatarKey: key);
+    } catch (e) {
+      _error = e.toString();
+      _user = _user!.copyWith(avatarKey: previous);
+      rethrow;
     } finally {
       _setLoading(false);
     }

--- a/lib/features/auth/data/dtos/user_data_dto.dart
+++ b/lib/features/auth/data/dtos/user_data_dto.dart
@@ -12,6 +12,7 @@ class UserDataDto {
   final bool publicProfile;
   final String role;
   final DateTime createdAt;
+  final String avatarKey;
 
   UserDataDto({
     required this.userId,
@@ -24,6 +25,7 @@ class UserDataDto {
     required this.publicProfile,
     required this.role,
     required this.createdAt,
+    this.avatarKey = 'default',
   });
 
   factory UserDataDto.fromDocument(DocumentSnapshot<Map<String, dynamic>> doc) {
@@ -41,6 +43,7 @@ class UserDataDto {
       publicProfile: data['publicProfile'] as bool? ?? false,
       role: data['role'] as String,
       createdAt: (data['createdAt'] as Timestamp).toDate(),
+      avatarKey: data['avatarKey'] as String? ?? 'default',
     );
   }
 
@@ -54,6 +57,7 @@ class UserDataDto {
     'publicProfile': publicProfile,
     'role': role,
     'createdAt': Timestamp.fromDate(createdAt),
+    'avatarKey': avatarKey,
   };
 
   UserData toModel() {
@@ -66,6 +70,7 @@ class UserDataDto {
       publicProfile: publicProfile,
       role: role,
       createdAt: createdAt,
+      avatarKey: avatarKey,
     );
   }
 }

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -48,6 +48,11 @@ class AuthRepositoryImpl implements AuthRepository {
   }
 
   @override
+  Future<void> setAvatarKey(String userId, String avatarKey) {
+    return _source.setAvatarKey(userId, avatarKey);
+  }
+
+  @override
   Future<bool> isUsernameAvailable(String username) {
     return _source.isUsernameAvailable(username);
   }

--- a/lib/features/auth/data/sources/firestore_auth_source.dart
+++ b/lib/features/auth/data/sources/firestore_auth_source.dart
@@ -113,6 +113,13 @@ class FirestoreAuthSource {
     });
   }
 
+  Future<void> setAvatarKey(String userId, String avatarKey) async {
+    await _firestore.collection('users').doc(userId).update({
+      'avatarKey': avatarKey,
+      'avatarUpdatedAt': FieldValue.serverTimestamp(),
+    });
+  }
+
   Future<void> sendPasswordResetEmail(String email) {
     final settings = ActionCodeSettings(
       url: 'https://tapem.page.link/reset',

--- a/lib/features/auth/domain/models/user_data.dart
+++ b/lib/features/auth/domain/models/user_data.dart
@@ -7,6 +7,7 @@ class UserData {
   final bool publicProfile;
   final String role;
   final DateTime createdAt;
+  final String avatarKey;
 
   const UserData({
     required this.id,
@@ -17,6 +18,7 @@ class UserData {
     required this.publicProfile,
     required this.role,
     required this.createdAt,
+    this.avatarKey = 'default',
   });
 
   UserData copyWith({
@@ -28,6 +30,7 @@ class UserData {
     bool? publicProfile,
     String? role,
     DateTime? createdAt,
+    String? avatarKey,
   }) {
     return UserData(
       id: id ?? this.id,
@@ -38,6 +41,7 @@ class UserData {
       publicProfile: publicProfile ?? this.publicProfile,
       role: role ?? this.role,
       createdAt: createdAt ?? this.createdAt,
+      avatarKey: avatarKey ?? this.avatarKey,
     );
   }
 }

--- a/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/features/auth/domain/repositories/auth_repository.dart
@@ -8,6 +8,7 @@ abstract class AuthRepository {
   Future<void> setUsername(String userId, String username);
   Future<void> setShowInLeaderboard(String userId, bool value);
   Future<void> setPublicProfile(String userId, bool value);
+  Future<void> setAvatarKey(String userId, String avatarKey);
   Future<bool> isUsernameAvailable(String username);
   Future<void> sendPasswordResetEmail(String email);
 }

--- a/lib/features/auth/domain/usecases/set_avatar_key.dart
+++ b/lib/features/auth/domain/usecases/set_avatar_key.dart
@@ -1,0 +1,12 @@
+import '../repositories/auth_repository.dart';
+import '../../data/repositories/auth_repository_impl.dart';
+
+class SetAvatarKeyUseCase {
+  final AuthRepository _repo;
+  SetAvatarKeyUseCase([AuthRepository? repo])
+      : _repo = repo ?? AuthRepositoryImpl();
+
+  Future<void> execute(String userId, String avatarKey) {
+    return _repo.setAvatarKey(userId, avatarKey);
+  }
+}

--- a/lib/features/friends/data/user_search_source.dart
+++ b/lib/features/friends/data/user_search_source.dart
@@ -20,6 +20,7 @@ class UserSearchSource {
           (data['gymCodes'] is List && (data['gymCodes'] as List).isNotEmpty)
               ? (data['gymCodes'] as List).first as String
               : null,
+      avatarKey: data['avatarKey'] as String? ?? 'default',
     );
   }
 
@@ -54,6 +55,7 @@ class UserSearchSource {
               (data['gymCodes'] is List && (data['gymCodes'] as List).isNotEmpty)
                   ? (data['gymCodes'] as List).first as String
                   : null,
+          avatarKey: data['avatarKey'] as String? ?? 'default',
         );
       }).toList();
     });

--- a/lib/features/friends/domain/models/public_profile.dart
+++ b/lib/features/friends/domain/models/public_profile.dart
@@ -4,12 +4,14 @@ class PublicProfile {
     required this.username,
     this.avatarUrl,
     this.primaryGymCode,
+    this.avatarKey,
   });
 
   final String uid;
   final String username;
   final String? avatarUrl;
   final String? primaryGymCode;
+  final String? avatarKey;
 
   factory PublicProfile.fromMap(String id, Map<String, dynamic> data) {
     return PublicProfile(
@@ -17,6 +19,7 @@ class PublicProfile {
       username: data['username'] as String? ?? '',
       avatarUrl: data['avatarUrl'] as String?,
       primaryGymCode: data['primaryGymCode'] as String?,
+      avatarKey: data['avatarKey'] as String? ?? 'default',
     );
   }
 }

--- a/lib/features/friends/presentation/widgets/friend_list_tile.dart
+++ b/lib/features/friends/presentation/widgets/friend_list_tile.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import '../../domain/models/public_profile.dart';
+import '../../providers/friend_presence_provider.dart';
+
+class FriendListTile extends StatelessWidget {
+  const FriendListTile({
+    super.key,
+    required this.profile,
+    required this.presence,
+    required this.onTap,
+  });
+
+  final PublicProfile profile;
+  final PresenceState presence;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final avatar = CircleAvatar(
+      radius: 20,
+      backgroundImage: AssetImage('assets/avatars/${profile.avatarKey}.png'),
+    );
+    final statusColor = presence == PresenceState.workedOutToday
+        ? theme.colorScheme.secondary
+        : theme.colorScheme.onSurfaceVariant;
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      leading: Stack(
+        children: [
+          avatar,
+          Positioned(
+            right: 0,
+            bottom: 0,
+            child: Container(
+              key: const ValueKey('status-dot'),
+              width: 10,
+              height: 10,
+              decoration: BoxDecoration(
+                color: statusColor,
+                shape: BoxShape.circle,
+                border: Border.all(
+                  color: theme.scaffoldBackgroundColor,
+                  width: 2,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+      title: Text(
+        profile.username,
+        style: theme.textTheme.titleMedium?.copyWith(
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.2,
+          color: theme.colorScheme.onSurface,
+        ),
+      ),
+      onTap: onTap,
+      minVerticalPadding: 8,
+    );
+  }
+}

--- a/lib/features/friends/providers/friend_presence_provider.dart
+++ b/lib/features/friends/providers/friend_presence_provider.dart
@@ -1,0 +1,124 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+
+enum PresenceState { workedOutToday, notWorkedOutToday, unknown }
+
+class FriendPresenceProvider extends ChangeNotifier {
+  FriendPresenceProvider({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance {
+    _scheduleMidnightReset();
+  }
+
+  final FirebaseFirestore _firestore;
+  final Map<String, PresenceState> _states = {};
+  final Map<String, StreamSubscription> _statsSubs = {};
+  final Map<String, StreamSubscription> _logSubs = {};
+
+  Map<String, PresenceState> get states => Map.unmodifiable(_states);
+
+  void updateUids(List<String> uids) {
+    for (final uid in uids) {
+      if (!_statsSubs.containsKey(uid)) {
+        _listen(uid);
+      }
+    }
+    final remove = _statsSubs.keys.where((u) => !uids.contains(u)).toList();
+    for (final uid in remove) {
+      _statsSubs.remove(uid)?.cancel();
+      _logSubs.remove(uid)?.cancel();
+      _states.remove(uid);
+    }
+  }
+
+  PresenceState stateFor(String uid) {
+    return _states[uid] ?? PresenceState.unknown;
+  }
+
+  void _listen(String uid) {
+    final statsRef = _firestore
+        .collection('stats')
+        .doc(_todayKey())
+        .collection('users')
+        .doc(uid);
+    _statsSubs[uid] = statsRef.snapshots().listen((snap) {
+      if (snap.exists) {
+        final has = snap.data()?['hasWorkout'] == true;
+        _states[uid] =
+            has ? PresenceState.workedOutToday : PresenceState.notWorkedOutToday;
+        notifyListeners();
+      } else {
+        _listenLogs(uid);
+      }
+    }, onError: (_) {
+      _listenLogs(uid);
+    });
+  }
+
+  void _listenLogs(String uid) {
+    if (_logSubs.containsKey(uid)) return;
+    final start = _todayStart();
+    final end = start.add(const Duration(days: 1));
+    final q = _firestore
+        .collectionGroup('logs')
+        .where('userId', isEqualTo: uid)
+        .where('timestamp', isGreaterThanOrEqualTo: Timestamp.fromDate(start))
+        .where('timestamp', isLessThan: Timestamp.fromDate(end))
+        .limit(1);
+    _logSubs[uid] = q.snapshots().listen((snap) {
+      _states[uid] = snap.docs.isNotEmpty
+          ? PresenceState.workedOutToday
+          : PresenceState.notWorkedOutToday;
+      notifyListeners();
+    }, onError: (_) {
+      _states[uid] = PresenceState.unknown;
+      notifyListeners();
+    });
+  }
+
+  DateTime _todayStart() {
+    final now = DateTime.now();
+    return DateTime(now.year, now.month, now.day);
+  }
+
+  String _todayKey() {
+    final d = _todayStart();
+    return '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+  }
+
+  void _scheduleMidnightReset() {
+    final now = DateTime.now();
+    final next = DateTime(now.year, now.month, now.day + 1);
+    final dur = next.difference(now);
+    _midnightTimer = Timer(dur, _reset);
+  }
+
+  Timer? _midnightTimer;
+
+  void _reset() {
+    for (final s in _statsSubs.values) {
+      s.cancel();
+    }
+    for (final s in _logSubs.values) {
+      s.cancel();
+    }
+    _statsSubs.clear();
+    _logSubs.clear();
+    _states.clear();
+    notifyListeners();
+    _scheduleMidnightReset();
+  }
+
+  @override
+  void dispose() {
+    for (final s in _statsSubs.values) {
+      s.cancel();
+    }
+    for (final s in _logSubs.values) {
+      s.cancel();
+    }
+    _midnightTimer?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -130,6 +130,42 @@ class _ProfileScreenState extends State<ProfileScreen> {
     );
   }
 
+  void _showAvatarSheet(AuthProvider auth) {
+    showModalBottomSheet(
+      context: context,
+      builder: (_) {
+        return SafeArea(
+          child: ListView(
+            shrinkWrap: true,
+            children: [
+              ListTile(
+                leading: const CircleAvatar(
+                  backgroundImage: AssetImage('assets/avatars/default.png'),
+                ),
+                title: const Text('Default'),
+                onTap: () async {
+                  Navigator.pop(context);
+                  try {
+                    await auth.setAvatarKey('default');
+                    // ignore: use_build_context_synchronously
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Avatar aktualisiert')),
+                    );
+                  } catch (_) {
+                    // ignore: use_build_context_synchronously
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Fehler beim Speichern')),
+                    );
+                  }
+                },
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
   void _showCreatineSheet() {
     final loc = AppLocalizations.of(context)!;
     final settingsProv = context.read<SettingsProvider>();
@@ -249,7 +285,8 @@ class _ProfileScreenState extends State<ProfileScreen> {
   Widget build(BuildContext context) {
     final prov = context.watch<ProfileProvider>();
     final loc = AppLocalizations.of(context)!;
-    final userId = context.read<AuthProvider>().userId ?? '';
+    final auth = context.watch<AuthProvider>();
+    final userId = auth.userId ?? '';
 
     return Scaffold(
       appBar: AppBar(
@@ -308,32 +345,51 @@ class _ProfileScreenState extends State<ProfileScreen> {
               : prov.error != null
               ? Center(child: Text('Fehler: ${prov.error}'))
               : Padding(
-                padding: const EdgeInsets.all(AppSpacing.sm),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    const Text(
-                      'Trainingstage',
-                      style: TextStyle(
-                        fontWeight: FontWeight.bold,
-                        fontSize: 16,
+                  padding: const EdgeInsets.all(AppSpacing.sm),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Row(
+                        children: [
+                          GestureDetector(
+                            onTap: () => _showAvatarSheet(auth),
+                            child: CircleAvatar(
+                              radius: 28,
+                              backgroundImage: AssetImage('assets/avatars/${auth.avatarKey}.png'),
+                            ),
+                          ),
+                          const SizedBox(width: AppSpacing.sm),
+                          Expanded(
+                            child: Text(
+                              auth.userName ?? '',
+                              style: Theme.of(context).textTheme.titleMedium,
+                            ),
+                          ),
+                        ],
                       ),
-                    ),
-                    const SizedBox(height: 8),
-                    Expanded(
-                      child: GestureDetector(
-                        behavior: HitTestBehavior.opaque,
-                        onTap: () => _openCalendarPopup(userId, prov.trainingDates),
-                        child: Calendar(
-                          trainingDates: prov.trainingDates,
-                          showNavigation: false,
-                          year: DateTime.now().year,
+                      const SizedBox(height: AppSpacing.md),
+                      const Text(
+                        'Trainingstage',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16,
                         ),
                       ),
-                    ),
-                  ],
-              ),
-            ),
+                      const SizedBox(height: 8),
+                      Expanded(
+                        child: GestureDetector(
+                          behavior: HitTestBehavior.opaque,
+                          onTap: () => _openCalendarPopup(userId, prov.trainingDates),
+                          child: Calendar(
+                            trainingDates: prov.trainingDates,
+                            showNavigation: false,
+                            year: DateTime.now().year,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
       bottomNavigationBar: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(AppSpacing.sm),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,6 +46,7 @@ import 'package:tapem/features/friends/data/friends_source.dart';
 import 'package:tapem/features/friends/data/user_search_source.dart';
 import 'package:tapem/features/friends/providers/friends_provider.dart';
 import 'package:tapem/features/friends/providers/friend_calendar_provider.dart';
+import 'package:tapem/features/friends/providers/friend_presence_provider.dart';
 import 'package:tapem/features/creatine/data/creatine_repository.dart';
 import 'package:tapem/features/creatine/providers/creatine_provider.dart';
 import 'package:tapem/features/friends/providers/friend_search_provider.dart';
@@ -306,6 +307,14 @@ Future<void> main() async {
         ),
         ChangeNotifierProvider(
           create: (_) => FriendCalendarProvider(),
+        ),
+        ChangeNotifierProxyProvider<FriendsProvider, FriendPresenceProvider>(
+          create: (_) => FriendPresenceProvider(),
+          update: (_, friends, prov) {
+            prov ??= FriendPresenceProvider();
+            prov.updateUids(friends.friends.map((e) => e.friendUid).toList());
+            return prov;
+          },
         ),
 
         // Numeric keypad

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -118,6 +118,7 @@ flutter:
     - assets/muscle_heatmap.svg
     - assets/body_front.svg
     - assets/body_back.svg
+    - assets/avatars/
 
 l10n:
   arb-dir: lib/l10n

--- a/test/features/friends/presentation/widgets/friend_list_tile_test.dart
+++ b/test/features/friends/presentation/widgets/friend_list_tile_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/features/friends/domain/models/public_profile.dart';
+import 'package:tapem/features/friends/presentation/widgets/friend_list_tile.dart';
+import 'package:tapem/features/friends/providers/friend_presence_provider.dart';
+
+void main() {
+  testWidgets('renders avatar and status dot', (tester) async {
+    const profile = PublicProfile(
+      uid: '1',
+      username: 'Alice',
+      avatarKey: 'default',
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: FriendListTile(
+          profile: profile,
+          presence: PresenceState.workedOutToday,
+          onTap: () {},
+        ),
+      ),
+    );
+    expect(find.byType(CircleAvatar), findsOneWidget);
+    expect(find.byKey(const ValueKey('status-dot')), findsOneWidget);
+  });
+});

--- a/test/features/friends/providers/friend_presence_provider_test.dart
+++ b/test/features/friends/providers/friend_presence_provider_test.dart
@@ -1,0 +1,26 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tapem/features/friends/providers/friend_presence_provider.dart';
+
+void main() {
+  test('fallback query detects workout', () async {
+    final fs = FakeFirebaseFirestore();
+    await fs.collection('logs').add({
+      'userId': 'u1',
+      'timestamp': Timestamp.fromDate(DateTime.now()),
+    });
+    final prov = FriendPresenceProvider(firestore: fs);
+    prov.updateUids(['u1']);
+    await Future.delayed(const Duration(milliseconds: 50));
+    expect(prov.stateFor('u1'), PresenceState.workedOutToday);
+  });
+
+  test('fallback query detects no workout', () async {
+    final fs = FakeFirebaseFirestore();
+    final prov = FriendPresenceProvider(firestore: fs);
+    prov.updateUids(['u2']);
+    await Future.delayed(const Duration(milliseconds: 50));
+    expect(prov.stateFor('u2'), PresenceState.notWorkedOutToday);
+  });
+}


### PR DESCRIPTION
## Summary
- add avatarKey field and profile avatar picker
- show friends with avatars and activity dot via new provider
- allow avatar updates in Firestore rules

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7343d0a4832094fff037ee549dc1