### PR TITLE
fix: cardio save and history parity

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -323,12 +323,18 @@ service cloud.firestore {
               'tz',
               'speedKmH',
               'durationSec',
+              'mode',
+              'intervals',
               'weight',
               'reps',
               'isBodyweight',
               'dropWeightKg',
               'dropReps'
-            ]);
+            ]) &&
+            (request.resource.data.speedKmH == null || request.resource.data.speedKmH is number) &&
+            (request.resource.data.durationSec == null || request.resource.data.durationSec is int) &&
+            (request.resource.data.mode == null || request.resource.data.mode is string) &&
+            (request.resource.data.intervals == null || (request.resource.data.intervals is list && request.resource.data.intervals.all(i, i.durationSec is int && i.speedKmH is number)));
           allow read: if resourceOwnerOrAdmin(gymId);
           allow update, delete: if false;
         }
@@ -348,11 +354,15 @@ service cloud.firestore {
               'uiHints',
               'isCardio',
               'mode',
-              'durationSec'
+              'durationSec',
+              'speedKmH',
+              'intervals'
             ]) &&
             (request.resource.data.isCardio == null || request.resource.data.isCardio is bool) &&
             (request.resource.data.mode == null || request.resource.data.mode is string) &&
-            (request.resource.data.durationSec == null || request.resource.data.durationSec is int);
+            (request.resource.data.durationSec == null || request.resource.data.durationSec is int) &&
+            (request.resource.data.speedKmH == null || request.resource.data.speedKmH is number) &&
+            (request.resource.data.intervals == null || (request.resource.data.intervals is list && request.resource.data.intervals.all(i, i.durationSec is int && i.speedKmH is number)));
           allow read: if resourceOwnerOrAdmin(gymId) ||
                        isFriend(resource.data.userId, request.auth.uid);
           allow update, delete: if false;

--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -1084,6 +1084,7 @@ class DeviceProvider extends ChangeNotifier {
     elogUi('cardio_session_saved', {
       'mode': 'timed',
       'durationSec': durationSec,
+      'intervalCount': 0,
     });
     return true;
   }

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -56,6 +56,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
   final _scrollController = ScrollController();
   final List<GlobalKey<SetCardState>> _setKeys = [];
   final _pagerKey = GlobalKey<DevicePagerState>();
+  late OverlayNumericKeypadController _keypad;
 
   @override
   void initState() {
@@ -83,6 +84,12 @@ class _DeviceScreenState extends State<DeviceScreen> {
       _dlog('loadDevice() → done');
       setState(() {});
     });
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _keypad = context.read<OverlayNumericKeypadController>();
   }
 
   void _addSet() {
@@ -116,7 +123,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
 
   void _closeKeyboard() {
     FocusManager.instance.primaryFocus?.unfocus();
-    context.read<OverlayNumericKeypadController>().close();
+    _keypad.close();
   }
 
   Widget _buildEditablePage(

--- a/lib/features/training_details/data/dtos/session_dto.dart
+++ b/lib/features/training_details/data/dtos/session_dto.dart
@@ -9,14 +9,19 @@ class SessionDto {
   final String exerciseId;
   final String userId;
   final DateTime timestamp;
-  final double weight;
-  final int reps;
+  final double? weight;
+  final int? reps;
   final int setNumber;
   final double? dropWeightKg;
   final int? dropReps;
   final String note;
   final DocumentReference<Map<String, dynamic>> reference;
   final bool isBodyweight;
+  final bool isCardio;
+  final String? mode;
+  final int? durationSec;
+  final double? speedKmH;
+  final List<Map<String, dynamic>>? intervals;
 
   SessionDto({
     required this.sessionId,
@@ -24,14 +29,19 @@ class SessionDto {
     required this.exerciseId,
     required this.userId,
     required this.timestamp,
-    required this.weight,
-    required this.reps,
+    this.weight,
+    this.reps,
     required this.setNumber,
     this.dropWeightKg,
     this.dropReps,
     required this.note,
     required this.reference,
     this.isBodyweight = false,
+    this.isCardio = false,
+    this.mode,
+    this.durationSec,
+    this.speedKmH,
+    this.intervals,
   });
 
   factory SessionDto.fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
@@ -52,20 +62,35 @@ class SessionDto {
       setNumber = 0;
     }
 
+    final isCardio = data['isCardio'] as bool? ?? false;
+    final intervalsRaw = data['intervals'] as List?;
+    final intervals = intervalsRaw
+        ?.whereType<Map<String, dynamic>>()
+        .map((e) => {
+              'durationSec': (e['durationSec'] as num?)?.toInt(),
+              'speedKmH': (e['speedKmH'] as num?)?.toDouble(),
+            })
+        .toList();
+
     return SessionDto(
       sessionId: data['sessionId'] as String,
       deviceId: deviceId, // nicht mehr data['deviceId']
       exerciseId: exerciseId,
       userId: userId,
       timestamp: (data['timestamp'] as Timestamp).toDate(),
-      weight: (data['weight'] as num).toDouble(),
-      reps: (data['reps'] as num).toInt(),
+      weight: (data['weight'] as num?)?.toDouble(),
+      reps: (data['reps'] as num?)?.toInt(),
       setNumber: setNumber,
       dropWeightKg: (data['dropWeightKg'] as num?)?.toDouble(),
       dropReps: (data['dropReps'] as num?)?.toInt(),
       note: data['note'] as String? ?? '',
       reference: doc.reference,
       isBodyweight: data['isBodyweight'] as bool? ?? false,
+      isCardio: isCardio,
+      mode: data['mode'] as String?,
+      durationSec: (data['durationSec'] as num?)?.toInt(),
+      speedKmH: (data['speedKmH'] as num?)?.toDouble(),
+      intervals: intervals,
     );
   }
 }

--- a/lib/features/training_details/data/repositories/session_repository_impl.dart
+++ b/lib/features/training_details/data/repositories/session_repository_impl.dart
@@ -83,16 +83,20 @@ class SessionRepositoryImpl implements SessionRepository {
         }
       }
 
-      final sets = list
-          .map((dto) => SessionSet(
-                weight: dto.weight,
-                reps: dto.reps,
-                setNumber: dto.setNumber,
-                dropWeightKg: dto.dropWeightKg,
-                dropReps: dto.dropReps,
-                isBodyweight: dto.isBodyweight,
-              ))
-          .toList();
+      final isCardio =
+          first.isCardio || first.mode != null || first.weight == null || first.reps == null;
+      final sets = isCardio
+          ? <SessionSet>[]
+          : list
+              .map((dto) => SessionSet(
+                    weight: dto.weight ?? 0,
+                    reps: dto.reps ?? 0,
+                    setNumber: dto.setNumber,
+                    dropWeightKg: dto.dropWeightKg,
+                    dropReps: dto.dropReps,
+                    isBodyweight: dto.isBodyweight,
+                  ))
+              .toList();
 
       final gymId = deviceRef.parent.parent!.id;
       DateTime? startTime;
@@ -125,6 +129,16 @@ class SessionRepositoryImpl implements SessionRepository {
           startTime: startTime,
           endTime: endTime,
           durationMs: durationMs,
+          isCardio: isCardio,
+          mode: first.mode,
+          durationSec: first.durationSec,
+          speedKmH: first.speedKmH,
+          intervals: first.intervals
+              ?.map((e) => CardioInterval(
+                    durationSec: e['durationSec'] as int?,
+                    speedKmH: e['speedKmH'] as double?,
+                  ))
+              .toList(),
         ),
       );
     }

--- a/lib/features/training_details/domain/models/session.dart
+++ b/lib/features/training_details/domain/models/session.dart
@@ -8,6 +8,21 @@ class Session {
   final String note;
   final List<SessionSet> sets;
 
+  /// True if this session represents a cardio workout.
+  final bool isCardio;
+
+  /// Cardio mode: "timed", "steady", or "intervals".
+  final String? mode;
+
+  /// Total duration in seconds for cardio sessions.
+  final int? durationSec;
+
+  /// Steady speed in km/h for steady cardio sessions.
+  final double? speedKmH;
+
+  /// Interval details for interval cardio sessions.
+  final List<CardioInterval>? intervals;
+
   /// Timestamp of when the session started, if known.
   final DateTime? startTime;
 
@@ -28,6 +43,11 @@ class Session {
     this.startTime,
     this.endTime,
     this.durationMs,
+    this.isCardio = false,
+    this.mode,
+    this.durationSec,
+    this.speedKmH,
+    this.intervals,
   });
 }
 
@@ -46,4 +66,10 @@ class SessionSet {
     this.dropReps,
     this.isBodyweight = false,
   });
+}
+
+class CardioInterval {
+  final int? durationSec;
+  final double? speedKmH;
+  CardioInterval({this.durationSec, this.speedKmH});
 }

--- a/lib/features/training_details/presentation/widgets/cardio_session_card.dart
+++ b/lib/features/training_details/presentation/widgets/cardio_session_card.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:tapem/core/widgets/brand_outline.dart';
+import 'package:tapem/core/util/duration_utils.dart';
+import '../../domain/models/session.dart';
+
+class CardioSessionCard extends StatelessWidget {
+  final Session session;
+  const CardioSessionCard({super.key, required this.session});
+
+  @override
+  Widget build(BuildContext context) {
+    final duration = formatHms(session.durationSec ?? 0);
+    Widget body;
+    switch (session.mode) {
+      case 'steady':
+        final sp = (session.speedKmH ?? 0).toStringAsFixed(1);
+        body = Text('$sp km/h • $duration', style: const TextStyle(fontSize: 14));
+        break;
+      case 'intervals':
+        body = Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Intervalle (Gesamt $duration)',
+                style: const TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 4),
+            for (final i in session.intervals ?? [])
+              Text('${_ms(i.durationSec)} @ ${(i.speedKmH ?? 0).toStringAsFixed(1)} km/h',
+                  style: const TextStyle(fontSize: 14)),
+          ],
+        );
+        break;
+      default:
+        body = Text('Zeit $duration', style: const TextStyle(fontSize: 14));
+    }
+    return BrandOutline(
+      padding: const EdgeInsets.all(12.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            session.deviceName,
+            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+          ),
+          if (session.deviceDescription.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(session.deviceDescription, style: const TextStyle(fontSize: 14)),
+          ],
+          const SizedBox(height: 8),
+          body,
+        ],
+      ),
+    );
+  }
+
+  String _ms(int? sec) {
+    final s = sec ?? 0;
+    final m = s ~/ 60;
+    final r = s % 60;
+    return '${m.toString().padLeft(2, '0')}:${r.toString().padLeft(2, '0')}';
+  }
+}

--- a/lib/features/training_details/presentation/widgets/day_sessions_overview.dart
+++ b/lib/features/training_details/presentation/widgets/day_sessions_overview.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../domain/models/session.dart';
 import 'session_exercise_card.dart';
+import 'cardio_session_card.dart';
 import 'package:tapem/core/logging/elog.dart';
 
 class DaySessionsOverview extends StatelessWidget {
@@ -29,11 +30,13 @@ class DaySessionsOverview extends StatelessWidget {
                   });
                   return SizedBox(
                     width: cardWidth,
-                    child: SessionExerciseCard(
-                      title: session.deviceName,
-                      subtitle: session.deviceDescription,
-                      sets: session.sets,
-                    ),
+                    child: session.isCardio
+                        ? CardioSessionCard(session: session)
+                        : SessionExerciseCard(
+                            title: session.deviceName,
+                            subtitle: session.deviceDescription,
+                            sets: session.sets,
+                          ),
                   );
                 },
               )

--- a/test/training_details/cardio_session_card_test.dart
+++ b/test/training_details/cardio_session_card_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/features/training_details/domain/models/session.dart';
+import 'package:tapem/features/training_details/presentation/widgets/cardio_session_card.dart';
+
+void main() {
+  testWidgets('renders timed cardio session', (tester) async {
+    final session = Session(
+      sessionId: 's1',
+      deviceId: 'c1',
+      deviceName: 'Treadmill',
+      deviceDescription: '',
+      timestamp: DateTime.now(),
+      note: '',
+      sets: const [],
+      isCardio: true,
+      mode: 'timed',
+      durationSec: 60,
+    );
+    await tester.pumpWidget(MaterialApp(home: CardioSessionCard(session: session)));
+    expect(find.textContaining('Zeit'), findsOneWidget);
+  });
+}

--- a/test/training_details/session_dto_cardio_test.dart
+++ b/test/training_details/session_dto_cardio_test.dart
@@ -1,0 +1,35 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/features/training_details/data/dtos/session_dto.dart';
+
+void main() {
+  test('cardio log without weight/reps parses', () async {
+    final ff = FakeFirebaseFirestore();
+    final ref = await ff
+        .collection('gyms')
+        .doc('g1')
+        .collection('devices')
+        .doc('c1')
+        .collection('logs')
+        .add({
+      'sessionId': 's1',
+      'deviceId': 'c1',
+      'exerciseId': 'e1',
+      'userId': 'u1',
+      'timestamp': Timestamp.now(),
+      'setNumber': 1,
+      'note': '',
+      'tz': 'UTC',
+      'isCardio': true,
+      'mode': 'timed',
+      'durationSec': 120,
+    });
+    final snap = await ref.get();
+    final dto = SessionDto.fromFirestore(snap);
+    expect(dto.isCardio, isTrue);
+    expect(dto.weight, isNull);
+    expect(dto.durationSec, 120);
+    expect(dto.mode, 'timed');
+  });
+}

--- a/test/training_details/session_repository_cardio_test.dart
+++ b/test/training_details/session_repository_cardio_test.dart
@@ -1,0 +1,49 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/features/training_details/data/repositories/session_repository_impl.dart';
+import 'package:tapem/features/training_details/data/sources/firestore_session_source.dart';
+import 'package:tapem/features/training_details/data/session_meta_source.dart';
+
+void main() {
+  test('loadSessions returns strength and cardio', () async {
+    final ff = FakeFirebaseFirestore();
+    final logs = ff.collection('gyms').doc('g1').collection('devices');
+    // strength log
+    await logs.doc('d1').collection('logs').add({
+      'sessionId': 's1',
+      'deviceId': 'd1',
+      'exerciseId': 'e1',
+      'userId': 'u1',
+      'timestamp': Timestamp.fromDate(DateTime(2024,1,1,12)),
+      'setNumber': 1,
+      'weight': 10,
+      'reps': 5,
+    });
+    // cardio log
+    await logs.doc('c1').collection('logs').add({
+      'sessionId': 's2',
+      'deviceId': 'c1',
+      'exerciseId': 'e1',
+      'userId': 'u1',
+      'timestamp': Timestamp.fromDate(DateTime(2024,1,1,13)),
+      'setNumber': 1,
+      'isCardio': true,
+      'mode': 'timed',
+      'durationSec': 180,
+    });
+    final repo = SessionRepositoryImpl(
+      FirestoreSessionSource(firestore: ff),
+      SessionMetaSource(firestore: ff),
+    );
+    final sessions = await repo.getSessionsForDate(
+      userId: 'u1',
+      date: DateTime(2024,1,1),
+    );
+    expect(sessions.length, 2);
+    final cardio = sessions.firstWhere((s) => s.isCardio);
+    expect(cardio.durationSec, 180);
+    final strength = sessions.firstWhere((s) => !s.isCardio);
+    expect(strength.sets.first.weight, 10);
+  });
+}

--- a/thesis/gamification/GAM-20250214-cardio-save-history-parity.md
+++ b/thesis/gamification/GAM-20250214-cardio-save-history-parity.md
@@ -1,0 +1,28 @@
+---
+change_id: GAM-20250214-cardio-save-history-parity
+title: Cardio save/history parity
+branch: fix/cardio-devicepage-save-history-parity
+pr_url: TBD
+commit_sha: 5426176b9b6dbe2526a88e4f406aa8f1d3ea9c06
+app_version: 1.0.0+1
+authors: CodeX
+created_at: 2025-02-14
+---
+
+## Prompt (Ziel & Kontext)
+Parität für das Speichern von Cardio-Sessions inklusive Snapshot & Log. Trainingsdetails sollen Cardio ohne Fehler laden.
+
+## Umsetzung (dieser PR)
+- Lifecycle-Fix für Devicepage ohne Provider-Lookup im dispose.
+- Cardio-aware Mapping und Repository; Session-Model erweitert.
+- Cardio-SessionCard in TrainingDetails.
+- Firestore-Rules erlauben Cardio-Felder.
+- Tests für Cardio-Mapping und Repository.
+
+## Ergebnis des PR
+_Screenshots der Devicepage, Save-Flow, Right-Swipe und Trainingsdetails werden nachgereicht._
+
+## Messplan
+- Crash-Rate Devicepage
+- Fehlerquote loadSessions
+- Anteil Cardio-Saves


### PR DESCRIPTION
## Summary
- fix dispose lifecycle by caching keypad provider
- map cardio sessions without null casts
- render cardio sessions in training details and allow new fields in rules

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c73e7c65e48320acdae5b7476c9eb4