### PR TITLE
refactor: unify avatar catalog and admin symbol flow

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -37,12 +37,12 @@ service cloud.firestore {
       return isAuthed() && request.auth.token.role == 'global_admin';
     }
 
-    // Admin for the gym of the given user
-    function isGymAdminFor(userId) {
+    // Admin for the given gym and user
+    function isGymAdminFor(userId, gymId) {
       return isAuthed() &&
              request.auth.token.role == 'admin' &&
-             request.auth.token.gymId != null &&
-             exists(/databases/$(database)/documents/gyms/$(request.auth.token.gymId)/users/$(userId));
+             request.auth.token.gymId == gymId &&
+             exists(/databases/$(database)/documents/gyms/$(gymId)/users/$(userId));
     }
 
     function isOwner(userId) {
@@ -158,7 +158,7 @@ service cloud.firestore {
       allow update: if isOwner(uid) &&
         request.resource.data.keys().hasOnly(['avatarKey']) &&
         request.resource.data.avatarKey is string;
-      allow update: if (isOwner(uid) || isGymAdminFor(uid)) &&
+      allow update: if (isOwner(uid) || isGymAdminFor(uid, request.auth.token.gymId)) &&
         request.resource.data.keys().hasOnly(['usernameLower']) &&
         request.resource.data.usernameLower is string;
       allow delete: if false;
@@ -216,14 +216,15 @@ service cloud.firestore {
       }
 
       match /avatarInventory/{key} {
-        allow read: if isOwner(uid) || isGymAdminFor(uid);
-        allow create: if isGymAdminFor(uid) &&
-          request.resource.data.keys().hasOnly(['addedAt', 'addedBy', 'source']) &&
-          request.resource.data.addedAt is timestamp &&
-          request.resource.data.addedBy == request.auth.uid &&
-          (request.resource.data.source == 'global' ||
-           request.resource.data.source == 'gym:' + request.auth.token.gymId);
-        allow delete: if isGymAdminFor(uid);
+        allow read: if isOwner(uid) || isGymAdminFor(uid, request.auth.token.gymId);
+        allow create: if isGymAdminFor(uid, request.auth.token.gymId) &&
+          request.resource.data.keys().hasOnly(['key', 'source', 'createdAt', 'createdBy', 'gymId']) &&
+          request.resource.data.createdAt is timestamp &&
+          request.resource.data.createdBy == request.auth.uid &&
+          request.resource.data.key == key &&
+          (request.resource.data.source == 'global' || request.resource.data.source == 'gym') &&
+          (!('gymId' in request.resource.data) || request.resource.data.gymId == request.auth.token.gymId);
+        allow delete: if isGymAdminFor(uid, request.auth.token.gymId);
         allow update: if false;
       }
 

--- a/lib/core/utils/avatar_assets.dart
+++ b/lib/core/utils/avatar_assets.dart
@@ -1,20 +1,7 @@
-import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
+/// Avatar key constants used throughout the app.
+class AvatarKeys {
+  AvatarKeys._();
 
-/// Legacy wrapper around [AvatarCatalog].
-///
-/// New code should depend on [AvatarCatalog] directly. This class remains only
-/// for backwards compatibility with existing call sites.
-class AvatarAssets {
-  AvatarAssets._();
-
-  /// Default avatar key.
-  static const defaultKey = 'global/default';
-
-  /// Returns global avatar keys.
-  static List<String> get keys => AvatarCatalog.instance.listGlobal();
-
-  /// Resolves [key] to an asset path using [AvatarCatalog].
-  static String path(String key) {
-    return AvatarCatalog.instance.resolvePath(key);
-  }
+  static const globalDefault = 'global/default';
+  static const globalDefault2 = 'global/default2';
 }

--- a/lib/features/admin/presentation/screens/admin_symbols_screen.dart
+++ b/lib/features/admin/presentation/screens/admin_symbols_screen.dart
@@ -92,15 +92,18 @@ class _AdminSymbolsScreenState extends State<AdminSymbolsScreen> {
                   itemBuilder: (context, index) {
                     final profile = profiles[index];
                     final avatarKey = profile.avatarKey ?? 'default';
-                    final path = AvatarCatalog.instance.resolvePath(avatarKey);
+                    final path = AvatarCatalog.instance
+                        .resolvePath(avatarKey, currentGymId: gymId);
+                    final image = Image.asset(path, errorBuilder:
+                        (_, __, ___) {
+                      if (kDebugMode) {
+                        debugPrint('[Avatar] failed to load $path');
+                      }
+                      return const Icon(Icons.person);
+                    });
                     return ListTile(
                       leading: CircleAvatar(
-                        backgroundImage: AssetImage(path),
-                        onBackgroundImageError: (_, __) {
-                          if (kDebugMode) {
-                            debugPrint('[Avatar] failed to load $path');
-                          }
-                        },
+                        backgroundImage: image.image,
                         child: const Icon(Icons.person),
                       ),
                       title: Text(profile.username.isNotEmpty

--- a/lib/features/avatars/presentation/providers/avatar_inventory_provider.dart
+++ b/lib/features/avatars/presentation/providers/avatar_inventory_provider.dart
@@ -29,7 +29,8 @@ class AvatarInventoryProvider extends ChangeNotifier {
     String uid,
     List<String> keys, {
     required String source,
-    required String addedBy,
+    required String createdBy,
+    String? gymId,
   }) async {
     final batch = _firestore.batch();
     final now = FieldValue.serverTimestamp();
@@ -40,9 +41,11 @@ class AvatarInventoryProvider extends ChangeNotifier {
           .collection('avatarInventory')
           .doc(key);
       batch.set(ref, {
-        'addedAt': now,
+        'key': key,
         'source': source,
-        'addedBy': addedBy,
+        'createdAt': now,
+        'createdBy': createdBy,
+        if (gymId != null) 'gymId': gymId,
       });
     }
     await batch.commit();

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -302,21 +302,26 @@ class _ProfileScreenState extends State<ProfileScreen> {
                       label: 'Profilbild ändern',
                       child: GestureDetector(
                         onTap: () => _showAvatarSheet(auth),
-                        child: CircleAvatar(
-                          radius: avatarSize / 2,
-                          backgroundImage: AssetImage(
-                            AvatarCatalog.instance
-                                .resolvePath(auth.avatarKey),
-                          ),
-                          onBackgroundImageError: (_, __) {
+                        child: Builder(builder: (context) {
+                          final gymId =
+                              context.read<AuthProvider>().gymCode;
+                          final path = AvatarCatalog.instance.resolvePath(
+                            auth.avatarKey,
+                            currentGymId: gymId,
+                          );
+                          final image = Image.asset(path, errorBuilder:
+                              (_, __, ___) {
                             if (kDebugMode) {
-                              debugPrint('[Avatar] failed to load ' +
-                                  AvatarCatalog.instance
-                                      .resolvePath(auth.avatarKey));
+                              debugPrint('[Avatar] failed to load $path');
                             }
-                          },
-                          child: const Icon(Icons.person),
-                        ),
+                            return const Icon(Icons.person);
+                          });
+                          return CircleAvatar(
+                            radius: avatarSize / 2,
+                            backgroundImage: image.image,
+                            child: const Icon(Icons.person),
+                          );
+                        }),
                       ),
                     ),
                   ),
@@ -488,19 +493,25 @@ class AvatarPicker extends StatelessWidget {
                         width: 2,
                       ),
                     ),
-                    child: CircleAvatar(
-                      radius: 40,
-                      backgroundImage: AssetImage(
-                        AvatarCatalog.instance.resolvePath(key),
-                      ),
-                      onBackgroundImageError: (_, __) {
+                    child: Builder(builder: (context) {
+                      final gymId = context.read<AuthProvider>().gymCode;
+                      final path = AvatarCatalog.instance.resolvePath(
+                        key,
+                        currentGymId: gymId,
+                      );
+                      final image = Image.asset(path, errorBuilder:
+                          (_, __, ___) {
                         if (kDebugMode) {
-                          debugPrint('[Avatar] failed to load ' +
-                              AvatarCatalog.instance.resolvePath(key));
+                          debugPrint('[Avatar] failed to load $path');
                         }
-                      },
-                      child: const Icon(Icons.person),
-                    ),
+                        return const Icon(Icons.person);
+                      });
+                      return CircleAvatar(
+                        radius: 40,
+                        backgroundImage: image.image,
+                        child: const Icon(Icons.person),
+                      );
+                    }),
                   ),
                   if (selected)
                     Positioned(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'dart:io' show Platform;
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, TargetPlatform, kDebugMode, kIsWeb;
 import 'package:flutter/services.dart';
+import 'features/avatars/domain/services/avatar_catalog.dart';
 
 import 'package:firebase_auth/firebase_auth.dart' as fb_auth;
 import 'package:firebase_core/firebase_core.dart';
@@ -227,31 +228,8 @@ Future<void> main() async {
   // Lokalisierung
   await initializeDateFormatting();
 
-  // Avatar asset health check (debug only)
-  if (kDebugMode) {
-    final manifestStr = await rootBundle.loadString('AssetManifest.json');
-    final Map<String, dynamic> manifest = json.decode(manifestStr);
-    const def1 = 'assets/avatars/global/default.png';
-    const def2 = 'assets/avatars/global/default2.png';
-    const legacy1 = 'assets/avatars/default.png';
-    const legacy2 = 'assets/avatars/default2.png';
-    if (!manifest.containsKey(def1)) {
-      if (manifest.containsKey(legacy1)) {
-        debugPrint('[AvatarCatalog] missing $def1, using legacy $legacy1');
-      } else {
-        debugPrint(
-            '[AvatarCatalog] missing $def1 and $legacy1 – app restart required: flutter clean && flutter pub get && flutter run');
-      }
-    }
-    if (!manifest.containsKey(def2)) {
-      if (manifest.containsKey(legacy2)) {
-        debugPrint('[AvatarCatalog] missing $def2, using legacy $legacy2');
-      } else {
-        debugPrint(
-            '[AvatarCatalog] missing $def2 and $legacy2 – app restart required: flutter clean && flutter pub get && flutter run');
-      }
-    }
-  }
+  // Warm up avatar catalog
+  await AvatarCatalog.instance.warmUp();
 
   // Reports vorbereiten
   final reportRepo = ReportRepositoryImpl();


### PR DESCRIPTION
## Summary
- normalize avatar catalog to <namespace>/<name> keys and add warm-up with manifest fallback
- rework admin symbol assignment to use gym document IDs and new catalog APIs
- enforce gym-scoped permissions and inventory fields in Firestore rules

## Testing
- `bash tool/check_avatar_paths.sh`
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7525a7c4832088b3fa43d9ff5db1