### PR TITLE
fix: remove profile icon overlay from avatars

### DIFF
--- a/lib/features/admin/presentation/screens/admin_symbols_screen.dart
+++ b/lib/features/admin/presentation/screens/admin_symbols_screen.dart
@@ -106,7 +106,6 @@ class _AdminSymbolsScreenState extends State<AdminSymbolsScreen> {
                     return ListTile(
                       leading: CircleAvatar(
                         backgroundImage: image.image,
-                        child: const Icon(Icons.person),
                       ),
                       title: Text(profile.username.isNotEmpty
                           ? profile.username

--- a/lib/features/admin/presentation/screens/user_symbols_screen.dart
+++ b/lib/features/admin/presentation/screens/user_symbols_screen.dart
@@ -188,7 +188,6 @@ class _UserSymbolsScreenState extends State<UserSymbolsScreen> {
                             CircleAvatar(
                               backgroundImage: image.image,
                               radius: 40,
-                              child: const Icon(Icons.person),
                             ),
                             Positioned(
                               left: 4,
@@ -367,7 +366,6 @@ class _UserSymbolsScreenState extends State<UserSymbolsScreen> {
                     CircleAvatar(
                       backgroundImage: image.image,
                       radius: 40,
-                      child: const Icon(Icons.person),
                     ),
                     Positioned(
                       left: 4,

--- a/lib/features/friends/presentation/widgets/friend_list_tile.dart
+++ b/lib/features/friends/presentation/widgets/friend_list_tile.dart
@@ -42,7 +42,6 @@ class FriendListTile extends StatelessWidget {
     final avatar = CircleAvatar(
       radius: 20,
       backgroundImage: image.image,
-      child: const Icon(Icons.person),
     );
     final statusColor = presence == PresenceState.workedOutToday
         ? theme.colorScheme.secondary

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -323,7 +323,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
                           return CircleAvatar(
                             radius: avatarSize / 2,
                             backgroundImage: image.image,
-                            child: const Icon(Icons.person),
                           );
                         }),
                       ),
@@ -546,7 +545,6 @@ class AvatarPicker extends StatelessWidget {
                       return CircleAvatar(
                         radius: 40,
                         backgroundImage: image.image,
-                        child: const Icon(Icons.person),
                       );
                     }),
                   ),


### PR DESCRIPTION
## Summary
- avoid stacking placeholder icon on avatars in friend list and profile views
- clean up admin screens to show only avatar images

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c09565a41883208824c88b37b601af