### PR TITLE
Remove profile header title

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -286,52 +286,40 @@ class _ProfileScreenState extends State<ProfileScreen> {
     return Scaffold(
       appBar: AppBar(
         automaticallyImplyLeading: false,
-        centerTitle: true,
-        title: Stack(
-          clipBehavior: Clip.none,
-          children: [
-            Center(child: Text(loc.profileTitle)),
-            Positioned(
-              left: AppSpacing.md,
-              top: 0,
-              bottom: 0,
-              child: Align(
-                alignment: Alignment.centerLeft,
-                child: SizedBox(
-                  width: avatarSize,
-                  height: avatarSize,
-                  child: Tooltip(
-                    message: 'Profilbild ändern',
-                    child: Semantics(
-                      button: true,
-                      label: 'Profilbild ändern',
-                      child: GestureDetector(
-                        onTap: () => _showAvatarSheet(auth),
-                        child: Builder(builder: (context) {
-                          final gymId =
-                              context.read<AuthProvider>().gymCode;
-                          final path = AvatarCatalog.instance
-                              .resolvePathOrFallback(auth.avatarKey,
-                                  gymId: gymId);
-                          final image = Image.asset(path, errorBuilder:
-                              (_, __, ___) {
-                            if (kDebugMode) {
-                              debugPrint('[Avatar] failed to load $path');
-                            }
-                            return const Icon(Icons.person);
-                          });
-                          return CircleAvatar(
-                            radius: avatarSize / 2,
-                            backgroundImage: image.image,
-                          );
-                        }),
-                      ),
-                    ),
-                  ),
+        leadingWidth: avatarSize + AppSpacing.md * 2,
+        leading: Padding(
+          padding: const EdgeInsets.only(left: AppSpacing.md),
+          child: SizedBox(
+            width: avatarSize,
+            height: avatarSize,
+            child: Tooltip(
+              message: 'Profilbild ändern',
+              child: Semantics(
+                button: true,
+                label: 'Profilbild ändern',
+                child: GestureDetector(
+                  onTap: () => _showAvatarSheet(auth),
+                  child: Builder(builder: (context) {
+                    final gymId = context.read<AuthProvider>().gymCode;
+                    final path = AvatarCatalog.instance
+                        .resolvePathOrFallback(auth.avatarKey,
+                            gymId: gymId);
+                    final image =
+                        Image.asset(path, errorBuilder: (_, __, ___) {
+                      if (kDebugMode) {
+                        debugPrint('[Avatar] failed to load $path');
+                      }
+                      return const Icon(Icons.person);
+                    });
+                    return CircleAvatar(
+                      radius: avatarSize / 2,
+                      backgroundImage: image.image,
+                    );
+                  }),
                 ),
               ),
             ),
-          ],
+          ),
         ),
         actions: [
           if (enableFriends)

--- a/test/features/profile/profile_screen_test.dart
+++ b/test/features/profile/profile_screen_test.dart
@@ -202,7 +202,7 @@ void main() {
 
     final appBar = tester.widget<AppBar>(find.byType(AppBar));
     expect(appBar.flexibleSpace, isNull);
-    expect(appBar.title, isA<Stack>());
+    expect(appBar.title, isNull);
 
     expect(find.text('Admin'), findsNothing);
     expect(find.text('Trainingstage'), findsOneWidget);


### PR DESCRIPTION
## Summary
- remove centered "Profil" title from profile screen header
- show avatar using AppBar leading slot
- update profile screen test for new header layout

## Testing
- `npm run rules-test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c67597808320a634ea21523f7a61