### PR TITLE
feat(friends): show avatars in requests and search

### DIFF
--- a/lib/features/friends/presentation/screens/friends_home_screen.dart
+++ b/lib/features/friends/presentation/screens/friends_home_screen.dart
@@ -112,38 +112,41 @@ class _FriendsHomeScreenState extends State<FriendsHomeScreen>
                   itemCount: prov.incomingPending.length,
                   itemBuilder: (_, i) {
                     final r = prov.incomingPending[i];
-                    return ListTile(
-                      title: FutureBuilder<PublicProfile?>(
-                        future: _fetchProfile(r.fromUserId),
-                        builder: (context, snapshot) {
-                          final name = snapshot.data?.username ?? r.fromUserId;
-                          return Text(name);
-                        },
-                      ),
-                      subtitle: Text(r.message ?? ''),
-                      trailing: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          IconButton(
-                            icon: const Icon(Icons.check),
-                            onPressed: () async {
-                              await prov.accept(r.fromUserId);
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(content: Text(loc.friends_snackbar_accepted)),
-                              );
-                            },
+                    return FutureBuilder<PublicProfile?>(
+                      future: _fetchProfile(r.fromUserId),
+                      builder: (context, snapshot) {
+                        final profile = snapshot.data;
+                        if (profile == null) {
+                          return const ListTile(title: Text('...'));
+                        }
+                        return FriendListTile(
+                          profile: profile,
+                          subtitle: r.message,
+                          trailing: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              IconButton(
+                                icon: const Icon(Icons.check),
+                                onPressed: () async {
+                                  await prov.accept(r.fromUserId);
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(content: Text(loc.friends_snackbar_accepted)),
+                                  );
+                                },
+                              ),
+                              IconButton(
+                                icon: const Icon(Icons.close),
+                                onPressed: () async {
+                                  await prov.decline(r.fromUserId);
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(content: Text(loc.friends_snackbar_declined)),
+                                  );
+                                },
+                              ),
+                            ],
                           ),
-                          IconButton(
-                            icon: const Icon(Icons.close),
-                            onPressed: () async {
-                              await prov.decline(r.fromUserId);
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(content: Text(loc.friends_snackbar_declined)),
-                              );
-                            },
-                          ),
-                        ],
-                      ),
+                        );
+                      },
                     );
                   },
                 ),
@@ -156,24 +159,27 @@ class _FriendsHomeScreenState extends State<FriendsHomeScreen>
                   itemCount: prov.outgoingPending.length,
                   itemBuilder: (_, i) {
                     final r = prov.outgoingPending[i];
-                    return ListTile(
-                      title: FutureBuilder<PublicProfile?>(
-                        future: _fetchProfile(r.toUserId),
-                        builder: (context, snapshot) {
-                          final name = snapshot.data?.username ?? r.toUserId;
-                          return Text(name);
-                        },
-                      ),
-                      subtitle: Text(r.message ?? ''),
-                      trailing: IconButton(
-                        icon: const Icon(Icons.cancel),
-                        onPressed: () async {
-                          await prov.cancel(r.toUserId);
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(content: Text(loc.friends_snackbar_canceled)),
-                          );
-                        },
-                      ),
+                    return FutureBuilder<PublicProfile?>(
+                      future: _fetchProfile(r.toUserId),
+                      builder: (context, snapshot) {
+                        final profile = snapshot.data;
+                        if (profile == null) {
+                          return const ListTile(title: Text('...'));
+                        }
+                        return FriendListTile(
+                          profile: profile,
+                          subtitle: r.message,
+                          trailing: IconButton(
+                            icon: const Icon(Icons.cancel),
+                            onPressed: () async {
+                              await prov.cancel(r.toUserId);
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text(loc.friends_snackbar_canceled)),
+                              );
+                            },
+                          ),
+                        );
+                      },
                     );
                   },
                 ),
@@ -385,16 +391,10 @@ class _FriendsHomeScreenState extends State<FriendsHomeScreen>
                       );
                       break;
                   }
-                  return ListTile(
-                    leading: p.avatarUrl != null
-                        ? CircleAvatar(
-                            backgroundImage: NetworkImage(p.avatarUrl!),
-                          )
-                        : const CircleAvatar(child: Icon(Icons.person)),
-                    title: Text(p.username),
-                    subtitle: p.primaryGymCode != null
-                        ? Text(p.primaryGymCode!)
-                        : null,
+                  return FriendListTile(
+                    profile: p,
+                    gymId: p.primaryGymCode,
+                    subtitle: p.primaryGymCode,
                     trailing: trailing,
                   );
                 },

--- a/lib/features/friends/presentation/widgets/friend_list_tile.dart
+++ b/lib/features/friends/presentation/widgets/friend_list_tile.dart
@@ -10,15 +10,19 @@ class FriendListTile extends StatelessWidget {
   const FriendListTile({
     super.key,
     required this.profile,
-    required this.presence,
-    required this.onTap,
+    this.presence,
+    this.onTap,
     this.gymId,
+    this.subtitle,
+    this.trailing,
   });
 
   final PublicProfile profile;
-  final PresenceState presence;
-  final VoidCallback onTap;
+  final PresenceState? presence;
+  final VoidCallback? onTap;
   final String? gymId;
+  final String? subtitle;
+  final Widget? trailing;
 
   @override
   Widget build(BuildContext context) {
@@ -43,12 +47,12 @@ class FriendListTile extends StatelessWidget {
       radius: 20,
       backgroundImage: image.image,
     );
-    final statusColor = presence == PresenceState.workedOutToday
-        ? theme.colorScheme.secondary
-        : theme.colorScheme.onSurfaceVariant;
-    return ListTile(
-      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      leading: Stack(
+    Widget leading = avatar;
+    if (presence != null) {
+      final statusColor = presence == PresenceState.workedOutToday
+          ? theme.colorScheme.secondary
+          : theme.colorScheme.onSurfaceVariant;
+      leading = Stack(
         children: [
           avatar,
           Positioned(
@@ -69,7 +73,11 @@ class FriendListTile extends StatelessWidget {
             ),
           ),
         ],
-      ),
+      );
+    }
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      leading: leading,
       title: Text(
         profile.username,
         style: theme.textTheme.titleMedium?.copyWith(
@@ -78,6 +86,8 @@ class FriendListTile extends StatelessWidget {
           color: theme.colorScheme.onSurface,
         ),
       ),
+      subtitle: subtitle != null ? Text(subtitle!) : null,
+      trailing: trailing,
       onTap: onTap,
       minVerticalPadding: 8,
     );


### PR DESCRIPTION
## Summary
- extend FriendListTile with optional subtitle, trailing, and presence
- render friend requests and search results with FriendListTile for consistent avatar display

## Testing
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cd84950483209db2a565386cf743