### PR TITLE
Ensure default avatar asset exists and cleanup profile sorting

### DIFF
--- a/lib/features/avatars/domain/services/avatar_catalog.dart
+++ b/lib/features/avatars/domain/services/avatar_catalog.dart
@@ -105,6 +105,9 @@ class AvatarCatalog {
       item = _items['global/$name'];
     }
     item ??= _items[AvatarKeys.globalDefault];
+    if (item == null) {
+      throw StateError('AvatarCatalog missing default avatar asset');
+    }
     if (kDebugMode && !_warned.contains(key) && !_items.containsKey(key)) {
       debugPrint('[AvatarCatalog] unknown key "$key" – using ${item.key}');
       _warned.add(key);

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -495,9 +495,13 @@ class AvatarPicker extends StatelessWidget {
         final entries = map.values.toList()
           ..sort((a, b) {
             if (a.source == 'global_default' &&
-                b.source != 'global_default') return -1;
+                b.source != 'global_default') {
+              return -1;
+            }
             if (a.source != 'global_default' &&
-                b.source == 'global_default') return 1;
+                b.source == 'global_default') {
+              return 1;
+            }
             final aTime = a.createdAt?.toDate() ?? DateTime(1970);
             final bTime = b.createdAt?.toDate() ?? DateTime(1970);
             return bTime.compareTo(aTime);


### PR DESCRIPTION
## Summary
- handle missing default avatar in `AvatarCatalog.pathForKey`
- wrap comparator `if` statements in `ProfileScreen` with braces

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5d924b688320ac871a3f067ddb7c