### PR TITLE
fix(device): avoid resolvedDeviceId redeclaration

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -709,7 +709,7 @@ class DeviceProvider extends ChangeNotifier {
     }
 
     final sessionId = _uuid.v4();
-    final resolvedDeviceId = _device!.uid;
+    String? resolvedDeviceId = _device!.uid;
     final traceId = XpTrace.buildTraceId(
       dayKey: dayKey,
       uid: userId,
@@ -901,7 +901,7 @@ class DeviceProvider extends ChangeNotifier {
         if (_device!.isCardio) 'totalDurationSec': totalDurationSec,
       });
 
-      final resolvedDeviceId = resolveDeviceId(snapshot);
+      resolvedDeviceId = resolveDeviceId(snapshot);
       if (resolvedDeviceId == null || resolvedDeviceId.isEmpty) {
         XpTrace.log('SKIP', {'reason': 'missingDeviceId', 'traceId': traceId});
         elogDeviceXp('SKIP_NO_DEVICE', {
@@ -930,7 +930,7 @@ class DeviceProvider extends ChangeNotifier {
               .addSessionXp(
             gymId: gymId,
             userId: userId,
-            deviceId: resolvedDeviceId,
+            deviceId: resolvedDeviceId!,
             sessionId: sessionId,
             showInLeaderboard: showInLeaderboard,
             isMulti: _device!.isMulti,
@@ -953,7 +953,7 @@ class DeviceProvider extends ChangeNotifier {
           await Provider.of<ChallengeProvider>(
             context,
             listen: false,
-          ).checkChallenges(gymId, userId, resolvedDeviceId);
+          ).checkChallenges(gymId, userId, resolvedDeviceId!);
         } catch (e, st) {
           XpTrace.log('CALL_RESULT', {
             'result': 'error',


### PR DESCRIPTION
## Summary
- handle `resolvedDeviceId` with a single nullable variable and assignment
- assert non-null when passing to XP and challenge providers

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c629ef0e9883208e04de4f48f4167b