### PR TITLE
Cardio: History crash fix, snapshot navigation, and XP parity (50 XP per session/day)

### DIFF
--- a/lib/features/device/domain/models/device_session_snapshot.dart
+++ b/lib/features/device/domain/models/device_session_snapshot.dart
@@ -16,6 +16,7 @@ class DeviceSessionSnapshot {
   final bool isCardio;
   final String? mode;
   final int? durationSec;
+  final double? speedKmH;
 
   const DeviceSessionSnapshot({
     required this.sessionId,
@@ -30,6 +31,7 @@ class DeviceSessionSnapshot {
     this.isCardio = false,
     this.mode,
     this.durationSec,
+    this.speedKmH,
   });
 
   factory DeviceSessionSnapshot.fromJson(Map<String, dynamic> j) {
@@ -48,6 +50,7 @@ class DeviceSessionSnapshot {
       isCardio: j['isCardio'] as bool? ?? false,
       mode: j['mode'] as String?,
       durationSec: (j['durationSec'] as num?)?.toInt(),
+      speedKmH: (j['speedKmH'] as num?)?.toDouble(),
     );
   }
 
@@ -64,6 +67,7 @@ class DeviceSessionSnapshot {
         'isCardio': isCardio,
         if (mode != null) 'mode': mode,
         if (durationSec != null) 'durationSec': durationSec,
+        if (speedKmH != null) 'speedKmH': speedKmH,
       };
 }
 

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -538,13 +538,21 @@ class _DeviceScreenState extends State<DeviceScreen> with WidgetsBindingObserver
             editablePage: CardioRunner(
               onCancel: () => Navigator.of(context).pop(),
               onSave: (sec) async {
-                await prov.saveCardioTimedSession(
+                final ok = await prov.saveCardioTimedSession(
                   context: context,
                   gymId: widget.gymId,
                   userId: auth.userId!,
                   durationSec: sec,
+                  showInLeaderboard: auth.showInLeaderboard ?? true,
                 );
-                if (context.mounted) Navigator.of(context).pop();
+                if (context.mounted) {
+                  if (ok) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text(loc.sessionSaved)),
+                    );
+                  }
+                  Navigator.of(context).pop();
+                }
               },
               capReached: prov.cardioCapReached,
               capMessage: loc.cardioCapHint,

--- a/lib/features/history/data/dtos/workout_log_dto.dart
+++ b/lib/features/history/data/dtos/workout_log_dto.dart
@@ -20,25 +20,38 @@ class WorkoutLogDto {
   @JsonKey(fromJson: _timestampToDate, toJson: _dateToTimestamp)
   final DateTime timestamp;
 
-  final double weight;
-  final int reps;
+  final double? weight;
+  final int? reps;
   final double? dropWeightKg;
   final int? dropReps;
   @JsonKey(fromJson: _setNumberFromJson)
   final int setNumber;
   final bool isBodyweight;
 
+  // Cardio fields
+  final bool isCardio;
+  final String? mode;
+  final int? durationSec;
+  final double? speedKmH;
+  @JsonKey(fromJson: _intervalsFromJson, toJson: _intervalsToJson)
+  final List<Map<String, dynamic>>? intervals;
+
   WorkoutLogDto({
     required this.userId,
     required this.sessionId,
     this.exerciseId,
     required this.timestamp,
-    required this.weight,
-    required this.reps,
+    this.weight,
+    this.reps,
     this.dropWeightKg,
     this.dropReps,
     required this.setNumber,
     this.isBodyweight = false,
+    this.isCardio = false,
+    this.mode,
+    this.durationSec,
+    this.speedKmH,
+    this.intervals,
   });
 
   factory WorkoutLogDto.fromJson(Map<String, dynamic> json) =>
@@ -70,6 +83,11 @@ class WorkoutLogDto {
     dropReps: dropReps,
     setNumber: setNumber,
     isBodyweight: isBodyweight,
+    isCardio: isCardio,
+    mode: mode,
+    durationSec: durationSec,
+    speedKmH: speedKmH,
+    intervals: intervals,
   );
 
   static DateTime _timestampToDate(Timestamp ts) => ts.toDate();
@@ -79,4 +97,11 @@ class WorkoutLogDto {
     if (v is String) return int.tryParse(v) ?? 0;
     return 0;
   }
+
+  static List<Map<String, dynamic>>? _intervalsFromJson(List<dynamic>? list) =>
+      list?.map((e) => Map<String, dynamic>.from(e as Map)).toList();
+
+  static List<Map<String, dynamic>>? _intervalsToJson(
+          List<Map<String, dynamic>>? list) =>
+      list;
 }

--- a/lib/features/history/data/dtos/workout_log_dto.g.dart
+++ b/lib/features/history/data/dtos/workout_log_dto.g.dart
@@ -12,12 +12,18 @@ WorkoutLogDto _$WorkoutLogDtoFromJson(Map<String, dynamic> json) =>
       sessionId: json['sessionId'] as String,
       exerciseId: json['exerciseId'] as String?,
       timestamp: WorkoutLogDto._timestampToDate(json['timestamp'] as Timestamp),
-      weight: (json['weight'] as num).toDouble(),
-      reps: (json['reps'] as num).toInt(),
+      weight: (json['weight'] as num?)?.toDouble(),
+      reps: (json['reps'] as num?)?.toInt(),
       dropWeightKg: (json['dropWeightKg'] as num?)?.toDouble(),
       dropReps: (json['dropReps'] as num?)?.toInt(),
       setNumber: WorkoutLogDto._setNumberFromJson(json['setNumber']),
       isBodyweight: json['isBodyweight'] as bool? ?? false,
+      isCardio: json['isCardio'] as bool? ?? false,
+      mode: json['mode'] as String?,
+      durationSec: (json['durationSec'] as num?)?.toInt(),
+      speedKmH: (json['speedKmH'] as num?)?.toDouble(),
+      intervals:
+          WorkoutLogDto._intervalsFromJson(json['intervals'] as List?),
     );
 
 Map<String, dynamic> _$WorkoutLogDtoToJson(WorkoutLogDto instance) =>
@@ -26,10 +32,16 @@ Map<String, dynamic> _$WorkoutLogDtoToJson(WorkoutLogDto instance) =>
       'sessionId': instance.sessionId,
       if (instance.exerciseId != null) 'exerciseId': instance.exerciseId,
       'timestamp': WorkoutLogDto._dateToTimestamp(instance.timestamp),
-      'weight': instance.weight,
-      'reps': instance.reps,
+      if (instance.weight != null) 'weight': instance.weight,
+      if (instance.reps != null) 'reps': instance.reps,
       if (instance.dropWeightKg != null) 'dropWeightKg': instance.dropWeightKg,
       if (instance.dropReps != null) 'dropReps': instance.dropReps,
       'setNumber': instance.setNumber,
       if (instance.isBodyweight) 'isBodyweight': true,
+      if (instance.isCardio) 'isCardio': true,
+      if (instance.mode != null) 'mode': instance.mode,
+      if (instance.durationSec != null) 'durationSec': instance.durationSec,
+      if (instance.speedKmH != null) 'speedKmH': instance.speedKmH,
+      if (instance.intervals != null)
+        'intervals': WorkoutLogDto._intervalsToJson(instance.intervals),
     };

--- a/lib/features/history/domain/models/workout_log.dart
+++ b/lib/features/history/domain/models/workout_log.dart
@@ -7,12 +7,19 @@ class WorkoutLog {
   final String sessionId;
   final String? exerciseId;
   final DateTime timestamp;
-  final double weight;
-  final int reps;
+  final double? weight;
+  final int? reps;
   final double? dropWeightKg;
   final int? dropReps;
   final int setNumber;
   final bool isBodyweight;
+
+  // Cardio fields
+  final bool isCardio;
+  final String? mode;
+  final int? durationSec;
+  final double? speedKmH;
+  final List<Map<String, dynamic>>? intervals;
 
   WorkoutLog({
     required this.id,
@@ -20,11 +27,16 @@ class WorkoutLog {
     required this.sessionId,
     this.exerciseId,
     required this.timestamp,
-    required this.weight,
-    required this.reps,
+    this.weight,
+    this.reps,
     this.dropWeightKg,
     this.dropReps,
     required this.setNumber,
     this.isBodyweight = false,
+    this.isCardio = false,
+    this.mode,
+    this.durationSec,
+    this.speedKmH,
+    this.intervals,
   });
 }

--- a/lib/features/history/presentation/screens/history_screen.dart
+++ b/lib/features/history/presentation/screens/history_screen.dart
@@ -8,6 +8,7 @@ import 'package:tapem/core/utils/nice_scale.dart';
 import 'package:tapem/features/history/domain/models/workout_log.dart';
 import 'package:tapem/features/training_details/domain/models/session.dart';
 import 'package:tapem/features/training_details/presentation/widgets/session_exercise_card.dart';
+import 'package:tapem/features/training_details/presentation/widgets/cardio_session_card.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
 import 'package:tapem/core/widgets/brand_outline.dart';
@@ -350,10 +351,46 @@ class _HistoryScreenState extends State<HistoryScreen> {
                 final titleDate = DateFormat.yMMMMd(localeString)
                     .format(logs.first.timestamp);
 
+                final first = logs.first;
+                final isCardio =
+                    first.isCardio ||
+                    first.mode != null ||
+                    first.weight == null ||
+                    first.reps == null;
+                if (isCardio) {
+                  final session = Session(
+                    sessionId: first.sessionId,
+                    deviceId: widget.deviceId,
+                    deviceName: title,
+                    deviceDescription: subtitle,
+                    timestamp: first.timestamp,
+                    note: '',
+                    sets: const [],
+                    isCardio: true,
+                    mode: first.mode,
+                    durationSec: first.durationSec,
+                    speedKmH: first.speedKmH,
+                    intervals: first.intervals
+                        ?.map((e) => CardioInterval(
+                              durationSec: e['durationSec'] as int?,
+                              speedKmH: (e['speedKmH'] as num?)?.toDouble(),
+                            ))
+                        .toList(),
+                  );
+                  return Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                    child: _HistoryExpansionTile(
+                      title: titleDate,
+                      child: CardioSessionCard(session: session),
+                    ),
+                  );
+                }
+
                 final sets = logs
                     .map((e) => SessionSet(
-                          weight: e.weight,
-                          reps: e.reps,
+                          weight: e.weight ?? 0,
+                          reps: e.reps ?? 0,
                           setNumber: e.setNumber,
                           dropWeightKg: e.dropWeightKg,
                           dropReps: e.dropReps,

--- a/test/features/history/workout_log_dto_cardio_test.dart
+++ b/test/features/history/workout_log_dto_cardio_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tapem/features/history/data/dtos/workout_log_dto.dart';
+
+void main() {
+  test('parses cardio log without weight/reps', () {
+    final dto = WorkoutLogDto.fromJson({
+      'userId': 'u1',
+      'sessionId': 's1',
+      'timestamp': Timestamp.fromDate(DateTime(2024)),
+      'setNumber': 1,
+      'isCardio': true,
+      'mode': 'timed',
+      'durationSec': 60,
+    });
+    dto.id = 'l1';
+    final model = dto.toModel();
+    expect(model.isCardio, isTrue);
+    expect(model.durationSec, 60);
+    expect(model.weight, isNull);
+    expect(model.reps, isNull);
+  });
+}

--- a/test/providers/device_provider_cardio_xp_test.dart
+++ b/test/providers/device_provider_cardio_xp_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/device_provider.dart';
+import 'package:tapem/core/providers/xp_provider.dart';
+import 'package:tapem/core/providers/challenge_provider.dart';
+import 'package:tapem/features/device/domain/models/device.dart';
+import 'package:tapem/features/device/domain/repositories/device_repository.dart';
+import 'package:tapem/features/device/domain/usecases/get_devices_for_gym.dart';
+import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
+import 'package:tapem/features/xp/domain/xp_repository.dart';
+import 'package:tapem/features/xp/domain/device_xp_result.dart';
+import 'package:tapem/features/challenges/domain/repositories/challenge_repository.dart';
+import 'package:tapem/features/challenges/domain/models/challenge.dart';
+import 'package:tapem/features/challenges/domain/models/badge.dart';
+import 'package:tapem/features/challenges/domain/models/completed_challenge.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tapem/services/membership_service.dart';
+
+class FakeDeviceRepository implements DeviceRepository {
+  FakeDeviceRepository(this.devices);
+  final List<Device> devices;
+  @override
+  Future<List<Device>> getDevicesForGym(String gymId) async => devices;
+  @override
+  Future<void> writeSessionSnapshot(String gymId, DeviceSessionSnapshot snapshot) async {}
+  @override
+  DocumentSnapshot? get lastSnapshotCursor => null;
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class FakeXpRepository implements XpRepository {
+  int calls = 0;
+  @override
+  Future<DeviceXpResult> addSessionXp({
+    required String gymId,
+    required String userId,
+    required String deviceId,
+    required String sessionId,
+    required bool showInLeaderboard,
+    required bool isMulti,
+    String? exerciseId,
+    required String traceId,
+  }) async {
+    calls++;
+    return DeviceXpResult.okAdded;
+  }
+
+  @override
+  Stream<int> watchDayXp({required String userId, required DateTime date}) => const Stream.empty();
+  @override
+  Stream<Map<String, int>> watchMuscleXp({required String gymId, required String userId}) => const Stream.empty();
+  @override
+  Stream<Map<String, int>> watchTrainingDaysXp(String userId) => const Stream.empty();
+  @override
+  Stream<int> watchDeviceXp({required String gymId, required String deviceId, required String userId}) => const Stream.empty();
+  @override
+  Stream<int> watchStatsDailyXp({required String gymId, required String userId}) => const Stream.empty();
+}
+
+class FakeChallengeRepository implements ChallengeRepository {
+  @override
+  Future<void> checkChallenges(String gymId, String userId, String deviceId) async {}
+  @override
+  Stream<List<Challenge>> watchActiveChallenges(String gymId) => const Stream.empty();
+  @override
+  Stream<List<Badge>> watchBadges(String userId) => const Stream.empty();
+  @override
+  Stream<List<CompletedChallenge>> watchCompletedChallenges(String gymId, String userId) => const Stream.empty();
+}
+
+class FakeMembershipService implements MembershipService {
+  @override
+  Future<void> ensureMembership(String gymId, String uid) async {}
+}
+
+void main() {
+  testWidgets('saveCardioTimedSession awards XP', (tester) async {
+    final firestore = FakeFirebaseFirestore();
+    final device = Device(uid: 'c1', id: 1, name: 'Cardio', isCardio: true);
+    final provider = DeviceProvider(
+      getDevicesForGym: GetDevicesForGym(FakeDeviceRepository([device])),
+      firestore: firestore,
+      log: (_, [__]) {},
+      membership: FakeMembershipService(),
+    );
+    await provider.loadDevice(
+      gymId: 'g1',
+      deviceId: 'c1',
+      exerciseId: 'ex1',
+      userId: 'u1',
+    );
+    final xpRepo = FakeXpRepository();
+    final xpProvider = XpProvider(repo: xpRepo);
+    final challengeProvider = ChallengeProvider(repo: FakeChallengeRepository());
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<XpProvider>.value(value: xpProvider),
+          ChangeNotifierProvider<ChallengeProvider>.value(value: challengeProvider),
+          ChangeNotifierProvider<DeviceProvider>.value(value: provider),
+        ],
+        child: const MaterialApp(home: SizedBox()),
+      ),
+    );
+    final ctx = tester.element(find.byType(SizedBox));
+    final ok = await provider.saveCardioTimedSession(
+      context: ctx,
+      gymId: 'g1',
+      userId: 'u1',
+      durationSec: 30,
+      showInLeaderboard: false,
+    );
+    expect(ok, isTrue);
+    expect(xpRepo.calls, 1);
+  });
+}

--- a/test/widgets/read_only_snapshot_page_test.dart
+++ b/test/widgets/read_only_snapshot_page_test.dart
@@ -51,4 +51,44 @@ void main() {
     );
     expect(find.textContaining('00:01:05'), findsOneWidget);
   });
+
+  testWidgets('renders steady cardio snapshot', (tester) async {
+    final snapshot = DeviceSessionSnapshot(
+      sessionId: 's3',
+      deviceId: 'd1',
+      createdAt: DateTime(2024),
+      userId: 'u1',
+      sets: const [SetEntry(speedKmH: 8, durationSec: 120)],
+      isCardio: true,
+      mode: 'steady',
+      durationSec: 120,
+      speedKmH: 8,
+    );
+    await tester.pumpWidget(
+      MaterialApp(home: ReadOnlySnapshotPage(snapshot: snapshot)),
+    );
+    expect(find.textContaining('8.0 km/h'), findsOneWidget);
+    expect(find.textContaining('00:02:00'), findsOneWidget);
+  });
+
+  testWidgets('renders interval cardio snapshot', (tester) async {
+    final snapshot = DeviceSessionSnapshot(
+      sessionId: 's4',
+      deviceId: 'd1',
+      createdAt: DateTime(2024),
+      userId: 'u1',
+      sets: const [
+        SetEntry(speedKmH: 8, durationSec: 60),
+        SetEntry(speedKmH: 10, durationSec: 90),
+      ],
+      isCardio: true,
+      mode: 'intervals',
+      durationSec: 150,
+    );
+    await tester.pumpWidget(
+      MaterialApp(home: ReadOnlySnapshotPage(snapshot: snapshot)),
+    );
+    expect(find.textContaining('00:01:00'), findsOneWidget);
+    expect(find.textContaining('00:01:30'), findsOneWidget);
+  });
 }

--- a/thesis/gamification/GAM-20250914-cardio-history-and-xp-parity.md
+++ b/thesis/gamification/GAM-20250914-cardio-history-and-xp-parity.md
@@ -1,0 +1,27 @@
+---
+change_id: GAM-20250914-cardio-history-and-xp-parity
+title: Cardio history crash fix, snapshot navigation, and XP parity
+branch: fix/cardio-history-and-xp-parity
+pr_url: TODO
+commit_sha: 1d8cb86782c83b7baa49499b651fdd224c22a34c
+app_version: 1.0.0+1
+authors: [CodeX]
+created_at: 2025-09-14
+---
+
+## Prompt (Ziel & Kontext)
+History page crashed on cardio logs lacking weight/reps. Cardio navigation and XP awarding differed from strength sessions.
+
+## Umsetzung (dieser PR)
+- Made workout log DTOs and models cardio-aware with nullable strength fields and cardio metadata.
+- Enabled cardio history and snapshot navigation with steady and interval displays.
+- Linked timed cardio saves to XP flow and updated UI feedback.
+- Added tests for DTO parsing, snapshot rendering, and cardio XP awarding.
+
+## Ergebnis des PR
+Screens: history cardio entries, cardio snapshot modes, XP indicator updates. Known limits: translations for interval headers use generic strings.
+
+## Messplan
+- Cardio-XP-Award-Rate
+- History-Crash-Rate = 0
+- Cap-Treffer


### PR DESCRIPTION
## Summary
- make history workout log DTO/model cardio-aware and avoid null-cast crashes
- render cardio sessions in history and snapshot views (timed, steady, intervals)
- award XP for cardio timed sessions and show snackbar on save

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c74d1f38148320a9d91819227c8bc9