### PR TITLE
feat: add admin symbol management scaffold

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -30,6 +30,8 @@ import 'package:tapem/features/friends/presentation/screens/friends_home_screen.
 import 'package:tapem/features/friends/presentation/screens/friend_detail_screen.dart';
 import 'package:tapem/features/friends/presentation/screens/friend_training_calendar_screen.dart';
 import 'package:tapem/features/creatine/presentation/screens/creatine_screen.dart';
+import 'package:tapem/features/admin/presentation/screens/admin_symbols_screen.dart';
+import 'package:tapem/features/admin/presentation/screens/user_symbols_screen.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/core/config/feature_flags.dart';
@@ -60,6 +62,8 @@ class AppRouter {
   static const deviceXp = '/device_xp';
   static const challenges = '/challenges';
   static const manageChallenges = '/manage_challenges';
+  static const adminSymbols = '/admin_symbols';
+  static const userSymbols = '/user_symbols';
   static const feedbackOverview = '/feedback_overview';
   static const surveyOverview = '/survey_overview';
   static const surveyVote = '/survey_vote';
@@ -151,6 +155,13 @@ class AppRouter {
 
       case manageChallenges:
         return MaterialPageRoute(builder: (_) => const ChallengeAdminScreen());
+
+      case adminSymbols:
+        return MaterialPageRoute(builder: (_) => const AdminSymbolsScreen());
+
+      case userSymbols:
+        final uid = settings.arguments as String? ?? '';
+        return MaterialPageRoute(builder: (_) => UserSymbolsScreen(uid: uid));
 
       case affiliate:
         return MaterialPageRoute(builder: (_) => const AffiliateScreen());

--- a/lib/features/admin/presentation/screens/admin_dashboard_screen.dart
+++ b/lib/features/admin/presentation/screens/admin_dashboard_screen.dart
@@ -17,6 +17,7 @@ import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/widgets/brand_primary_button.dart';
 import 'package:tapem/core/widgets/brand_action_tile.dart';
 import 'package:tapem/core/logging/elog.dart';
+import 'package:tapem/l10n/app_localizations.dart';
 
 class AdminDashboardScreen extends StatefulWidget {
   const AdminDashboardScreen({Key? key}) : super(key: key);
@@ -187,6 +188,7 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen> {
   @override
   Widget build(BuildContext context) {
     final auth = context.watch<AuthProvider>();
+    final loc = AppLocalizations.of(context)!;
     if (!auth.isAdmin) {
       return Scaffold(
         appBar: AppBar(title: const Text('Adminbereich')),
@@ -241,6 +243,18 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen> {
                       onTap: () {
                         Navigator.of(context)
                             .pushNamed(AppRouter.manageChallenges);
+                      },
+                      variant: BrandActionTileVariant.outlined,
+                      showChevron: false,
+                      uiLogEvent: 'ADMIN_CARD_RENDER',
+                    ),
+                    const SizedBox(height: AppSpacing.sm),
+                    BrandActionTile(
+                      leadingIcon: Icons.person,
+                      title: loc.admin_symbols_title,
+                      onTap: () {
+                        Navigator.of(context)
+                            .pushNamed(AppRouter.adminSymbols);
                       },
                       variant: BrandActionTileVariant.outlined,
                       showChevron: false,

--- a/lib/features/admin/presentation/screens/admin_symbols_screen.dart
+++ b/lib/features/admin/presentation/screens/admin_symbols_screen.dart
@@ -1,0 +1,104 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/app_router.dart';
+import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
+class AdminSymbolsScreen extends StatefulWidget {
+  const AdminSymbolsScreen({super.key, this.firestore});
+
+  final FirebaseFirestore? firestore;
+
+  @override
+  State<AdminSymbolsScreen> createState() => _AdminSymbolsScreenState();
+}
+
+class _AdminSymbolsScreenState extends State<AdminSymbolsScreen> {
+  String _query = '';
+  Timer? _debounce;
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    final auth = context.watch<AuthProvider>();
+    if (!auth.isAdmin) {
+      return Scaffold(
+        appBar: AppBar(title: Text(loc.admin_symbols_title)),
+        body: const Center(child: Text('Kein Zugriff')),
+      );
+    }
+    final gymId = auth.gymCode ?? '';
+    final fs = widget.firestore ?? FirebaseFirestore.instance;
+    final stream = fs
+        .collection('users')
+        .where('gymCodes', arrayContains: gymId)
+        .snapshots();
+    return Scaffold(
+      appBar: AppBar(title: Text(loc.admin_symbols_title)),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: TextField(
+              decoration: InputDecoration(
+                hintText: loc.admin_symbols_search_hint,
+                prefixIcon: const Icon(Icons.search),
+              ),
+              onChanged: (v) {
+                _debounce?.cancel();
+                _debounce = Timer(const Duration(milliseconds: 350), () {
+                  setState(() => _query = v.toLowerCase());
+                });
+              },
+            ),
+          ),
+          Expanded(
+            child: StreamBuilder<QuerySnapshot>(
+              stream: stream,
+              builder: (context, snapshot) {
+                final docs = snapshot.data?.docs ?? [];
+                final filtered = docs.where((d) {
+                  final uname = (d['usernameLower'] as String?) ?? '';
+                  return uname.startsWith(_query);
+                }).toList();
+                if (filtered.isEmpty) {
+                  return Center(child: Text(loc.no_members_found));
+                }
+                return ListView.builder(
+                  itemCount: filtered.length,
+                  itemBuilder: (context, index) {
+                    final doc = filtered[index];
+                    final data = doc.data() as Map<String, dynamic>;
+                    final avatarKey = (data['avatarKey'] as String?) ?? 'global/default';
+                    final path = AvatarCatalog.instance.resolvePath(avatarKey);
+                    return ListTile(
+                      leading: CircleAvatar(backgroundImage: AssetImage(path)),
+                      title: Text(data['username'] ?? doc.id),
+                      onTap: () {
+                        Navigator.of(context).pushNamed(
+                          AppRouter.userSymbols,
+                          arguments: doc.id,
+                        );
+                      },
+                    );
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/features/admin/presentation/screens/user_symbols_screen.dart
+++ b/lib/features/admin/presentation/screens/user_symbols_screen.dart
@@ -1,0 +1,150 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
+import 'package:tapem/features/avatars/presentation/providers/avatar_inventory_provider.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
+class UserSymbolsScreen extends StatelessWidget {
+  const UserSymbolsScreen({super.key, required this.uid, this.firestore});
+
+  final String uid;
+  final FirebaseFirestore? firestore;
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    final auth = context.watch<AuthProvider>();
+    if (!auth.isAdmin) {
+      return Scaffold(
+        appBar: AppBar(title: Text(loc.user_symbols_title(''))),
+        body: const Center(child: Text('Kein Zugriff')),
+      );
+    }
+    final invProv = context.read<AvatarInventoryProvider>();
+    final gymId = auth.gymCode ?? '';
+    final fs = firestore ?? FirebaseFirestore.instance;
+    return Scaffold(
+      appBar: AppBar(
+        title: StreamBuilder<DocumentSnapshot<Map<String, dynamic>>>(
+          stream: fs.collection('users').doc(uid).snapshots(),
+          builder: (context, snap) {
+            final name = snap.data?.data()?['username'] as String? ?? uid;
+            return Text(loc.user_symbols_title(name));
+          },
+        ),
+      ),
+      body: StreamBuilder<List<String>>(
+        stream: invProv.inventoryKeys(uid),
+        builder: (context, snapshot) {
+          final inv = snapshot.data ?? const <String>[];
+          if (inv.isEmpty) {
+            return Center(child: Text(loc.empty_inventory_hint));
+          }
+          return GridView.builder(
+            padding: const EdgeInsets.all(16),
+            gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+              maxCrossAxisExtent: 100,
+              mainAxisSpacing: 16,
+              crossAxisSpacing: 16,
+            ),
+            itemCount: inv.length,
+            itemBuilder: (context, index) {
+              final key = inv[index];
+              final path = AvatarCatalog.instance.resolvePath(key);
+              return CircleAvatar(
+                backgroundImage: AssetImage(path),
+                radius: 40,
+              );
+            },
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          final currentInv = await invProv.inventoryKeys(uid).first;
+          final allGymKeys = AvatarCatalog.instance.listForGym(gymId);
+          final available = allGymKeys.where((k) => !currentInv.contains(k)).toList();
+          if (available.isEmpty) {
+            // ignore: use_build_context_synchronously
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(loc.empty_gym_library_hint)),
+            );
+            return;
+          }
+          final selected = await showModalBottomSheet<List<String>>(
+            context: context,
+            builder: (ctx) {
+              final sel = <String>{};
+              return StatefulBuilder(
+                builder: (ctx2, setSt) {
+                  return SafeArea(
+                    child: Column(
+                      children: [
+                        Expanded(
+                          child: GridView.builder(
+                            padding: const EdgeInsets.all(16),
+                            gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+                              maxCrossAxisExtent: 100,
+                              mainAxisSpacing: 16,
+                              crossAxisSpacing: 16,
+                            ),
+                            itemCount: available.length,
+                            itemBuilder: (context, index) {
+                              final key = available[index];
+                              final selectedKey = sel.contains(key);
+                              final path = AvatarCatalog.instance.resolvePath(key);
+                              return GestureDetector(
+                                onTap: () => setSt(() {
+                                  if (selectedKey) {
+                                    sel.remove(key);
+                                  } else {
+                                    sel.add(key);
+                                  }
+                                }),
+                                child: Stack(
+                                  alignment: Alignment.center,
+                                  children: [
+                                    CircleAvatar(
+                                      backgroundImage: AssetImage(path),
+                                      radius: 40,
+                                    ),
+                                    if (selectedKey)
+                                      const Positioned(
+                                        right: 4,
+                                        bottom: 4,
+                                        child: Icon(Icons.check_circle, color: Colors.green),
+                                      ),
+                                  ],
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.pop(ctx2, sel.toList()),
+                          child: Text(loc.add_symbols_cta + (sel.isEmpty ? '' : ' (${sel.length})')),
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              );
+            },
+          );
+          if (selected != null && selected.isNotEmpty) {
+            await invProv.addKeys(uid, selected,
+                source: 'gym:$gymId', addedBy: auth.userId ?? '');
+            // ignore: use_build_context_synchronously
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(loc.saved_snackbar)),
+            );
+          }
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+

--- a/test/features/admin/admin_symbols_screen_test.dart
+++ b/test/features/admin/admin_symbols_screen_test.dart
@@ -1,0 +1,56 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/features/admin/presentation/screens/admin_symbols_screen.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
+class _FakeAuth extends ChangeNotifier implements AuthProvider {
+  @override
+  bool get isAdmin => true;
+  @override
+  String? get gymCode => 'g1';
+  @override
+  String? get userId => 'A1';
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  testWidgets('lists members and filters by search', (tester) async {
+    final fs = FakeFirebaseFirestore();
+    await fs.collection('users').doc('u1').set({
+      'username': 'Alice',
+      'usernameLower': 'alice',
+      'avatarKey': 'global/default',
+      'gymCodes': ['g1'],
+    });
+    await fs.collection('users').doc('u2').set({
+      'username': 'Bob',
+      'usernameLower': 'bob',
+      'avatarKey': 'global/default',
+      'gymCodes': ['g1'],
+    });
+
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AuthProvider>(
+        create: (_) => _FakeAuth(),
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: AdminSymbolsScreen(firestore: fs),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    expect(find.text('Alice'), findsOneWidget);
+    expect(find.text('Bob'), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), 'bo');
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(find.text('Alice'), findsNothing);
+    expect(find.text('Bob'), findsOneWidget);
+  });
+}

--- a/test/features/admin/user_symbols_screen_test.dart
+++ b/test/features/admin/user_symbols_screen_test.dart
@@ -1,0 +1,52 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/features/admin/presentation/screens/user_symbols_screen.dart';
+import 'package:tapem/features/avatars/presentation/providers/avatar_inventory_provider.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
+class _FakeAuth extends ChangeNotifier implements AuthProvider {
+  @override
+  bool get isAdmin => true;
+  @override
+  String? get gymCode => 'g1';
+  @override
+  String? get userId => 'A1';
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  testWidgets('shows inventory items', (tester) async {
+    final fs = FakeFirebaseFirestore();
+    await fs.collection('users').doc('u1').set({'username': 'Alice'});
+    await fs
+        .collection('users')
+        .doc('u1')
+        .collection('avatarInventory')
+        .doc('global/default')
+        .set({'addedAt': Timestamp.now(), 'source': 'global', 'addedBy': 'A1'});
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<AuthProvider>(create: (_) => _FakeAuth()),
+          ChangeNotifierProvider(
+            create: (_) => AvatarInventoryProvider(firestore: fs),
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: UserSymbolsScreen(uid: 'u1', firestore: fs),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    expect(find.byType(CircleAvatar), findsWidgets);
+  });
+}


### PR DESCRIPTION
## Summary
- add routes for admin symbol management
- list gym members for avatar assignment
- scaffold inventory management with gym library picker

## Testing
- `flutter test test/features/admin/admin_symbols_screen_test.dart` *(fails: command not found)*
- `flutter test test/features/admin/user_symbols_screen_test.dart` *(fails: command not found)*
- `npm run test:rules` *(fails: download failed, status 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbfbd3adc8320a2e73f32f73c4579