### PR TITLE
fix: sanitize avatar inventory doc ids

### DIFF
--- a/lib/features/avatars/presentation/providers/avatar_inventory_provider.dart
+++ b/lib/features/avatars/presentation/providers/avatar_inventory_provider.dart
@@ -27,6 +27,8 @@ class AvatarInventoryProvider extends ChangeNotifier {
 
   Set<String>? _cache;
 
+  String _docId(String key) => key.replaceAll('/', '__');
+
   /// Stream of normalised inventory entries for [uid].
   Stream<List<AvatarInventoryEntry>> inventory(String uid,
       {String? currentGymId}) {
@@ -38,7 +40,8 @@ class AvatarInventoryProvider extends ChangeNotifier {
         .snapshots()
         .map((snap) => snap.docs.map((d) {
               final data = d.data();
-              final rawKey = data['key'] as String? ?? d.id;
+              final rawKey =
+                  data['key'] as String? ?? d.id.replaceAll('__', '/');
               final normalised = AvatarAssets.normalizeAvatarKey(rawKey,
                   currentGymId: currentGymId);
               return AvatarInventoryEntry(
@@ -96,7 +99,7 @@ class AvatarInventoryProvider extends ChangeNotifier {
           .collection('users')
           .doc(uid)
           .collection('avatarInventory')
-          .doc(normalised);
+          .doc(_docId(normalised));
       batch.set(
           ref,
           {
@@ -117,7 +120,7 @@ class AvatarInventoryProvider extends ChangeNotifier {
         .collection('users')
         .doc(uid)
         .collection('avatarInventory')
-        .doc(key)
+        .doc(_docId(key))
         .delete();
   }
 

--- a/test/features/avatars/presentation/providers/avatar_inventory_provider_test.dart
+++ b/test/features/avatars/presentation/providers/avatar_inventory_provider_test.dart
@@ -1,0 +1,33 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/features/avatars/presentation/providers/avatar_inventory_provider.dart';
+
+void main() {
+  group('AvatarInventoryProvider', () {
+    test('addKeys and removeKey use sanitized doc ids', () async {
+      final fs = FakeFirebaseFirestore();
+      final provider = AvatarInventoryProvider(firestore: fs);
+
+      await provider.addKeys('u1', ['global/kurzhantel'],
+          source: 'global', createdBy: 'admin', gymId: 'g1');
+
+      final doc = await fs
+          .collection('users')
+          .doc('u1')
+          .collection('avatarInventory')
+          .doc('global__kurzhantel')
+          .get();
+      expect(doc.exists, true);
+      expect(doc.data()?['key'], 'global/kurzhantel');
+
+      await provider.removeKey('u1', 'global/kurzhantel');
+      final after = await fs
+          .collection('users')
+          .doc('u1')
+          .collection('avatarInventory')
+          .doc('global__kurzhantel')
+          .get();
+      expect(after.exists, false);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- sanitize avatar inventory document IDs to avoid Firestore path errors when assigning symbols
- cover AvatarInventoryProvider add/remove logic with unit test

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bf711a98908320b34899430cee3501