### PR TITLE
refactor: consolidate avatar assets path

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -224,7 +224,7 @@ service cloud.firestore {
           request.resource.data.keys().hasOnly(['key', 'source', 'createdAt', 'createdBy', 'gymId']) &&
           request.resource.data.createdAt is timestamp &&
           request.resource.data.createdBy == request.auth.uid &&
-          request.resource.data.key.matches('^[^/]+/[^/]+$') &&
+          request.resource.data.key.matches('^(global|[A-Za-z0-9_-]+)/[A-Za-z0-9_-]+$') &&
           ((request.resource.data.source == 'global' && !('gymId' in request.resource.data)) ||
            (request.resource.data.source == 'gym' && request.resource.data.gymId == request.auth.token.gymId));
         allow delete: if isGymAdminFor(uid, request.auth.token.gymId);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -118,8 +118,7 @@ flutter:
     - assets/muscle_heatmap.svg
     - assets/body_front.svg
     - assets/body_back.svg
-    - assets/avatars/global/
-    - assets/avatars/gym_01/
+    - assets/avatars/
 
 l10n:
   arb-dir: lib/l10n


### PR DESCRIPTION
## Summary
- point Flutter asset configuration to a single `assets/avatars/` root
- tighten Firestore rules avatar key validation

## Testing
- `bash tool/check_avatar_paths.sh`
- `flutter test test/features/avatars/domain/services/avatar_catalog_test.dart` *(fails: command not found)*
- `npm run test:rules` *(fails: download failed, status 403: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7a63a09c8320a1a40028e85e2520