### PR TITLE
feat: unify avatar key resolution

### DIFF
--- a/lib/core/utils/avatar_assets.dart
+++ b/lib/core/utils/avatar_assets.dart
@@ -1,7 +1,51 @@
-/// Avatar key constants used throughout the app.
+import 'package:flutter/foundation.dart';
+import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
+
+/// Avatar key constants and helpers used throughout the app.
 class AvatarKeys {
   AvatarKeys._();
 
   static const globalDefault = 'global/default';
   static const globalDefault2 = 'global/default2';
 }
+
+/// Utilities for working with avatar keys.
+class AvatarAssets {
+  AvatarAssets._();
+
+  static final Set<String> _warned = <String>{};
+
+  /// Normalises [input] to the `<namespace>/<name>` format.
+  ///
+  /// Legacy inputs such as `default` or `default2` are mapped to
+  /// `global/default` and `global/default2` respectively. Unqualified names
+  /// will prefer the [currentGymId] namespace when available in the
+  /// [AvatarCatalog]; otherwise the global namespace is used. Unknown names
+  /// fall back to [AvatarKeys.globalDefault] with a single debug warning.
+  static String normalizeAvatarKey(
+    String input, {
+    String? currentGymId,
+    bool preferGymNamespaceForNonDefaults = true,
+  }) {
+    if (input.contains('/')) return input;
+    if (input == 'default') return AvatarKeys.globalDefault;
+    if (input == 'default2') return AvatarKeys.globalDefault2;
+
+    final catalog = AvatarCatalog.instance;
+
+    if (currentGymId != null && preferGymNamespaceForNonDefaults) {
+      final gymKey = '$currentGymId/$input';
+      if (catalog.hasKey(gymKey)) return gymKey;
+    }
+
+    final globalKey = 'global/$input';
+    if (catalog.hasKey(globalKey)) return globalKey;
+
+    if (kDebugMode && !_warned.contains(input)) {
+      debugPrint('[Avatar] unknown key "$input" – using global/default');
+      _warned.add(input);
+    }
+    return AvatarKeys.globalDefault;
+  }
+}
+

--- a/lib/features/admin/presentation/screens/admin_symbols_screen.dart
+++ b/lib/features/admin/presentation/screens/admin_symbols_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/core/utils/avatar_assets.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/features/friends/domain/models/public_profile.dart';
@@ -93,7 +94,9 @@ class _AdminSymbolsScreenState extends State<AdminSymbolsScreen> {
                     final profile = profiles[index];
                     final avatarKey = profile.avatarKey ?? 'default';
                     final path = AvatarCatalog.instance
-                        .pathForKey(avatarKey, gymId: gymId);
+                        .pathForKey(
+                            AvatarAssets.normalizeAvatarKey(avatarKey,
+                                currentGymId: gymId));
                     final image = Image.asset(path, errorBuilder:
                         (_, __, ___) {
                       if (kDebugMode) {

--- a/lib/features/admin/presentation/screens/user_symbols_screen.dart
+++ b/lib/features/admin/presentation/screens/user_symbols_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/core/utils/avatar_assets.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 import 'package:tapem/features/avatars/presentation/providers/avatar_inventory_provider.dart';
 import 'package:tapem/l10n/app_localizations.dart';
@@ -46,7 +47,8 @@ class _UserSymbolsScreenState extends State<UserSymbolsScreen> {
       _permitted = context.read<AuthProvider>().isAdmin && membership.exists;
       if (_permitted) {
         final inv = await _inventory.inventoryKeys(widget.uid).first;
-        _keys = inv.toSet();
+        _keys =
+            inv.map((k) => AvatarAssets.normalizeAvatarKey(k, currentGymId: _gymId)).toSet();
       }
     } catch (_) {
       _permitted = false;

--- a/lib/features/avatars/domain/services/avatar_catalog.dart
+++ b/lib/features/avatars/domain/services/avatar_catalog.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:tapem/core/utils/avatar_assets.dart';
 
 /// Representation of an avatar asset.
 class AvatarItem {
@@ -96,42 +97,22 @@ class AvatarCatalog {
     }
   }
 
-  String pathForKey(String key, {String? gymId}) {
+  String pathForKey(String key) {
     if (!_loaded) unawaited(warmUp());
-    String lookup = key;
-    AvatarItem? item = _items[lookup];
+    AvatarItem? item = _items[key];
     if (item == null) {
-      // legacy mapping
-      if (lookup == 'default') {
-        lookup = 'global/default';
-        item = _items[lookup];
-      } else if (lookup == 'default2') {
-        lookup = 'global/default2';
-        item = _items[lookup];
-      } else if (!lookup.contains('/')) {
-        if (gymId != null) {
-          final gymKey = '$gymId/$lookup';
-          item = _items[gymKey];
-          if (item != null) lookup = gymKey;
-        }
-        item ??= _items['global/$lookup'];
-        if (item != null) lookup = item.key;
-      }
-    }
-    // gym fallback to global
-    if (item == null && gymId != null && lookup.startsWith('$gymId/')) {
-      final name = lookup.split('/').last;
+      final name = key.split('/').last;
       item = _items['global/$name'];
     }
-    item ??= _items['global/default'];
+    item ??= _items[AvatarKeys.globalDefault];
     if (kDebugMode && !_warned.contains(key) && !_items.containsKey(key)) {
-      debugPrint('[AvatarCatalog] unknown key "$key" – using global/default');
+      debugPrint('[AvatarCatalog] unknown key "$key" – using ${item.key}');
       _warned.add(key);
     }
-    return item?.path ?? 'assets/avatars/global/default.png';
+    return item.path;
   }
 
-  bool has(String key) => _items.containsKey(key);
+  bool hasKey(String key) => _items.containsKey(key);
 
   bool hasPath(String path) =>
       _items.values.any((element) => element.path == path);

--- a/lib/features/friends/presentation/widgets/friend_list_tile.dart
+++ b/lib/features/friends/presentation/widgets/friend_list_tile.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../../domain/models/public_profile.dart';
 import '../../providers/friend_presence_provider.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/core/utils/avatar_assets.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 
 class FriendListTile extends StatelessWidget {
@@ -23,7 +24,7 @@ class FriendListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final avatarKey = profile.avatarKey ?? 'default';
+    final rawKey = profile.avatarKey ?? 'default';
     AuthProvider? auth;
     try {
       auth = Provider.of<AuthProvider>(context, listen: false);
@@ -31,8 +32,9 @@ class FriendListTile extends StatelessWidget {
       auth = null;
     }
     final currentGym = gymId ?? auth?.gymCode;
-    final path = AvatarCatalog.instance
-        .pathForKey(avatarKey, gymId: currentGym);
+    final avatarKey = AvatarAssets.normalizeAvatarKey(rawKey,
+        currentGymId: currentGym);
+    final path = AvatarCatalog.instance.pathForKey(avatarKey);
     final image = Image.asset(path, errorBuilder: (_, __, ___) {
       if (kDebugMode) {
         debugPrint('[Avatar] failed to load $path');

--- a/test/features/avatars/domain/services/avatar_catalog_test.dart
+++ b/test/features/avatars/domain/services/avatar_catalog_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/core/utils/avatar_assets.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 
 void main() {
@@ -38,9 +39,12 @@ void main() {
     expect(gymList.map((e) => e.key), contains('gym_01/kurzhantel'));
     expect(catalog.pathForKey('gym_01/kurzhantel'),
         'assets/avatars/gym_01/kurzhantel.png');
-    expect(catalog.pathForKey('kurzhantel', gymId: 'gym_01'),
+    expect(
+        catalog.pathForKey(AvatarAssets.normalizeAvatarKey('kurzhantel',
+            currentGymId: 'gym_01')),
         'assets/avatars/gym_01/kurzhantel.png');
-    expect(catalog.pathForKey('unknown'),
+    expect(
+        catalog.pathForKey(AvatarAssets.normalizeAvatarKey('unknown')),
         'assets/avatars/global/default.png');
   });
 }

--- a/test/features/friends/presentation/widgets/friend_list_tile_test.dart
+++ b/test/features/friends/presentation/widgets/friend_list_tile_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:tapem/features/friends/domain/models/public_profile.dart';
 import 'package:tapem/features/friends/presentation/widgets/friend_list_tile.dart';
 import 'package:tapem/features/friends/providers/friend_presence_provider.dart';
+import 'package:tapem/core/utils/avatar_assets.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 
 void main() {
@@ -24,7 +25,7 @@ void main() {
     final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarCatalog.instance.pathForKey('default'),
+      AvatarCatalog.instance.pathForKey(AvatarKeys.globalDefault),
     );
     expect(find.byKey(const ValueKey('status-dot')), findsOneWidget);
   });
@@ -53,7 +54,7 @@ void main() {
     var avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarCatalog.instance.pathForKey('default'),
+      AvatarCatalog.instance.pathForKey(AvatarKeys.globalDefault),
     );
 
     await tester.pumpWidget(
@@ -68,7 +69,7 @@ void main() {
     avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarCatalog.instance.pathForKey('default2'),
+      AvatarCatalog.instance.pathForKey(AvatarKeys.globalDefault2),
     );
   });
 
@@ -90,7 +91,7 @@ void main() {
     final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarCatalog.instance.pathForKey('default'),
+      AvatarCatalog.instance.pathForKey(AvatarKeys.globalDefault),
     );
   });
 }

--- a/test/features/profile/profile_screen_test.dart
+++ b/test/features/profile/profile_screen_test.dart
@@ -19,6 +19,7 @@ import 'package:tapem/features/friends/providers/friend_search_provider.dart';
 import 'package:tapem/features/friends/providers/friends_provider.dart';
 import 'package:tapem/features/profile/presentation/screens/profile_screen.dart';
 import 'package:tapem/l10n/app_localizations.dart';
+import 'package:tapem/core/utils/avatar_assets.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 import 'package:tapem/features/avatars/presentation/providers/avatar_inventory_provider.dart';
 
@@ -184,7 +185,7 @@ void main() {
   testWidgets('no username row and avatar in app bar', (tester) async {
     final auth = MockAuthProvider();
     when(() => auth.userId).thenReturn('u1');
-    when(() => auth.avatarKey).thenReturn('default');
+    when(() => auth.avatarKey).thenReturn(AvatarKeys.globalDefault);
     when(() => auth.userName).thenReturn('Admin');
 
     await pumpProfileScreen(tester, auth);
@@ -214,7 +215,7 @@ void main() {
   });
 
   testWidgets('selecting avatar updates header and persists', (tester) async {
-    var key = 'default';
+    var key = AvatarKeys.globalDefault;
     final auth = MockAuthProvider();
     when(() => auth.userId).thenReturn('u1');
     when(() => auth.avatarKey).thenAnswer((_) => key);
@@ -229,11 +230,11 @@ void main() {
     await tester.tap(find.byTooltip('Avatar 2'));
     await tester.pumpAndSettle();
 
-    verify(() => auth.setAvatarKey('default2')).called(1);
+    verify(() => auth.setAvatarKey(AvatarKeys.globalDefault2)).called(1);
     final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarCatalog.instance.pathForKey('default2'),
+      AvatarCatalog.instance.pathForKey(AvatarKeys.globalDefault2),
     );
   });
 
@@ -246,14 +247,14 @@ void main() {
     final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarCatalog.instance.pathForKey('default'),
+      AvatarCatalog.instance.pathForKey(AvatarKeys.globalDefault),
     );
   });
 
   testWidgets('actions are tappable', (tester) async {
     final auth = MockAuthProvider();
     when(() => auth.userId).thenReturn('u1');
-    when(() => auth.avatarKey).thenReturn('default');
+    when(() => auth.avatarKey).thenReturn(AvatarKeys.globalDefault);
     when(() => auth.logout()).thenAnswer((_) async {});
 
     final observer = MockNavigatorObserver();


### PR DESCRIPTION
## Summary
- add `normalizeAvatarKey` and centralize avatar key mapping
- harden `AvatarCatalog` and remove gym parameter from path lookup
- dedupe avatar inventories and use normalized keys across UI

## Testing
- `npm test` *(fails: Error: no test specified)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5a10a3b883208c1efe5086743037