### PR TITLE
fix: load avatars and allow admin assignment

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -200,6 +200,9 @@ service cloud.firestore {
           'avatarUpdatedAt',
           'equippedAvatarRef'
         ]);
+      allow update: if isGymAdminFor(uid, request.auth.token.gymId) &&
+        request.resource.data.keys().hasOnly(['avatarKey']) &&
+        request.resource.data.avatarKey is string;
 
       // Friends list (symmetrische Kante)
       match /friends/{fid} {

--- a/lib/features/admin/presentation/screens/user_symbols_screen.dart
+++ b/lib/features/admin/presentation/screens/user_symbols_screen.dart
@@ -37,9 +37,13 @@ class _UserSymbolsScreenState extends State<UserSymbolsScreen> {
 
   Future<void> _init() async {
     try {
-      final doc = await _fs.collection('users').doc(widget.uid).get();
-      final gyms = (doc.data()?['gymCodes'] as List?) ?? const [];
-      _permitted = context.read<AuthProvider>().isAdmin && gyms.contains(_gymId);
+      final membership = await _fs
+          .collection('gyms')
+          .doc(_gymId)
+          .collection('users')
+          .doc(widget.uid)
+          .get();
+      _permitted = context.read<AuthProvider>().isAdmin && membership.exists;
       if (_permitted) {
         final inv = await _inventory.inventoryKeys(widget.uid).first;
         _keys = inv.toSet();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -118,7 +118,8 @@ flutter:
     - assets/muscle_heatmap.svg
     - assets/body_front.svg
     - assets/body_back.svg
-    - assets/avatars/
+    - assets/avatars/global/
+    - assets/avatars/gym_01/
 
 l10n:
   arb-dir: lib/l10n

--- a/tests/rules/run.js
+++ b/tests/rules/run.js
@@ -172,6 +172,14 @@ test('U2 cannot write U1 avatarKey', async () => {
   await assertFails(db.doc('users/U1').update({ avatarKey: 'global/default' }));
 });
 
+test('A1 admin G1 can write U1 avatarKey', async () => {
+  const admin = adminDb();
+  await admin.doc('users/U1').set({});
+  await admin.doc('gyms/G1/users/U1').set({ role: 'member' });
+  const db = authed('A1', { role: 'admin', gymId: 'G1' });
+  await assertSucceeds(db.doc('users/U1').update({ avatarKey: 'global/default' }));
+});
+
 // Equip tests
 
 test('U1 can write own equippedAvatarRef', async () => {


### PR DESCRIPTION
## Summary
- ensure avatar assets are bundled so profile images load
- validate gym membership via gyms/{gym}/users before showing admin symbol screen
- permit gym admins to update a user's avatarKey in Firestore rules
- cover admin avatarKey write with security rule test

## Testing
- `npm run test:rules` *(fails: download failed, status 403: Forbidden)*
- `npm run rules-test` *(fails: fetch failed / connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_68bf502d52408320b43ec90e0327bfd3