### PR TITLE
refactor: update avatar catalog usage

### DIFF
--- a/lib/features/admin/presentation/screens/admin_symbols_screen.dart
+++ b/lib/features/admin/presentation/screens/admin_symbols_screen.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
-import 'package:tapem/core/utils/avatar_assets.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/features/friends/domain/models/public_profile.dart';
@@ -93,10 +92,10 @@ class _AdminSymbolsScreenState extends State<AdminSymbolsScreen> {
                   itemBuilder: (context, index) {
                     final profile = profiles[index];
                     final avatarKey = profile.avatarKey ?? 'default';
-                    final path = AvatarCatalog.instance
-                        .pathForKey(
-                            AvatarAssets.normalizeAvatarKey(avatarKey,
-                                currentGymId: gymId));
+                    final path = AvatarCatalog.instance.resolvePathOrFallback(
+                      avatarKey,
+                      gymId: gymId,
+                    );
                     final image = Image.asset(path, errorBuilder:
                         (_, __, ___) {
                       if (kDebugMode) {

--- a/lib/features/avatars/presentation/providers/avatar_inventory_provider.dart
+++ b/lib/features/avatars/presentation/providers/avatar_inventory_provider.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
 import 'package:tapem/core/utils/avatar_assets.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 

--- a/lib/features/friends/presentation/widgets/friend_list_tile.dart
+++ b/lib/features/friends/presentation/widgets/friend_list_tile.dart
@@ -4,7 +4,6 @@ import 'package:provider/provider.dart';
 import '../../domain/models/public_profile.dart';
 import '../../providers/friend_presence_provider.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
-import 'package:tapem/core/utils/avatar_assets.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 
 class FriendListTile extends StatelessWidget {
@@ -32,9 +31,8 @@ class FriendListTile extends StatelessWidget {
       auth = null;
     }
     final currentGym = gymId ?? auth?.gymCode;
-    final avatarKey = AvatarAssets.normalizeAvatarKey(rawKey,
-        currentGymId: currentGym);
-    final path = AvatarCatalog.instance.pathForKey(avatarKey);
+    final path =
+        AvatarCatalog.instance.resolvePathOrFallback(rawKey, gymId: currentGym);
     final image = Image.asset(path, errorBuilder: (_, __, ___) {
       if (kDebugMode) {
         debugPrint('[Avatar] failed to load $path');

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -310,12 +310,9 @@ class _ProfileScreenState extends State<ProfileScreen> {
                         child: Builder(builder: (context) {
                           final gymId =
                               context.read<AuthProvider>().gymCode;
-                          final normalized = AvatarAssets.normalizeAvatarKey(
-                            auth.avatarKey,
-                            currentGymId: gymId,
-                          );
-                          final path =
-                              AvatarCatalog.instance.pathForKey(normalized);
+                          final path = AvatarCatalog.instance
+                              .resolvePathOrFallback(auth.avatarKey,
+                                  gymId: gymId);
                           final image = Image.asset(path, errorBuilder:
                               (_, __, ___) {
                             if (kDebugMode) {
@@ -535,12 +532,10 @@ class AvatarPicker extends StatelessWidget {
                     ),
                     child: Builder(builder: (context) {
                       final gymId = context.read<AuthProvider>().gymCode;
-                      final normalized = AvatarAssets.normalizeAvatarKey(
+                      final path = AvatarCatalog.instance.resolvePathOrFallback(
                         key,
-                        currentGymId: gymId,
+                        gymId: gymId,
                       );
-                      final path =
-                          AvatarCatalog.instance.pathForKey(normalized);
                       final image = Image.asset(path, errorBuilder:
                           (_, __, ___) {
                         if (kDebugMode) {

--- a/test/features/avatars/domain/services/avatar_catalog_test.dart
+++ b/test/features/avatars/domain/services/avatar_catalog_test.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:tapem/core/utils/avatar_assets.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 
 void main() {
@@ -38,19 +37,14 @@ void main() {
 
   test('catalog mapping and resolver', () {
     final catalog = AvatarCatalog.instance;
-    final gymList = catalog.listGym('gym_01');
-    expect(gymList.map((e) => e.key), contains('gym_01/kurzhantel'));
-    expect(catalog.listGlobal().map((e) => e.key),
-        containsAll(['global/default', 'global/default2']));
-    expect(catalog.hasKey('Club Aktiv/ignored'), isFalse);
-    expect(catalog.pathForKey('gym_01/kurzhantel'),
+    expect(catalog.globalCount, 2);
+    expect(catalog.gymCount('gym_01'), 1);
+    expect(catalog.resolvePathOrFallback('gym_01/kurzhantel'),
         'assets/avatars/gym_01/kurzhantel.png');
     expect(
-        catalog.pathForKey(AvatarAssets.normalizeAvatarKey('kurzhantel',
-            currentGymId: 'gym_01')),
+        catalog.resolvePathOrFallback('kurzhantel', gymId: 'gym_01'),
         'assets/avatars/gym_01/kurzhantel.png');
-    expect(
-        catalog.pathForKey(AvatarAssets.normalizeAvatarKey('unknown')),
+    expect(catalog.resolvePathOrFallback('unknown'),
         'assets/avatars/global/default.png');
   });
 }

--- a/test/features/friends/presentation/widgets/friend_list_tile_test.dart
+++ b/test/features/friends/presentation/widgets/friend_list_tile_test.dart
@@ -34,7 +34,8 @@ void main() {
     final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarCatalog.instance.pathForKey(AvatarKeys.globalDefault),
+      AvatarCatalog.instance
+          .resolvePathOrFallback(AvatarKeys.globalDefault),
     );
     expect(find.byKey(const ValueKey('status-dot')), findsOneWidget);
   });
@@ -63,7 +64,8 @@ void main() {
     var avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarCatalog.instance.pathForKey(AvatarKeys.globalDefault),
+      AvatarCatalog.instance
+          .resolvePathOrFallback(AvatarKeys.globalDefault),
     );
 
     await tester.pumpWidget(
@@ -78,7 +80,8 @@ void main() {
     avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarCatalog.instance.pathForKey(AvatarKeys.globalDefault2),
+      AvatarCatalog.instance
+          .resolvePathOrFallback(AvatarKeys.globalDefault2),
     );
   });
 
@@ -100,7 +103,8 @@ void main() {
     final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarCatalog.instance.pathForKey(AvatarKeys.globalDefault),
+      AvatarCatalog.instance
+          .resolvePathOrFallback(AvatarKeys.globalDefault),
     );
   });
 }

--- a/test/features/profile/profile_screen_test.dart
+++ b/test/features/profile/profile_screen_test.dart
@@ -244,7 +244,8 @@ void main() {
     final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarCatalog.instance.pathForKey(AvatarKeys.globalDefault2),
+      AvatarCatalog.instance
+          .resolvePathOrFallback(AvatarKeys.globalDefault2),
     );
   });
 
@@ -257,7 +258,8 @@ void main() {
     final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
     expect(
       (avatar.backgroundImage as AssetImage).assetName,
-      AvatarCatalog.instance.pathForKey(AvatarKeys.globalDefault),
+      AvatarCatalog.instance
+          .resolvePathOrFallback(AvatarKeys.globalDefault),
     );
   });
 


### PR DESCRIPTION
## Summary
- fix AvatarInventoryProvider by importing ChangeNotifier
- replace deprecated AvatarCatalog.pathForKey with resolvePathOrFallback across app and tests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c07ddb29288320aa994bfd64f9899d