### PR TITLE
fix: allow cardio session duration as number

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -334,7 +334,7 @@ service cloud.firestore {
               'dropReps'
             ]) &&
             (request.resource.data.speedKmH == null || request.resource.data.speedKmH is number) &&
-            (request.resource.data.durationSec == null || request.resource.data.durationSec is int) &&
+            (request.resource.data.durationSec == null || request.resource.data.durationSec is number) &&
             (request.resource.data.mode == null || request.resource.data.mode is string) &&
             (request.resource.data.intervals == null || (request.resource.data.intervals is list && request.resource.data.intervals.all(i, i.durationSec is int && i.speedKmH is number)));
           allow read: if resourceOwnerOrAdmin(gymId);
@@ -362,7 +362,7 @@ service cloud.firestore {
             ]) &&
             (request.resource.data.isCardio == null || request.resource.data.isCardio is bool) &&
             (request.resource.data.mode == null || request.resource.data.mode is string) &&
-            (request.resource.data.durationSec == null || request.resource.data.durationSec is int) &&
+            (request.resource.data.durationSec == null || request.resource.data.durationSec is number) &&
             (request.resource.data.speedKmH == null || request.resource.data.speedKmH is number) &&
             (request.resource.data.intervals == null || (request.resource.data.intervals is list && request.resource.data.intervals.all(i, i.durationSec is int && i.speedKmH is number)));
           allow read: if resourceOwnerOrAdmin(gymId) ||


### PR DESCRIPTION
## Summary
- relax Firestore rules so cardio session duration accepts numeric values

## Testing
- `flutter test test/providers/device_provider_cardio_xp_test.dart` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / network 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c75d97d340832099f465cc0dd15a17