### PR TITLE
feat(ui): outline session cards

### DIFF
--- a/lib/features/history/presentation/screens/history_screen.dart
+++ b/lib/features/history/presentation/screens/history_screen.dart
@@ -10,6 +10,7 @@ import 'package:tapem/features/training_details/domain/models/session.dart';
 import 'package:tapem/features/training_details/presentation/widgets/session_exercise_card.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
+import 'package:tapem/core/widgets/brand_outline.dart';
 import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/logging/elog.dart';
@@ -432,43 +433,46 @@ class _HistoryExpansionTileState extends State<_HistoryExpansionTile> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final surface = theme.extension<AppBrandTheme>();
-    final baseRadius = surface?.radius as BorderRadius? ?? BorderRadius.circular(AppRadius.card);
-    final bottomRadius = BorderRadius.only(
-      bottomLeft: baseRadius.bottomLeft,
-      bottomRight: baseRadius.bottomRight,
-    );
+    final brand = Theme.of(context).extension<AppBrandTheme>()!;
+    final innerRadius =
+        (brand.outlineRadius as BorderRadius) - BorderRadius.circular(brand.outlineWidth);
 
-    return Column(
-      children: [
-        BrandGradientHeader(
-          expanded: _expanded,
-          onTap: () => setState(() => _expanded = !_expanded),
-          child: Row(
-            children: [
-              Expanded(
-                child: Text(
-                  widget.title,
-                  style: const TextStyle(fontWeight: FontWeight.bold),
-                ),
-              ),
-              Icon(
-                _expanded ? Icons.expand_less : Icons.expand_more,
-              ),
-            ],
-          ),
-        ),
-        if (_expanded)
-          Container(
-            decoration: BoxDecoration(
-              color: theme.colorScheme.surface,
-              borderRadius: bottomRadius,
+    return BrandOutline(
+      padding: EdgeInsets.zero,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          InkWell(
+            borderRadius: BorderRadius.only(
+              topLeft: innerRadius.topLeft,
+              topRight: innerRadius.topRight,
             ),
-            padding: const EdgeInsets.all(AppSpacing.sm),
-            child: widget.child,
+            onTap: () => setState(() => _expanded = !_expanded),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                vertical: AppSpacing.sm,
+                horizontal: AppSpacing.sm,
+              ),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      widget.title,
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  Icon(_expanded ? Icons.expand_less : Icons.expand_more),
+                ],
+              ),
+            ),
           ),
-      ],
+          if (_expanded)
+            Padding(
+              padding: const EdgeInsets.all(AppSpacing.sm),
+              child: widget.child,
+            ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/training_details/presentation/widgets/session_exercise_card.dart
+++ b/lib/features/training_details/presentation/widgets/session_exercise_card.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:tapem/core/widgets/brand_gradient_card.dart';
-import 'package:tapem/core/theme/brand_on_colors.dart';
+import 'package:tapem/core/widgets/brand_outline.dart';
 import '../../domain/models/session.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 
@@ -21,9 +20,7 @@ class SessionExerciseCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final onBrand =
-        Theme.of(context).extension<BrandOnColors>()?.onGradient ?? Colors.black;
-    return BrandGradientCard(
+    return BrandOutline(
       padding: padding,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -39,8 +36,7 @@ class SessionExerciseCard extends StatelessWidget {
             const SizedBox(height: 4),
             Text(
               subtitle!,
-              style: TextStyle(
-                color: onBrand,
+              style: const TextStyle(
                 fontSize: 14,
               ),
             ),
@@ -69,8 +65,7 @@ class SessionExerciseCard extends StatelessWidget {
                             : '${set.weight.toStringAsFixed(1)} kg';
                         return Text(
                           wt,
-                          style: TextStyle(
-                            color: onBrand,
+                          style: const TextStyle(
                             fontSize: 14,
                           ),
                         );
@@ -83,8 +78,7 @@ class SessionExerciseCard extends StatelessWidget {
                       const SizedBox(width: 4),
                       Text(
                         '${set.reps} Wdh',
-                        style: TextStyle(
-                          color: onBrand,
+                        style: const TextStyle(
                           fontSize: 14,
                         ),
                       ),
@@ -95,8 +89,7 @@ class SessionExerciseCard extends StatelessWidget {
                       padding: const EdgeInsets.only(left: 20, top: 2),
                       child: Text(
                         '↘︎ ${set.dropWeightKg!.toStringAsFixed(1)} kg × ${set.dropReps}',
-                        style: TextStyle(
-                          color: onBrand,
+                        style: const TextStyle(
                           fontSize: 12,
                         ),
                       ),

--- a/test/ui/brand_widgets_test.dart
+++ b/test/ui/brand_widgets_test.dart
@@ -102,16 +102,8 @@ void main() {
     expect(opacity.opacity, brand.outlineDisabledOpacity);
   });
 
-  testWidgets('SessionExerciseCard uses black foreground', (tester) async {
-    final theme = ThemeData(extensions: [
-      AppBrandTheme.defaultTheme(),
-      const BrandOnColors(
-        onPrimary: Colors.black,
-        onSecondary: Colors.black,
-        onGradient: Colors.black,
-        onCta: Colors.black,
-      ),
-    ]);
+  testWidgets('SessionExerciseCard uses surface foreground', (tester) async {
+    final theme = ThemeData(extensions: [AppBrandTheme.defaultTheme()]);
 
     await tester.pumpWidget(MaterialApp(
       theme: theme,
@@ -123,9 +115,9 @@ void main() {
     ));
 
     final rich = tester.widget<RichText>(find.text('Bench'));
-    expect(rich.text.style?.color, Colors.black);
+    expect(rich.text.style?.color, theme.colorScheme.onSurface);
     final iconColor =
         IconTheme.of(tester.element(find.byIcon(Icons.fitness_center))).color;
-    expect(iconColor, Colors.black);
+    expect(iconColor, theme.iconTheme.color);
   });
 }


### PR DESCRIPTION
## Summary
- switch SessionExerciseCard to BrandOutline for outline styling
- apply BrandOutline to history expansion tiles
- update widget test for new card foreground

## Testing
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c3fdbc77b0832095f12b772a996714