### PR TITLE
fix: add fail-loud logging for avatars

### DIFF
--- a/lib/core/utils/avatar_assets.dart
+++ b/lib/core/utils/avatar_assets.dart
@@ -46,9 +46,13 @@ class AvatarAssets {
     if (kDebugMode && _warned.add(warnKey)) {
       debugPrint('[Avatar] unknown key "$input" gymId=${currentGymId ?? '-'}');
     }
-    return catalog.hasKey(AvatarKeys.globalDefault)
-        ? AvatarKeys.globalDefault
-        : 'global/$input';
+    if (catalog.hasKey(AvatarKeys.globalDefault)) {
+      return AvatarKeys.globalDefault;
+    }
+    if (kDebugMode && _warned.add('no_default')) {
+      debugPrint('[Avatar] manifest_missing ${AvatarKeys.globalDefault}');
+    }
+    return 'global/$input';
   }
 }
 

--- a/lib/features/admin/presentation/screens/user_symbols_screen.dart
+++ b/lib/features/admin/presentation/screens/user_symbols_screen.dart
@@ -103,13 +103,13 @@ class _UserSymbolsScreenState extends State<UserSymbolsScreen> {
     }
   }
 
-  Future<void> _openAddDialog() async {
-    final catalog = AvatarCatalog.instance.allForContext(_gymId);
-    final avail = _inventory.availableKeys(_keys, _gymId);
-    final global = avail.global;
-    final gym = avail.gym;
-    debugPrint(
-        '[UserSymbols] add_open gymId=$_gymId uid=${widget.uid} + Counts: available_global=${global.length}, available_gym=${gym.length}');
+    Future<void> _openAddDialog() async {
+      final catalog = AvatarCatalog.instance.allForContext(_gymId);
+      final avail = _inventory.availableKeys(_keys, _gymId);
+      final global = avail.global;
+      final gym = avail.gym;
+      debugPrint(
+          '[UserSymbols] add_open gymId=$_gymId uid=${widget.uid} + Counts: catalog_global=${catalog.global.length}, catalog_gym=${catalog.gym.length}, available_global=${global.length}, available_gym=${gym.length}');
 
     final selected = await showModalBottomSheet<List<String>>(
       context: context,
@@ -117,16 +117,19 @@ class _UserSymbolsScreenState extends State<UserSymbolsScreen> {
       builder: (context) {
         final picks = <String>{};
         return StatefulBuilder(builder: (context, setState) {
-          Widget buildSection(
-              String title, List<AvatarItem> items, int catalogCount) {
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Text('$title (${items.length})',
-                      style: Theme.of(context).textTheme.titleMedium),
-                ),
+            Widget buildSection(
+                String title, List<AvatarItem> items, int catalogCount) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Text(
+                        kDebugMode
+                            ? '$title (${items.length}/$catalogCount)'
+                            : '$title (${items.length})',
+                        style: Theme.of(context).textTheme.titleMedium),
+                  ),
                 if (items.isEmpty)
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 16),


### PR DESCRIPTION
## Summary
- improve AvatarCatalog warmup diagnostics and fallback warnings
- show catalog counts and sample asset paths for easier debugging
- warn when global default avatar asset is missing

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0686086fc83208a3ff6d72f338cd5