### PR TITLE
profile: avatar overlay in header and cleanup body

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -290,7 +290,44 @@ class _ProfileScreenState extends State<ProfileScreen> {
 
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: false,
+        centerTitle: true,
         title: Text(loc.profileTitle),
+        flexibleSpace: Builder(
+          builder: (context) {
+            const avatarSize = 44.0;
+            final top = MediaQuery.of(context).padding.top;
+            return Stack(
+              clipBehavior: Clip.none,
+              children: [
+                Positioned(
+                  left: AppSpacing.md,
+                  top: top + (kToolbarHeight - avatarSize) / 2,
+                  child: SizedBox(
+                    width: avatarSize,
+                    height: avatarSize,
+                    child: Tooltip(
+                      message: 'Profilbild ändern',
+                      child: Semantics(
+                        button: true,
+                        label: 'Profilbild ändern',
+                        child: GestureDetector(
+                          onTap: () => _showAvatarSheet(auth),
+                          child: CircleAvatar(
+                            radius: avatarSize / 2,
+                            backgroundImage: AssetImage(
+                              'assets/avatars/${auth.avatarKey}.png',
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
         actions: [
           if (enableFriends)
             Consumer<FriendsProvider>(
@@ -349,25 +386,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                      Row(
-                        children: [
-                          GestureDetector(
-                            onTap: () => _showAvatarSheet(auth),
-                            child: CircleAvatar(
-                              radius: 28,
-                              backgroundImage: AssetImage('assets/avatars/${auth.avatarKey}.png'),
-                            ),
-                          ),
-                          const SizedBox(width: AppSpacing.sm),
-                          Expanded(
-                            child: Text(
-                              auth.userName ?? '',
-                              style: Theme.of(context).textTheme.titleMedium,
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: AppSpacing.md),
                       const Text(
                         'Trainingstage',
                         style: TextStyle(

--- a/test/features/profile/profile_screen_test.dart
+++ b/test/features/profile/profile_screen_test.dart
@@ -1,0 +1,217 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/app_router.dart';
+import 'package:tapem/core/providers/app_provider.dart' as app;
+import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/core/providers/gym_provider.dart';
+import 'package:tapem/core/providers/profile_provider.dart';
+import 'package:tapem/core/providers/settings_provider.dart';
+import 'package:tapem/features/friends/data/friends_api.dart';
+import 'package:tapem/features/friends/data/friends_source.dart';
+import 'package:tapem/features/friends/data/user_search_source.dart';
+import 'package:tapem/features/friends/domain/models/friend.dart';
+import 'package:tapem/features/friends/domain/models/friend_request.dart';
+import 'package:tapem/features/friends/domain/models/public_profile.dart';
+import 'package:tapem/features/friends/providers/friend_presence_provider.dart';
+import 'package:tapem/features/friends/providers/friend_search_provider.dart';
+import 'package:tapem/features/friends/providers/friends_provider.dart';
+import 'package:tapem/features/profile/presentation/screens/profile_screen.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
+class MockAuthProvider extends Mock implements AuthProvider {}
+
+class MockNavigatorObserver extends Mock implements NavigatorObserver {}
+
+class FakeProfileProvider extends ProfileProvider {
+  @override
+  Future<void> loadTrainingDates(BuildContext context) async {}
+}
+
+class FakeSettingsProvider extends ChangeNotifier implements SettingsProvider {
+  bool _creatine = false;
+
+  @override
+  bool get creatineEnabled => _creatine;
+
+  @override
+  bool get isLoading => false;
+
+  @override
+  String? get error => null;
+
+  @override
+  Future<void> load(String uid) async {}
+
+  @override
+  Future<void> setCreatineEnabled(bool value) async {
+    _creatine = value;
+    notifyListeners();
+  }
+}
+
+class FakeFriendsSource implements FriendsSource {
+  @override
+  Stream<List<Friend>> watchFriends(String meUid) => const Stream.empty();
+
+  @override
+  Stream<List<FriendRequest>> watchIncoming(String meUid) => const Stream.empty();
+
+  @override
+  Stream<List<FriendRequest>> watchOutgoing(String meUid) => const Stream.empty();
+
+  @override
+  Stream<List<FriendRequest>> watchOutgoingAccepted(String meUid) =>
+      const Stream.empty();
+}
+
+class FakeFriendsApi implements FriendsApi {
+  @override
+  Future<void> sendRequest(String toUserId, {String? message}) async {}
+
+  @override
+  Future<void> cancelRequest(String toUserId) async {}
+
+  @override
+  Future<void> acceptRequest(String fromUserId) async {}
+
+  @override
+  Future<void> declineRequest(String fromUserId) async {}
+
+  @override
+  Future<void> removeFriend(String otherUserId) async {}
+
+  @override
+  Future<void> ensureFriendEdge(String otherUserId) async {}
+}
+
+class FakeFriendsProvider extends FriendsProvider {
+  FakeFriendsProvider() : super(FakeFriendsSource(), FakeFriendsApi());
+
+  @override
+  void listen(String meUid) {}
+}
+
+class FakeUserSearchSource implements UserSearchSource {
+  @override
+  Future<PublicProfile> getProfile(String uid) async =>
+      PublicProfile(uid: uid, username: '', avatarKey: 'default');
+
+  @override
+  Stream<List<PublicProfile>> streamByUsernamePrefix(String q,
+          {int limit = 20}) =>
+      const Stream.empty();
+}
+
+class FakeFriendPresenceProvider extends ChangeNotifier
+    implements FriendPresenceProvider {
+  @override
+  Map<String, PresenceState> get states => {};
+
+  @override
+  void updateUids(List<String> uids) {}
+
+  @override
+  PresenceState stateFor(String uid) => PresenceState.unknown;
+}
+
+class FakeRoute extends Fake implements Route<dynamic> {}
+
+Future<void> pumpProfileScreen(
+  WidgetTester tester,
+  AuthProvider auth, {
+  NavigatorObserver? observer,
+}) async {
+  final userSearch = FakeUserSearchSource();
+  await tester.pumpWidget(
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider<AuthProvider>.value(value: auth),
+        ChangeNotifierProvider<ProfileProvider>(
+            create: (_) => FakeProfileProvider()),
+        ChangeNotifierProvider<FriendsProvider>(
+            create: (_) => FakeFriendsProvider()),
+        ChangeNotifierProvider<SettingsProvider>(
+            create: (_) => FakeSettingsProvider()),
+        ChangeNotifierProvider<GymProvider>(create: (_) => GymProvider()),
+        ChangeNotifierProvider<app.AppProvider>(
+            create: (_) => app.AppProvider()),
+        Provider<UserSearchSource>.value(value: userSearch),
+        ChangeNotifierProvider<FriendSearchProvider>(
+            create: (_) => FriendSearchProvider(userSearch)),
+        ChangeNotifierProvider<FriendPresenceProvider>(
+            create: (_) => FakeFriendPresenceProvider()),
+      ],
+      child: MaterialApp(
+        locale: const Locale('de'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        routes: {AppRouter.auth: (_) => const SizedBox()},
+        home: const ProfileScreen(),
+        navigatorObservers: observer != null ? [observer] : [],
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeRoute());
+  });
+
+  testWidgets('no username row and avatar in app bar', (tester) async {
+    final auth = MockAuthProvider();
+    when(() => auth.userId).thenReturn('u1');
+    when(() => auth.avatarKey).thenReturn('default');
+    when(() => auth.userName).thenReturn('Admin');
+
+    await pumpProfileScreen(tester, auth);
+
+    expect(find.text('Admin'), findsNothing);
+    expect(find.text('Trainingstage'), findsOneWidget);
+    expect(find.byTooltip('Profilbild ändern'), findsOneWidget);
+  });
+
+  testWidgets('tap on avatar opens selector sheet', (tester) async {
+    final auth = MockAuthProvider();
+    when(() => auth.userId).thenReturn('u1');
+    when(() => auth.avatarKey).thenReturn('default');
+
+    await pumpProfileScreen(tester, auth);
+
+    await tester.tap(find.byTooltip('Profilbild ändern'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Default'), findsOneWidget);
+  });
+
+  testWidgets('actions are tappable', (tester) async {
+    final auth = MockAuthProvider();
+    when(() => auth.userId).thenReturn('u1');
+    when(() => auth.avatarKey).thenReturn('default');
+    when(() => auth.logout()).thenAnswer((_) async {});
+
+    final observer = MockNavigatorObserver();
+    await pumpProfileScreen(tester, auth, observer: observer);
+    reset(observer);
+
+    await tester.tap(find.byTooltip('Freunde'));
+    await tester.pumpAndSettle();
+    verify(() => observer.didPush(any(), any())).called(1);
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Einstellungen'));
+    await tester.pumpAndSettle();
+    expect(find.text('Einstellungen'), findsOneWidget);
+    await tester.tap(find.text('Abbrechen'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Abmelden'));
+    await tester.pumpAndSettle();
+    verify(() => auth.logout()).called(1);
+  });
+}
+


### PR DESCRIPTION
## Summary
- overlay avatar in profile app bar top-left while keeping centered title
- remove legacy username row so training days list starts immediately
- add widget tests ensuring avatar placement and tappable actions

## Testing
- ⚠️ `flutter test test/features/profile/profile_screen_test.dart` (command not found)

------
https://chatgpt.com/codex/tasks/task_e_68bb7bfa1c1c8320a872a7f730ce9fc8