### PR TITLE
fix(rank): add userId for leaderboard updates

### DIFF
--- a/lib/features/rank/data/sources/firestore_rank_source.dart
+++ b/lib/features/rank/data/sources/firestore_rank_source.dart
@@ -86,7 +86,8 @@ class FirestoreRankSource {
                 'xp': info.xp,
                 'level': info.level,
                 'updatedAt': FieldValue.serverTimestamp(),
-                'userId': userId,
+                if (!(userSnap.data()?.containsKey('userId') ?? false))
+                  'userId': userId,
                 if (!(userSnap.data()?.containsKey('showInLeaderboard') ?? false))
                   'showInLeaderboard': showInLeaderboard,
               });


### PR DESCRIPTION
## Summary
- include `userId` when creating leaderboard entries
- backfill missing `userId` in existing leaderboard documents on update

## Testing
- `dart format lib/features/rank/data/sources/firestore_rank_source.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a6a2f9c083209d7d060d6284ddc5