### PR TITLE
fix: handle null avatar item and clean test imports

### DIFF
--- a/lib/features/avatars/domain/services/avatar_catalog.dart
+++ b/lib/features/avatars/domain/services/avatar_catalog.dart
@@ -154,7 +154,7 @@ class AvatarCatalog {
         item = _placeholder;
       }
     }
-    return item.path;
+    return item?.path ?? _placeholder.path;
   }
 
   bool hasKey(String key) => _items.containsKey(key);

--- a/test/features/avatars/domain/services/avatar_catalog_test.dart
+++ b/test/features/avatars/domain/services/avatar_catalog_test.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/features/avatars/presentation/providers/avatar_inventory_provider_test.dart
+++ b/test/features/avatars/presentation/providers/avatar_inventory_provider_test.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter/services.dart';


### PR DESCRIPTION
## Summary
- ensure avatar catalog returns placeholder path when item is null
- remove unnecessary dart:typed_data imports in avatar tests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c06ae6303c83209b6d72e8eb6815de