### PR TITLE
Add avatar inventory provider and picker integration

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -188,8 +188,25 @@ service cloud.firestore {
       }
 
       match /avatarInventory/{key} {
-        allow read: if isOwner(uid);
-        allow write: if isOwner(uid);
+        allow read: if isOwner(uid) || (
+          request.auth != null &&
+          request.auth.token.role == 'admin' &&
+          request.auth.token.gymId != null &&
+          exists(/databases/$(database)/documents/gyms/$(request.auth.token.gymId)/users/$(uid))
+        );
+        allow create: if request.auth != null &&
+          request.auth.token.role == 'admin' &&
+          request.auth.token.gymId != null &&
+          exists(/databases/$(database)/documents/gyms/$(request.auth.token.gymId)/users/$(uid)) &&
+          request.resource.data.keys().hasOnly(['addedAt', 'addedBy', 'source']) &&
+          request.resource.data.addedAt is timestamp &&
+          request.resource.data.addedBy == request.auth.uid &&
+          request.resource.data.source == 'gym:' + request.auth.token.gymId;
+        allow delete: if request.auth != null &&
+          request.auth.token.role == 'admin' &&
+          request.auth.token.gymId != null &&
+          exists(/databases/$(database)/documents/gyms/$(request.auth.token.gymId)/users/$(uid));
+        allow update: if false;
       }
 
       // Privacy-aware public calendar (server writes)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,6 +38,7 @@ import 'package:tapem/core/providers/rank_provider.dart';
 import 'package:tapem/core/providers/xp_provider.dart';
 import 'package:tapem/core/providers/training_plan_provider.dart';
 import 'package:tapem/core/providers/branding_provider.dart';
+import 'package:tapem/features/avatars/presentation/providers/avatar_inventory_provider.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/features/feedback/feedback_provider.dart';
 import 'package:tapem/features/survey/survey_provider.dart';
@@ -286,6 +287,7 @@ Future<void> main() async {
         // App state
         ChangeNotifierProvider(create: (_) => AppProvider()),
         ChangeNotifierProvider(create: (_) => AuthProvider()),
+        ChangeNotifierProvider(create: (_) => AvatarInventoryProvider()),
         ChangeNotifierProvider(create: (_) => SettingsProvider()),
 
         // Friends feature

--- a/test/features/profile/profile_screen_test.dart
+++ b/test/features/profile/profile_screen_test.dart
@@ -20,6 +20,7 @@ import 'package:tapem/features/friends/providers/friends_provider.dart';
 import 'package:tapem/features/profile/presentation/screens/profile_screen.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
+import 'package:tapem/features/avatars/presentation/providers/avatar_inventory_provider.dart';
 
 class MockAuthProvider extends Mock implements AuthProvider {}
 
@@ -119,16 +120,34 @@ class FakeFriendPresenceProvider extends ChangeNotifier
 
 class FakeRoute extends Fake implements Route<dynamic> {}
 
+class FakeAvatarInventoryProvider extends AvatarInventoryProvider {
+  FakeAvatarInventoryProvider(this._keys) : super();
+
+  final List<String> _keys;
+
+  @override
+  Stream<List<String>> inventoryKeys(String uid) => Stream.value(_keys);
+
+  @override
+  Future<Set<String>> getOwnedAvatarIds() async => _keys.toSet();
+
+  @override
+  bool isOwned(String avatarId) => _keys.contains(avatarId);
+}
+
 Future<void> pumpProfileScreen(
   WidgetTester tester,
   AuthProvider auth, {
   NavigatorObserver? observer,
+  AvatarInventoryProvider? inventory,
 }) async {
   final userSearch = FakeUserSearchSource();
   await tester.pumpWidget(
     MultiProvider(
       providers: [
         ChangeNotifierProvider<AuthProvider>.value(value: auth),
+        ChangeNotifierProvider<AvatarInventoryProvider>.value(
+            value: inventory ?? FakeAvatarInventoryProvider(const [])),
         ChangeNotifierProvider<ProfileProvider>(
             create: (_) => FakeProfileProvider()),
         ChangeNotifierProvider<FriendsProvider>(


### PR DESCRIPTION
## Summary
- add AvatarInventoryProvider with stream/add/remove methods
- update profile picker to read avatar inventory with global fallback
- restrict Firestore rules so only gym admins manage avatar inventories and add tests

## Testing
- `flutter test test/features/profile/profile_screen_test.dart` *(fails: command not found)*
- `npm run rules-test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb6d27a2083208aea6427d2a4b71c