### PR TITLE
Allow strength session snapshots

### DIFF
--- a/firestore-tests/security_rules.test.js
+++ b/firestore-tests/security_rules.test.js
@@ -297,6 +297,39 @@ describe('Security Rules v1', function () {
       );
     });
 
+    it('allows member to write strength session snapshot with drops', async () => {
+      const db = userA().firestore();
+      const ref = db
+        .collection('gyms')
+        .doc('G1')
+        .collection('devices')
+        .doc('D1')
+        .collection('sessions')
+        .doc('strength1');
+      await assertSucceeds(
+        ref.set({
+          sessionId: 'strength1',
+          deviceId: 'D1',
+          createdAt: FieldValue.serverTimestamp(),
+          userId: 'userA',
+          note: null,
+          sets: [
+            {
+              kg: 20,
+              reps: 5,
+              done: true,
+              isBodyweight: false,
+              drops: [
+                { kg: 10, reps: 3 },
+              ],
+            },
+          ],
+          renderVersion: 1,
+          uiHints: { plannedTableCollapsed: false },
+        }),
+      );
+    });
+
     it('denies friend from writing session snapshot', async () => {
       const db = friend().firestore();
       const ref = db

--- a/firestore.rules
+++ b/firestore.rules
@@ -364,7 +364,21 @@ service cloud.firestore {
             (request.resource.data.mode == null || request.resource.data.mode is string) &&
             (request.resource.data.durationSec == null || request.resource.data.durationSec is number) &&
             (request.resource.data.speedKmH == null || request.resource.data.speedKmH is number) &&
-            (request.resource.data.intervals == null || (request.resource.data.intervals is list && request.resource.data.intervals.all(i, i.durationSec is int && i.speedKmH is number)));
+            (request.resource.data.intervals == null || (request.resource.data.intervals is list && request.resource.data.intervals.all(i, i.durationSec is int && i.speedKmH is number))) &&
+            (request.resource.data.sets is list && request.resource.data.sets.all(s,
+              s.keys().hasOnly(['kg','reps','done','drops','isBodyweight','speedKmH','durationSec']) &&
+              (s.kg == null || s.kg is number) &&
+              (s.reps == null || s.reps is int) &&
+              (s.done == null || s.done is bool) &&
+              (s.isBodyweight == null || s.isBodyweight is bool) &&
+              (s.speedKmH == null || s.speedKmH is number) &&
+              (s.durationSec == null || s.durationSec is int) &&
+              (s.drops is list && s.drops.all(d,
+                d.keys().hasOnly(['kg','reps']) &&
+                d.kg is number &&
+                d.reps is int
+              ))
+            )));
           allow read: if resourceOwnerOrAdmin(gymId) ||
                        isFriend(resource.data.userId, request.auth.uid);
           allow delete: if false;


### PR DESCRIPTION
## Summary
- permit strength session snapshots with sets containing weight, reps, drops and bodyweight info
- add security rule test for strength session snapshots with drops

## Testing
- `npm run --silent rules-test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c806cd3cc08320addd2c341e4fd168