### PR TITLE
fix: compact training duration in details header

### DIFF
--- a/lib/core/utils/duration_format.dart
+++ b/lib/core/utils/duration_format.dart
@@ -18,3 +18,13 @@ String formatDuration(Duration duration, {Locale? locale}) {
   final s = duration.inSeconds;
   return l == 'de' ? '$s s' : '$s s';
 }
+
+/// Formats [duration] as `HH:mm`, always showing hours and minutes.
+/// Hours and minutes are zero-padded to two digits.
+String formatDurationHm(Duration duration) {
+  final h = duration.inHours;
+  final m = duration.inMinutes % 60;
+  final hStr = h.toString().padLeft(2, '0');
+  final mStr = m.toString().padLeft(2, '0');
+  return '$hStr:$mStr';
+}

--- a/lib/features/training_details/presentation/screens/training_details_screen.dart
+++ b/lib/features/training_details/presentation/screens/training_details_screen.dart
@@ -83,16 +83,21 @@ class _AppBar extends StatelessWidget implements PreferredSizeWidget {
     );
     if (durationMs != null) {
       final dur = Duration(milliseconds: durationMs!);
-      final formatted =
-          formatDuration(dur, locale: Localizations.localeOf(context));
+      final formatted = formatDurationHm(dur);
       titleWidget = Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Text(
-            title,
-            style: TextStyle(color: Theme.of(context).colorScheme.secondary),
+          Expanded(
+            child: Text(
+              title,
+              style:
+                  TextStyle(color: Theme.of(context).colorScheme.secondary),
+              overflow: TextOverflow.ellipsis,
+            ),
           ),
-          Text('⏱ $formatted'),
+          Text(
+            '⏱ $formatted',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
         ],
       );
     }

--- a/test/core/utils/duration_format_test.dart
+++ b/test/core/utils/duration_format_test.dart
@@ -19,4 +19,11 @@ void main() {
     final d = Duration(seconds: 45);
     expect(formatDuration(d, locale: const Locale('en')), '45 s');
   });
+
+  test('formats HH:mm correctly', () {
+    final d1 = Duration(hours: 1, minutes: 5);
+    expect(formatDurationHm(d1), '01:05');
+    final d2 = Duration(minutes: 7);
+    expect(formatDurationHm(d2), '00:07');
+  });
 }


### PR DESCRIPTION
## Summary
- show training duration in HH:mm to save space
- prevent overflow by shrinking and constraining header text
- add tests for HH:mm duration formatting

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f9a332fc832092ad6aa2d8266d0e