### PR TITLE
feat: close keypad after last set

### DIFF
--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -388,8 +388,12 @@ class OverlayNumericKeypad extends StatelessWidget {
     final idx = prov.completeNextFilledSet();
     if (idx != null) {
       elogUi('AUTO_CHECK_NEXT_OK', {'completedIndex': idx});
+      if (prov.nextFilledNotDoneIndex() == null) {
+        controller.close();
+      }
     } else {
       elogUi('AUTO_CHECK_NEXT_SKIP', {'reason': 'none'});
+      controller.close();
     }
     _haptic(context);
   }

--- a/test/ui/overlay_numeric_keypad_test.dart
+++ b/test/ui/overlay_numeric_keypad_test.dart
@@ -1,6 +1,42 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tapem/ui/numeric_keypad/overlay_numeric_keypad.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/device_provider.dart';
+import 'package:tapem/features/device/domain/repositories/device_repository.dart';
+import 'package:tapem/features/device/domain/models/device.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
+import 'package:tapem/services/membership_service.dart';
+
+class _FakeDeviceRepository implements DeviceRepository {
+  @override
+  Future<List<Device>> getDevicesForGym(String gymId) async => [];
+  @override
+  Future<void> createDevice(String gymId, Device device) => throw UnimplementedError();
+  @override
+  Future<Device?> getDeviceByNfcCode(String gymId, String nfcCode) => throw UnimplementedError();
+  @override
+  Future<void> deleteDevice(String gymId, String deviceId) => throw UnimplementedError();
+  @override
+  Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) => throw UnimplementedError();
+  @override
+  Future<void> setMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) => throw UnimplementedError();
+  @override
+  Future<void> writeSessionSnapshot(String gymId, DeviceSessionSnapshot snapshot) async {}
+  @override
+  Future<List<DeviceSessionSnapshot>> fetchSessionSnapshotsPaginated({required String gymId, required String deviceId, required String userId, required int limit, DocumentSnapshot? startAfter,}) async => <DeviceSessionSnapshot>[];
+  @override
+  Future<DeviceSessionSnapshot?> getSnapshotBySessionId({required String gymId, required String deviceId, required String sessionId,}) async => null;
+  @override
+  DocumentSnapshot? get lastSnapshotCursor => null;
+}
+
+class _FakeMembershipService implements MembershipService {
+  @override
+  Future<void> ensureMembership(String gymId, String uid) async {}
+}
 
 void main() {
   testWidgets('Overlay keypad inputs and backspace works', (tester) async {
@@ -92,6 +128,40 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(pressed, true);
+    expect(controller.isOpen, false);
+  });
+
+  testWidgets('check button closes overlay when all sets done', (tester) async {
+    final controller = OverlayNumericKeypadController();
+    final textCtrl = TextEditingController();
+    final provider = DeviceProvider(
+      firestore: FakeFirebaseFirestore(),
+      deviceRepository: _FakeDeviceRepository(),
+      membership: _FakeMembershipService(),
+    );
+    provider.addSet();
+    provider.updateSet(0, weight: '10', reps: '5');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ChangeNotifierProvider<DeviceProvider>.value(
+          value: provider,
+          child: OverlayNumericKeypadHost(
+            controller: controller,
+            child: TextField(controller: textCtrl),
+          ),
+        ),
+      ),
+    );
+
+    controller.openFor(textCtrl);
+    await tester.pumpAndSettle();
+    expect(controller.isOpen, true);
+
+    await tester.tap(find.byIcon(Icons.check_rounded));
+    await tester.pump();
+
+    expect(provider.sets.first['done'], true);
     expect(controller.isOpen, false);
   });
 }


### PR DESCRIPTION
## Summary
- close overlay keypad automatically when no more sets remain
- cover keypad closing behavior with widget test

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b6d2c9f48320a41e657b8026e20a