### PR TITLE
feat: support slug-based gym avatar namespaces

### DIFF
--- a/lib/core/utils/avatar_assets.dart
+++ b/lib/core/utils/avatar_assets.dart
@@ -1,3 +1,5 @@
+import 'package:path/path.dart' as p;
+
 /// Avatar key constants and helpers used throughout the app.
 class AvatarKeys {
   AvatarKeys._();
@@ -12,21 +14,50 @@ class AvatarAssets {
 
   static const manifestPrefix = 'assets/avatars/';
   static const placeholderPath = 'assets/logos/logo.png';
+  static final RegExp _slugPattern = RegExp(r'^[a-z0-9_]+$');
+
+  static bool isGlobalNamespace(String ns) => ns == 'global';
+  static bool isGymNamespace(String ns) =>
+      ns != 'global' && _slugPattern.hasMatch(ns);
 
   /// Normalises [input] to the `<namespace>/<name>` format.
   ///
-  /// Legacy inputs such as `default` or `default2` are mapped to the
-  /// respective `global/` variants. Unqualified names prefer [currentGymId]
-  /// when provided; otherwise the global namespace is used.
-  static String normalizeAvatarKey(
+  /// Inputs may already be in `<namespace>/<name>` or full asset paths like
+  /// `assets/avatars/<namespace>/<name>.png`. Optional `.png` suffixes are
+  /// removed. Legacy names like `default`/`default2` are mapped to the
+  /// respective global keys. Unqualified names prefer [currentGymId] when
+  /// provided; otherwise the global namespace is used.
+  static String normalizeKey(
     String input, {
     String? currentGymId,
   }) {
-    if (input.contains('/')) return input;
-    if (input == 'default') return AvatarKeys.globalDefault;
-    if (input == 'default2') return AvatarKeys.globalDefault2;
-    final ns = currentGymId ?? 'global';
-    return '$ns/$input';
+    var key = input.trim();
+    if (key.isEmpty) return AvatarKeys.globalDefault;
+
+    if (key.startsWith(manifestPrefix)) {
+      key = key.substring(manifestPrefix.length);
+    }
+
+    key = key.replaceAll('\\', '/');
+
+    if (!key.contains('/')) {
+      if (key == 'default') return AvatarKeys.globalDefault;
+      if (key == 'default2') return AvatarKeys.globalDefault2;
+      final ns = currentGymId ?? 'global';
+      return '$ns/${p.basenameWithoutExtension(key)}';
+    }
+
+    final parts = key.split('/');
+    final ns = parts.first;
+    final name = p.basenameWithoutExtension(parts.last);
+    return '$ns/$name';
   }
+
+  @Deprecated('Use normalizeKey')
+  static String normalizeAvatarKey(
+    String input, {
+    String? currentGymId,
+  }) =>
+      normalizeKey(input, currentGymId: currentGymId);
 }
 

--- a/lib/features/admin/presentation/screens/user_symbols_screen.dart
+++ b/lib/features/admin/presentation/screens/user_symbols_screen.dart
@@ -112,9 +112,16 @@ class _UserSymbolsScreenState extends State<UserSymbolsScreen> {
 
     Future<void> _openAddDialog() async {
       final catalog = AvatarCatalog.instance;
-      final avail = catalog.availableKeys(owned: _keys, gymId: _gymId);
-      final global = avail.global;
-      final gym = avail.gym;
+      final global = catalog
+          .availableGlobalKeys()
+          .where((k) => !_keys.contains(k))
+          .toList()
+        ..sort();
+      final gym = catalog
+          .availableGymKeys(_gymId)
+          .where((k) => !_keys.contains(k))
+          .toList()
+        ..sort();
       debugPrint('[UserSymbols] add_open gymId=$_gymId uid=${widget.uid} + Counts: catalog_global='
           '${catalog.globalCount}, catalog_gym=${catalog.gymCount(_gymId)}, available_global=${global.length}, available_gym=${gym.length}');
 


### PR DESCRIPTION
## Summary
- support slugs for gym avatar namespaces instead of gym_ prefix
- index avatar assets by namespace/gym slug from manifest
- show gym-specific avatars in admin UI using slug-based lookups

## Testing
- `dart format lib/core/utils/avatar_assets.dart lib/features/avatars/domain/services/avatar_catalog.dart lib/features/admin/presentation/screens/user_symbols_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bdfe2f68832095cc96bfcd47a224