### PR TITLE
fix firestore rules syntax

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -378,7 +378,7 @@ service cloud.firestore {
                 d.kg is number &&
                 d.reps is int
               ))
-            )));
+            ));
           allow read: if resourceOwnerOrAdmin(gymId) ||
                        isFriend(resource.data.userId, request.auth.uid);
           allow delete: if false;


### PR DESCRIPTION
## Summary
- fix syntax error in Firestore security rules by removing extra parenthesis

## Testing
- `make rules` *(fails: Failed to authenticate, have you run firebase login?)*
- `npm run test:rules` *(fails: download failed, status 403: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c80d6dc0c88320aaaa4331e22dfe54