### PR TITLE
Prevent device page from hiding after save errors

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -477,7 +477,7 @@ class _DeviceScreenState extends State<DeviceScreen> with WidgetsBindingObserver
       scaffold = const Scaffold(
         body: Center(child: CircularProgressIndicator()),
       );
-    } else if (prov.error != null || prov.device == null) {
+    } else if (prov.device == null) {
       scaffold = Scaffold(
         appBar: AppBar(title: const Text('Gerät nicht gefunden')),
         body: Center(child: Text('Fehler: ${prov.error ?? "Unbekannt"}')),


### PR DESCRIPTION
## Summary
- Show "device not found" page only when no device is loaded
- Keep existing device view after save errors to avoid misleading redirect

## Testing
- `flutter test test/providers/device_provider_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c81342b52c8320b3d75db0767baee2