### PR TITLE
feat: cardio device runner timer

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -335,7 +335,24 @@ service cloud.firestore {
 
         // Session snapshots per user (read owner/admin; write owner-only)
         match /sessions/{sessionId} {
-          allow create: if requestOwnerInGym(gymId);
+          allow create: if requestOwnerInGym(gymId) &&
+            request.resource.data.keys().hasOnly([
+              'sessionId',
+              'deviceId',
+              'exerciseId',
+              'createdAt',
+              'userId',
+              'note',
+              'sets',
+              'renderVersion',
+              'uiHints',
+              'isCardio',
+              'mode',
+              'durationSec'
+            ]) &&
+            (request.resource.data.isCardio == null || request.resource.data.isCardio is bool) &&
+            (request.resource.data.mode == null || request.resource.data.mode is string) &&
+            (request.resource.data.durationSec == null || request.resource.data.durationSec is int);
           allow read: if resourceOwnerOrAdmin(gymId) ||
                        isFriend(resource.data.userId, request.auth.uid);
           allow update, delete: if false;

--- a/lib/features/device/domain/models/device_session_snapshot.dart
+++ b/lib/features/device/domain/models/device_session_snapshot.dart
@@ -13,6 +13,9 @@ class DeviceSessionSnapshot {
   final List<SetEntry> sets;
   final int renderVersion;
   final Map<String, dynamic>? uiHints;
+  final bool isCardio;
+  final String? mode;
+  final int? durationSec;
 
   const DeviceSessionSnapshot({
     required this.sessionId,
@@ -24,6 +27,9 @@ class DeviceSessionSnapshot {
     required this.sets,
     this.renderVersion = 1,
     this.uiHints,
+    this.isCardio = false,
+    this.mode,
+    this.durationSec,
   });
 
   factory DeviceSessionSnapshot.fromJson(Map<String, dynamic> j) {
@@ -39,6 +45,9 @@ class DeviceSessionSnapshot {
           .toList(),
       renderVersion: j['renderVersion'] as int? ?? 1,
       uiHints: j['uiHints'] as Map<String, dynamic>?,
+      isCardio: j['isCardio'] as bool? ?? false,
+      mode: j['mode'] as String?,
+      durationSec: (j['durationSec'] as num?)?.toInt(),
     );
   }
 
@@ -52,6 +61,9 @@ class DeviceSessionSnapshot {
         'sets': sets.map((s) => s.toJson()).toList(),
         'renderVersion': renderVersion,
         'uiHints': uiHints,
+        'isCardio': isCardio,
+        if (mode != null) 'mode': mode,
+        if (durationSec != null) 'durationSec': durationSec,
       };
 }
 

--- a/lib/features/device/presentation/providers/cardio_timer_provider.dart
+++ b/lib/features/device/presentation/providers/cardio_timer_provider.dart
@@ -1,0 +1,56 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+/// Simple state machine for cardio timer.
+/// States: idle -> running -> stopped.
+class CardioTimerProvider extends ChangeNotifier {
+  CardioTimerState _state = CardioTimerState.idle;
+  DateTime? _startedAt;
+  int _elapsedSec = 0; // accumulated seconds when stopped
+  Timer? _ticker;
+
+  CardioTimerState get state => _state;
+
+  /// Elapsed seconds depending on state.
+  int get elapsedSec {
+    if (_state == CardioTimerState.running && _startedAt != null) {
+      return _elapsedSec + DateTime.now().difference(_startedAt!).inSeconds;
+    }
+    return _elapsedSec;
+  }
+
+  bool get isRunning => _state == CardioTimerState.running;
+  bool get isStopped => _state == CardioTimerState.stopped;
+
+  void start() {
+    if (_state == CardioTimerState.running) return;
+    _startedAt = DateTime.now();
+    _ticker?.cancel();
+    _ticker = Timer.periodic(const Duration(seconds: 1), (_) => notifyListeners());
+    _state = CardioTimerState.running;
+    notifyListeners();
+  }
+
+  void pause() {
+    if (_state != CardioTimerState.running) return;
+    _elapsedSec = elapsedSec;
+    _ticker?.cancel();
+    _ticker = null;
+    _startedAt = null;
+    _state = CardioTimerState.stopped;
+    notifyListeners();
+  }
+
+  void reset() {
+    _ticker?.cancel();
+    _ticker = null;
+    _startedAt = null;
+    _elapsedSec = 0;
+    _state = CardioTimerState.idle;
+    notifyListeners();
+  }
+}
+
+enum CardioTimerState { idle, running, stopped }
+

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -30,6 +30,8 @@ import 'package:tapem/features/feedback/presentation/widgets/feedback_button.dar
 import 'package:tapem/ui/timer/session_timer_bar.dart';
 import 'package:tapem/core/logging/elog.dart';
 import 'package:tapem/core/time/logic_day.dart';
+import 'package:tapem/features/device/presentation/widgets/cardio_runner.dart';
+import 'package:tapem/features/device/presentation/providers/cardio_timer_provider.dart';
 
 void _dlog(String m) {}
 
@@ -453,6 +455,28 @@ class _DeviceScreenState extends State<DeviceScreen> {
       scaffold = Scaffold(
         appBar: AppBar(title: const Text('Gerät nicht gefunden')),
         body: Center(child: Text('Fehler: ${prov.error ?? "Unbekannt"}')),
+      );
+    } else if (prov.device!.isCardio) {
+      scaffold = ChangeNotifierProvider(
+        create: (_) => CardioTimerProvider(),
+        child: Scaffold(
+          appBar: AppBar(
+            title: Text(prov.device!.name),
+            centerTitle: true,
+          ),
+          body: CardioRunner(
+            onCancel: () => Navigator.of(context).pop(),
+            onSave: (sec) async {
+              await prov.saveCardioTimedSession(
+                context: context,
+                gymId: widget.gymId,
+                userId: auth.userId!,
+                durationSec: sec,
+              );
+              if (context.mounted) Navigator.of(context).pop();
+            },
+          ),
+        ),
       );
     } else {
       scaffold = Scaffold(

--- a/lib/features/device/presentation/widgets/cardio_runner.dart
+++ b/lib/features/device/presentation/widgets/cardio_runner.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/features/device/presentation/providers/cardio_timer_provider.dart';
+import 'package:tapem/core/util/duration_utils.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+import 'package:tapem/core/logging/elog.dart';
+import 'package:tapem/core/providers/device_provider.dart';
+
+/// UI for cardio devices: large timer and play/pause button.
+class CardioRunner extends StatelessWidget {
+  final VoidCallback onCancel;
+  final ValueChanged<int> onSave;
+
+  const CardioRunner({
+    super.key,
+    required this.onCancel,
+    required this.onSave,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context);
+    return Consumer<CardioTimerProvider>(
+      builder: (context, timer, _) {
+        final time = formatHms(timer.elapsedSec);
+        final theme = Theme.of(context);
+        return Column(
+          children: [
+            const SizedBox(height: 24),
+            Semantics(
+              label: loc.cardioTotalTimeLabel,
+              child: Text(
+                time,
+                style: theme.textTheme.displaySmall,
+              ),
+            ),
+            const Spacer(),
+            Semantics(
+              label: timer.isRunning
+                  ? loc.cardioPauseButtonLabel
+                  : loc.cardioPlayButtonLabel,
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  shape: const CircleBorder(),
+                  padding: const EdgeInsets.all(32),
+                ),
+                onPressed: () {
+                  if (timer.isRunning) {
+                    timer.pause();
+                    elogUi('cardio_timer_paused', {
+                      'elapsedSec': timer.elapsedSec,
+                    });
+                  } else {
+                    timer.start();
+                    final deviceId =
+                        context.read<DeviceProvider>().device?.uid;
+                    elogUi('cardio_timer_started', {
+                      'deviceId': deviceId,
+                    });
+                  }
+                },
+                child: Icon(
+                  timer.isRunning ? Icons.pause : Icons.play_arrow,
+                  size: 48,
+                ),
+              ),
+            ),
+            const Spacer(),
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  TextButton(
+                    onPressed: onCancel,
+                    child: Text(loc.cancelButton),
+                  ),
+                  ElevatedButton(
+                    onPressed: timer.isStopped && timer.elapsedSec > 0
+                        ? () => onSave(timer.elapsedSec)
+                        : null,
+                    child: Text(loc.saveButton),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/features/device/presentation/widgets/read_only_snapshot_page.dart
+++ b/lib/features/device/presentation/widgets/read_only_snapshot_page.dart
@@ -13,6 +13,36 @@ class ReadOnlySnapshotPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final dateStr = DateFormat('dd.MM.yyyy HH:mm').format(snapshot.createdAt);
+    final loc = AppLocalizations.of(context)!;
+    if (snapshot.isCardio && snapshot.mode == 'timed') {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Text(dateStr,
+                style: const TextStyle(fontWeight: FontWeight.bold)),
+          ),
+          Expanded(
+            child: Center(
+              child: Text(
+                '${loc.cardioTotalTimeLabel}: ${formatHms(snapshot.durationSec ?? 0)}',
+                style: const TextStyle(fontSize: 24),
+              ),
+            ),
+          ),
+          if (snapshot.note != null && snapshot.note!.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: BrandGradientCard(
+                padding: const EdgeInsets.all(12),
+                child: Text(snapshot.note!),
+              ),
+            ),
+        ],
+      );
+    }
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -52,7 +82,6 @@ class ReadOnlySnapshotPage extends StatelessWidget {
                 );
               }
               final drops = s.drops.isNotEmpty ? s.drops : _legacyDrops(snapshot, i);
-              final loc = AppLocalizations.of(context)!;
               final weightText = s.isBodyweight
                   ? ((s.kg ?? 0) == 0
                       ? loc.bodyweight

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -413,6 +413,16 @@
   "@saveButton": {
     "description": "Beschriftung für Speichern-Button"
   },
+  "cardioPlayButtonLabel": "Trainingstimer starten",
+  "@cardioPlayButtonLabel": {
+    "description": "A11y-Label zum Starten des Cardio-Timers"
+  },
+  "cardioPauseButtonLabel": "Trainingstimer pausieren",
+  "@cardioPauseButtonLabel": {
+    "description": "A11y-Label zum Pausieren des Cardio-Timers"
+  },
+  "cardioTotalTimeLabel": "Gesamtzeit",
+  "@cardioTotalTimeLabel": {"description": "Label für die verstrichene Zeit"},
 
   "settingsIconTooltip": "Einstellungen",
   "@settingsIconTooltip": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -411,6 +411,16 @@
   "@saveButton": {
     "description": "Label for the save button"
   },
+  "cardioPlayButtonLabel": "Start training timer",
+  "@cardioPlayButtonLabel": {
+    "description": "A11y label to start cardio timer"
+  },
+  "cardioPauseButtonLabel": "Pause training timer",
+  "@cardioPauseButtonLabel": {
+    "description": "A11y label to pause cardio timer"
+  },
+  "cardioTotalTimeLabel": "Total time",
+  "@cardioTotalTimeLabel": {"description": "Label for elapsed cardio time"},
 
   "settingsIconTooltip": "Settings",
   "@settingsIconTooltip": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -659,6 +659,12 @@ abstract class AppLocalizations {
   /// **'Save'**
   String get saveButton;
 
+  String get cardioPlayButtonLabel;
+
+  String get cardioPauseButtonLabel;
+
+  String get cardioTotalTimeLabel;
+
   /// Tooltip for the settings icon
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -310,6 +310,12 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get saveButton => 'Speichern';
 
+  String get cardioPlayButtonLabel => 'Trainingstimer starten';
+
+  String get cardioPauseButtonLabel => 'Trainingstimer pausieren';
+
+  String get cardioTotalTimeLabel => 'Gesamtzeit';
+
   @override
   String get settingsIconTooltip => 'Einstellungen';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -310,6 +310,12 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get saveButton => 'Save';
 
+  String get cardioPlayButtonLabel => 'Start training timer';
+
+  String get cardioPauseButtonLabel => 'Pause training timer';
+
+  String get cardioTotalTimeLabel => 'Total time';
+
   @override
   String get settingsIconTooltip => 'Settings';
 

--- a/test/features/device/domain/models/device_session_snapshot_test.dart
+++ b/test/features/device/domain/models/device_session_snapshot_test.dart
@@ -21,6 +21,9 @@ void main() {
         SetEntry(kg: 0, reps: 5, isBodyweight: true),
         SetEntry(speedKmH: 10, durationSec: 90, done: true),
       ],
+      isCardio: true,
+      mode: 'timed',
+      durationSec: 90,
     );
 
     final json = snapshot.toJson();
@@ -36,5 +39,8 @@ void main() {
     expect(decoded.sets[1].kg, 0);
     expect(decoded.sets[2].speedKmH, 10);
     expect(decoded.sets[2].durationSec, 90);
+    expect(decoded.isCardio, true);
+    expect(decoded.mode, 'timed');
+    expect(decoded.durationSec, 90);
   });
 }

--- a/test/providers/cardio_timer_provider_test.dart
+++ b/test/providers/cardio_timer_provider_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/features/device/presentation/providers/cardio_timer_provider.dart';
+
+void main() {
+  test('state transitions idle -> running -> stopped', () async {
+    final prov = CardioTimerProvider();
+    expect(prov.state, CardioTimerState.idle);
+    prov.start();
+    expect(prov.state, CardioTimerState.running);
+    await Future.delayed(const Duration(seconds: 1));
+    prov.pause();
+    expect(prov.state, CardioTimerState.stopped);
+    expect(prov.elapsedSec > 0, true);
+    prov.reset();
+    expect(prov.state, CardioTimerState.idle);
+    expect(prov.elapsedSec, 0);
+  });
+}

--- a/test/widgets/read_only_snapshot_page_test.dart
+++ b/test/widgets/read_only_snapshot_page_test.dart
@@ -34,4 +34,21 @@ void main() {
     expect(find.text('10'), findsOneWidget);
     expect(find.text('00:01:30'), findsOneWidget);
   });
+
+  testWidgets('renders timed cardio session summary', (tester) async {
+    final snapshot = DeviceSessionSnapshot(
+      sessionId: 's2',
+      deviceId: 'd1',
+      createdAt: DateTime(2024),
+      userId: 'u1',
+      sets: const [],
+      isCardio: true,
+      mode: 'timed',
+      durationSec: 65,
+    );
+    await tester.pumpWidget(
+      MaterialApp(home: ReadOnlySnapshotPage(snapshot: snapshot)),
+    );
+    expect(find.textContaining('00:01:05'), findsOneWidget);
+  });
 }

--- a/thesis/gamification/GAM-20250914-cardio-runner-ui-rebuild.md
+++ b/thesis/gamification/GAM-20250914-cardio-runner-ui-rebuild.md
@@ -1,0 +1,28 @@
+---
+change_id: GAM-20250914-cardio-runner-ui-rebuild
+title: Cardio Devicepage Runner UI Rebuild
+branch: feature/cardio-devicepage-runner-ui
+pr_url: TODO
+commit_sha: 7327c34ba137caaeb2f959dd387a15c715fa498a
+app_version: TODO
+authors: CodeX
+created_at: 2025-09-14
+---
+
+## Prompt (Ziel & Kontext)
+Rebuild the cardio device page with a large timer and play/pause button. Saving a paused timer persists a timed cardio session.
+
+## Umsetzung (dieser PR)
+- Introduced `CardioTimerProvider` with idle→running→stopped state machine.
+- Added `CardioRunner` widget showing big timer, play/pause button, and save flow.
+- Added simple persistence for cardio sessions with `mode: "timed"` and `durationSec`.
+- Localizations for timer labels.
+- Firestore rules updated to accept new fields.
+
+## Ergebnis des PR
+Screenshots pending.
+
+## Messplan
+- cardio_session_saved events count
+- average duration
+- save/abort ratio


### PR DESCRIPTION
## Summary
- add cardio runner UI with play/pause timer
- persist timed cardio sessions with durationSec
- add localization and Firestore rule support

## Checklist
- [ ] large timer and play/pause on cardio device page
- [ ] cardio session saves duration and mode
- [ ] docs added in `thesis/gamification/GAM-20250914-cardio-runner-ui-rebuild.md`

## Testing
- `flutter gen-l10n` *(fails: command not found)*
- `flutter test test/providers/cardio_timer_provider_test.dart test/features/device/domain/models/device_session_snapshot_test.dart test/widgets/read_only_snapshot_page_test.dart` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c735ac88ec8320b9d65c00d2bc9500