### PR TITLE
Add workout timer button to global header

### DIFF
--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -17,6 +17,7 @@ import 'package:tapem/features/training_plan/presentation/screens/plan_overview_
 import 'package:tapem/features/auth/presentation/widgets/username_dialog.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/config/feature_flags.dart';
+import 'package:tapem/core/widgets/workout_timer_button.dart';
 import 'package:tapem/features/nfc/widgets/nfc_scan_button.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -122,6 +123,7 @@ class _HomeScreenState extends State<HomeScreen> {
       appBar: AppBar(
         title: Text(userDisplay),
         actions: const [
+          WorkoutTimerButton(),
           NfcScanButton(),
         ],
       ),


### PR DESCRIPTION
## Summary
- Add workout timer button to the app bar so users can start and stop session timing from anywhere

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3811954b883208845825d16e45e6e