### PR TITLE
Fix session meta retrieval for training details

### DIFF
--- a/lib/core/providers/training_details_provider.dart
+++ b/lib/core/providers/training_details_provider.dart
@@ -22,13 +22,13 @@ class TrainingDetailsProvider extends ChangeNotifier {
   int? get dayDurationMs => _dayDurationMs;
 
   TrainingDetailsProvider()
-    : _meta = SessionMetaSource(),
-      _getSessions = GetSessionsForDate(
-        SessionRepositoryImpl(
-          FirestoreSessionSource(),
-          SessionMetaSource(),
-        ),
-      );
+      : _meta = SessionMetaSource(),
+        _getSessions = GetSessionsForDate(
+          SessionRepositoryImpl(
+            FirestoreSessionSource(),
+            _meta,
+          ),
+        );
 
   /// Lädt alle Sessions für [userId] am [date].
   Future<void> loadSessions({

--- a/lib/features/training_details/data/repositories/session_repository_impl.dart
+++ b/lib/features/training_details/data/repositories/session_repository_impl.dart
@@ -99,7 +99,7 @@ class SessionRepositoryImpl implements SessionRepository {
       DateTime? endTime;
       int? durationMs;
       try {
-        final meta = await _meta.getMeta(
+        final meta = await _meta.getMetaBySessionId(
           gymId: gymId,
           uid: first.userId,
           sessionId: first.sessionId,


### PR DESCRIPTION
## Summary
- share a single SessionMetaSource instance between TrainingDetailsProvider and SessionRepositoryImpl
- update SessionRepositoryImpl to use `getMetaBySessionId`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c37835053c83209da9469bc129e960