### PR TITLE
Handle nullable weights in history stats and update test fakes

### DIFF
--- a/lib/core/providers/history_provider.dart
+++ b/lib/core/providers/history_provider.dart
@@ -98,13 +98,18 @@ class HistoryProvider extends ChangeNotifier {
     _setsPerSessionAvg = double.parse(
         (_logs.length / (_workoutCount == 0 ? 1 : _workoutCount))
             .toStringAsFixed(1));
-    _heaviest = logsSorted.map((e) => e.weight).reduce((a, b) => a > b ? a : b);
+    final weights =
+        logsSorted.map((e) => e.weight).where((w) => w != null).cast<double>();
+    _heaviest = weights.isNotEmpty
+        ? weights.reduce((a, b) => a > b ? a : b)
+        : 0;
 
     _e1rmChart = sessionEntries.map((e) {
       final date = e.value.first.timestamp;
-      final e1rm = e.value
-          .map((l) => l.weight * (1 + l.reps / 30))
-          .reduce((a, b) => a > b ? a : b);
+      final vals = e.value
+          .where((l) => l.weight != null && l.reps != null)
+          .map((l) => l.weight! * (1 + l.reps! / 30));
+      final e1rm = vals.isNotEmpty ? vals.reduce((a, b) => a > b ? a : b) : 0;
       return ChartPoint(date, e1rm);
     }).toList();
 

--- a/test/providers/device_provider_cardio_xp_test.dart
+++ b/test/providers/device_provider_cardio_xp_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide Badge;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:provider/provider.dart';
@@ -27,6 +27,15 @@ class FakeDeviceRepository implements DeviceRepository {
   Future<void> writeSessionSnapshot(String gymId, DeviceSessionSnapshot snapshot) async {}
   @override
   DocumentSnapshot? get lastSnapshotCursor => null;
+  @override
+  Future<void> deleteDevice(String gymId, String deviceId) async {}
+  @override
+  Future<bool> hasSessionForDate({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    required DateTime date,
+  }) async => false;
   @override
   noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
@@ -66,7 +75,8 @@ class FakeChallengeRepository implements ChallengeRepository {
   @override
   Stream<List<Challenge>> watchActiveChallenges(String gymId) => const Stream.empty();
   @override
-  Stream<List<Badge>> watchBadges(String userId) => const Stream.empty();
+  Stream<List<Badge>> watchBadges(String userId) =>
+      const Stream<List<Badge>>.empty();
   @override
   Stream<List<CompletedChallenge>> watchCompletedChallenges(String gymId, String userId) => const Stream.empty();
 }

--- a/test/providers/device_provider_test.dart
+++ b/test/providers/device_provider_test.dart
@@ -28,7 +28,7 @@ class FakeDeviceRepository implements DeviceRepository {
   @override
   Future<Device?> getDeviceByNfcCode(String gymId, String nfcCode) => throw UnimplementedError();
   @override
-  Future<void> deleteDevice(String gymId, String deviceId) => throw UnimplementedError();
+  Future<void> deleteDevice(String gymId, String deviceId) async {}
   @override
   Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) => throw UnimplementedError();
   @override
@@ -56,6 +56,13 @@ class FakeDeviceRepository implements DeviceRepository {
 
   @override
   DocumentSnapshot? get lastSnapshotCursor => null;
+  @override
+  Future<bool> hasSessionForDate({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    required DateTime date,
+  }) async => false;
 }
 
 class FakeMembershipService implements MembershipService {
@@ -87,6 +94,15 @@ class _ExerciseSnapRepo implements DeviceRepository {
   @override
   DocumentSnapshot? get lastSnapshotCursor => null;
 
+  @override
+  Future<void> deleteDevice(String gymId, String deviceId) async {}
+  @override
+  Future<bool> hasSessionForDate({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    required DateTime date,
+  }) async => false;
   @override
   noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/test/ui/exercise_list_chips_update_test.dart
+++ b/test/ui/exercise_list_chips_update_test.dart
@@ -112,6 +112,13 @@ class _FakeDeviceRepo implements DeviceRepository {
 
   @override
   DocumentSnapshot? get lastSnapshotCursor => null;
+  @override
+  Future<bool> hasSessionForDate({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    required DateTime date,
+  }) async => false;
 }
 
 class _FakeMuscleGroupProvider extends MuscleGroupProvider {

--- a/test/ui/gym/device_card_test.dart
+++ b/test/ui/gym/device_card_test.dart
@@ -84,6 +84,13 @@ class _DummyDeviceRepo implements DeviceRepository {
 
   @override
   DocumentSnapshot? get lastSnapshotCursor => null;
+  @override
+  Future<bool> hasSessionForDate({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    required DateTime date,
+  }) async => false;
 }
 
 MuscleGroupProvider _makeProvider() {

--- a/test/ui/gym/search_and_filters_test.dart
+++ b/test/ui/gym/search_and_filters_test.dart
@@ -83,6 +83,13 @@ class _DummyDeviceRepo implements DeviceRepository {
 
   @override
   DocumentSnapshot? get lastSnapshotCursor => null;
+  @override
+  Future<bool> hasSessionForDate({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    required DateTime date,
+  }) async => false;
 }
 
 class _TestMuscleGroupProvider extends MuscleGroupProvider {

--- a/test/ui/overlay_numeric_keypad_test.dart
+++ b/test/ui/overlay_numeric_keypad_test.dart
@@ -18,7 +18,7 @@ class _FakeDeviceRepository implements DeviceRepository {
   @override
   Future<Device?> getDeviceByNfcCode(String gymId, String nfcCode) => throw UnimplementedError();
   @override
-  Future<void> deleteDevice(String gymId, String deviceId) => throw UnimplementedError();
+  Future<void> deleteDevice(String gymId, String deviceId) async {}
   @override
   Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) => throw UnimplementedError();
   @override
@@ -31,6 +31,13 @@ class _FakeDeviceRepository implements DeviceRepository {
   Future<DeviceSessionSnapshot?> getSnapshotBySessionId({required String gymId, required String deviceId, required String sessionId,}) async => null;
   @override
   DocumentSnapshot? get lastSnapshotCursor => null;
+  @override
+  Future<bool> hasSessionForDate({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    required DateTime date,
+  }) async => false;
 }
 
 class _FakeMembershipService implements MembershipService {

--- a/test/widgets/cardio_set_card_test.dart
+++ b/test/widgets/cardio_set_card_test.dart
@@ -16,6 +16,15 @@ class _Repo implements DeviceRepository {
   @override
   Future<List<Device>> getDevicesForGym(String gymId) async => devices;
   @override
+  Future<void> deleteDevice(String gymId, String deviceId) async {}
+  @override
+  Future<bool> hasSessionForDate({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    required DateTime date,
+  }) async => false;
+  @override
   noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 

--- a/test/widgets/device_pager_cardio_swipe_test.dart
+++ b/test/widgets/device_pager_cardio_swipe_test.dart
@@ -9,6 +9,7 @@ import 'package:tapem/features/device/domain/models/device_session_snapshot.dart
 import 'package:tapem/features/device/domain/repositories/device_repository.dart';
 import 'package:tapem/features/device/presentation/widgets/cardio_runner.dart';
 import 'package:tapem/features/device/presentation/widgets/device_pager.dart';
+import 'package:tapem/features/device/presentation/widgets/read_only_snapshot_page.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/services/membership_service.dart';
 import 'package:tapem/features/device/domain/usecases/get_devices_for_gym.dart';
@@ -39,6 +40,8 @@ class FakeDeviceRepository implements DeviceRepository {
   Future<void> writeSessionSnapshot(String gymId, DeviceSessionSnapshot snapshot) async {}
   @override
   Future<List<DeviceSessionSnapshot>> fetchSessionSnapshotsPaginated({required String gymId, required String deviceId, required String userId, required int limit, String? exerciseId, DocumentSnapshot? startAfter}) async => [];
+  @override
+  Future<void> deleteDevice(String gymId, String deviceId) async {}
   @override
   Future<bool> hasSessionForDate({required String gymId, required String deviceId, required String userId, required DateTime date}) async => false;
 }

--- a/test/widgets/device_pager_test.dart
+++ b/test/widgets/device_pager_test.dart
@@ -26,6 +26,15 @@ class _FakeDeviceRepository implements DeviceRepository {
   DocumentSnapshot? get lastSnapshotCursor => null;
 
   @override
+  Future<void> deleteDevice(String gymId, String deviceId) async {}
+  @override
+  Future<bool> hasSessionForDate({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    required DateTime date,
+  }) async => false;
+  @override
   noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 

--- a/test/widgets/dismissible_session_list_test.dart
+++ b/test/widgets/dismissible_session_list_test.dart
@@ -21,7 +21,7 @@ class _FakeRepo implements DeviceRepository {
   @override
   Future<Device?> getDeviceByNfcCode(String gymId, String nfcCode) => throw UnimplementedError();
   @override
-  Future<void> deleteDevice(String gymId, String deviceId) => throw UnimplementedError();
+  Future<void> deleteDevice(String gymId, String deviceId) async {}
   @override
   Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) => throw UnimplementedError();
   @override
@@ -49,6 +49,13 @@ class _FakeRepo implements DeviceRepository {
 
   @override
   DocumentSnapshot? get lastSnapshotCursor => null;
+  @override
+  Future<bool> hasSessionForDate({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    required DateTime date,
+  }) async => false;
 }
 
 class FakeMembershipService implements MembershipService {

--- a/test/widgets/exercise_bottom_sheet_selected_preview_test.dart
+++ b/test/widgets/exercise_bottom_sheet_selected_preview_test.dart
@@ -81,6 +81,13 @@ class _FakeDeviceRepo implements DeviceRepository {
 
   @override
   DocumentSnapshot? get lastSnapshotCursor => null;
+  @override
+  Future<bool> hasSessionForDate({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    required DateTime date,
+  }) async => false;
 }
 
 class FakeMuscleGroupProvider extends MuscleGroupProvider {

--- a/test/widgets/muscle_group_list_selector_test.dart
+++ b/test/widgets/muscle_group_list_selector_test.dart
@@ -77,6 +77,13 @@ class _FakeDeviceRepo implements DeviceRepository {
 
   @override
   DocumentSnapshot? get lastSnapshotCursor => null;
+  @override
+  Future<bool> hasSessionForDate({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    required DateTime date,
+  }) async => false;
 }
 
 class _FakeMuscleGroupProvider extends MuscleGroupProvider {

--- a/test/widgets/muscle_group_selector_test.dart
+++ b/test/widgets/muscle_group_selector_test.dart
@@ -79,6 +79,13 @@ class _FakeDeviceRepo implements DeviceRepository {
 
   @override
   DocumentSnapshot? get lastSnapshotCursor => null;
+  @override
+  Future<bool> hasSessionForDate({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    required DateTime date,
+  }) async => false;
 }
 
 class FakeMuscleGroupProvider extends MuscleGroupProvider {

--- a/test/widgets/set_card_test.dart
+++ b/test/widgets/set_card_test.dart
@@ -23,7 +23,7 @@ class _FakeRepo implements DeviceRepository {
   @override
   Future<Device?> getDeviceByNfcCode(String gymId, String nfcCode) => throw UnimplementedError();
   @override
-  Future<void> deleteDevice(String gymId, String deviceId) => throw UnimplementedError();
+  Future<void> deleteDevice(String gymId, String deviceId) async {}
   @override
   Future<void> updateMuscleGroups(String gymId, String deviceId, List<String> primaryGroups, List<String> secondaryGroups) => throw UnimplementedError();
   @override
@@ -51,6 +51,13 @@ class _FakeRepo implements DeviceRepository {
 
   @override
   DocumentSnapshot? get lastSnapshotCursor => null;
+  @override
+  Future<bool> hasSessionForDate({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    required DateTime date,
+  }) async => false;
 }
 
 class FakeMembershipService implements MembershipService {

--- a/test/widgets/set_card_timer_golden_test.dart
+++ b/test/widgets/set_card_timer_golden_test.dart
@@ -17,6 +17,15 @@ class _FakeRepo implements DeviceRepository {
   @override
   Future<List<Device>> getDevicesForGym(String gymId) async => devices;
   @override
+  Future<void> deleteDevice(String gymId, String deviceId) async {}
+  @override
+  Future<bool> hasSessionForDate({
+    required String gymId,
+    required String deviceId,
+    required String userId,
+    required DateTime date,
+  }) async => false;
+  @override
   noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 


### PR DESCRIPTION
## Summary
- Guard against null weights and reps when computing history statistics
- Adjust test fakes to implement new DeviceRepository APIs and avoid Badge import conflicts

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7519e57908320b8f77980d9887584