### PR TITLE
test: update FakeAvatarInventoryProvider override

### DIFF
--- a/test/features/profile/profile_screen_test.dart
+++ b/test/features/profile/profile_screen_test.dart
@@ -127,7 +127,8 @@ class FakeAvatarInventoryProvider extends AvatarInventoryProvider {
   final List<String> _keys;
 
   @override
-  Stream<List<String>> inventoryKeys(String uid) => Stream.value(_keys);
+  Stream<List<String>> inventoryKeys(String uid, {String? currentGymId}) =>
+      Stream.value(_keys);
 
   @override
   Future<Set<String>> getOwnedAvatarIds() async => _keys.toSet();


### PR DESCRIPTION
## Summary
- update fake inventory provider to match avatar inventory provider API

## Testing
- `flutter test test/features/profile/profile_screen_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf72d994a483208387400f3b1c791a