### PR TITLE
feat: apply magenta theme to lifthouse_koblenz

### DIFF
--- a/lib/core/theme/app_brand_theme.dart
+++ b/lib/core/theme/app_brand_theme.dart
@@ -193,7 +193,7 @@ class AppBrandTheme extends ThemeExtension<AppBrandTheme> {
     );
   }
 
-  /// Magenta/violet CTA preset used for `gym_01`.
+  /// Magenta/violet CTA preset used for `lifthouse_koblenz`.
   static AppBrandTheme magenta() {
     final gradient = AppGradients.brandGradient;
     final lums = gradient.colors.map((c) => c.computeLuminance());

--- a/lib/core/theme/design_tokens.dart
+++ b/lib/core/theme/design_tokens.dart
@@ -64,7 +64,7 @@ class Tone {
   }
 }
 
-/// Dynamic tone tokens used for brightness normalisation in `gym_01`.
+/// Dynamic tone tokens used for brightness normalisation in `lifthouse_koblenz`.
 class MagentaTones {
   /// Reference luminance derived from the "Letzte Session" card.
   static double brightnessAnchor =

--- a/lib/core/theme/theme_loader.dart
+++ b/lib/core/theme/theme_loader.dart
@@ -25,7 +25,7 @@ class ThemeLoader extends ChangeNotifier {
 
   /// Wendet Branding-Daten auf das aktuelle Theme an.
   void applyBranding(String? gymId, Branding? branding) {
-    if (gymId == 'gym_01') {
+    if (gymId == 'lifthouse_koblenz') {
       if (branding == null) {
         _applyMagentaDefaults();
         notifyListeners();

--- a/test/theme/theme_loader_test.dart
+++ b/test/theme/theme_loader_test.dart
@@ -8,16 +8,16 @@ import 'package:tapem/core/theme/brand_on_colors.dart';
 
 void main() {
   group('ThemeLoader', () {
-    test('gym_01 without branding uses magenta theme', () {
+    test('lifthouse_koblenz without branding uses magenta theme', () {
       final loader = ThemeLoader()..loadDefault();
-      loader.applyBranding('gym_01', null);
+      loader.applyBranding('lifthouse_koblenz', null);
       expect(loader.theme.colorScheme.primary, MagentaColors.primary600);
     });
 
-    test('gym_01 with branding applies custom colors', () {
+    test('lifthouse_koblenz with branding applies custom colors', () {
       final loader = ThemeLoader()..loadDefault();
       loader.applyBranding(
-        'gym_01',
+        'lifthouse_koblenz',
         Branding(primaryColor: '#123456', secondaryColor: '#654321'),
       );
       expect(loader.theme.colorScheme.primary,
@@ -65,9 +65,9 @@ void main() {
       expect(on.onCta, Colors.black);
     });
 
-    test('gym_01 surfaces are normalised to reference luminance', () {
+    test('lifthouse_koblenz surfaces are normalised to reference luminance', () {
       final loader = ThemeLoader()..loadDefault();
-      loader.applyBranding('gym_01', null);
+      loader.applyBranding('lifthouse_koblenz', null);
 
       final anchor = MagentaTones.brightnessAnchor;
       final grad = AppGradients.brandGradient;


### PR DESCRIPTION
## Summary
- activate magenta theme for `lifthouse_koblenz` gym
- update design tokens and brand theme docs for new gym id
- adjust ThemeLoader tests to use `lifthouse_koblenz`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a80c08f08320b8b7dba23ab0428a