### PR TITLE
feat: extend workout timer persistence

### DIFF
--- a/lib/core/providers/training_details_provider.dart
+++ b/lib/core/providers/training_details_provider.dart
@@ -4,21 +4,26 @@ import 'package:tapem/features/training_details/data/sources/firestore_session_s
 import 'package:tapem/features/training_details/data/session_meta_source.dart';
 import 'package:tapem/features/training_details/domain/usecases/get_sessions_for_date.dart';
 import 'package:tapem/features/training_details/domain/models/session.dart';
+import 'package:tapem/core/time/logic_day.dart';
 
 /// Notifier für den TrainingDetailsScreen.
 class TrainingDetailsProvider extends ChangeNotifier {
   final GetSessionsForDate _getSessions;
+  final SessionMetaSource _meta;
 
   bool _isLoading = false;
   String? _error;
   List<Session> _sessions = [];
+  int? _dayDurationMs;
 
   bool get isLoading => _isLoading;
   String? get error => _error;
   List<Session> get sessions => List.unmodifiable(_sessions);
+  int? get dayDurationMs => _dayDurationMs;
 
   TrainingDetailsProvider()
-    : _getSessions = GetSessionsForDate(
+    : _meta = SessionMetaSource(),
+      _getSessions = GetSessionsForDate(
         SessionRepositoryImpl(
           FirestoreSessionSource(),
           SessionMetaSource(),
@@ -29,8 +34,9 @@ class TrainingDetailsProvider extends ChangeNotifier {
   Future<void> loadSessions({
     required String userId,
     required DateTime date,
+    required String gymId,
   }) async {
-    debugPrint('📆 loadSessions user=$userId date=$date');
+    debugPrint('📆 loadSessions user=$userId date=$date gym=$gymId');
     _isLoading = true;
     _error = null;
     notifyListeners();
@@ -38,6 +44,14 @@ class TrainingDetailsProvider extends ChangeNotifier {
     try {
       _sessions = await _getSessions.execute(userId: userId, date: date);
       debugPrint('✅ loaded ${_sessions.length} sessions');
+      if (_sessions.isNotEmpty) {
+        _dayDurationMs = _sessions.first.durationMs;
+      } else {
+        final dayKey = logicDayKey(date);
+        final meta = await _meta.getMetaByDayKey(
+            gymId: gymId, uid: userId, dayKey: dayKey);
+        _dayDurationMs = (meta?['durationMs'] as num?)?.toInt();
+      }
     } catch (e) {
       _error = e.toString();
       debugPrint('❌ loadSessions error: $e');

--- a/lib/core/services/workout_timer_telemetry.dart
+++ b/lib/core/services/workout_timer_telemetry.dart
@@ -1,0 +1,5 @@
+abstract class WorkoutTimerTelemetry {
+  void timerStart();
+  void timerStopSave({required int durationMs, required String dayKey, required bool hasSets});
+  void timerStopDiscard({required int durationMs, required String dayKey, required bool hasSets});
+}

--- a/lib/core/time/logic_day.dart
+++ b/lib/core/time/logic_day.dart
@@ -1,4 +1,8 @@
-String logicDayKey(DateTime nowUtc) {
-  final utc = nowUtc.toUtc();
-  return utc.toIso8601String().split('T').first;
+/// Returns a `YYYY-MM-DD` key for the given local [date].
+///
+/// The [date] is treated as already being in the desired locale/timezone and
+/// no conversion is performed. This ensures that sessions crossing midnight are
+/// still attributed to the day of their *start* in the user's local timezone.
+String logicDayKey(DateTime date) {
+  return date.toIso8601String().split('T').first;
 }

--- a/lib/core/widgets/workout_timer_button.dart
+++ b/lib/core/widgets/workout_timer_button.dart
@@ -42,9 +42,14 @@ class WorkoutTimerButton extends StatelessWidget {
           ),
           onPressed: () async {
             if (service.isRunning) {
-              final res = await service.stopAndPrompt(context);
+              final res = await service.confirmStop(context);
               if (res == StopResult.save) {
                 await service.save();
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Dauer gespeichert')),
+                  );
+                }
               } else if (res == StopResult.discard) {
                 await service.discard();
               }

--- a/lib/features/training_details/data/session_meta_source.dart
+++ b/lib/features/training_details/data/session_meta_source.dart
@@ -5,7 +5,23 @@ class SessionMetaSource {
   SessionMetaSource({FirebaseFirestore? firestore})
       : _firestore = firestore ?? FirebaseFirestore.instance;
 
-  Future<Map<String, dynamic>?> getMeta({
+  Future<void> upsertMeta({
+    required String gymId,
+    required String uid,
+    required String sessionId,
+    required Map<String, dynamic> meta,
+  }) async {
+    await _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('users')
+        .doc(uid)
+        .collection('session_meta')
+        .doc(sessionId)
+        .set(meta, SetOptions(merge: true));
+  }
+
+  Future<Map<String, dynamic>?> getMetaBySessionId({
     required String gymId,
     required String uid,
     required String sessionId,
@@ -19,5 +35,23 @@ class SessionMetaSource {
         .doc(sessionId)
         .get();
     return doc.data();
+  }
+
+  Future<Map<String, dynamic>?> getMetaByDayKey({
+    required String gymId,
+    required String uid,
+    required String dayKey,
+  }) async {
+    final snap = await _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('users')
+        .doc(uid)
+        .collection('session_meta')
+        .where('dayKey', isEqualTo: dayKey)
+        .limit(1)
+        .get();
+    if (snap.docs.isEmpty) return null;
+    return snap.docs.first.data();
   }
 }

--- a/lib/features/training_details/presentation/screens/training_details_screen.dart
+++ b/lib/features/training_details/presentation/screens/training_details_screen.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
 
 import 'package:tapem/core/providers/training_details_provider.dart';
+import 'package:tapem/core/providers/branding_provider.dart';
 import 'package:tapem/features/training_details/domain/models/session.dart';
 import '../widgets/day_sessions_overview.dart';
 import 'package:tapem/core/utils/duration_format.dart';
@@ -18,10 +19,11 @@ class TrainingDetailsScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final gymId = context.read<BrandingProvider>().gymId!;
     return ChangeNotifierProvider<TrainingDetailsProvider>(
       create: (_) {
         final prov = TrainingDetailsProvider();
-        prov.loadSessions(userId: userId, date: date);
+        prov.loadSessions(userId: userId, date: date, gymId: gymId);
         return prov;
       },
       child: Consumer<TrainingDetailsProvider>(
@@ -42,8 +44,7 @@ class TrainingDetailsScreen extends StatelessWidget {
           }
           // Data state
           final sessions = prov.sessions;
-          final duration =
-              sessions.isNotEmpty ? sessions.first.durationMs : null;
+          final duration = prov.dayDurationMs;
           return Scaffold(
             appBar: _AppBar(titleDate: date, durationMs: duration),
             body: sessions.isEmpty

--- a/test/core/time/logic_day_test.dart
+++ b/test/core/time/logic_day_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/core/time/logic_day.dart';
+
+void main() {
+  test('returns YYYY-MM-DD for local date', () {
+    final dt = DateTime.parse('2024-03-01T12:00:00+02:00');
+    expect(logicDayKey(dt), '2024-03-01');
+  });
+
+  test('keeps start day across midnight', () {
+    final start = DateTime(2024, 03, 01, 23, 30);
+    expect(logicDayKey(start), '2024-03-01');
+  });
+}


### PR DESCRIPTION
## Summary
- refine day key calculation to use local start times
- add stop confirmation, offline queue and telemetry hooks to workout timer
- show stored session duration on training details even without sets

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c371150d4c83208ca89fd1192af018