### PR TITLE
feat: admin add symbols dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
 ## Unreleased
-- Admin symbol management now separates user inventory, global assets, and gym-specific assets.
+- Added admin add-symbol dialog showing available global and gym assets.
 - Deduplicated default avatars in catalog and inventory streams.
-- Firestore rules tightened for `avatarInventory` with explicit source and gym checks.
+- Firestore rules tightened for `avatarInventory` with explicit source, gym checks and timestamp validation.

--- a/firestore-tests/avatar_inventory_rules.test.js
+++ b/firestore-tests/avatar_inventory_rules.test.js
@@ -1,0 +1,97 @@
+const path = require('path');
+const fs = require('fs');
+const {
+  initializeTestEnvironment,
+  assertFails,
+  assertSucceeds,
+} = require('@firebase/rules-unit-testing');
+const { FieldValue } = require('firebase/firestore');
+
+const firestoreRules = fs.readFileSync(
+  path.resolve(__dirname, '../firestore.rules'),
+  'utf8',
+);
+
+describe('avatarInventory rules', function () {
+  this.timeout(20000);
+  let testEnv;
+
+  before(async () => {
+    testEnv = await initializeTestEnvironment({
+      projectId: 'tap-em',
+      firestore: { rules: firestoreRules, host: '127.0.0.1', port: 8080 },
+    });
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const db = context.firestore();
+      await db.collection('gyms').doc('g1').set({ code: 'g1' });
+      await db.collection('gyms').doc('g1').collection('users').doc('userA').set({ role: 'member' });
+      await db.collection('gyms').doc('g1').collection('users').doc('adminA').set({ role: 'admin' });
+      await db.collection('gyms').doc('g2').collection('users').doc('adminB').set({ role: 'admin' });
+      await db.collection('users').doc('userA').set({});
+    });
+  });
+
+  after(async () => {
+    await testEnv.cleanup();
+  });
+
+  const adminA = () => testEnv.authenticatedContext('adminA', { gymId: 'g1', role: 'admin' });
+  const adminB = () => testEnv.authenticatedContext('adminB', { gymId: 'g2', role: 'admin' });
+  const member = () => testEnv.authenticatedContext('userA', { gymId: 'g1', role: 'member' });
+
+  it('allows gym admin to create', async () => {
+    const db = adminA().firestore();
+    const ref = db.collection('users').doc('userA').collection('avatarInventory').doc('global__x');
+    await assertSucceeds(
+      ref.set({
+        key: 'global/x',
+        source: 'admin/manual',
+        createdAt: FieldValue.serverTimestamp(),
+        createdBy: 'adminA',
+        gymId: 'g1',
+      }),
+    );
+  });
+
+  it('denies other gym admin', async () => {
+    const db = adminB().firestore();
+    const ref = db.collection('users').doc('userA').collection('avatarInventory').doc('global__y');
+    await assertFails(
+      ref.set({
+        key: 'global/y',
+        source: 'admin/manual',
+        createdAt: FieldValue.serverTimestamp(),
+        createdBy: 'adminB',
+        gymId: 'g2',
+      }),
+    );
+  });
+
+  it('denies non-admin', async () => {
+    const db = member().firestore();
+    const ref = db.collection('users').doc('userA').collection('avatarInventory').doc('global__z');
+    await assertFails(
+      ref.set({
+        key: 'global/z',
+        source: 'admin/manual',
+        createdAt: FieldValue.serverTimestamp(),
+        createdBy: 'userA',
+        gymId: 'g1',
+      }),
+    );
+  });
+
+  it('denies invalid document', async () => {
+    const db = adminA().firestore();
+    const ref = db.collection('users').doc('userA').collection('avatarInventory').doc('bad');
+    await assertFails(
+      ref.set({
+        key: 'bad key',
+        source: 'admin/manual',
+        createdAt: FieldValue.serverTimestamp(),
+        createdBy: 'adminA',
+        gymId: 'g1',
+      }),
+    );
+  });
+});

--- a/firestore.rules
+++ b/firestore.rules
@@ -229,7 +229,7 @@ service cloud.firestore {
             'createdBy',
             'gymId'
           ]) &&
-          request.resource.data.createdAt is timestamp &&
+          request.resource.data.createdAt == request.time &&
           request.resource.data.createdBy == request.auth.uid &&
           request.resource.data.key.matches('^(global|[A-Za-z0-9_-]+)/[A-Za-z0-9_-]+$') &&
           request.resource.data.source in ['admin/manual', 'system/default', 'xp', 'challenge'] &&

--- a/lib/features/admin/presentation/screens/user_symbols_screen.dart
+++ b/lib/features/admin/presentation/screens/user_symbols_screen.dart
@@ -1,7 +1,11 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'dart:async';
+
+import 'package:cloud_functions/cloud_functions.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:tapem/core/config/remote_config.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 import 'package:tapem/features/avatars/presentation/providers/avatar_inventory_provider.dart';
@@ -99,6 +103,183 @@ class _UserSymbolsScreenState extends State<UserSymbolsScreen> {
     }
   }
 
+  Future<void> _openAddDialog() async {
+    debugPrint('[UserSymbols] add_open gymId=$_gymId uid=${widget.uid}');
+    final catalog = AvatarCatalog.instance.allForContext(_gymId);
+    final global = _inventory.filterNotOwnedItems(
+        catalog.global, _keys,
+        currentGymId: _gymId);
+    final gym = _inventory.filterNotOwnedItems(
+        catalog.gym, _keys,
+        currentGymId: _gymId);
+
+    final selected = await showModalBottomSheet<List<String>>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) {
+        final picks = <String>{};
+        return StatefulBuilder(builder: (context, setState) {
+          Widget buildSection(String title, List<AvatarItem> items) {
+            if (items.isEmpty) {
+              return Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text('Keine Symbole verfügbar'),
+              );
+            }
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Text('$title (${items.length})',
+                      style: Theme.of(context).textTheme.titleMedium),
+                ),
+                GridView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  gridDelegate:
+                      const SliverGridDelegateWithMaxCrossAxisExtent(
+                    maxCrossAxisExtent: 100,
+                    mainAxisSpacing: 16,
+                    crossAxisSpacing: 16,
+                  ),
+                  itemCount: items.length,
+                  itemBuilder: (context, index) {
+                    final item = items[index];
+                    final selected = picks.contains(item.key);
+                    final image = Image.asset(item.path, errorBuilder: (_, __, ___) {
+                      if (kDebugMode) {
+                        debugPrint('[Avatar] failed to load ${item.path}');
+                      }
+                      return const Icon(Icons.person);
+                    });
+                    final ns = item.key.split('/').first;
+                    return GestureDetector(
+                      onTap: () {
+                        debugPrint(
+                            '[UserSymbols] add_select key=${item.key} source=$ns');
+                        setState(() {
+                          if (selected) {
+                            picks.remove(item.key);
+                          } else {
+                            picks.add(item.key);
+                          }
+                        });
+                      },
+                      child: Stack(
+                        alignment: Alignment.center,
+                        children: [
+                          CircleAvatar(
+                            backgroundImage: image.image,
+                            radius: 40,
+                            child: const Icon(Icons.person),
+                          ),
+                          Positioned(
+                            left: 4,
+                            top: 4,
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 4, vertical: 2),
+                              decoration: BoxDecoration(
+                                color: Colors.black54,
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                              child: Text(ns,
+                                  style: const TextStyle(
+                                      color: Colors.white, fontSize: 10)),
+                            ),
+                          ),
+                          if (selected)
+                            const Positioned(
+                              right: 4,
+                              bottom: 4,
+                              child: Icon(Icons.check_circle, color: Colors.green),
+                            ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ],
+            );
+          }
+
+          return SafeArea(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      children: [
+                        buildSection('Global', global),
+                        buildSection(_gymId, gym),
+                      ],
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: Row(
+                    children: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(context),
+                        child: const Text('Abbrechen'),
+                      ),
+                      const Spacer(),
+                      ElevatedButton(
+                        onPressed: picks.isEmpty
+                            ? null
+                            : () => Navigator.pop(context, picks.toList()),
+                        child:
+                            Text('Hinzufügen (${picks.length})'),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          );
+        });
+      },
+    );
+
+    if (selected != null && selected.isNotEmpty) {
+      setState(() => _keys.addAll(selected));
+      try {
+        await _inventory.addKeys(widget.uid, selected,
+            source: 'admin/manual',
+            createdBy: context.read<AuthProvider>().userId ?? '',
+            gymId: _gymId);
+        if (RC.avatarsV2Enabled && RC.avatarsV2GrantsEnabled) {
+          final fn = FirebaseFunctions.instance.httpsCallable('adminGrantAvatar');
+          for (final k in selected) {
+            unawaited(fn.call({'uid': widget.uid, 'key': k, 'gymId': _gymId}));
+          }
+        }
+        debugPrint(
+            '[UserSymbols] add_commit count=${selected.length} success=true');
+        // ignore: use_build_context_synchronously
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('${selected.length} Symbol(e) hinzugefügt')),
+        );
+      } on FirebaseException catch (e) {
+        setState(() => _keys.removeAll(selected));
+        debugPrint(
+            '[UserSymbols] add_commit count=${selected.length} success=false e=$e');
+        if (e.code == 'permission-denied') {
+          // ignore: use_build_context_synchronously
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+                content: Text(AppLocalizations.of(context)!
+                    .no_permission_symbols)),
+          );
+        }
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
@@ -114,17 +295,10 @@ class _UserSymbolsScreenState extends State<UserSymbolsScreen> {
         body: const Center(child: Text('Kein Zugriff')),
       );
     }
-    final catalog = AvatarCatalog.instance.allForContext(_gymId);
     final inventoryItems = _keys
         .map((k) => AvatarItem(k, AvatarCatalog.instance.pathForKey(k)))
         .toList()
       ..sort((a, b) => a.key.compareTo(b.key));
-    final globalItems = catalog.global
-        .where((item) => !_keys.contains(item.key))
-        .toList();
-    final gymItems = catalog.gym
-        .where((item) => !_keys.contains(item.key))
-        .toList();
 
     Widget buildSection(String title, List<AvatarItem> items,
         {bool allowRemove = false}) {
@@ -208,13 +382,18 @@ class _UserSymbolsScreenState extends State<UserSymbolsScreen> {
         final name = snap.data?.data()?['username'] as String? ?? widget.uid;
         return Scaffold(
           appBar: AppBar(title: Text(loc.user_symbols_title(name))),
+          floatingActionButton: _permitted && _gymId.isNotEmpty
+              ? FloatingActionButton(
+                  onPressed: _openAddDialog,
+                  tooltip: 'Symbole hinzufügen',
+                  child: const Icon(Icons.add),
+                )
+              : null,
           body: SingleChildScrollView(
             child: Column(
               children: [
                 buildSection('Inventar von $name', inventoryItems,
                     allowRemove: true),
-                buildSection('Global', globalItems),
-                buildSection(_gymId, gymItems),
               ],
             ),
           ),

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "set-admin": "node scripts/setAdmin.js",
-    "rules-test": "mocha --timeout 120000 firestore-tests/security_rules.test.js",
+    "rules-test": "mocha --timeout 120000 firestore-tests/*.test.js",
     "test:rules": "firebase emulators:exec --only firestore 'node --test ./tests/rules/run.js'",
     "test:functions": "cd functions && npm test",
     "test:all": "npm run test:rules && npm run test:functions"

--- a/test/features/avatars/presentation/providers/avatar_inventory_provider_test.dart
+++ b/test/features/avatars/presentation/providers/avatar_inventory_provider_test.dart
@@ -1,5 +1,6 @@
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 import 'package:tapem/features/avatars/presentation/providers/avatar_inventory_provider.dart';
 
 void main() {
@@ -28,6 +29,20 @@ void main() {
           .doc('global__kurzhantel')
           .get();
       expect(after.exists, false);
+    });
+
+    test('filterNotOwnedItems merges catalog and excludes owned', () {
+      final provider = AvatarInventoryProvider();
+      final catalogItems = [
+        const AvatarItem('global/default', 'p1'),
+        const AvatarItem('global/extra', 'p2'),
+        const AvatarItem('g1/kurzhantel', 'p3'),
+        const AvatarItem('g1/kurzhantel', 'p3'), // duplicate
+      ];
+      final owned = ['global/default', 'g1/other'];
+      final result =
+          provider.filterNotOwnedItems(catalogItems, owned, currentGymId: 'g1');
+      expect(result.map((e) => e.key).toList(), ['global/extra', 'g1/kurzhantel']);
     });
   });
 }


### PR DESCRIPTION
## Summary
- allow gym admins to assign extra avatar symbols via add dialog
- dedupe catalog items against inventory in provider helper
- tighten avatarInventory rules to require server timestamp

## Testing
- `flutter test` *(fails: command not found)*
- `npm run rules-test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8522b8048320b31a6382fc95a886