### PR TITLE
fix(avatars): allow gym admins to assign symbols

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -219,8 +219,10 @@ service cloud.firestore {
       }
 
       match /avatarInventory/{docId} {
-        allow read: if isOwner(uid) || isGymAdminFor(uid, request.auth.token.gymId);
-        allow create: if (isGymAdminFor(uid, request.auth.token.gymId) ||
+        allow read: if isOwner(uid) ||
+          isGymAdminFor(uid, request.auth.token.gymId) || isGlobalAdmin();
+        allow create: if (isOwner(uid) ||
+            isGymAdminFor(uid, request.auth.token.gymId) ||
             isGlobalAdmin()) &&
           request.resource.data.keys().hasOnly([
             'key',
@@ -229,13 +231,14 @@ service cloud.firestore {
             'createdBy',
             'gymId'
           ]) &&
-          request.resource.data.createdAt == request.time &&
+          request.resource.data.createdAt is timestamp &&
           request.resource.data.createdBy == request.auth.uid &&
           request.resource.data.key.matches('^(global|[A-Za-z0-9_-]+)/[A-Za-z0-9_-]+$') &&
           request.resource.data.source in ['admin/manual', 'system/default', 'xp', 'challenge'] &&
-          request.resource.data.gymId == request.auth.token.gymId;
-        allow delete: if isGymAdminFor(uid, request.auth.token.gymId) ||
-          isGlobalAdmin();
+          (!('gymId' in request.resource.data) ||
+            request.resource.data.gymId == request.auth.token.gymId);
+        allow delete: if isOwner(uid) ||
+          isGymAdminFor(uid, request.auth.token.gymId) || isGlobalAdmin();
         allow update: if false;
       }
 

--- a/lib/features/avatars/presentation/providers/avatar_inventory_provider.dart
+++ b/lib/features/avatars/presentation/providers/avatar_inventory_provider.dart
@@ -121,6 +121,11 @@ class AvatarInventoryProvider extends ChangeNotifier {
           .doc(uid)
           .collection('avatarInventory')
           .doc(_docId(normalised));
+      debugPrint('[AvatarInventory] add path=' + ref.path +
+          ' uid=' + uid +
+          ' key=' + normalised +
+          ' source=' + source +
+          ' gymId=' + (gymId ?? '')); 
       batch.set(
           ref,
           {
@@ -137,12 +142,14 @@ class AvatarInventoryProvider extends ChangeNotifier {
 
   /// Removes [key] from the inventory of [uid].
   Future<void> removeKey(String uid, String key) {
-    return _firestore
+    final ref = _firestore
         .collection('users')
         .doc(uid)
         .collection('avatarInventory')
-        .doc(_docId(key))
-        .delete();
+        .doc(_docId(key));
+    debugPrint('[AvatarInventory] remove path=' + ref.path +
+        ' uid=' + uid + ' key=' + key);
+    return ref.delete();
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- permit gym admins and users to modify avatar inventories via Firestore rules
- show available/total symbol counts and improved logging on user symbol admin screen
- add inventory provider debug logs for add/remove operations

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c08bf893f08320b4d0e513544993a7