### PR TITLE
fix: resolve analyzer errors in provider and tests

### DIFF
--- a/lib/features/avatars/presentation/providers/avatar_catalog_provider.dart
+++ b/lib/features/avatars/presentation/providers/avatar_catalog_provider.dart
@@ -3,7 +3,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import '../../data/avatar_repository.dart';
 import '../../domain/models/avatar_catalog_item.dart';
 import '../../domain/models/visible_avatar.dart';
-import '../../../core/config/remote_config.dart';
+import 'package:tapem/core/config/remote_config.dart';
 
 class AvatarCatalogProvider extends ChangeNotifier {
   AvatarCatalogProvider({FirebaseFirestore? firestore})

--- a/lib/features/friends/domain/models/public_profile.dart
+++ b/lib/features/friends/domain/models/public_profile.dart
@@ -1,5 +1,5 @@
 class PublicProfile {
-  PublicProfile({
+  const PublicProfile({
     required this.uid,
     required this.username,
     this.usernameLower,

--- a/test/features/creatine/creatine_screen_test.dart
+++ b/test/features/creatine/creatine_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/features/profile/presentation/widgets/calendar.dart';
 import 'package:tapem/features/profile/presentation/widgets/calendar_popup.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+import 'package:url_launcher_platform_interface/link.dart';
 
 class FakeRepo implements CreatineRepository {
   Set<String> dates;

--- a/test/features/profile/profile_screen_test.dart
+++ b/test/features/profile/profile_screen_test.dart
@@ -217,7 +217,7 @@ void main() {
     var key = 'default';
     final auth = MockAuthProvider();
     when(() => auth.userId).thenReturn('u1');
-    when(() => auth.avatarKey).thenAnswer(() => key);
+    when(() => auth.avatarKey).thenAnswer((_) => key);
     when(() => auth.setAvatarKey(any())).thenAnswer((invocation) async {
       key = invocation.positionalArguments.first as String;
     });


### PR DESCRIPTION
## Summary
- fix remote config import for avatar catalog provider
- mark PublicProfile constructor const for test usage
- import LinkDelegate and correct mock callback in tests

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5d66ffe08320a93ca837622fd6a3