### PR TITLE
avatars: add runtime catalog and unify asset resolution

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -187,6 +187,11 @@ service cloud.firestore {
         allow write: if false;
       }
 
+      match /avatarInventory/{key} {
+        allow read: if isOwner(uid);
+        allow write: if isOwner(uid);
+      }
+
       // Privacy-aware public calendar (server writes)
       match /publicCalendar/{month} {
         allow read: if isAuthed() && (

--- a/lib/core/utils/avatar_assets.dart
+++ b/lib/core/utils/avatar_assets.dart
@@ -1,11 +1,20 @@
+import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
+
+/// Legacy wrapper around [AvatarCatalog].
+///
+/// New code should depend on [AvatarCatalog] directly. This class remains only
+/// for backwards compatibility with existing call sites.
 class AvatarAssets {
   AvatarAssets._();
 
-  static const defaultKey = 'default';
-  static const keys = [defaultKey, 'default2'];
+  /// Default avatar key.
+  static const defaultKey = 'global/default';
 
+  /// Returns global avatar keys.
+  static List<String> get keys => AvatarCatalog.instance.listGlobal();
+
+  /// Resolves [key] to an asset path using [AvatarCatalog].
   static String path(String key) {
-    final resolved = keys.contains(key) ? key : defaultKey;
-    return 'assets/avatars/' + resolved + '.png';
+    return AvatarCatalog.instance.resolvePath(key);
   }
 }

--- a/lib/features/avatars/domain/services/avatar_catalog.dart
+++ b/lib/features/avatars/domain/services/avatar_catalog.dart
@@ -1,0 +1,104 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+
+/// Catalog of avatar assets discovered at runtime from the [AssetManifest].
+///
+/// Keys are relative paths without the `assets/avatars/` prefix and without the
+/// `.png` extension, e.g. `global/default` or `gym_01/kurzhantel`.
+class AvatarCatalog {
+  AvatarCatalog._internal();
+
+  static final AvatarCatalog instance = AvatarCatalog._internal();
+
+  bool _loaded = false;
+  bool _loading = false;
+
+  final List<String> _global = <String>['global/default', 'global/default2'];
+  final Map<String, List<String>> _byGym = <String, List<String>>{};
+  final Set<String> _allKeys = <String>{'global/default', 'global/default2'};
+
+  Future<void> load() async {
+    if (_loaded || _loading) return;
+    _loading = true;
+    try {
+      final manifest =
+          await rootBundle.loadString('AssetManifest.json');
+      final Map<String, dynamic> data =
+          json.decode(manifest) as Map<String, dynamic>;
+      const prefix = 'assets/avatars/';
+      const ext = '.png';
+      for (final path in data.keys) {
+        if (path.startsWith(prefix) && path.endsWith(ext)) {
+          final key = path.substring(prefix.length, path.length - ext.length);
+          if (_allKeys.contains(key)) continue;
+          _allKeys.add(key);
+          if (key.startsWith('global/')) {
+            _global.add(key);
+          } else {
+            final slash = key.indexOf('/');
+            if (slash != -1) {
+              final gymId = key.substring(0, slash);
+              (_byGym[gymId] ??= <String>[]).add(key);
+            }
+          }
+        }
+      }
+      // sort for stable order
+      _global.sort();
+      for (final list in _byGym.values) {
+        list.sort();
+      }
+    } finally {
+      _loaded = true;
+      _loading = false;
+    }
+  }
+
+  /// Returns all global avatar keys.
+  List<String> listGlobal() {
+    if (!_loaded) {
+      // fire and forget load
+      unawaited(load());
+    }
+    return List<String>.from(_global);
+  }
+
+  /// Returns all avatar keys for a given gym.
+  List<String> listForGym(String gymId) {
+    if (!_loaded) {
+      unawaited(load());
+    }
+    return List<String>.from(_byGym[gymId] ?? const <String>[]);
+  }
+
+  /// Resolves [key] to the asset path. Unknown keys fall back to global/default.
+  String resolvePath(String key) {
+    final normalized = _normalize(key);
+    if (!_loaded) {
+      unawaited(load());
+    }
+    final resolved = _allKeys.contains(normalized)
+        ? normalized
+        : 'global/default';
+    return 'assets/avatars/' + resolved + '.png';
+  }
+
+  bool exists(String key) {
+    final normalized = _normalize(key);
+    if (!_loaded) {
+      unawaited(load());
+    }
+    return _allKeys.contains(normalized);
+  }
+
+  String _normalize(String key) {
+    // migration: bare "default" -> "global/default"
+    if (!key.contains('/')) {
+      return 'global/' + key;
+    }
+    return key;
+  }
+}
+

--- a/lib/features/friends/presentation/widgets/friend_list_tile.dart
+++ b/lib/features/friends/presentation/widgets/friend_list_tile.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../domain/models/public_profile.dart';
 import '../../providers/friend_presence_provider.dart';
-import 'package:tapem/core/utils/avatar_assets.dart';
+import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 
 class FriendListTile extends StatelessWidget {
   const FriendListTile({
@@ -18,11 +18,11 @@ class FriendListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final avatarKey = profile.avatarKey ?? 'default';
+    final avatarPath = AvatarCatalog.instance.resolvePath(avatarKey);
     final avatar = CircleAvatar(
       radius: 20,
-      backgroundImage: AssetImage(
-        AvatarAssets.path(profile.avatarKey ?? AvatarAssets.defaultKey),
-      ),
+      backgroundImage: AssetImage(avatarPath),
     );
     final statusColor = presence == PresenceState.workedOutToday
         ? theme.colorScheme.secondary

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -12,7 +12,7 @@ import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/widgets/brand_action_tile.dart';
 import 'package:tapem/core/logging/elog.dart';
-import 'package:tapem/core/utils/avatar_assets.dart';
+import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 import '../widgets/calendar.dart';
 import '../widgets/calendar_popup.dart';
 import '../../../survey/presentation/screens/survey_vote_screen.dart';
@@ -302,8 +302,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
                         onTap: () => _showAvatarSheet(auth),
                         child: CircleAvatar(
                           radius: avatarSize / 2,
-                          backgroundImage:
-                              AssetImage(AvatarAssets.path(auth.avatarKey)),
+                          backgroundImage: AssetImage(
+                            AvatarCatalog.instance
+                                .resolvePath(auth.avatarKey),
+                          ),
                         ),
                       ),
                     ),
@@ -433,16 +435,14 @@ class AvatarPicker extends StatelessWidget {
     super.key,
     required this.currentKey,
     required this.onSelect,
-    this.showLabels = false,
   });
 
   final String currentKey;
   final ValueChanged<String> onSelect;
-  final bool showLabels;
 
   @override
   Widget build(BuildContext context) {
-    final keys = AvatarAssets.keys;
+    final keys = AvatarCatalog.instance.listGlobal();
     final theme = Theme.of(context);
     return SafeArea(
       child: GridView.builder(
@@ -472,7 +472,9 @@ class AvatarPicker extends StatelessWidget {
                 ),
                 child: CircleAvatar(
                   radius: 40,
-                  backgroundImage: AssetImage(AvatarAssets.path(key)),
+                  backgroundImage: AssetImage(
+                    AvatarCatalog.instance.resolvePath(key),
+                  ),
                 ),
               ),
               if (selected)
@@ -487,16 +489,7 @@ class AvatarPicker extends StatelessWidget {
                 ),
             ],
           );
-          final child = showLabels
-              ? Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    avatar,
-                    const SizedBox(height: AppSpacing.xs),
-                    Text(label),
-                  ],
-                )
-              : avatar;
+          final child = avatar;
           return Tooltip(
             message: label,
             child: Semantics(

--- a/test/features/avatars/domain/services/avatar_catalog_test.dart
+++ b/test/features/avatars/domain/services/avatar_catalog_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
+
+void main() {
+  test('resolves known and unknown keys with fallback', () {
+    final catalog = AvatarCatalog.instance;
+    expect(catalog.resolvePath('default'),
+        'assets/avatars/global/default.png');
+    expect(catalog.resolvePath('global/default2'),
+        'assets/avatars/global/default2.png');
+    expect(catalog.resolvePath('mystery'),
+        'assets/avatars/global/default.png');
+  });
+}

--- a/test/features/friends/presentation/widgets/friend_list_tile_test.dart
+++ b/test/features/friends/presentation/widgets/friend_list_tile_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tapem/features/friends/domain/models/public_profile.dart';
 import 'package:tapem/features/friends/presentation/widgets/friend_list_tile.dart';
 import 'package:tapem/features/friends/providers/friend_presence_provider.dart';
-import 'package:tapem/core/utils/avatar_assets.dart';
+import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 
 void main() {
   testWidgets('renders avatar and status dot', (tester) async {
@@ -24,7 +24,7 @@ void main() {
     final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarAssets.path('default'),
+      AvatarCatalog.instance.resolvePath('default'),
     );
     expect(find.byKey(const ValueKey('status-dot')), findsOneWidget);
   });
@@ -53,7 +53,7 @@ void main() {
     var avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarAssets.path('default'),
+      AvatarCatalog.instance.resolvePath('default'),
     );
 
     await tester.pumpWidget(
@@ -68,7 +68,7 @@ void main() {
     avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarAssets.path('default2'),
+      AvatarCatalog.instance.resolvePath('default2'),
     );
   });
 
@@ -90,7 +90,7 @@ void main() {
     final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarAssets.path('default'),
+      AvatarCatalog.instance.resolvePath('default'),
     );
   });
 });

--- a/test/features/profile/profile_screen_test.dart
+++ b/test/features/profile/profile_screen_test.dart
@@ -19,7 +19,7 @@ import 'package:tapem/features/friends/providers/friend_search_provider.dart';
 import 'package:tapem/features/friends/providers/friends_provider.dart';
 import 'package:tapem/features/profile/presentation/screens/profile_screen.dart';
 import 'package:tapem/l10n/app_localizations.dart';
-import 'package:tapem/core/utils/avatar_assets.dart';
+import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 
 class MockAuthProvider extends Mock implements AuthProvider {}
 
@@ -214,7 +214,7 @@ void main() {
     final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarAssets.path('default2'),
+      AvatarCatalog.instance.resolvePath('default2'),
     );
   });
 
@@ -227,7 +227,7 @@ void main() {
     final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarAssets.path('default'),
+      AvatarCatalog.instance.resolvePath('default'),
     );
   });
 


### PR DESCRIPTION
## Summary
- build `AvatarCatalog` to index avatar assets from `AssetManifest` and resolve paths with global fallback
- update profile and friends screens to render avatars through the catalog and streamline picker grid
- extend Firestore rules to expose `avatarInventory` collection

## Testing
- `dart format lib/core/utils/avatar_assets.dart lib/features/avatars/domain/services/avatar_catalog.dart lib/features/friends/presentation/widgets/friend_list_tile.dart lib/features/profile/presentation/screens/profile_screen.dart test/features/friends/presentation/widgets/friend_list_tile_test.dart test/features/profile/profile_screen_test.dart test/features/avatars/domain/services/avatar_catalog_test.dart firestore.rules` *(command failed: dart: command not found)*
- `flutter test` *(command failed: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb089290883209e0af95c1e0e54ad