### PR TITLE
refactor(rank): remove unused variable

### DIFF
--- a/lib/features/rank/data/sources/firestore_rank_source.dart
+++ b/lib/features/rank/data/sources/firestore_rank_source.dart
@@ -81,7 +81,6 @@ class FirestoreRankSource {
             }
 
             const xpDelta = LevelService.xpPerSession;
-            final xpBefore = (userSnap.data()?['xp'] as int?) ?? 0;
             var info = LevelInfo.fromMap(userSnap.data());
             info = LevelService().addXp(info, xpDelta);
             final xpAfter = info.xp;


### PR DESCRIPTION
## Summary
- remove unused `xpBefore` variable from Firestore rank source

## Testing
- `dart format lib/features/rank/data/sources/firestore_rank_source.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ba3a3464832085e6c96476ad07c7