### PR TITLE
fix: handle avatar keys with slash

### DIFF
--- a/firestore-tests/security_rules.test.js
+++ b/firestore-tests/security_rules.test.js
@@ -449,8 +449,13 @@ describe('Security Rules v1', function () {
           .collection('users')
           .doc('userA')
           .collection('avatarInventory')
-          .doc('global/default')
-          .set({ addedAt: new Date(), source: 'global' });
+          .doc('default')
+          .set({
+            key: 'global/default',
+            createdAt: new Date(),
+            source: 'global',
+            createdBy: 'seed',
+          });
       });
       const db = userA().firestore();
       await assertSucceeds(
@@ -461,7 +466,7 @@ describe('Security Rules v1', function () {
           .collection('users')
           .doc('userA')
           .collection('avatarInventory')
-          .doc('global/default2')
+          .doc('default2')
           .set({ addedAt: new Date(), source: 'global', addedBy: 'userA' })
       );
     });
@@ -473,11 +478,13 @@ describe('Security Rules v1', function () {
           .collection('users')
           .doc('userA')
           .collection('avatarInventory')
-          .doc('gym_01/kurzhantel')
+          .doc('kurzhantel')
           .set({
-            addedAt: new Date(),
-            source: 'gym:G1',
-            addedBy: 'adminA',
+            key: 'G1/kurzhantel',
+            source: 'gym',
+            createdAt: new Date(),
+            createdBy: 'adminA',
+            gymId: 'G1',
           })
       );
     });
@@ -489,11 +496,13 @@ describe('Security Rules v1', function () {
           .collection('users')
           .doc('userB')
           .collection('avatarInventory')
-          .doc('gym_01/kurzhantel')
+          .doc('kurzhantel')
           .set({
-            addedAt: new Date(),
-            source: 'gym:G1',
-            addedBy: 'adminA',
+            key: 'G1/kurzhantel',
+            source: 'gym',
+            createdAt: new Date(),
+            createdBy: 'adminA',
+            gymId: 'G1',
           })
       );
     });

--- a/lib/features/avatars/presentation/providers/avatar_inventory_provider.dart
+++ b/lib/features/avatars/presentation/providers/avatar_inventory_provider.dart
@@ -60,11 +60,12 @@ class AvatarInventoryProvider extends ChangeNotifier {
     final batch = _firestore.batch();
     final now = FieldValue.serverTimestamp();
     for (final key in keys) {
+      final docId = key.split('/').last;
       final ref = _firestore
           .collection('users')
           .doc(uid)
           .collection('avatarInventory')
-          .doc(key);
+          .doc(docId);
       batch.set(ref, {
         'key': key,
         'source': source,
@@ -78,11 +79,12 @@ class AvatarInventoryProvider extends ChangeNotifier {
 
   /// Removes [key] from the inventory of [uid].
   Future<void> removeKey(String uid, String key) {
+    final docId = key.split('/').last;
     return _firestore
         .collection('users')
         .doc(uid)
         .collection('avatarInventory')
-        .doc(key)
+        .doc(docId)
         .delete();
   }
 

--- a/test/features/admin/user_symbols_screen_test.dart
+++ b/test/features/admin/user_symbols_screen_test.dart
@@ -38,8 +38,13 @@ void main() {
         .collection('users')
         .doc('u1')
         .collection('avatarInventory')
-        .doc('global/default')
-        .set({'addedAt': Timestamp.now(), 'source': 'global', 'addedBy': 'A1'});
+        .doc('default')
+        .set({
+          'key': 'global/default',
+          'addedAt': Timestamp.now(),
+          'source': 'global',
+          'addedBy': 'A1'
+        });
 
     await tester.pumpWidget(
       MultiProvider(


### PR DESCRIPTION
## Summary
- avoid crashing when avatar keys contain `/` by storing inventory docs under sanitized IDs
- adjust tests for new inventory storage format

## Testing
- `flutter test` *(fails: command not found)*
- `npm run rules-test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*
- `npm run test:rules` *(fails: download failed, status 403: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bf66b4ff8c83208a04ed2b336cad59