### PR TITLE
fix(settings): default creatine tracker disabled

### DIFF
--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -37,15 +37,8 @@ class SettingsProvider extends ChangeNotifier {
       if (data != null && data['creatineEnabled'] != null) {
         _creatineEnabled = data['creatineEnabled'] as bool;
       } else {
-        final hasIntakes = await _firestore
-            .collection('users')
-            .doc(uid)
-            .collection('creatine_intakes')
-            .limit(1)
-            .get();
-        final def = hasIntakes.docs.isNotEmpty;
-        _creatineEnabled = def;
-        await ref.set({'creatineEnabled': def}, SetOptions(merge: true));
+        _creatineEnabled = false;
+        await ref.set({'creatineEnabled': false}, SetOptions(merge: true));
       }
     } catch (e) {
       _error = e.toString();

--- a/test/providers/settings_provider_test.dart
+++ b/test/providers/settings_provider_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:tapem/core/providers/settings_provider.dart';
+
+void main() {
+  test('load defaults creatine tracker to disabled', () async {
+    final firestore = FakeFirebaseFirestore();
+    final prov = SettingsProvider(firestore: firestore);
+    await prov.load('u1');
+    expect(prov.creatineEnabled, false);
+    final doc = await firestore
+        .collection('users')
+        .doc('u1')
+        .collection('settings')
+        .doc('settings')
+        .get();
+    expect(doc.data()?['creatineEnabled'], false);
+  });
+}


### PR DESCRIPTION
## Summary
- default creatine tracker to off unless user enables
- test SettingsProvider default

## Testing
- `flutter test` *(fails: command not found: flutter)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c5234a448320804b1edb1a6b0428