### PR TITLE
Handle nullable weights in session set view model

### DIFF
--- a/lib/features/device/presentation/models/session_set_vm.dart
+++ b/lib/features/device/presentation/models/session_set_vm.dart
@@ -21,8 +21,8 @@ List<SessionSetVM> mapSnapshotToVM(DeviceSessionSnapshot snap) {
   for (final s in snap.sets) {
     vm.add(SessionSetVM(
       ordinal: ordinal++,
-      kg: s.kg,
-      reps: s.reps,
+      kg: s.kg ?? 0,
+      reps: s.reps ?? 0,
       drops: s.drops,
       isBodyweight: s.isBodyweight,
     ));

--- a/lib/features/device/presentation/widgets/read_only_snapshot_page.dart
+++ b/lib/features/device/presentation/widgets/read_only_snapshot_page.dart
@@ -51,10 +51,10 @@ class ReadOnlySnapshotPage extends StatelessWidget {
               final drops = s.drops.isNotEmpty ? s.drops : _legacyDrops(snapshot, i);
               final loc = AppLocalizations.of(context)!;
               final weightText = s.isBodyweight
-                  ? (s.kg == 0
+                  ? ((s.kg ?? 0) == 0
                       ? loc.bodyweight
-                      : loc.bodyweightPlus(s.kg))
-                  : s.kg.toString();
+                      : loc.bodyweightPlus(s.kg ?? 0))
+                  : (s.kg?.toString() ?? '0');
               return Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
@@ -63,7 +63,7 @@ class ReadOnlySnapshotPage extends StatelessWidget {
                     set: {
                       'number': '${i + 1}',
                       'weight': weightText,
-                      'reps': s.reps.toString(),
+                      'reps': s.reps?.toString() ?? '0',
                       'dropWeight': '',
                       'dropReps': '',
                       'done': s.done,


### PR DESCRIPTION
## Summary
- prevent null weight and rep values when mapping session snapshots
- safely render bodyweight text and reps in read-only snapshot page

## Testing
- `dart format lib/features/device/presentation/models/session_set_vm.dart lib/features/device/presentation/widgets/read_only_snapshot_page.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c61d9ae3c88320910f9e4d24b5cb85