### PR TITLE
fix: show sessions chronologically

### DIFF
--- a/lib/features/training_details/data/repositories/session_repository_impl.dart
+++ b/lib/features/training_details/data/repositories/session_repository_impl.dart
@@ -129,7 +129,7 @@ class SessionRepositoryImpl implements SessionRepository {
       );
     }
 
-    sessions.sort((a, b) => b.timestamp.compareTo(a.timestamp));
+    sessions.sort((a, b) => a.timestamp.compareTo(b.timestamp));
     return sessions;
   }
 }


### PR DESCRIPTION
## Summary
- sort training sessions in ascending order so first session appears at the top

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c401de55a8832081eb0915d073e609