### PR TITLE
Fix device XP watchers and multi device loading

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -461,11 +461,10 @@ class _DeviceScreenState extends State<DeviceScreen> {
           ),
           centerTitle: true,
           actions: [
-            if (!prov.device!.isMulti)
-              Padding(
-                padding: const EdgeInsets.only(right: 8.0),
-                child: XpInfoButton(xp: prov.xp, level: prov.level),
-              ),
+            Padding(
+              padding: const EdgeInsets.only(right: 8.0),
+              child: XpInfoButton(xp: prov.xp, level: prov.level),
+            ),
             FeedbackButton(gymId: widget.gymId, deviceId: widget.deviceId),
             IconButton(
               icon: Icon(

--- a/lib/features/xp/presentation/screens/device_xp_screen.dart
+++ b/lib/features/xp/presentation/screens/device_xp_screen.dart
@@ -17,18 +17,38 @@ class DeviceXpScreen extends StatefulWidget {
 }
 
 class _DeviceXpScreenState extends State<DeviceXpScreen> {
+  late final GymProvider _gymProv;
+  late final XpProvider _xpProv;
+  late final AuthProvider _auth;
+
   @override
   void initState() {
     super.initState();
-    final auth = context.read<AuthProvider>();
-      final gymProv = context.read<GymProvider>();
-      final xpProv = context.read<XpProvider>();
-      final uid = auth.userId;
-      final gymId = gymProv.currentGymId;
-      if (uid != null && gymId.isNotEmpty) {
-        final deviceIds = gymProv.devices.map((d) => d.uid).toList();
-        xpProv.watchDeviceXp(gymId, uid, deviceIds);
-      }
+    _gymProv = context.read<GymProvider>();
+    _xpProv = context.read<XpProvider>();
+    _auth = context.read<AuthProvider>();
+    _gymProv.addListener(_syncWatchers);
+    _syncWatchers();
+  }
+
+  void _syncWatchers() {
+    final uid = _auth.userId;
+    final gymId = _gymProv.currentGymId;
+    if (uid != null && gymId.isNotEmpty) {
+      final deviceIds = _gymProv.devices.map((d) => d.uid).toList();
+      _xpProv.watchDeviceXp(gymId, uid, deviceIds);
+    }
+  }
+
+  @override
+  void dispose() {
+    _gymProv.removeListener(_syncWatchers);
+    final uid = _auth.userId;
+    final gymId = _gymProv.currentGymId;
+    if (uid != null && gymId.isNotEmpty) {
+      _xpProv.watchDeviceXp(gymId, uid, []);
+    }
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
## Summary
- load user XP for multi devices and update level after successful XP credit
- show XP info on device screen for all devices
- manage device XP watchers reactively based on gym device list

## Testing
- `dart test test/providers/device_provider_test.dart` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68c49735811083209e2dd91d6bc7a079