### PR TITLE
feat: improve avatar catalog loading and admin selection

### DIFF
--- a/lib/core/utils/avatar_assets.dart
+++ b/lib/core/utils/avatar_assets.dart
@@ -42,7 +42,8 @@ class AvatarAssets {
     if (catalog.hasKey(globalKey)) return globalKey;
 
     if (kDebugMode && !_warned.contains(input)) {
-      debugPrint('[Avatar] unknown key "$input" – using global/default');
+      debugPrint(
+          '[Avatar] unknown key "$input" gymId=${currentGymId ?? '-'} – using global/default');
       _warned.add(input);
     }
     return AvatarKeys.globalDefault;

--- a/lib/features/avatars/presentation/providers/avatar_inventory_provider.dart
+++ b/lib/features/avatars/presentation/providers/avatar_inventory_provider.dart
@@ -49,6 +49,18 @@ class AvatarInventoryProvider extends ChangeNotifier {
     }).toList();
   }
 
+  /// Computes available catalog items for [gymId] excluding [ownedKeys].
+  ({List<AvatarItem> global, List<AvatarItem> gym}) availableKeys(
+    Iterable<String> ownedKeys,
+    String gymId,
+  ) {
+    final catalog = AvatarCatalog.instance.allForContext(gymId);
+    return (
+      global: filterNotOwnedItems(catalog.global, ownedKeys, currentGymId: gymId),
+      gym: filterNotOwnedItems(catalog.gym, ownedKeys, currentGymId: gymId),
+    );
+  }
+
   /// Stream of normalised inventory entries for [uid].
   Stream<List<AvatarInventoryEntry>> inventory(String uid,
       {String? currentGymId}) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -118,6 +118,7 @@ flutter:
     - assets/muscle_heatmap.svg
     - assets/body_front.svg
     - assets/body_back.svg
+    # Bundle all avatar assets recursively
     - assets/avatars/
 
 l10n:

--- a/test/features/admin/user_symbols_screen_test.dart
+++ b/test/features/admin/user_symbols_screen_test.dart
@@ -46,6 +46,18 @@ void main() {
           'createdBy': 'A1',
           'gymId': 'gym_01'
         });
+    await fs
+        .collection('users')
+        .doc('u1')
+        .collection('avatarInventory')
+        .doc('default2')
+        .set({
+          'key': 'global/default2',
+          'createdAt': Timestamp.now(),
+          'source': 'admin/manual',
+          'createdBy': 'A1',
+          'gymId': 'gym_01'
+        });
     await fs.collection('gyms').doc('gym_01').collection('users').doc('u1').set({});
 
     await tester.pumpWidget(
@@ -70,6 +82,9 @@ void main() {
 
     await tester.tap(find.byType(FloatingActionButton));
     await tester.pumpAndSettle();
+    expect(find.text('Global (0)'), findsOneWidget);
+    expect(find.text('Alle globalen Symbole bereits zugewiesen.'),
+        findsOneWidget);
     expect(find.text('gym_01 (1)'), findsOneWidget);
     await tester.tap(find.byType(CircleAvatar).last);
     await tester.pump();

--- a/test/features/avatars/domain/services/avatar_catalog_test.dart
+++ b/test/features/avatars/domain/services/avatar_catalog_test.dart
@@ -1,4 +1,6 @@
 import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tapem/core/utils/avatar_assets.dart';
@@ -11,7 +13,9 @@ void main() {
     AvatarCatalog.instance.resetForTests();
     const manifest = {
       'assets/avatars/global/default.png': [],
+      'assets/avatars/global/default2.png': [],
       'assets/avatars/gym_01/kurzhantel.png': [],
+      'assets/avatars/Club Aktiv/ignored.png': [],
     };
     ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
       'flutter/assets',
@@ -37,6 +41,9 @@ void main() {
     final catalog = AvatarCatalog.instance;
     final gymList = catalog.listGym('gym_01');
     expect(gymList.map((e) => e.key), contains('gym_01/kurzhantel'));
+    expect(catalog.listGlobal().map((e) => e.key),
+        containsAll(['global/default', 'global/default2']));
+    expect(catalog.hasKey('Club Aktiv/ignored'), isFalse);
     expect(catalog.pathForKey('gym_01/kurzhantel'),
         'assets/avatars/gym_01/kurzhantel.png');
     expect(

--- a/test/features/avatars/presentation/providers/avatar_inventory_provider_test.dart
+++ b/test/features/avatars/presentation/providers/avatar_inventory_provider_test.dart
@@ -1,9 +1,14 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 import 'package:tapem/features/avatars/presentation/providers/avatar_inventory_provider.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   group('AvatarInventoryProvider', () {
     test('addKeys and removeKey use sanitized doc ids', () async {
       final fs = FakeFirebaseFirestore();
@@ -43,6 +48,37 @@ void main() {
       final result =
           provider.filterNotOwnedItems(catalogItems, owned, currentGymId: 'g1');
       expect(result.map((e) => e.key).toList(), ['global/extra', 'g1/kurzhantel']);
+    });
+
+    test('availableKeys returns union minus inventory', () async {
+      AvatarCatalog.instance.resetForTests();
+      const manifest = {
+        'assets/avatars/global/default.png': [],
+        'assets/avatars/global/default2.png': [],
+        'assets/avatars/gym_01/kurzhantel.png': [],
+      };
+      ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+        'flutter/assets',
+        (message) async {
+          final key = utf8.decode(message!.buffer.asUint8List());
+          if (key == 'AssetManifest.json') {
+            final data = utf8.encode(json.encode(manifest));
+            return ByteData.view(Uint8List.fromList(data).buffer);
+          }
+          return null;
+        },
+      );
+      await AvatarCatalog.instance.warmUp();
+      addTearDown(() {
+        ServicesBinding.instance.defaultBinaryMessenger
+            .setMockMessageHandler('flutter/assets', null);
+        AvatarCatalog.instance.resetForTests();
+      });
+      final provider = AvatarInventoryProvider();
+      final owned = {'global/default', 'gym_01/kurzhantel'};
+      final avail = provider.availableKeys(owned, 'gym_01');
+      expect(avail.global.map((e) => e.key), ['global/default2']);
+      expect(avail.gym, isEmpty);
     });
   });
 }


### PR DESCRIPTION
## Summary
- bundle avatar assets recursively in pubspec
- filter non-gym directories and log catalog warmup counts
- show available avatar symbols with empty-state reasons in admin UI

## Testing
- `flutter format lib/core/utils/avatar_assets.dart lib/features/avatars/domain/services/avatar_catalog.dart lib/features/avatars/presentation/providers/avatar_inventory_provider.dart lib/features/admin/presentation/screens/user_symbols_screen.dart test/features/avatars/domain/services/avatar_catalog_test.dart test/features/avatars/presentation/providers/avatar_inventory_provider_test.dart test/features/admin/user_symbols_screen_test.dart` *(fails: command not found)*
- `flutter test test/assets_manifest_defaults_test.dart test/features/avatars/domain/services/avatar_catalog_test.dart test/features/avatars/presentation/providers/avatar_inventory_provider_test.dart test/features/admin/user_symbols_screen_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c012b23d54832082e1bb6deb3ecf73