### PR TITLE
refactor: improve avatar catalog and rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -147,18 +147,18 @@ service cloud.firestore {
     // ─────────────────────────
     // Public profiles
     // ─────────────────────────
-    match /publicProfiles/{uid} {
+    match /public_profiles/{uid} {
       allow read: if isAuthed();
       allow create: if isOwner(uid) &&
-        request.resource.data.keys().hasOnly(['username','usernameLower','createdAt']) &&
-        request.resource.data.username is string &&
+        request.resource.data.keys().hasOnly(['avatarKey', 'usernameLower', 'createdAt']) &&
+        request.resource.data.avatarKey is string &&
         request.resource.data.createdAt is timestamp &&
-        (!('usernameLower' in request.resource.data) ||
-          request.resource.data.usernameLower is string);
+        (!('usernameLower' in request.resource.data) || request.resource.data.usernameLower is string);
       allow update: if isOwner(uid) &&
-        request.resource.data.keys().hasOnly(['avatarKey']) &&
-        request.resource.data.avatarKey is string;
-      allow update: if (isOwner(uid) || isGymAdminFor(uid, request.auth.token.gymId)) &&
+        request.resource.data.keys().hasOnly(['avatarKey', 'usernameLower']) &&
+        request.resource.data.avatarKey is string &&
+        (!('usernameLower' in request.resource.data) || request.resource.data.usernameLower is string);
+      allow update: if isGymAdminFor(uid, request.auth.token.gymId) &&
         request.resource.data.keys().hasOnly(['usernameLower']) &&
         request.resource.data.usernameLower is string;
       allow delete: if false;
@@ -215,15 +215,15 @@ service cloud.firestore {
         allow write: if false;
       }
 
-      match /avatarInventory/{key} {
+      match /avatarInventory/{docId} {
         allow read: if isOwner(uid) || isGymAdminFor(uid, request.auth.token.gymId);
         allow create: if isGymAdminFor(uid, request.auth.token.gymId) &&
           request.resource.data.keys().hasOnly(['key', 'source', 'createdAt', 'createdBy', 'gymId']) &&
           request.resource.data.createdAt is timestamp &&
           request.resource.data.createdBy == request.auth.uid &&
-          request.resource.data.key == key &&
-          (request.resource.data.source == 'global' || request.resource.data.source == 'gym') &&
-          (!('gymId' in request.resource.data) || request.resource.data.gymId == request.auth.token.gymId);
+          request.resource.data.key.matches('^[^/]+/[^/]+$') &&
+          ((request.resource.data.source == 'global' && !('gymId' in request.resource.data)) ||
+           (request.resource.data.source == 'gym' && request.resource.data.gymId == request.auth.token.gymId));
         allow delete: if isGymAdminFor(uid, request.auth.token.gymId);
         allow update: if false;
       }

--- a/lib/features/admin/presentation/screens/admin_symbols_screen.dart
+++ b/lib/features/admin/presentation/screens/admin_symbols_screen.dart
@@ -93,7 +93,7 @@ class _AdminSymbolsScreenState extends State<AdminSymbolsScreen> {
                     final profile = profiles[index];
                     final avatarKey = profile.avatarKey ?? 'default';
                     final path = AvatarCatalog.instance
-                        .resolvePath(avatarKey, currentGymId: gymId);
+                        .pathForKey(avatarKey, gymId: gymId);
                     final image = Image.asset(path, errorBuilder:
                         (_, __, ___) {
                       if (kDebugMode) {

--- a/lib/features/friends/presentation/widgets/friend_list_tile.dart
+++ b/lib/features/friends/presentation/widgets/friend_list_tile.dart
@@ -32,7 +32,7 @@ class FriendListTile extends StatelessWidget {
     }
     final currentGym = gymId ?? auth?.gymCode;
     final path = AvatarCatalog.instance
-        .resolvePath(avatarKey, currentGymId: currentGym);
+        .pathForKey(avatarKey, gymId: currentGym);
     final image = Image.asset(path, errorBuilder: (_, __, ___) {
       if (kDebugMode) {
         debugPrint('[Avatar] failed to load $path');

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -305,9 +305,9 @@ class _ProfileScreenState extends State<ProfileScreen> {
                         child: Builder(builder: (context) {
                           final gymId =
                               context.read<AuthProvider>().gymCode;
-                          final path = AvatarCatalog.instance.resolvePath(
+                          final path = AvatarCatalog.instance.pathForKey(
                             auth.avatarKey,
-                            currentGymId: gymId,
+                            gymId: gymId,
                           );
                           final image = Image.asset(path, errorBuilder:
                               (_, __, ___) {
@@ -498,9 +498,9 @@ class AvatarPicker extends StatelessWidget {
                     ),
                     child: Builder(builder: (context) {
                       final gymId = context.read<AuthProvider>().gymCode;
-                      final path = AvatarCatalog.instance.resolvePath(
+                      final path = AvatarCatalog.instance.pathForKey(
                         key,
-                        currentGymId: gymId,
+                        gymId: gymId,
                       );
                       final image = Image.asset(path, errorBuilder:
                           (_, __, ___) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -228,7 +228,7 @@ Future<void> main() async {
   await initializeDateFormatting();
 
   // Warm up avatar catalog
-  await AvatarCatalog.instance.warmUp();
+  await AvatarCatalog.instance.warmUp(bundle: rootBundle);
 
   // Reports vorbereiten
   final reportRepo = ReportRepositoryImpl();

--- a/test/assets_manifest_defaults_test.dart
+++ b/test/assets_manifest_defaults_test.dart
@@ -1,0 +1,20 @@
+import 'dart:convert';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('asset manifest contains required avatar defaults', () async {
+    String manifestStr;
+    try {
+      manifestStr = await rootBundle.loadString('AssetManifest.json');
+    } catch (_) {
+      manifestStr = await rootBundle.loadString('AssetManifest.bin.json');
+    }
+    final Map<String, dynamic> manifest = json.decode(manifestStr) as Map<String, dynamic>;
+    expect(manifest.containsKey('assets/avatars/global/default.png'), isTrue);
+    expect(manifest.containsKey('assets/avatars/global/default2.png'), isTrue);
+    expect(manifest.containsKey('assets/avatars/gym_01/kurzhantel.png'), isTrue);
+  });
+}

--- a/test/features/avatars/domain/services/avatar_catalog_test.dart
+++ b/test/features/avatars/domain/services/avatar_catalog_test.dart
@@ -36,11 +36,11 @@ void main() {
     final catalog = AvatarCatalog.instance;
     final gymList = catalog.listGym('gym_01');
     expect(gymList.map((e) => e.key), contains('gym_01/kurzhantel'));
-    expect(catalog.resolvePath('gym_01/kurzhantel'),
+    expect(catalog.pathForKey('gym_01/kurzhantel'),
         'assets/avatars/gym_01/kurzhantel.png');
-    expect(catalog.resolvePath('kurzhantel', currentGymId: 'gym_01'),
+    expect(catalog.pathForKey('kurzhantel', gymId: 'gym_01'),
         'assets/avatars/gym_01/kurzhantel.png');
-    expect(catalog.resolvePath('unknown'),
+    expect(catalog.pathForKey('unknown'),
         'assets/avatars/global/default.png');
   });
 }

--- a/test/features/friends/presentation/widgets/friend_list_tile_test.dart
+++ b/test/features/friends/presentation/widgets/friend_list_tile_test.dart
@@ -24,7 +24,7 @@ void main() {
     final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarCatalog.instance.resolvePath('default'),
+      AvatarCatalog.instance.pathForKey('default'),
     );
     expect(find.byKey(const ValueKey('status-dot')), findsOneWidget);
   });
@@ -53,7 +53,7 @@ void main() {
     var avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarCatalog.instance.resolvePath('default'),
+      AvatarCatalog.instance.pathForKey('default'),
     );
 
     await tester.pumpWidget(
@@ -68,7 +68,7 @@ void main() {
     avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarCatalog.instance.resolvePath('default2'),
+      AvatarCatalog.instance.pathForKey('default2'),
     );
   });
 
@@ -90,7 +90,7 @@ void main() {
     final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarCatalog.instance.resolvePath('default'),
+      AvatarCatalog.instance.pathForKey('default'),
     );
   });
 }

--- a/test/features/profile/profile_screen_test.dart
+++ b/test/features/profile/profile_screen_test.dart
@@ -233,7 +233,7 @@ void main() {
     final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarCatalog.instance.resolvePath('default2'),
+      AvatarCatalog.instance.pathForKey('default2'),
     );
   });
 
@@ -246,7 +246,7 @@ void main() {
     final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarCatalog.instance.resolvePath('default'),
+      AvatarCatalog.instance.pathForKey('default'),
     );
   });
 


### PR DESCRIPTION
## Summary
- add bundle-aware warm-up and key fallback in AvatarCatalog
- verify avatar assets via manifest test
- tighten Firestore rules for avatar inventory and public profiles

## Testing
- `tool/check_avatar_paths.sh`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0cb50d8483209a33d34188b38e30