### PR TITLE
chore: depend on path and use new avatar key helper

### DIFF
--- a/lib/features/avatars/presentation/providers/avatar_inventory_provider.dart
+++ b/lib/features/avatars/presentation/providers/avatar_inventory_provider.dart
@@ -52,8 +52,8 @@ class AvatarInventoryProvider extends ChangeNotifier {
               final data = d.data();
               final rawKey =
                   data['key'] as String? ?? d.id.replaceAll('__', '/');
-              final normalised = AvatarAssets.normalizeAvatarKey(rawKey,
-                  currentGymId: currentGymId);
+              final normalised =
+                  AvatarAssets.normalizeKey(rawKey, currentGymId: currentGymId);
               return AvatarInventoryEntry(
                 key: normalised,
                 source: data['source'] as String? ?? '',
@@ -114,7 +114,7 @@ class AvatarInventoryProvider extends ChangeNotifier {
     final now = FieldValue.serverTimestamp();
     for (final key in keys) {
       final normalised =
-          AvatarAssets.normalizeAvatarKey(key, currentGymId: gymId);
+          AvatarAssets.normalizeKey(key, currentGymId: gymId);
       final ref = _firestore
           .collection('users')
           .doc(uid)

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -138,7 +138,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
     showModalBottomSheet(
       context: context,
       builder: (_) {
-        final normalized = AvatarAssets.normalizeAvatarKey(
+        final normalized = AvatarAssets.normalizeKey(
           auth.avatarKey,
           currentGymId: auth.gymCode,
         );
@@ -459,7 +459,7 @@ class AvatarPicker extends StatelessWidget {
         final currentGym = auth.gymCode;
         final Map<String, AvatarInventoryEntry> map = {};
         for (final item in items) {
-          final norm = AvatarAssets.normalizeAvatarKey(
+          final norm = AvatarAssets.normalizeKey(
             item.key,
             currentGymId: currentGym,
           );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -960,7 +960,7 @@ packages:
     source: hosted
     version: "2.2.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   googleapis: ^14.0.0 # nur falls wirklich benötigt
   file_picker: ^10.2.0
   async: ^2.11.0
+  path: ^1.9.1
 
   # Firebase (stabile, bereits verwendete Major-Versionen)
   firebase_core: ^3.15.2


### PR DESCRIPTION
## Summary
- declare `path` as a direct dependency
- replace deprecated `normalizeAvatarKey` calls with `normalizeKey`

## Testing
- `dart format pubspec.yaml lib/features/avatars/presentation/providers/avatar_inventory_provider.dart lib/features/profile/presentation/screens/profile_screen.dart lib/core/utils/avatar_assets.dart pubspec.lock >/tmp/format.log && tail -n 20 /tmp/format.log` *(fails: command not found)*
- `flutter pub get >/tmp/pubget.log && tail -n 20 /tmp/pubget.log` *(fails: command not found)*
- `flutter analyze >/tmp/analyze.log && tail -n 20 /tmp/analyze.log` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e0e31aa48320ae1810c876bef3dd