### PR TITLE
Allow users to create device logs

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -99,12 +99,14 @@ service cloud.firestore {
     }
 
     // ─────────────────────────
-    // Global logs read (owner-only)
+    // Global logs read/write (owner-only)
     // ─────────────────────────
     match /{path=**}/logs/{logId} {
       allow read: if isAuthed() &&
         (resource.data.userId == request.auth.uid ||
          isFriend(resource.data.userId, request.auth.uid));
+      allow create: if isAuthed() &&
+        request.resource.data.userId == request.auth.uid;
     }
 
     // ─────────────────────────


### PR DESCRIPTION
## Summary
- permit authenticated users to create log documents in Firestore rules

## Testing
- `npm run rules-test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_68c75b69bf208320957068bde07ffca5