### PR TITLE
fix: handle localization nullability and clean up tests

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -938,7 +938,7 @@ class DeviceProvider extends ChangeNotifier {
               .addSessionXp(
             gymId: gymId,
             userId: userId,
-            deviceId: resolvedDeviceId!,
+            deviceId: resolvedDeviceId,
             sessionId: sessionId,
             showInLeaderboard: showInLeaderboard,
             isMulti: _device!.isMulti,
@@ -961,7 +961,7 @@ class DeviceProvider extends ChangeNotifier {
           await Provider.of<ChallengeProvider>(
             context,
             listen: false,
-          ).checkChallenges(gymId, userId, resolvedDeviceId!);
+          ).checkChallenges(gymId, userId, resolvedDeviceId);
         } catch (e, st) {
           XpTrace.log('CALL_RESULT', {
             'result': 'error',

--- a/lib/features/device/presentation/widgets/cardio_runner.dart
+++ b/lib/features/device/presentation/widgets/cardio_runner.dart
@@ -19,7 +19,7 @@ class CardioRunner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context);
+    final loc = AppLocalizations.of(context)!;
     return Consumer<CardioTimerProvider>(
       builder: (context, timer, _) {
         final time = formatHms(timer.elapsedSec);

--- a/test/providers/device_provider_test.dart
+++ b/test/providers/device_provider_test.dart
@@ -487,10 +487,11 @@ void main() {
         exerciseId: 'ex1',
         userId: 'u1',
       );
-      provider.updateSet(0, speed: '10,5');
-      expect(provider.toggleSetDone(0), true);
-      provider.updateSet(0, done: false, speed: '005');
-      expect(provider.toggleSetDone(0), true);
+        provider.updateSet(0, speed: '10,5');
+        expect(provider.toggleSetDone(0), true);
+        provider.toggleSetDone(0);
+        provider.updateSet(0, speed: '005');
+        expect(provider.toggleSetDone(0), true);
     });
 
     test('speed over max invalid', () async {


### PR DESCRIPTION
## Summary
- ensure cardio runner handles localization non-null
- remove unnecessary null assertions in device provider
- adjust device provider test to use toggle instead of undefined done parameter

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c73a0e17808320a1995d9cfc24c315