### PR TITLE
fix: allow strength session snapshots

### DIFF
--- a/firestore-tests/security_rules.test.js
+++ b/firestore-tests/security_rules.test.js
@@ -903,5 +903,39 @@ describe('Security Rules v1', function () {
         })
       );
     });
+
+    it('allows member to write strength session snapshot', async () => {
+      const db = userA().firestore();
+      const ref = db
+        .collection('gyms')
+        .doc('G1')
+        .collection('devices')
+        .doc('D1')
+        .collection('sessions')
+        .doc('sStrength');
+      await assertSucceeds(
+        ref.set({
+          sessionId: 'sStrength',
+          deviceId: 'D1',
+          exerciseId: 'ex1',
+          createdAt: FieldValue.serverTimestamp(),
+          userId: 'userA',
+          note: '',
+          sets: [
+            {
+              kg: 20,
+              reps: 10,
+              done: true,
+              drops: [],
+              isBodyweight: false,
+            },
+          ],
+          renderVersion: 1,
+          uiHints: { plannedTableCollapsed: false },
+          showInLeaderboard: true,
+          restricted: false,
+        })
+      );
+    });
   });
 });

--- a/firestore.rules
+++ b/firestore.rules
@@ -358,12 +358,16 @@ service cloud.firestore {
               'mode',
               'durationSec',
               'speedKmH',
-              'intervals'
+              'intervals',
+              'restricted',
+              'showInLeaderboard'
             ]) &&
             (request.resource.data.isCardio == null || request.resource.data.isCardio is bool) &&
             (request.resource.data.mode == null || request.resource.data.mode is string) &&
             (request.resource.data.durationSec == null || request.resource.data.durationSec is number) &&
             (request.resource.data.speedKmH == null || request.resource.data.speedKmH is number) &&
+            (request.resource.data.restricted == null || request.resource.data.restricted is bool) &&
+            (request.resource.data.showInLeaderboard == null || request.resource.data.showInLeaderboard is bool) &&
             (request.resource.data.intervals == null || (request.resource.data.intervals is list && request.resource.data.intervals.all(i, i.durationSec is int && i.speedKmH is number))) &&
             (request.resource.data.sets is list && request.resource.data.sets.all(s,
               s.keys().hasOnly(['kg','reps','done','drops','isBodyweight','speedKmH','durationSec']) &&


### PR DESCRIPTION
## Summary
- extend session security rules to permit `restricted` and `showInLeaderboard` flags
- cover strength-session snapshot creation with a Firestore rules test

## Testing
- `npm run --silent rules-test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_68c80e8d645483208b8ac2829a0d2853