### PR TITLE
Avatars-V2 Phase 1: Schema, Rules, Flags, Read-only Catalog Loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ Die zugehörigen Definitionen stehen in `project/roadmap/issues_pilot.json`.
 
 ---
 
+## Avatars V2 Flags
+
+Für lokale Tests mit dem Firebase Emulator können die Remote-Config-Flags so gesetzt werden:
+
+```bash
+firebase remoteconfig:set avatars_v2_enabled=true avatars_v2_migration_on=false avatars_v2_images_cdn=false
+```
+
+Standardmäßig sind alle Flags `false`.
+
 ## Changelog
 
 - `OverlayNumericKeypadHost.closeOnOutsideTap` wurde entfernt. Nutze stattdessen

--- a/docs/avatars_v2.md
+++ b/docs/avatars_v2.md
@@ -1,0 +1,58 @@
+# Avatars V2
+
+## Collections
+
+### `gyms/{gymId}/avatarCatalog/{avatarId}`
+- `name` (string)
+- `description` (string, optional)
+- `assetStoragePath` (string) or `assetUrl` (string)
+- `isActive` (bool)
+- `tier` (string enum: `common`|`rare`|`legendary`, optional)
+- `unlock` (map)
+  - `type` (`xp`|`challenge`|`event`|`manual`)
+  - `params` (map, free-form)
+- `createdAt` (timestamp)
+- `updatedAt` (timestamp)
+- `createdBy` (uid)
+- `updatedBy` (uid)
+
+### `catalogAvatarsGlobal/{avatarId}`
+- same fields as above
+
+### `users/{uid}/avatarsOwned/{avatarId}`
+- `source` ("gym:{gymId}" | "global")
+- `unlockedAt` (timestamp)
+- `reason` (string)
+- `by` ("system"|adminId)
+- `grantHash` (string)
+
+### `users/{uid}`
+- `equippedAvatarRef` (string, path to catalog entry)
+
+## Indices
+- `avatarCatalog` collection group: `isActive` ASC, `tier` ASC
+- `catalogAvatarsGlobal` collection group: `isActive` ASC, `tier` ASC
+
+## Flags
+| Flag | Default |
+|------|---------|
+| `avatars_v2_enabled` | false |
+| `avatars_v2_migration_on` | false |
+| `avatars_v2_images_cdn` | false |
+
+## Read Rights
+- Gym catalog readable only for members of the gym
+- Global catalog readable for authenticated users
+- Inventory readable only by its owner
+
+## Unlock Examples
+- `{ "type": "xp", "params": { "xpThreshold": 1000 } }`
+- `{ "type": "challenge", "params": { "challengeId": "c1" } }`
+- `{ "type": "event", "params": { "eventId": "e1", "window": "2024-01" } }`
+
+## Roadmap
+1. **Phase 2** – Inventory & Equip
+2. **Phase 3** – Grant Pipeline
+3. **Phase 4** – Rules & Functions Tests
+4. **Phase 5** – Migration V1→V2
+5. **Phase 6** – Telemetry & Rollout

--- a/docs/avatars_v2_rules_tests.md
+++ b/docs/avatars_v2_rules_tests.md
@@ -1,0 +1,9 @@
+# Avatars V2 Rules Tests
+
+Planned emulator test cases:
+
+- **Nicht-Mitglied kann Gym-Katalog nicht lesen.**
+- **Mitglied kann Gym-Katalog lesen.**
+- **Client kann `users/{uid}/avatarsOwned` nicht schreiben.**
+- **Authed Nutzer kann globalen Katalog lesen.**
+- **Unangemeldeter Nutzer kann globale Kataloge nicht lesen.**

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -94,6 +94,22 @@
       ]
     },
     {
+      "collectionGroup": "avatarCatalog",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "isActive", "order": "ASCENDING" },
+        { "fieldPath": "tier", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "catalogAvatarsGlobal",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "isActive", "order": "ASCENDING" },
+        { "fieldPath": "tier", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionId": "users",
       "queryScope": "COLLECTION",
       "fields": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -25,6 +25,18 @@ service cloud.firestore {
       );
     }
 
+    // Custom claim based gym admin
+    function isGymAdmin(gymId) {
+      return isAuthed() &&
+             request.auth.token.role == 'gym_admin' &&
+             request.auth.token.gymId == gymId;
+    }
+
+    // Global admin claim
+    function isGlobalAdmin() {
+      return isAuthed() && request.auth.token.role == 'global_admin';
+    }
+
     function isOwner(userId) {
       return isAuthed() && request.auth.uid == userId;
     }
@@ -117,6 +129,14 @@ service cloud.firestore {
     }
 
     // ─────────────────────────
+    // Avatar catalog global
+    // ─────────────────────────
+    match /catalogAvatarsGlobal/{avatarId} {
+      allow read: if isAuthed();
+      allow write: if isGlobalAdmin();
+    }
+
+    // ─────────────────────────
     // Usernames mapping
     // ─────────────────────────
       match /usernames/{name} {
@@ -159,6 +179,11 @@ service cloud.firestore {
           request.resource.data.keys().hasOnly(['createdAt']) &&
           request.resource.data.createdAt is timestamp;
         allow delete: if isOwner(uid);
+      }
+
+      match /avatarsOwned/{avatarId} {
+        allow read: if isOwner(uid);
+        allow write: if false;
       }
 
       // Privacy-aware public calendar (server writes)
@@ -213,6 +238,12 @@ service cloud.firestore {
       match /config/{docId} {
         allow read: if isAuthed();
         allow write: if isAdmin(gymId);
+      }
+
+      // Avatar catalog per gym
+      match /avatarCatalog/{avatarId} {
+        allow read: if inGym(gymId);
+        allow write: if isGymAdmin(gymId);
       }
 
       // Devices

--- a/lib/core/config/remote_config.dart
+++ b/lib/core/config/remote_config.dart
@@ -1,0 +1,22 @@
+import 'package:firebase_remote_config/firebase_remote_config.dart';
+
+class RC {
+  RC._();
+
+  static final FirebaseRemoteConfig _rc = FirebaseRemoteConfig.instance;
+
+  static Future<void> init() async {
+    await _rc.setDefaults(<String, dynamic>{
+      'avatars_v2_enabled': false,
+      'avatars_v2_migration_on': false,
+      'avatars_v2_images_cdn': false,
+    });
+    await _rc.fetchAndActivate();
+  }
+
+  static bool get avatarsV2Enabled => _rc.getBool('avatars_v2_enabled');
+  static bool get avatarsV2MigrationOn =>
+      _rc.getBool('avatars_v2_migration_on');
+  static bool get avatarsV2ImagesCdn =>
+      _rc.getBool('avatars_v2_images_cdn');
+}

--- a/lib/features/avatars/data/avatar_repository.dart
+++ b/lib/features/avatars/data/avatar_repository.dart
@@ -1,0 +1,32 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../domain/models/avatar_catalog_item.dart';
+
+class AvatarRepository {
+  AvatarRepository(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  Future<List<AvatarCatalogItem>> loadCatalog(String gymId) async {
+    final globalSnap = await _firestore
+        .collection('catalogAvatarsGlobal')
+        .where('isActive', isEqualTo: true)
+        .get();
+    final gymSnap = await _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('avatarCatalog')
+        .where('isActive', isEqualTo: true)
+        .get();
+
+    final Map<String, AvatarCatalogItem> merged = {
+      for (final doc in globalSnap.docs)
+        doc.id: AvatarCatalogItem.fromMap(doc.id, doc.data())
+    };
+    for (final doc in gymSnap.docs) {
+      merged[doc.id] = AvatarCatalogItem.fromMap(doc.id, doc.data());
+    }
+    final items = merged.values.toList();
+    items.sort((a, b) => a.id.compareTo(b.id));
+    return items;
+  }
+}

--- a/lib/features/avatars/domain/models/avatar_catalog_item.dart
+++ b/lib/features/avatars/domain/models/avatar_catalog_item.dart
@@ -1,0 +1,65 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class AvatarUnlock {
+  AvatarUnlock({required this.type, this.params});
+
+  final String type; // xp|challenge|event|manual
+  final Map<String, dynamic>? params;
+
+  factory AvatarUnlock.fromMap(Map<String, dynamic>? data) {
+    if (data == null) {
+      return AvatarUnlock(type: 'manual');
+    }
+    return AvatarUnlock(
+      type: data['type'] as String? ?? 'manual',
+      params: data['params'] as Map<String, dynamic>?,
+    );
+  }
+}
+
+class AvatarCatalogItem {
+  AvatarCatalogItem({
+    required this.id,
+    required this.name,
+    this.description,
+    this.assetStoragePath,
+    this.assetUrl,
+    required this.isActive,
+    this.tier,
+    required this.unlock,
+    this.createdAt,
+    this.updatedAt,
+    this.createdBy,
+    this.updatedBy,
+  });
+
+  final String id;
+  final String name;
+  final String? description;
+  final String? assetStoragePath;
+  final String? assetUrl;
+  final bool isActive;
+  final String? tier; // common|rare|legendary
+  final AvatarUnlock unlock;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+  final String? createdBy;
+  final String? updatedBy;
+
+  factory AvatarCatalogItem.fromMap(String id, Map<String, dynamic> data) {
+    return AvatarCatalogItem(
+      id: id,
+      name: data['name'] as String? ?? '',
+      description: data['description'] as String?,
+      assetStoragePath: data['assetStoragePath'] as String?,
+      assetUrl: data['assetUrl'] as String?,
+      isActive: data['isActive'] as bool? ?? false,
+      tier: data['tier'] as String?,
+      unlock: AvatarUnlock.fromMap(data['unlock'] as Map<String, dynamic>?),
+      createdAt: (data['createdAt'] as Timestamp?)?.toDate(),
+      updatedAt: (data['updatedAt'] as Timestamp?)?.toDate(),
+      createdBy: data['createdBy'] as String?,
+      updatedBy: data['updatedBy'] as String?,
+    );
+  }
+}

--- a/lib/features/avatars/domain/models/avatar_owned.dart
+++ b/lib/features/avatars/domain/models/avatar_owned.dart
@@ -1,0 +1,30 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class AvatarOwned {
+  AvatarOwned({
+    required this.id,
+    required this.source,
+    this.unlockedAt,
+    this.reason,
+    this.by,
+    this.grantHash,
+  });
+
+  final String id;
+  final String source; // "gym:{gymId}" | "global"
+  final DateTime? unlockedAt;
+  final String? reason;
+  final String? by; // "system" or admin uid
+  final String? grantHash;
+
+  factory AvatarOwned.fromMap(String id, Map<String, dynamic> data) {
+    return AvatarOwned(
+      id: id,
+      source: data['source'] as String? ?? 'global',
+      unlockedAt: (data['unlockedAt'] as Timestamp?)?.toDate(),
+      reason: data['reason'] as String?,
+      by: data['by'] as String?,
+      grantHash: data['grantHash'] as String?,
+    );
+  }
+}

--- a/lib/features/avatars/domain/models/visible_avatar.dart
+++ b/lib/features/avatars/domain/models/visible_avatar.dart
@@ -1,0 +1,8 @@
+import 'avatar_catalog_item.dart';
+
+class VisibleAvatar {
+  VisibleAvatar({required this.item, required this.locked});
+
+  final AvatarCatalogItem item;
+  final bool locked;
+}

--- a/lib/features/avatars/presentation/providers/avatar_catalog_provider.dart
+++ b/lib/features/avatars/presentation/providers/avatar_catalog_provider.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/foundation.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../data/avatar_repository.dart';
+import '../../domain/models/avatar_catalog_item.dart';
+import '../../domain/models/visible_avatar.dart';
+import '../../../core/config/remote_config.dart';
+
+class AvatarCatalogProvider extends ChangeNotifier {
+  AvatarCatalogProvider({FirebaseFirestore? firestore})
+      : _repo = AvatarRepository(firestore ?? FirebaseFirestore.instance);
+
+  final AvatarRepository _repo;
+  List<AvatarCatalogItem> _items = [];
+  bool _isLoaded = false;
+
+  bool get isLoaded => _isLoaded;
+
+  Future<void> load(String gymId) async {
+    if (!RC.avatarsV2Enabled) return;
+    _items = await _repo.loadCatalog(gymId);
+    _isLoaded = true;
+    assert(() {
+      debugPrint('Loaded avatars: ' + _items.map((e) => e.id).join(', '));
+      return true;
+    }());
+    notifyListeners();
+  }
+
+  List<VisibleAvatar> getAllVisibleAvatarsForUser(String userId, String gymId) {
+    if (!_isLoaded || !RC.avatarsV2Enabled) return [];
+    return _items
+        .map((e) => VisibleAvatar(item: e, locked: true))
+        .toList(growable: false);
+  }
+}


### PR DESCRIPTION
## Summary
- implement avatars v2 remote config flags and accessors
- add firestore schema rules and indexes for avatar catalogs and inventory
- provide read-only avatar catalog provider merging global and gym catalogs
- document schema, flags, and planned rules tests

## Testing
- `dart format lib/core/config/remote_config.dart lib/features/avatars/domain/models/avatar_catalog_item.dart lib/features/avatars/domain/models/avatar_owned.dart lib/features/avatars/domain/models/visible_avatar.dart lib/features/avatars/data/avatar_repository.dart lib/features/avatars/presentation/providers/avatar_catalog_provider.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc07ff1ea0832084ef8619c594c833