### PR TITLE
avatars(debug): asset healthcheck & usernameLower backfill

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -137,6 +137,30 @@ service cloud.firestore {
     }
 
     // ─────────────────────────
+    // Public profiles
+    // ─────────────────────────
+    match /publicProfiles/{uid} {
+      allow read: if isAuthed();
+      allow create: if isOwner(uid) &&
+        request.resource.data.keys().hasOnly(['username','usernameLower','createdAt']) &&
+        request.resource.data.username is string &&
+        request.resource.data.createdAt is timestamp &&
+        (!('usernameLower' in request.resource.data) ||
+          request.resource.data.usernameLower is string);
+      allow update: if (
+          isOwner(uid) || (
+            request.auth != null &&
+            request.auth.token.role == 'admin' &&
+            request.auth.token.gymId != null &&
+            exists(/databases/$(database)/documents/gyms/$(request.auth.token.gymId)/users/$(uid))
+          )
+        ) &&
+        request.resource.data.keys().hasOnly(['usernameLower']) &&
+        request.resource.data.usernameLower is string;
+      allow delete: if false;
+    }
+
+    // ─────────────────────────
     // Usernames mapping
     // ─────────────────────────
       match /usernames/{name} {

--- a/lib/features/admin/presentation/screens/user_symbols_screen.dart
+++ b/lib/features/admin/presentation/screens/user_symbols_screen.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
@@ -55,7 +56,13 @@ class UserSymbolsScreen extends StatelessWidget {
               final path = AvatarCatalog.instance.resolvePath(key);
               return CircleAvatar(
                 backgroundImage: AssetImage(path),
+                onBackgroundImageError: (_, __) {
+                  if (kDebugMode) {
+                    debugPrint('[Avatar] failed to load $path');
+                  }
+                },
                 radius: 40,
+                child: const Icon(Icons.person),
               );
             },
           );
@@ -108,7 +115,13 @@ class UserSymbolsScreen extends StatelessWidget {
                                   children: [
                                     CircleAvatar(
                                       backgroundImage: AssetImage(path),
+                                      onBackgroundImageError: (_, __) {
+                                        if (kDebugMode) {
+                                          debugPrint('[Avatar] failed to load $path');
+                                        }
+                                      },
                                       radius: 40,
+                                      child: const Icon(Icons.person),
                                     ),
                                     if (selectedKey)
                                       const Positioned(

--- a/lib/features/avatars/domain/services/avatar_catalog.dart
+++ b/lib/features/avatars/domain/services/avatar_catalog.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 /// Catalog of avatar assets discovered at runtime from the [AssetManifest].
@@ -79,9 +80,11 @@ class AvatarCatalog {
     if (!_loaded) {
       unawaited(load());
     }
-    final resolved = _allKeys.contains(normalized)
-        ? normalized
-        : 'global/default';
+    final exists = _allKeys.contains(normalized);
+    if (!exists && kDebugMode) {
+      debugPrint('[AvatarCatalog] unknown key "$key" – using global/default');
+    }
+    final resolved = exists ? normalized : 'global/default';
     return 'assets/avatars/' + resolved + '.png';
   }
 

--- a/lib/features/friends/domain/models/public_profile.dart
+++ b/lib/features/friends/domain/models/public_profile.dart
@@ -2,6 +2,7 @@ class PublicProfile {
   PublicProfile({
     required this.uid,
     required this.username,
+    this.usernameLower,
     this.avatarUrl,
     this.primaryGymCode,
     this.avatarKey,
@@ -9,14 +10,19 @@ class PublicProfile {
 
   final String uid;
   final String username;
+  final String? usernameLower;
   final String? avatarUrl;
   final String? primaryGymCode;
   final String? avatarKey;
+
+  String get computedUsernameLower =>
+      usernameLower ?? username.toLowerCase();
 
   factory PublicProfile.fromMap(String id, Map<String, dynamic> data) {
     return PublicProfile(
       uid: id,
       username: data['username'] as String? ?? '',
+      usernameLower: data['usernameLower'] as String?,
       avatarUrl: data['avatarUrl'] as String?,
       primaryGymCode: data['primaryGymCode'] as String?,
       avatarKey: data['avatarKey'] as String? ?? 'default',

--- a/lib/features/friends/presentation/widgets/friend_list_tile.dart
+++ b/lib/features/friends/presentation/widgets/friend_list_tile.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import '../../domain/models/public_profile.dart';
 import '../../providers/friend_presence_provider.dart';
@@ -23,6 +24,12 @@ class FriendListTile extends StatelessWidget {
     final avatar = CircleAvatar(
       radius: 20,
       backgroundImage: AssetImage(avatarPath),
+      onBackgroundImageError: (_, __) {
+        if (kDebugMode) {
+          debugPrint('[Avatar] failed to load $avatarPath');
+        }
+      },
+      child: const Icon(Icons.person),
     );
     final statusColor = presence == PresenceState.workedOutToday
         ? theme.colorScheme.secondary

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -1,5 +1,6 @@
 // lib/features/profile/presentation/screens/profile_screen.dart
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/app_provider.dart' as app;
@@ -307,6 +308,14 @@ class _ProfileScreenState extends State<ProfileScreen> {
                             AvatarCatalog.instance
                                 .resolvePath(auth.avatarKey),
                           ),
+                          onBackgroundImageError: (_, __) {
+                            if (kDebugMode) {
+                              debugPrint('[Avatar] failed to load ' +
+                                  AvatarCatalog.instance
+                                      .resolvePath(auth.avatarKey));
+                            }
+                          },
+                          child: const Icon(Icons.person),
                         ),
                       ),
                     ),
@@ -484,6 +493,13 @@ class AvatarPicker extends StatelessWidget {
                       backgroundImage: AssetImage(
                         AvatarCatalog.instance.resolvePath(key),
                       ),
+                      onBackgroundImageError: (_, __) {
+                        if (kDebugMode) {
+                          debugPrint('[Avatar] failed to load ' +
+                              AvatarCatalog.instance.resolvePath(key));
+                        }
+                      },
+                      child: const Icon(Icons.person),
                     ),
                   ),
                   if (selected)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,10 +2,12 @@
 // ignore_for_file: avoid_print, use_super_parameters
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart'
-    show defaultTargetPlatform, TargetPlatform, kIsWeb;
+    show defaultTargetPlatform, TargetPlatform, kDebugMode, kIsWeb;
+import 'package:flutter/services.dart';
 
 import 'package:firebase_auth/firebase_auth.dart' as fb_auth;
 import 'package:firebase_core/firebase_core.dart';
@@ -224,6 +226,22 @@ Future<void> main() async {
 
   // Lokalisierung
   await initializeDateFormatting();
+
+  // Avatar asset health check (debug only)
+  if (kDebugMode) {
+    final manifestStr = await rootBundle.loadString('AssetManifest.json');
+    final Map<String, dynamic> manifest = json.decode(manifestStr);
+    const def1 = 'assets/avatars/global/default.png';
+    const def2 = 'assets/avatars/global/default2.png';
+    if (!manifest.containsKey(def1)) {
+      debugPrint(
+          '[AvatarCatalog] missing $def1 in AssetBundle – app restart required: flutter clean && flutter pub get && flutter run');
+    }
+    if (!manifest.containsKey(def2)) {
+      debugPrint(
+          '[AvatarCatalog] missing $def2 in AssetBundle – app restart required: flutter clean && flutter pub get && flutter run');
+    }
+  }
 
   // Reports vorbereiten
   final reportRepo = ReportRepositoryImpl();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -118,8 +118,7 @@ flutter:
     - assets/muscle_heatmap.svg
     - assets/body_front.svg
     - assets/body_back.svg
-    - assets/avatars/default.png
-    - assets/avatars/default2.png
+    - assets/avatars/
 
 l10n:
   arb-dir: lib/l10n

--- a/test/features/admin/admin_symbols_screen_test.dart
+++ b/test/features/admin/admin_symbols_screen_test.dart
@@ -32,6 +32,11 @@ void main() {
       'avatarKey': 'global/default',
       'gymCodes': ['g1'],
     });
+    await fs.collection('users').doc('u3').set({
+      'username': 'Alina',
+      'avatarKey': 'global/default',
+      'gymCodes': ['g1'],
+    });
 
     await tester.pumpWidget(
       ChangeNotifierProvider<AuthProvider>(
@@ -47,10 +52,12 @@ void main() {
     await tester.pump();
     expect(find.text('Alice'), findsOneWidget);
     expect(find.text('Bob'), findsOneWidget);
+    expect(find.text('Alina'), findsOneWidget);
 
-    await tester.enterText(find.byType(TextField), 'bo');
+    await tester.enterText(find.byType(TextField), 'al');
     await tester.pump(const Duration(milliseconds: 400));
-    expect(find.text('Alice'), findsNothing);
-    expect(find.text('Bob'), findsOneWidget);
+    expect(find.text('Alice'), findsOneWidget);
+    expect(find.text('Alina'), findsOneWidget);
+    expect(find.text('Bob'), findsNothing);
   });
 }

--- a/test/features/avatars/domain/services/avatar_catalog_test.dart
+++ b/test/features/avatars/domain/services/avatar_catalog_test.dart
@@ -1,14 +1,24 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 
 void main() {
-  test('resolves known and unknown keys with fallback', () {
+  test('logs and falls back for unknown key', () {
+    final catalog = AvatarCatalog.instance;
+    final logs = <String?>[];
+    final old = debugPrint;
+    debugPrint = (String? message, {int? wrapWidth}) => logs.add(message);
+    expect(catalog.resolvePath('mystery'),
+        'assets/avatars/global/default.png');
+    expect(logs.last, contains('mystery'));
+    debugPrint = old;
+  });
+
+  test('legacy key normalization', () {
     final catalog = AvatarCatalog.instance;
     expect(catalog.resolvePath('default'),
         'assets/avatars/global/default.png');
-    expect(catalog.resolvePath('global/default2'),
+    expect(catalog.resolvePath('default2'),
         'assets/avatars/global/default2.png');
-    expect(catalog.resolvePath('mystery'),
-        'assets/avatars/global/default.png');
   });
 }

--- a/test/features/friends/domain/public_profile_test.dart
+++ b/test/features/friends/domain/public_profile_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/features/friends/domain/models/public_profile.dart';
+
+void main() {
+  test('computedUsernameLower falls back when field missing', () {
+    final profile = PublicProfile.fromMap('u1', {'username': 'Alice'});
+    expect(profile.computedUsernameLower, 'alice');
+  });
+
+  test('computedUsernameLower uses existing field', () {
+    final profile =
+        PublicProfile.fromMap('u1', {'username': 'Alice', 'usernameLower': 'ali'});
+    expect(profile.computedUsernameLower, 'ali');
+  });
+}


### PR DESCRIPTION
## Summary
- ensure avatars folder bundled and add startup asset health check
- log and fallback when avatar keys or assets are missing; add UI placeholders
- make PublicProfile usernameLower optional with computed getter and admin search fallback
- allow owner/admin to backfill usernameLower via Firestore rules

## Testing
- `flutter test test/features/avatars/domain/services/avatar_catalog_test.dart test/features/friends/domain/public_profile_test.dart test/features/admin/admin_symbols_screen_test.dart` *(fails: flutter not installed)*
- `npm run test:rules` *(fails: Error: download failed, status 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc8c4ea5483208bfd294c5a943977