### PR TITLE
fix(profile): center Trainingstage heading

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -381,6 +381,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                     children: [
                       const Text(
                         'Trainingstage',
+                        textAlign: TextAlign.center,
                         style: TextStyle(
                           fontWeight: FontWeight.bold,
                           fontSize: 16,


### PR DESCRIPTION
## Summary
- center "Trainingstage" heading on profile screen

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c99668c48320955ca2a942453582