### PR TITLE
Avatars-V2 Phase 4: Emulator-Tests (Rules + Functions) + CI Scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,28 @@ jobs:
           name: rules-test-log
           path: rules-test.log
 
+  avatars_emulator_tests:
+    name: Avatars Emulator Tests
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+      - name: Install root dependencies
+        run: npm ci
+      - name: Install functions dependencies
+        run: cd functions && npm ci
+      - name: Run rules tests
+        run: npm run test:rules
+      - name: Run functions tests
+        run: npm run test:functions
+
   build:
     name: Build Debug APK
     needs: rules_test

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Tap’em ist eine Flutter-App für Fitnessstudios. Sie setzt auf ein modulares K
 - **Offline-Support**: Firestore-Persistence für unterbrechungsfreie Datenerfassung
 - **CI/CD ready**: GitHub Actions für Analyse, Tests und Matrix-Builds von Flavors
 
+## Tests lokal & CI
+
+Die Avatars-V2 Rules- und Functions-Tests laufen komplett im Firebase Emulator. Lokal können sie mit folgendem Befehl gestartet werden:
+
+```bash
+npm run test:all
+```
+
+CI führt denselben Ablauf aus, siehe Workflow `avatars_emulator_tests`.
+
 ---
 
 ## Projektstruktur

--- a/docs/avatars_v2_rules_tests.md
+++ b/docs/avatars_v2_rules_tests.md
@@ -1,19 +1,35 @@
-# Avatars V2 Rules Tests
+# Avatars V2 Emulator Tests
 
-Planned emulator test cases:
+This suite exercises Firestore security rules and Cloud Functions for the Avatars V2 feature using the Firebase Emulator Suite.
 
-- **Nicht-Mitglied kann Gym-Katalog nicht lesen.**
-- **Mitglied kann Gym-Katalog lesen.**
-- **Client kann `users/{uid}/avatarsOwned` nicht schreiben.**
-- **Authed Nutzer kann globalen Katalog lesen.**
-- **Unangemeldeter Nutzer kann globale Kataloge nicht lesen.**
-- **Owner darf `users/{uid}.equippedAvatarRef` setzen/ändern/löschen.**
-- **Fremder User darf `equippedAvatarRef` nicht schreiben.**
-- **Lesen von `users/{uid}/avatarsOwned` nur durch Owner.**
-- **Write auf `users/{uid}/avatarsOwned` bleibt verboten.**
-- **Mirror-Trigger aktualisiert `publicProfiles/{uid}` korrekt.**
-- **Admin eines Gyms kann nur Gym-eigene Avatare an seine Mitglieder vergeben.**
-- **Fremd-Gym-Vergabe scheitert.**
-- **XP-Threshold überschritten → genau ein Grant.**
-- **Challenge/Event Grant nur bei erfülltem Zustand/Window.**
-- **Defaults werden beim User-OnCreate auto-grantet (idempotent).**
+## Test Matrix
+
+### Rules
+- Gym catalog read/write permissions
+- Global catalog readability
+- Inventory read / client write deny
+- Equip owner-write
+
+### Functions
+- Default avatar bootstrap on user create
+- Admin grant with tenant isolation and idempotence
+- XP, Challenge and Event based grants
+- Mirror of equipped avatar into public profile
+
+## Running Tests
+
+Start via npm scripts which launch the emulator automatically:
+
+```bash
+npm run test:rules   # Firestore rules tests
+npm run test:functions   # Functions tests with coverage
+npm run test:all     # Run both suites
+```
+
+## Flags
+
+Functions tests stub Remote Config flags so `avatars_v2_enabled` and `avatars_v2_grants_enabled` are ON.
+
+## Notes
+
+The emulator is reset between tests to guarantee determinism. Challenge/event scenarios use synthetic windows and IDs as described in the fixtures.

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,6 +13,14 @@
     "jest": "^29.7.0"
   },
   "scripts": {
-    "test": "jest"
+    "test": "firebase emulators:exec --only firestore,functions \"jest --runInBand --coverage\""
+  },
+  "jest": {
+    "coverageThreshold": {
+      "global": {
+        "statements": 70,
+        "branches": 60
+      }
+    }
   }
 }

--- a/functions/test/avatars.test.js
+++ b/functions/test/avatars.test.js
@@ -1,0 +1,164 @@
+const admin = require('firebase-admin');
+const functionsTest = require('firebase-functions-test')({ projectId: 'avatars-v2-test' });
+functionsTest.mockConfig({ app: { avatars_v2_enabled: true, avatars_v2_grants_enabled: true } });
+const { clearFirestoreData } = require('@firebase/rules-unit-testing');
+const myFunctions = require('../index');
+const assert = require('assert');
+
+async function seedBase(eventWindowNow = true) {
+  const db = admin.firestore();
+  // Global catalog
+  await db.collection('catalog').doc('avatarsGlobal').collection('items').doc('default').set({
+    isActive: true,
+    unlock: { type: 'manual' },
+    assetUrl: 'https://example.com/default.png',
+  });
+  await db.collection('catalog').doc('avatarsGlobal').collection('items').doc('default2').set({
+    isActive: true,
+    unlock: { type: 'manual' },
+  });
+  await db.collection('catalog').doc('avatarsGlobal').collection('items').doc('globalX').set({
+    isActive: true,
+    unlock: { type: 'manual' },
+  });
+  // Gyms and members
+  await db.collection('gyms').doc('G1').set({});
+  await db.collection('gyms').doc('G1').collection('users').doc('U1').set({ role: 'member' });
+  await db.collection('gyms').doc('G1').collection('users').doc('A1').set({ role: 'admin' });
+  await db.collection('gyms').doc('G2').set({});
+  await db.collection('gyms').doc('G2').collection('users').doc('A2').set({ role: 'admin' });
+  // Gym catalog
+  await db.collection('gyms').doc('G1').collection('avatarCatalog').doc('g1_x').set({
+    isActive: true,
+    unlock: { type: 'manual' },
+  });
+  await db.collection('gyms').doc('G1').collection('avatarCatalog').doc('g1_xp').set({
+    isActive: true,
+    unlock: { type: 'xp', params: { xpThreshold: 5000 } },
+  });
+  await db.collection('gyms').doc('G1').collection('avatarCatalog').doc('g1_chal').set({
+    isActive: true,
+    unlock: { type: 'challenge', params: { challengeId: 'c123' } },
+  });
+  const window = eventWindowNow
+    ? {
+        start: new Date(Date.now() - 1000).toISOString(),
+        end: new Date(Date.now() + 60 * 1000).toISOString(),
+      }
+    : {
+        start: new Date(Date.now() + 60 * 1000).toISOString(),
+        end: new Date(Date.now() + 120 * 1000).toISOString(),
+      };
+  await db.collection('gyms').doc('G1').collection('avatarCatalog').doc('g1_event').set({
+    isActive: true,
+    unlock: { type: 'event', params: { eventId: 'e777', window } },
+  });
+}
+
+beforeEach(async () => {
+  await clearFirestoreData({ projectId: 'avatars-v2-test' });
+  await seedBase();
+});
+
+after(() => functionsTest.cleanup());
+
+function wrap(name) {
+  return functionsTest.wrap(myFunctions[name]);
+}
+
+test('onUserCreateDefaults grants two defaults once', async () => {
+  const fn = wrap('onUserCreateDefaults');
+  await fn({ uid: 'U9' });
+  const db = admin.firestore();
+  let snap = await db.collection('users').doc('U9').collection('avatarsOwned').get();
+  assert.strictEqual(snap.size, 2);
+  await fn({ uid: 'U9' });
+  snap = await db.collection('users').doc('U9').collection('avatarsOwned').get();
+  assert.strictEqual(snap.size, 2);
+});
+
+test('adminGrantAvatar respects gym boundaries and idempotence', async () => {
+  const fn = wrap('adminGrantAvatar');
+  const context = { auth: { uid: 'A1', token: { role: 'gym_admin', gymId: 'G1' } } };
+  let res = await fn({ uid: 'U1', avatarPath: 'gyms/G1/avatarCatalog/g1_x' }, context);
+  assert.strictEqual(res.status, 'granted');
+  await assert.rejects(
+    fn({ uid: 'U1', avatarPath: 'gyms/G2/avatarCatalog/g2_x' }, context),
+    /permission-denied/
+  );
+  res = await fn({ uid: 'U2', avatarPath: 'gyms/G1/avatarCatalog/g1_x' }, context);
+  assert.strictEqual(res.status, 'not_member');
+  res = await fn({ uid: 'U1', avatarPath: 'catalog/avatarsGlobal/globalX' }, context);
+  assert.strictEqual(res.status, 'granted');
+  res = await fn({ uid: 'U1', avatarPath: 'catalog/avatarsGlobal/globalX' }, context);
+  assert.strictEqual(res.status, 'noop');
+});
+
+test('onXpUpdate grants once when threshold crossed', async () => {
+  const fn = wrap('onXpUpdate');
+  const db = admin.firestore();
+  await db.collection('users').doc('U1').set({ xp: 4900 });
+  const before = { data: () => ({ xp: 4900 }) };
+  const after = { data: () => ({ xp: 5100 }) };
+  await fn({ before, after }, { params: { uid: 'U1' } });
+  let snap = await db.collection('users').doc('U1').collection('avatarsOwned').get();
+  assert.strictEqual(snap.size, 1);
+  const after2 = { data: () => ({ xp: 5200 }) };
+  await fn({ before: after, after: after2 }, { params: { uid: 'U1' } });
+  snap = await db.collection('users').doc('U1').collection('avatarsOwned').get();
+  assert.strictEqual(snap.size, 1);
+});
+
+test('onChallengeState grants once on completion', async () => {
+  const fn = wrap('onChallengeState');
+  const db = admin.firestore();
+  const before = { data: () => ({ state: 'started' }) };
+  const after = { data: () => ({ state: 'completed' }) };
+  await fn({ before, after }, { params: { gymId: 'G1', challengeId: 'c123', uid: 'U1' } });
+  let snap = await db.collection('users').doc('U1').collection('avatarsOwned').get();
+  assert.strictEqual(snap.size, 1);
+  await fn({ before: after, after }, { params: { gymId: 'G1', challengeId: 'c123', uid: 'U1' } });
+  snap = await db.collection('users').doc('U1').collection('avatarsOwned').get();
+  assert.strictEqual(snap.size, 1);
+});
+
+test('onEventParticipation grants within window and not outside', async () => {
+  const fn = wrap('onEventParticipation');
+  const db = admin.firestore();
+  // within window (seedBase already set window around now)
+  await fn({ data: () => ({}) }, { params: { gymId: 'G1', eventId: 'e777', uid: 'U1' } });
+  let snap = await db.collection('users').doc('U1').collection('avatarsOwned').get();
+  assert.strictEqual(snap.size, 1);
+  // idempotent
+  await fn({ data: () => ({}) }, { params: { gymId: 'G1', eventId: 'e777', uid: 'U1' } });
+  snap = await db.collection('users').doc('U1').collection('avatarsOwned').get();
+  assert.strictEqual(snap.size, 1);
+  // outside window
+  await clearFirestoreData({ projectId: 'avatars-v2-test' });
+  await seedBase(false); // window in future
+  await fn({ data: () => ({}) }, { params: { gymId: 'G1', eventId: 'e777', uid: 'U1' } });
+  snap = await admin.firestore().collection('users').doc('U1').collection('avatarsOwned').get();
+  assert.strictEqual(snap.size, 0);
+});
+
+test('mirrorEquippedAvatar mirrors url when asset present', async () => {
+  const fn = wrap('mirrorEquippedAvatar');
+  const db = admin.firestore();
+  const before = { data: () => ({}) };
+  const after = { data: () => ({ equippedAvatarRef: 'catalog/avatarsGlobal/default' }) };
+  await fn({ before, after }, { params: { uid: 'U1' } });
+  const profile = await db.collection('publicProfiles').doc('U1').get();
+  assert.strictEqual(profile.data().equippedAvatarRef, 'catalog/avatarsGlobal/default');
+  assert.ok(profile.data().resolvedAvatarUrl);
+});
+
+test('mirrorEquippedAvatar mirrors without url when asset missing', async () => {
+  const fn = wrap('mirrorEquippedAvatar');
+  const db = admin.firestore();
+  const before = { data: () => ({}) };
+  const after = { data: () => ({ equippedAvatarRef: 'catalog/avatarsGlobal/default2' }) };
+  await fn({ before, after }, { params: { uid: 'U1' } });
+  const profile = await db.collection('publicProfiles').doc('U1').get();
+  assert.strictEqual(profile.data().equippedAvatarRef, 'catalog/avatarsGlobal/default2');
+  assert.ok(!profile.data().resolvedAvatarUrl);
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "set-admin": "node scripts/setAdmin.js",
-    "rules-test": "mocha --timeout 120000 firestore-tests/security_rules.test.js"
+    "rules-test": "mocha --timeout 120000 firestore-tests/security_rules.test.js",
+    "test:rules": "firebase emulators:exec --only firestore 'node --test ./tests/rules/run.js'",
+    "test:functions": "cd functions && npm test",
+    "test:all": "npm run test:rules && npm run test:functions"
   },
   "repository": {
     "type": "git",

--- a/tests/rules/run.js
+++ b/tests/rules/run.js
@@ -1,0 +1,114 @@
+const { initializeTestEnvironment, assertSucceeds, assertFails } = require('@firebase/rules-unit-testing');
+const { test, before, beforeEach, after } = require('node:test');
+const assert = require('assert');
+
+let env;
+const projectId = 'avatars-v2-test';
+
+before(async () => {
+  env = await initializeTestEnvironment({ projectId });
+});
+
+after(async () => {
+  await env.cleanup();
+});
+
+beforeEach(async () => {
+  await env.clearFirestore();
+});
+
+function authed(uid, claims) {
+  return env.authenticatedContext(uid, claims).firestore();
+}
+
+function adminDb() {
+  return env.unauthenticatedContext().firestore();
+}
+
+// Gym catalog read tests
+
+test('U1 member G1 can read gyms/G1/avatarCatalog', async () => {
+  const admin = adminDb();
+  await admin.doc('gyms/G1/users/U1').set({ role: 'member' });
+  await admin.doc('gyms/G1/avatarCatalog/a').set({});
+  const db = authed('U1');
+  await assertSucceeds(db.doc('gyms/G1/avatarCatalog/a').get());
+});
+
+test('U1 cannot read gyms/G2/avatarCatalog', async () => {
+  const admin = adminDb();
+  await admin.doc('gyms/G1/users/U1').set({ role: 'member' });
+  await admin.doc('gyms/G2/avatarCatalog/a').set({});
+  const db = authed('U1');
+  await assertFails(db.doc('gyms/G2/avatarCatalog/a').get());
+});
+
+test('U2 non-member cannot read gyms/G1/avatarCatalog', async () => {
+  const admin = adminDb();
+  await admin.doc('gyms/G1/avatarCatalog/a').set({});
+  const db = authed('U2');
+  await assertFails(db.doc('gyms/G1/avatarCatalog/a').get());
+});
+
+// Global catalog read
+
+test('any authed user can read global catalog', async () => {
+  const admin = adminDb();
+  await admin.doc('catalogAvatarsGlobal/default').set({});
+  const db = authed('U1');
+  await assertSucceeds(db.doc('catalogAvatarsGlobal/default').get());
+});
+
+// Gym catalog write
+
+test('A1 admin G1 can write gyms/G1/avatarCatalog', async () => {
+  const db = authed('A1', { role: 'gym_admin', gymId: 'G1' });
+  await assertSucceeds(db.doc('gyms/G1/avatarCatalog/new').set({ isActive: true }));
+});
+
+test('A1 cannot write gyms/G2/avatarCatalog', async () => {
+  const db = authed('A1', { role: 'gym_admin', gymId: 'G1' });
+  await assertFails(db.doc('gyms/G2/avatarCatalog/new').set({ isActive: true }));
+});
+
+test('U1 cannot write gyms/G1/avatarCatalog', async () => {
+  const db = authed('U1');
+  await assertFails(db.doc('gyms/G1/avatarCatalog/new').set({ isActive: true }));
+});
+
+// Inventory
+
+test('U1 can read own avatarsOwned', async () => {
+  const admin = adminDb();
+  await admin.doc('users/U1/avatarsOwned/a').set({});
+  const db = authed('U1');
+  await assertSucceeds(db.doc('users/U1/avatarsOwned/a').get());
+});
+
+test('U2 cannot read U1 avatarsOwned', async () => {
+  const admin = adminDb();
+  await admin.doc('users/U1/avatarsOwned/a').set({});
+  const db = authed('U2');
+  await assertFails(db.doc('users/U1/avatarsOwned/a').get());
+});
+
+test('no client can write avatarsOwned', async () => {
+  const db = authed('U1');
+  await assertFails(db.doc('users/U1/avatarsOwned/a').set({}));
+});
+
+// Equip tests
+
+test('U1 can write own equippedAvatarRef', async () => {
+  const admin = adminDb();
+  await admin.doc('users/U1').set({});
+  const db = authed('U1');
+  await assertSucceeds(db.doc('users/U1').update({ equippedAvatarRef: 'catalog/avatarsGlobal/default' }));
+});
+
+test('U2 cannot write U1 equippedAvatarRef', async () => {
+  const admin = adminDb();
+  await admin.doc('users/U1').set({});
+  const db = authed('U2');
+  await assertFails(db.doc('users/U1').update({ equippedAvatarRef: 'catalog/avatarsGlobal/default' }));
+});


### PR DESCRIPTION
## Summary
- add Firestore rules test suite with gym catalog, inventory and equip checks
- add Cloud Functions tests covering default bootstrap, admin grants, XP/challenge/event unlocks and mirror consistency
- integrate emulator test scripts and GitHub Actions job

## Assumptions & Decisions
- Global avatars can be granted by any gym admin
- Cross-gym equip validation is handled outside these tests
- Emulator downloads failed in this environment; logs retained

## Testing
- `npm run test:rules` *(fails: download failed, status 403: Forbidden)*
- `npm run test:functions` *(fails: download failed, status 403: Forbidden)*

## Backout
- Revert commit `f07accc0`

------
https://chatgpt.com/codex/tasks/task_e_68bca4d1d5a0832080d1a40a1aea24a8