### PR TITLE
feat: manifest-driven avatar catalog

### DIFF
--- a/lib/core/utils/avatar_assets.dart
+++ b/lib/core/utils/avatar_assets.dart
@@ -1,6 +1,3 @@
-import 'package:flutter/foundation.dart';
-import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
-
 /// Avatar key constants and helpers used throughout the app.
 class AvatarKeys {
   AvatarKeys._();
@@ -9,50 +6,27 @@ class AvatarKeys {
   static const globalDefault2 = 'global/default2';
 }
 
-/// Utilities for working with avatar keys.
+/// Constants and helpers for avatar assets.
 class AvatarAssets {
   AvatarAssets._();
 
-  static final Set<String> _warned = <String>{};
+  static const manifestPrefix = 'assets/avatars/';
+  static const placeholderPath = 'assets/logos/logo.png';
 
   /// Normalises [input] to the `<namespace>/<name>` format.
   ///
-  /// Legacy inputs such as `default` or `default2` are mapped to
-    /// `global/default` and `global/default2` respectively. Unqualified names
-    /// will prefer the [currentGymId] namespace when available in the
-    /// [AvatarCatalog]; otherwise the global namespace is used. Unknown names
-    /// log once and fall back to [AvatarKeys.globalDefault] when present in the
-    /// manifest; otherwise a placeholder is used.
+  /// Legacy inputs such as `default` or `default2` are mapped to the
+  /// respective `global/` variants. Unqualified names prefer [currentGymId]
+  /// when provided; otherwise the global namespace is used.
   static String normalizeAvatarKey(
     String input, {
     String? currentGymId,
-    bool preferGymNamespaceForNonDefaults = true,
   }) {
     if (input.contains('/')) return input;
     if (input == 'default') return AvatarKeys.globalDefault;
     if (input == 'default2') return AvatarKeys.globalDefault2;
-
-    final catalog = AvatarCatalog.instance;
-
-    if (currentGymId != null && preferGymNamespaceForNonDefaults) {
-      final gymKey = '$currentGymId/$input';
-      if (catalog.hasKey(gymKey)) return gymKey;
-    }
-
-    final globalKey = 'global/$input';
-    if (catalog.hasKey(globalKey)) return globalKey;
-
-    final warnKey = '${currentGymId ?? '-'}:$input';
-    if (kDebugMode && _warned.add(warnKey)) {
-      debugPrint('[Avatar] unknown key "$input" gymId=${currentGymId ?? '-'}');
-    }
-    if (catalog.hasKey(AvatarKeys.globalDefault)) {
-      return AvatarKeys.globalDefault;
-    }
-    if (kDebugMode && _warned.add('no_default')) {
-      debugPrint('[Avatar] manifest_missing ${AvatarKeys.globalDefault}');
-    }
-    return 'global/$input';
+    final ns = currentGymId ?? 'global';
+    return '$ns/$input';
   }
 }
 

--- a/lib/features/avatars/presentation/providers/avatar_inventory_provider.dart
+++ b/lib/features/avatars/presentation/providers/avatar_inventory_provider.dart
@@ -1,6 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter/foundation.dart';
 import 'package:tapem/core/utils/avatar_assets.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 
@@ -30,35 +29,13 @@ class AvatarInventoryProvider extends ChangeNotifier {
 
   String _docId(String key) => key.replaceAll('/', '__');
 
-  /// Filters [items] to only those whose normalised key is not present in
-  /// [ownedKeys]. Also deduplicates keys.
-  List<AvatarItem> filterNotOwnedItems(
-    Iterable<AvatarItem> items,
-    Iterable<String> ownedKeys, {
-    String? currentGymId,
-  }) {
-    final owned = ownedKeys
-        .map((k) => AvatarAssets.normalizeAvatarKey(k, currentGymId: currentGymId))
-        .toSet();
-    final seen = <String>{};
-    return items.where((item) {
-      final key =
-          AvatarAssets.normalizeAvatarKey(item.key, currentGymId: currentGymId);
-      if (owned.contains(key) || !seen.add(key)) return false;
-      return true;
-    }).toList();
-  }
-
-  /// Computes available catalog items for [gymId] excluding [ownedKeys].
-  ({List<AvatarItem> global, List<AvatarItem> gym}) availableKeys(
+  /// Computes available catalog keys for [gymId] excluding [ownedKeys].
+  ({List<String> global, List<String> gym}) availableKeys(
     Iterable<String> ownedKeys,
     String gymId,
   ) {
-    final catalog = AvatarCatalog.instance.allForContext(gymId);
-    return (
-      global: filterNotOwnedItems(catalog.global, ownedKeys, currentGymId: gymId),
-      gym: filterNotOwnedItems(catalog.gym, ownedKeys, currentGymId: gymId),
-    );
+    final owned = ownedKeys.toSet();
+    return AvatarCatalog.instance.availableKeys(owned: owned, gymId: gymId);
   }
 
   /// Stream of normalised inventory entries for [uid].

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -230,6 +230,14 @@ Future<void> main() async {
 
   // Warm up avatar catalog
   await AvatarCatalog.instance.warmUp(bundle: rootBundle);
+  assert(() {
+    if (!AvatarCatalog.instance.warmed ||
+        !AvatarCatalog.instance.manifestHasPrefix) {
+      debugPrint(
+          '[AvatarCatalog] manifest_missing_prefix assets/avatars/ – check pubspec.yaml and assets/avatars/');
+    }
+    return true;
+  }());
 
   // Reports vorbereiten
   final reportRepo = ReportRepositoryImpl();

--- a/test/features/avatars/presentation/providers/avatar_inventory_provider_test.dart
+++ b/test/features/avatars/presentation/providers/avatar_inventory_provider_test.dart
@@ -35,20 +35,6 @@ void main() {
       expect(after.exists, false);
     });
 
-    test('filterNotOwnedItems merges catalog and excludes owned', () {
-      final provider = AvatarInventoryProvider();
-      final catalogItems = [
-        const AvatarItem('global/default', 'p1'),
-        const AvatarItem('global/extra', 'p2'),
-        const AvatarItem('g1/kurzhantel', 'p3'),
-        const AvatarItem('g1/kurzhantel', 'p3'), // duplicate
-      ];
-      final owned = ['global/default', 'g1/other'];
-      final result =
-          provider.filterNotOwnedItems(catalogItems, owned, currentGymId: 'g1');
-      expect(result.map((e) => e.key).toList(), ['global/extra', 'g1/kurzhantel']);
-    });
-
     test('availableKeys returns union minus inventory', () async {
       AvatarCatalog.instance.resetForTests();
       const manifest = {
@@ -76,7 +62,7 @@ void main() {
       final provider = AvatarInventoryProvider();
       final owned = {'global/default', 'gym_01/kurzhantel'};
       final avail = provider.availableKeys(owned, 'gym_01');
-      expect(avail.global.map((e) => e.key), ['global/default2']);
+      expect(avail.global, ['global/default2']);
       expect(avail.gym, isEmpty);
     });
   });

--- a/tool/check_avatar_paths.sh
+++ b/tool/check_avatar_paths.sh
@@ -1,9 +1,30 @@
-#!/bin/bash
-set -e
-# Fail if assets/avatars is referenced directly in lib/** excluding resolver and main.dart
-files=$(rg -l "assets/avatars" lib | grep -v "avatar_catalog.dart" | grep -v "core/utils/avatar_assets.dart" | grep -v "lib/main.dart" || true)
-if [ -n "$files" ]; then
-  echo "Disallowed assets/avatars references found:" >&2
-  echo "$files" >&2
+#!/usr/bin/env bash
+set -euo pipefail
+
+MANIFEST=${1:-build/flutter_assets/AssetManifest.json}
+
+if [[ ! -f "$MANIFEST" ]]; then
+  echo "AssetManifest not found: $MANIFEST"
   exit 1
 fi
+
+missing=0
+
+grep -q "\"assets/avatars/global/default.png\"" "$MANIFEST" || {
+  echo "missing: assets/avatars/global/default.png"
+  missing=1
+}
+
+while IFS= read -r file; do
+  rel=${file#./}
+  grep -q "\"$rel\"" "$MANIFEST" || {
+    echo "missing: $rel"
+    missing=1
+  }
+  done < <(find assets/avatars -path 'assets/avatars/gym_*/*.png' -print)
+
+if [[ $missing -ne 0 ]]; then
+  exit 1
+fi
+
+echo "All avatar paths present."


### PR DESCRIPTION
## Summary
- centralize avatar asset constants and key normalization
- implement manifest-driven avatar catalog with fallback handling
- update admin symbol flow to use new catalog and counts
- add avatar manifest check script

## Testing
- `flutter format lib/core/utils/avatar_assets.dart lib/features/avatars/domain/services/avatar_catalog.dart lib/features/avatars/presentation/providers/avatar_inventory_provider.dart lib/features/admin/presentation/screens/user_symbols_screen.dart lib/main.dart test/features/avatars/presentation/providers/avatar_inventory_provider_test.dart tool/check_avatar_paths.sh` *(fails: command not found: flutter)*
- `flutter analyze` *(fails: command not found: flutter)*
- `flutter test` *(fails: command not found: flutter)*
- `tool/check_avatar_paths.sh` *(fails: AssetManifest not found: build/flutter_assets/AssetManifest.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0787fa25c8320a2423b847fe9f5d2