### PR TITLE
fix leaderboard xp updates for members

### DIFF
--- a/docs/xp_device_flow.md
+++ b/docs/xp_device_flow.md
@@ -1,0 +1,11 @@
+# XP Device Flow
+
+This document outlines the XP credit flow for device-based sessions.
+
+## Troubleshooting: User has 0 XP while others accrue
+
+If a member's XP remains at 0 while others earn points, check the device leaderboard entry in Firestore:
+
+- The document must contain `userId`, `xp`, and `level` fields.
+- Missing `userId` prevents write access due to security rules.
+- Run `node scripts/repair_leaderboard.js <gymId> <deviceId>` to repair existing entries.

--- a/firestore-tests/security_rules.test.js
+++ b/firestore-tests/security_rules.test.js
@@ -664,4 +664,56 @@ describe('Security Rules v1', function () {
       await assertFails(ref.update({ username: 'bad' }));
     });
   });
+
+  describe('leaderboard rules', () => {
+    it('member can create and update own leaderboard entry', async () => {
+      const db = userA().firestore();
+      const ref = db
+        .collection('gyms')
+        .doc('G1')
+        .collection('devices')
+        .doc('D1')
+        .collection('leaderboard')
+        .doc('userA');
+      await assertSucceeds(
+        ref.set({ userId: 'userA', xp: 0, level: 1, showInLeaderboard: true })
+      );
+      await assertSucceeds(ref.update({ xp: 10 }));
+    });
+
+    it('fails without userId field', async () => {
+      const db = userA().firestore();
+      const ref = db
+        .collection('gyms')
+        .doc('G1')
+        .collection('devices')
+        .doc('D1')
+        .collection('leaderboard')
+        .doc('userA');
+      await assertFails(ref.set({ xp: 0 }));
+    });
+
+    it('update denied when existing doc missing userId', async () => {
+      await testEnv.withSecurityRulesDisabled(async (context) => {
+        const db = context.firestore();
+        await db
+          .collection('gyms')
+          .doc('G1')
+          .collection('devices')
+          .doc('D1')
+          .collection('leaderboard')
+          .doc('userA')
+          .set({ xp: 0 });
+      });
+      const db = userA().firestore();
+      const ref = db
+        .collection('gyms')
+        .doc('G1')
+        .collection('devices')
+        .doc('D1')
+        .collection('leaderboard')
+        .doc('userA');
+      await assertFails(ref.update({ xp: 5 }));
+    });
+  });
 });

--- a/lib/features/rank/data/sources/firestore_rank_source.dart
+++ b/lib/features/rank/data/sources/firestore_rank_source.dart
@@ -77,6 +77,7 @@ class FirestoreRankSource {
             if (!userSnap.exists) {
               tx.set(lbUser, {
                 ...info.toMap(),
+                'userId': userId,
                 'showInLeaderboard': showInLeaderboard,
                 'updatedAt': FieldValue.serverTimestamp(),
               });
@@ -85,6 +86,7 @@ class FirestoreRankSource {
                 'xp': info.xp,
                 'level': info.level,
                 'updatedAt': FieldValue.serverTimestamp(),
+                'userId': userId,
                 if (!(userSnap.data()?.containsKey('showInLeaderboard') ?? false))
                   'showInLeaderboard': showInLeaderboard,
               });

--- a/scripts/repair_leaderboard.js
+++ b/scripts/repair_leaderboard.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Repair leaderboard documents by ensuring required fields exist.
+// Usage: node scripts/repair_leaderboard.js <gymId> <deviceId>
+
+const admin = require('firebase-admin');
+const path = require('path');
+const fs = require('fs');
+
+const credPath = path.join(__dirname, 'admin.example.json');
+if (!fs.existsSync(credPath)) {
+  console.error('Missing admin credential file at', credPath);
+  process.exit(1);
+}
+const serviceAccount = require(credPath);
+admin.initializeApp({ credential: admin.credential.cert(serviceAccount) });
+
+async function repair(gymId, deviceId) {
+  const db = admin.firestore();
+  const col = db
+    .collection('gyms')
+    .doc(gymId)
+    .collection('devices')
+    .doc(deviceId)
+    .collection('leaderboard');
+
+  const snap = await col.get();
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const updates = {};
+    if (!('userId' in data)) updates.userId = doc.id;
+    if (!('xp' in data)) updates.xp = 0;
+    if (!('level' in data)) updates.level = 1;
+    if (Object.keys(updates).length) {
+      console.log('Repairing', doc.ref.path, updates);
+      await doc.ref.set(updates, { merge: true });
+    }
+  }
+}
+
+const [gymId, deviceId] = process.argv.slice(2);
+if (!gymId || !deviceId) {
+  console.error('Usage: node scripts/repair_leaderboard.js <gymId> <deviceId>');
+  process.exit(1);
+}
+
+repair(gymId, deviceId)
+  .then(() => {
+    console.log('Done');
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error('Error', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- include `userId` in leaderboard transaction writes so member updates pass security rules
- document device XP flow and provide repair script for existing leaderboard docs
- test security rules for leaderboard create/update scenarios

## Testing
- `npm run rules-test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*
- `npm run test:rules` *(fails: download failed, status 403)*
- `flutter test test/providers/rank_provider_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a29888588320afc059401aa6afaf