### PR TITLE
feat(profile): show roman numeral level

### DIFF
--- a/lib/features/profile/presentation/widgets/daily_xp_avatar.dart
+++ b/lib/features/profile/presentation/widgets/daily_xp_avatar.dart
@@ -24,7 +24,7 @@ class DailyXpAvatar extends StatelessWidget {
     final progress = level >= LevelService.maxLevel
         ? 1.0
         : xp / LevelService.xpPerLevel;
-    final badgeText = level >= LevelService.maxLevel ? 'MAX' : 'L$level';
+    final badgeText = _toRoman(level);
     return Stack(
       alignment: Alignment.center,
       children: [
@@ -50,20 +50,54 @@ class DailyXpAvatar extends StatelessWidget {
           child: Semantics(
             label: 'Level $level',
             child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+              width: 24,
+              height: 24,
               decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.secondary,
-                borderRadius: BorderRadius.circular(8),
+                shape: BoxShape.circle,
+                border: Border.all(
+                  color: Theme.of(context).colorScheme.secondary,
+                ),
               ),
+              alignment: Alignment.center,
               child: Text(
                 badgeText,
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(fontSize: 10),
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      fontSize: 10,
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
               ),
             ),
           ),
         ),
       ],
     );
+  }
+
+  String _toRoman(int number) {
+    const Map<int, String> romans = {
+      1000: 'M',
+      900: 'CM',
+      500: 'D',
+      400: 'CD',
+      100: 'C',
+      90: 'XC',
+      50: 'L',
+      40: 'XL',
+      10: 'X',
+      9: 'IX',
+      5: 'V',
+      4: 'IV',
+      1: 'I',
+    };
+    var result = '';
+    var remaining = number;
+    romans.forEach((value, numeral) {
+      while (remaining >= value) {
+        result += numeral;
+        remaining -= value;
+      }
+    });
+    return result;
   }
 }
 


### PR DESCRIPTION
## Summary
- display user level badge using Roman numerals I–XXX
- style level badge as outlined circle in theme color

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5965841e48320829d841b8899c7c3