### PR TITLE
fix: allow members to save session snapshots

### DIFF
--- a/firestore-tests/security_rules.test.js
+++ b/firestore-tests/security_rules.test.js
@@ -247,6 +247,30 @@ describe('Security Rules v1', function () {
       await assertSucceeds(ref.get());
     });
 
+    it('allows member to write own session snapshot', async () => {
+      const db = userA().firestore();
+      const ref = db
+        .collection('gyms')
+        .doc('G1')
+        .collection('devices')
+        .doc('D1')
+        .collection('sessions')
+        .doc('newSession');
+      await assertSucceeds(
+        ref.set({
+          sessionId: 'newSession',
+          deviceId: 'D1',
+          createdAt: FieldValue.serverTimestamp(),
+          userId: 'userA',
+          note: null,
+          sets: [],
+          renderVersion: 1,
+          uiHints: { plannedTableCollapsed: false },
+          isCardio: false,
+        }),
+      );
+    });
+
     it('denies friend from writing session snapshot', async () => {
       const db = friend().firestore();
       const ref = db

--- a/firestore.rules
+++ b/firestore.rules
@@ -343,7 +343,7 @@ service cloud.firestore {
 
         // Session snapshots per user (read owner/admin; write owner-only)
         match /sessions/{sessionId} {
-          allow create: if requestOwnerInGym(gymId) &&
+          allow write: if requestOwnerInGym(gymId) &&
             request.resource.data.keys().hasOnly([
               'sessionId',
               'deviceId',
@@ -367,7 +367,7 @@ service cloud.firestore {
             (request.resource.data.intervals == null || (request.resource.data.intervals is list && request.resource.data.intervals.all(i, i.durationSec is int && i.speedKmH is number)));
           allow read: if resourceOwnerOrAdmin(gymId) ||
                        isFriend(resource.data.userId, request.auth.uid);
-          allow update, delete: if false;
+          allow delete: if false;
         }
 
         // Per-user notes for device


### PR DESCRIPTION
## Summary
- allow gym members to write device session snapshots
- test writing a session snapshot as the owner

## Testing
- `npm run rules-test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_68c800360ac48320845c37f7418fe8e1