### PR TITLE
docs: document session timing fields

### DIFF
--- a/lib/features/training_details/domain/models/session.dart
+++ b/lib/features/training_details/domain/models/session.dart
@@ -7,8 +7,14 @@ class Session {
   final DateTime timestamp;
   final String note;
   final List<SessionSet> sets;
+
+  /// Timestamp of when the session started, if known.
   final DateTime? startTime;
+
+  /// Timestamp of when the session ended, if known.
   final DateTime? endTime;
+
+  /// Total duration of the session in milliseconds.
   final int? durationMs;
 
   Session({


### PR DESCRIPTION
## Summary
- clarify purpose of session timing metadata fields

## Testing
- `dart format lib/features/training_details/domain/models/session.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c37f1040fc832099cae4a80a680049