### PR TITLE
Fix cardio log permission by adding mode and speed fields

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -1087,6 +1087,8 @@ class DeviceProvider extends ChangeNotifier {
       'setNumber': 1,
       'note': _note,
       'tz': tz,
+      'mode': 'timed',
+      'speedKmH': 0,
       'durationSec': durationSec,
     });
 


### PR DESCRIPTION
## Summary
- include `mode: 'timed'` and `speedKmH: 0` in cardio log writes

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `npm run test:rules` *(fails: download failed, status 403: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c754169910832096b766d59b4da4ef