### PR TITLE
profile: show avatar in title stack

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -287,46 +287,45 @@ class _ProfileScreenState extends State<ProfileScreen> {
     final loc = AppLocalizations.of(context)!;
     final auth = context.watch<AuthProvider>();
     final userId = auth.userId ?? '';
+    const avatarSize = 44.0;
 
     return Scaffold(
       appBar: AppBar(
         automaticallyImplyLeading: false,
         centerTitle: true,
-        title: Text(loc.profileTitle),
-        flexibleSpace: Builder(
-          builder: (context) {
-            const avatarSize = 44.0;
-            final top = MediaQuery.of(context).padding.top;
-            return Stack(
-              clipBehavior: Clip.none,
-              children: [
-                Positioned(
-                  left: AppSpacing.md,
-                  top: top + (kToolbarHeight - avatarSize) / 2,
-                  child: SizedBox(
-                    width: avatarSize,
-                    height: avatarSize,
-                    child: Tooltip(
-                      message: 'Profilbild ändern',
-                      child: Semantics(
-                        button: true,
-                        label: 'Profilbild ändern',
-                        child: GestureDetector(
-                          onTap: () => _showAvatarSheet(auth),
-                          child: CircleAvatar(
-                            radius: avatarSize / 2,
-                            backgroundImage: AssetImage(
-                              'assets/avatars/${auth.avatarKey}.png',
-                            ),
+        title: Stack(
+          clipBehavior: Clip.none,
+          children: [
+            Center(child: Text(loc.profileTitle)),
+            Positioned(
+              left: AppSpacing.md,
+              top: 0,
+              bottom: 0,
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: SizedBox(
+                  width: avatarSize,
+                  height: avatarSize,
+                  child: Tooltip(
+                    message: 'Profilbild ändern',
+                    child: Semantics(
+                      button: true,
+                      label: 'Profilbild ändern',
+                      child: GestureDetector(
+                        onTap: () => _showAvatarSheet(auth),
+                        child: CircleAvatar(
+                          radius: avatarSize / 2,
+                          backgroundImage: AssetImage(
+                            'assets/avatars/${auth.avatarKey}.png',
                           ),
                         ),
                       ),
                     ),
                   ),
                 ),
-              ],
-            );
-          },
+              ),
+            ),
+          ],
         ),
         actions: [
           if (enableFriends)
@@ -393,7 +392,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                           fontSize: 16,
                         ),
                       ),
-                      const SizedBox(height: 8),
+                      const SizedBox(height: AppSpacing.sm),
                       Expanded(
                         child: GestureDetector(
                           behavior: HitTestBehavior.opaque,

--- a/test/features/profile/profile_screen_test.dart
+++ b/test/features/profile/profile_screen_test.dart
@@ -169,6 +169,10 @@ void main() {
 
     await pumpProfileScreen(tester, auth);
 
+    final appBar = tester.widget<AppBar>(find.byType(AppBar));
+    expect(appBar.flexibleSpace, isNull);
+    expect(appBar.title, isA<Stack>());
+
     expect(find.text('Admin'), findsNothing);
     expect(find.text('Trainingstage'), findsOneWidget);
     expect(find.byTooltip('Profilbild ändern'), findsOneWidget);


### PR DESCRIPTION
## Summary
- move avatar from flexibleSpace to AppBar title stack so it's visible and tappable
- streamline profile body spacing
- ensure avatar placement and action tappability via widget tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb82a1f9148320850c73112ad52248