### PR TITLE
fix: allow admins to manage symbols

### DIFF
--- a/lib/features/admin/presentation/screens/admin_symbols_screen.dart
+++ b/lib/features/admin/presentation/screens/admin_symbols_screen.dart
@@ -113,6 +113,7 @@ class _AdminSymbolsScreenState extends State<AdminSymbolsScreen> {
                           ? profile.username
                           : profile.uid),
                       onTap: () {
+                        debugPrint('[AdminSymbols] open uid=${profile.uid} gymId=$gymId');
                         Navigator.of(context).pushNamed(
                           AppRouter.userSymbols,
                           arguments: profile.uid,

--- a/lib/features/admin/presentation/screens/user_symbols_screen.dart
+++ b/lib/features/admin/presentation/screens/user_symbols_screen.dart
@@ -37,6 +37,7 @@ class _UserSymbolsScreenState extends State<UserSymbolsScreen> {
   }
 
   Future<void> _init() async {
+    debugPrint('[UserSymbols] init uid=${widget.uid} gymId=$_gymId');
     try {
       final membership = await _fs
           .collection('gyms')
@@ -44,14 +45,21 @@ class _UserSymbolsScreenState extends State<UserSymbolsScreen> {
           .collection('users')
           .doc(widget.uid)
           .get();
-      _permitted = context.read<AuthProvider>().isAdmin && membership.exists;
-      if (_permitted) {
+      debugPrint('[UserSymbols] membership exists=${membership.exists}');
+    } catch (e) {
+      debugPrint('[UserSymbols] membership fetch error: $e');
+    }
+    _permitted = context.read<AuthProvider>().isAdmin;
+    if (_permitted) {
+      try {
         final inv = await _inventory.inventoryKeys(widget.uid).first;
-        _keys =
-            inv.map((k) => AvatarAssets.normalizeAvatarKey(k, currentGymId: _gymId)).toSet();
+        _keys = inv
+            .map((k) =>
+                AvatarAssets.normalizeAvatarKey(k, currentGymId: _gymId))
+            .toSet();
+      } catch (e) {
+        debugPrint('[UserSymbols] inventory error: $e');
       }
-    } catch (_) {
-      _permitted = false;
     }
     if (mounted) {
       setState(() => _loading = false);

--- a/test/features/admin/user_symbols_screen_test.dart
+++ b/test/features/admin/user_symbols_screen_test.dart
@@ -19,6 +19,17 @@ class _FakeAuth extends ChangeNotifier implements AuthProvider {
   noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+class _NonAdminAuth extends ChangeNotifier implements AuthProvider {
+  @override
+  bool get isAdmin => false;
+  @override
+  String? get gymCode => 'g1';
+  @override
+  String? get userId => 'U2';
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
 void main() {
   testWidgets('shows inventory items', (tester) async {
     final fs = FakeFirebaseFirestore();
@@ -48,5 +59,27 @@ void main() {
 
     await tester.pump();
     expect(find.byType(CircleAvatar), findsWidgets);
+  });
+
+  testWidgets('denies access for non-admin', (tester) async {
+    final fs = FakeFirebaseFirestore();
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<AuthProvider>(create: (_) => _NonAdminAuth()),
+          ChangeNotifierProvider(
+            create: (_) => AvatarInventoryProvider(firestore: fs),
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: UserSymbolsScreen(uid: 'u1', firestore: fs),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    expect(find.text('Kein Zugriff'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- allow admin symbol management even without membership document
- log gym and membership info when opening symbol screens
- cover non-admin access with unit test

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf607407408320b2530ed9c844468f