### PR TITLE
profile: move avatar into header and remove username row

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -290,6 +290,25 @@ class _ProfileScreenState extends State<ProfileScreen> {
 
     return Scaffold(
       appBar: AppBar(
+        leadingWidth: 72,
+        leading: Padding(
+          padding: const EdgeInsets.only(left: AppSpacing.md),
+          child: GestureDetector(
+            onTap: () => _showAvatarSheet(auth),
+            child: Tooltip(
+              message: 'Profilbild ändern',
+              child: Semantics(
+                label: 'Profilbild ändern',
+                child: CircleAvatar(
+                  radius: 24,
+                  backgroundImage:
+                      AssetImage('assets/avatars/${auth.avatarKey}.png'),
+                ),
+              ),
+            ),
+          ),
+        ),
+        centerTitle: true,
         title: Text(loc.profileTitle),
         actions: [
           if (enableFriends)
@@ -349,25 +368,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                      Row(
-                        children: [
-                          GestureDetector(
-                            onTap: () => _showAvatarSheet(auth),
-                            child: CircleAvatar(
-                              radius: 28,
-                              backgroundImage: AssetImage('assets/avatars/${auth.avatarKey}.png'),
-                            ),
-                          ),
-                          const SizedBox(width: AppSpacing.sm),
-                          Expanded(
-                            child: Text(
-                              auth.userName ?? '',
-                              style: Theme.of(context).textTheme.titleMedium,
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: AppSpacing.md),
                       const Text(
                         'Trainingstage',
                         style: TextStyle(

--- a/test/features/profile/profile_screen_test.dart
+++ b/test/features/profile/profile_screen_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/core/providers/gym_provider.dart';
+import 'package:tapem/core/providers/profile_provider.dart';
+import 'package:tapem/core/providers/settings_provider.dart';
+import 'package:tapem/features/friends/providers/friends_provider.dart';
+import 'package:tapem/features/profile/presentation/screens/profile_screen.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
+class MockAuthProvider extends Mock with ChangeNotifier implements AuthProvider {}
+class MockProfileProvider extends Mock with ChangeNotifier implements ProfileProvider {}
+class MockSettingsProvider extends Mock with ChangeNotifier implements SettingsProvider {}
+class MockFriendsProvider extends Mock with ChangeNotifier implements FriendsProvider {}
+class MockGymProvider extends Mock with ChangeNotifier implements GymProvider {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue<String>('');
+  });
+
+  Widget buildScreen({
+    required AuthProvider auth,
+    required ProfileProvider profile,
+    required SettingsProvider settings,
+    required FriendsProvider friends,
+    required GymProvider gym,
+  }) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider<AuthProvider>.value(value: auth),
+        ChangeNotifierProvider<ProfileProvider>.value(value: profile),
+        ChangeNotifierProvider<SettingsProvider>.value(value: settings),
+        ChangeNotifierProvider<FriendsProvider>.value(value: friends),
+        ChangeNotifierProvider<GymProvider>.value(value: gym),
+      ],
+      child: MaterialApp(
+        locale: const Locale('de'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const ProfileScreen(),
+      ),
+    );
+  }
+
+  testWidgets('Profile header shows avatar and no username', (tester) async {
+    final auth = MockAuthProvider();
+    final profile = MockProfileProvider();
+    final settings = MockSettingsProvider();
+    final friends = MockFriendsProvider();
+    final gym = MockGymProvider();
+
+    when(() => auth.avatarKey).thenReturn('a1');
+    when(() => auth.userId).thenReturn('u1');
+    when(() => auth.userName).thenReturn('Admin');
+    when(() => profile.isLoading).thenReturn(false);
+    when(() => profile.error).thenReturn(null);
+    when(() => profile.trainingDates).thenReturn([]);
+    when(() => profile.loadTrainingDates(any())).thenAnswer((_) async {});
+    when(() => settings.creatineEnabled).thenReturn(false);
+    when(() => settings.load(any())).thenAnswer((_) async {});
+    when(() => friends.pendingCount).thenReturn(0);
+    when(() => friends.listen(any())).thenReturn(null);
+    when(() => gym.currentGymId).thenReturn('g1');
+
+    await tester.pumpWidget(
+      buildScreen(
+        auth: auth,
+        profile: profile,
+        settings: settings,
+        friends: friends,
+        gym: gym,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.descendant(
+          of: find.byType(AppBar), matching: find.byType(CircleAvatar)),
+      findsOneWidget,
+    );
+    expect(find.text('Admin'), findsNothing);
+  });
+
+  testWidgets('tap avatar opens selector and updates image', (tester) async {
+    var avatarKey = 'old';
+    final auth = MockAuthProvider();
+    final profile = MockProfileProvider();
+    final settings = MockSettingsProvider();
+    final friends = MockFriendsProvider();
+    final gym = MockGymProvider();
+
+    when(() => auth.avatarKey).thenAnswer(() => avatarKey);
+    when(() => auth.userId).thenReturn('u1');
+    when(() => auth.setAvatarKey(any())).thenAnswer((invocation) async {
+      avatarKey = invocation.positionalArguments.first as String;
+      auth.notifyListeners();
+    });
+    when(() => profile.isLoading).thenReturn(false);
+    when(() => profile.error).thenReturn(null);
+    when(() => profile.trainingDates).thenReturn([]);
+    when(() => profile.loadTrainingDates(any())).thenAnswer((_) async {});
+    when(() => settings.creatineEnabled).thenReturn(false);
+    when(() => settings.load(any())).thenAnswer((_) async {});
+    when(() => friends.pendingCount).thenReturn(0);
+    when(() => friends.listen(any())).thenReturn(null);
+    when(() => gym.currentGymId).thenReturn('g1');
+
+    await tester.pumpWidget(
+      buildScreen(
+        auth: auth,
+        profile: profile,
+        settings: settings,
+        friends: friends,
+        gym: gym,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Profilbild ändern'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Default'), findsOneWidget);
+    await tester.tap(find.text('Default'));
+    await tester.pumpAndSettle();
+
+    verify(() => auth.setAvatarKey('default')).called(1);
+    final avatar = tester.widget<CircleAvatar>(find.descendant(
+        of: find.byType(AppBar), matching: find.byType(CircleAvatar)));
+    final image = avatar.backgroundImage as AssetImage;
+    expect(image.assetName, 'assets/avatars/default.png');
+  });
+}


### PR DESCRIPTION
## Summary
- Show the user's avatar directly in the profile app bar and remove the username row
- Keep avatar picker on tap with optimistic persistence
- Add widget tests for the profile header layout and avatar picker

## Testing
- ⚠️ `flutter test test/features/profile/profile_screen_test.dart` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bb77d5cb248320aafded38601a9da4