### PR TITLE
style: show avatars in rank lists

### DIFF
--- a/lib/features/xp/presentation/screens/device_xp_screen.dart
+++ b/lib/features/xp/presentation/screens/device_xp_screen.dart
@@ -5,6 +5,9 @@ import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/gym_provider.dart';
 import '../../../../core/providers/xp_provider.dart';
 import '../../../../core/logging/elog.dart';
+import 'package:tapem/features/friends/domain/models/public_profile.dart';
+import 'package:tapem/features/friends/presentation/widgets/friend_list_tile.dart';
+import 'leaderboard_screen.dart';
 
 class DeviceXpScreen extends StatefulWidget {
   const DeviceXpScreen({Key? key}) : super(key: key);
@@ -60,9 +63,10 @@ class _DeviceXpScreenState extends State<DeviceXpScreen> {
                 final entries = await Future.wait(
                   snap.docs.map((doc) async {
                     final user = await fs.collection('users').doc(doc.id).get();
-                    final name = user.data()?['username'] as String? ?? doc.id;
+                    final profile = PublicProfile.fromMap(
+                        doc.id, user.data() ?? <String, dynamic>{});
                     final xp = doc.data()['xp'] as int? ?? 0;
-                    return {'username': name, 'xp': xp};
+                    return LeaderboardEntry(profile: profile, xp: xp);
                   }),
                 );
               showDialog(
@@ -73,10 +77,11 @@ class _DeviceXpScreenState extends State<DeviceXpScreen> {
                       content: Column(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          for (final e in entries)
-                            ListTile(
-                              title: Text(e['username'] as String),
-                              trailing: Text('${e['xp']} XP'),
+                          for (final e in entries.asMap().entries)
+                            FriendListTile(
+                              profile: e.value.profile,
+                              subtitle: '#${e.key + 1}',
+                              trailing: Text('${e.value.xp} XP'),
                             ),
                         ],
                       ),

--- a/lib/features/xp/presentation/screens/leaderboard_screen.dart
+++ b/lib/features/xp/presentation/screens/leaderboard_screen.dart
@@ -1,16 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:tapem/features/friends/domain/models/public_profile.dart';
+import 'package:tapem/features/friends/presentation/widgets/friend_list_tile.dart';
 import '../widgets/xp_time_series_chart.dart';
 
-/// A simple model representing a single leaderboard entry. This can be
-/// expanded later to include avatar URLs, rank icons and badges.
+/// A simple model representing a single leaderboard entry. This now includes
+/// the user's public profile so that avatar and name can be displayed
+/// consistently with the friends page.
 class LeaderboardEntry {
-  final String userId;
-  final String username;
+  final PublicProfile profile;
   final int xp;
 
   LeaderboardEntry({
-    required this.userId,
-    required this.username,
+    required this.profile,
     required this.xp,
   });
 }
@@ -115,58 +116,39 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
                     : _entries == null
                     ? const SizedBox.shrink()
                     : ListView.builder(
-                      itemCount: _entries!.length,
-                      itemBuilder: (context, index) {
-                        final entry = _entries![index];
-                        final maxXp = _entries!.first.xp;
-                        final fraction = maxXp > 0 ? entry.xp / maxXp : 0.0;
-                        return ListTile(
-                          contentPadding: const EdgeInsets.symmetric(
-                            horizontal: 16.0,
-                            vertical: 8.0,
-                          ),
-                          leading: CircleAvatar(
-                            backgroundColor: Colors.grey.shade700,
-                            child: Text(
-                              '${index + 1}',
-                              style: const TextStyle(color: Colors.white),
-                            ),
-                          ),
-                          title: Text(
-                            entry.username.isNotEmpty
-                                ? entry.username
-                                : entry.userId,
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 16,
-                              fontWeight: FontWeight.w500,
-                            ),
-                          ),
-                          subtitle: Padding(
-                            padding: const EdgeInsets.only(top: 4.0),
-                            child: LinearProgressIndicator(
-                              value: fraction.clamp(0.0, 1.0),
-                              minHeight: 6,
-                              valueColor: AlwaysStoppedAnimation<Color>(
-                                Color.lerp(
-                                  const Color(0xFF00E676),
-                                  const Color(0xFFFFC107),
-                                  fraction,
-                                )!,
+                        itemCount: _entries!.length,
+                        itemBuilder: (context, index) {
+                          final entry = _entries![index];
+                          final maxXp = _entries!.first.xp;
+                          final fraction = maxXp > 0 ? entry.xp / maxXp : 0.0;
+                          return Column(
+                            children: [
+                              FriendListTile(
+                                profile: entry.profile,
+                                subtitle: '#${index + 1}',
+                                trailing: Text('${entry.xp} XP'),
                               ),
-                              backgroundColor: Colors.grey.shade800,
-                            ),
-                          ),
-                          trailing: Text(
-                            '${entry.xp} XP',
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 14,
-                            ),
-                          ),
-                        );
-                      },
-                    ),
+                              Padding(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 16.0,
+                                ),
+                                child: LinearProgressIndicator(
+                                  value: fraction.clamp(0.0, 1.0),
+                                  minHeight: 6,
+                                  valueColor: AlwaysStoppedAnimation<Color>(
+                                    Color.lerp(
+                                      const Color(0xFF00E676),
+                                      const Color(0xFFFFC107),
+                                      fraction,
+                                    )!,
+                                  ),
+                                  backgroundColor: Colors.grey.shade800,
+                                ),
+                              ),
+                            ],
+                          );
+                        },
+                      ),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- show avatar + username via FriendListTile on XP leaderboards
- include PublicProfile in leaderboard entries
- display friend-style entries in device XP dialogs

## Testing
- `dart format lib/features/xp/presentation/screens/leaderboard_screen.dart lib/features/xp/presentation/screens/day_xp_screen.dart lib/features/xp/presentation/screens/device_xp_screen.dart` (failed: command not found)
- `flutter test` (failed: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c1d6cc7c348320bcad34dab7bb2c54