### PR TITLE
Fix training details provider initialization

### DIFF
--- a/lib/core/providers/training_details_provider.dart
+++ b/lib/core/providers/training_details_provider.dart
@@ -8,8 +8,8 @@ import 'package:tapem/core/time/logic_day.dart';
 
 /// Notifier für den TrainingDetailsScreen.
 class TrainingDetailsProvider extends ChangeNotifier {
-  final GetSessionsForDate _getSessions;
-  final SessionMetaSource _meta;
+  late final GetSessionsForDate _getSessions;
+  final SessionMetaSource _meta = SessionMetaSource();
 
   bool _isLoading = false;
   String? _error;
@@ -21,14 +21,14 @@ class TrainingDetailsProvider extends ChangeNotifier {
   List<Session> get sessions => List.unmodifiable(_sessions);
   int? get dayDurationMs => _dayDurationMs;
 
-  TrainingDetailsProvider()
-      : _meta = SessionMetaSource(),
-        _getSessions = GetSessionsForDate(
-          SessionRepositoryImpl(
-            FirestoreSessionSource(),
-            _meta,
-          ),
-        );
+  TrainingDetailsProvider() {
+    _getSessions = GetSessionsForDate(
+      SessionRepositoryImpl(
+        FirestoreSessionSource(),
+        _meta,
+      ),
+    );
+  }
 
   /// Lädt alle Sessions für [userId] am [date].
   Future<void> loadSessions({


### PR DESCRIPTION
## Summary
- Initialize GetSessionsForDate in constructor body and avoid accessing instance fields in initializer

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_68c37d0c9684832097091d8762973ae9