### PR TITLE
fix: avoid isCardio field for strength sessions

### DIFF
--- a/firestore-tests/security_rules.test.js
+++ b/firestore-tests/security_rules.test.js
@@ -266,7 +266,33 @@ describe('Security Rules v1', function () {
           sets: [],
           renderVersion: 1,
           uiHints: { plannedTableCollapsed: false },
-          isCardio: false,
+        }),
+      );
+    });
+
+    it('allows member to write cardio session snapshot', async () => {
+      const db = userA().firestore();
+      const ref = db
+        .collection('gyms')
+        .doc('G1')
+        .collection('devices')
+        .doc('D1')
+        .collection('sessions')
+        .doc('cardio1');
+      await assertSucceeds(
+        ref.set({
+          sessionId: 'cardio1',
+          deviceId: 'D1',
+          createdAt: FieldValue.serverTimestamp(),
+          userId: 'userA',
+          note: null,
+          sets: [],
+          renderVersion: 1,
+          uiHints: { plannedTableCollapsed: false },
+          isCardio: true,
+          durationSec: 100,
+          speedKmH: 10,
+          mode: 'steady',
         }),
       );
     });

--- a/lib/features/device/domain/models/device_session_snapshot.dart
+++ b/lib/features/device/domain/models/device_session_snapshot.dart
@@ -64,7 +64,7 @@ class DeviceSessionSnapshot {
         'sets': sets.map((s) => s.toJson()).toList(),
         'renderVersion': renderVersion,
         'uiHints': uiHints,
-        'isCardio': isCardio,
+        if (isCardio) 'isCardio': true,
         if (mode != null) 'mode': mode,
         if (durationSec != null) 'durationSec': durationSec,
         if (speedKmH != null) 'speedKmH': speedKmH,

--- a/test/features/device/domain/models/device_session_snapshot_test.dart
+++ b/test/features/device/domain/models/device_session_snapshot_test.dart
@@ -43,4 +43,16 @@ void main() {
     expect(decoded.mode, 'timed');
     expect(decoded.durationSec, 90);
   });
+
+  test('toJson omits isCardio when false', () {
+    final snapshot = DeviceSessionSnapshot(
+      sessionId: 's2',
+      deviceId: 'd1',
+      createdAt: DateTime.fromMillisecondsSinceEpoch(0),
+      userId: 'u1',
+      sets: const [],
+    );
+    final json = snapshot.toJson();
+    expect(json.containsKey('isCardio'), false);
+  });
 }


### PR DESCRIPTION
## Summary
- only include `isCardio` in session snapshots when the workout is cardio
- expand tests to cover cardio snapshots and ensure `isCardio` is omitted for strength sessions

## Testing
- `npm run rules-test` (fails: connect ECONNREFUSED 127.0.0.1:8080)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c8045bad348320b11c1efc461a103e