### PR TITLE
fix(rank): provide required isMulti and traceId

### DIFF
--- a/lib/features/rank/data/repositories/rank_repository_impl.dart
+++ b/lib/features/rank/data/repositories/rank_repository_impl.dart
@@ -14,13 +14,17 @@ class RankRepositoryImpl implements RankRepository {
     String sessionId,
     bool showInLeaderboard,
   ) {
-    return _source.addXp(
-      gymId: gymId,
-      userId: userId,
-      deviceId: deviceId,
-      sessionId: sessionId,
-      showInLeaderboard: showInLeaderboard,
-    );
+    return _source
+        .addXp(
+          gymId: gymId,
+          userId: userId,
+          deviceId: deviceId,
+          sessionId: sessionId,
+          showInLeaderboard: showInLeaderboard,
+          isMulti: false,
+          traceId: '',
+        )
+        .then((_) {});
   }
 
   @override


### PR DESCRIPTION
## Summary
- provide required `isMulti` and `traceId` defaults when adding XP to leaderboard

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ae8a4c8c832081fea6ef36b13e37