### PR TITLE
Import Flutter services for AvatarCatalog warm-up

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:tapem/core/providers/functions_provider.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:tapem/core/providers/challenge_provider.dart';
 import 'package:tapem/l10n/app_localizations.dart';


### PR DESCRIPTION
## Summary
- fix undefined `rootBundle` by importing Flutter services in `main.dart`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68be0f2ed9c48320a63908bb9318ecbb