### PR TITLE
Handle leaderboard flags in snapshots and return to gym after save

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -890,6 +890,8 @@ class DeviceProvider extends ChangeNotifier {
         speedKmH: _device!.isCardio ? avgSpeedKmH : null,
         durationSec: _device!.isCardio ? totalDurationSec : null,
         mode: _device!.isCardio ? cardioMode : null,
+        showInLeaderboard: showInLeaderboard,
+        restricted: false,
       );
 
       await batch.commit();
@@ -1109,6 +1111,8 @@ class DeviceProvider extends ChangeNotifier {
         isCardio: true,
         mode: 'timed',
         durationSec: durationSec,
+        restricted: false,
+        showInLeaderboard: showInLeaderboard,
       );
       await deviceRepository.writeSessionSnapshot(gymId, snap);
       elogUi('cardio_session_saved', {
@@ -1212,6 +1216,8 @@ class DeviceProvider extends ChangeNotifier {
     double? speedKmH,
     int? durationSec,
     String? mode,
+    bool showInLeaderboard = true,
+    bool restricted = false,
   }) {
     return DeviceSessionSnapshot(
       sessionId: sessionId,
@@ -1263,6 +1269,8 @@ class DeviceProvider extends ChangeNotifier {
       mode: mode,
       durationSec: durationSec,
       speedKmH: speedKmH,
+      restricted: restricted,
+      showInLeaderboard: showInLeaderboard,
     );
   }
 

--- a/lib/features/device/domain/models/device_session_snapshot.dart
+++ b/lib/features/device/domain/models/device_session_snapshot.dart
@@ -17,6 +17,8 @@ class DeviceSessionSnapshot {
   final String? mode;
   final int? durationSec;
   final double? speedKmH;
+  final bool restricted;
+  final bool showInLeaderboard;
 
   const DeviceSessionSnapshot({
     required this.sessionId,
@@ -32,6 +34,8 @@ class DeviceSessionSnapshot {
     this.mode,
     this.durationSec,
     this.speedKmH,
+    this.restricted = false,
+    this.showInLeaderboard = true,
   });
 
   factory DeviceSessionSnapshot.fromJson(Map<String, dynamic> j) {
@@ -51,6 +55,8 @@ class DeviceSessionSnapshot {
       mode: j['mode'] as String?,
       durationSec: (j['durationSec'] as num?)?.toInt(),
       speedKmH: (j['speedKmH'] as num?)?.toDouble(),
+      restricted: j['restricted'] as bool? ?? false,
+      showInLeaderboard: j['showInLeaderboard'] as bool? ?? true,
     );
   }
 
@@ -68,6 +74,8 @@ class DeviceSessionSnapshot {
         if (mode != null) 'mode': mode,
         if (durationSec != null) 'durationSec': durationSec,
         if (speedKmH != null) 'speedKmH': speedKmH,
+        'restricted': restricted,
+        'showInLeaderboard': showInLeaderboard,
       };
 }
 

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -423,6 +423,7 @@ class _DeviceScreenState extends State<DeviceScreen> with WidgetsBindingObserver
                               ),
                             ),
                           );
+                          Navigator.of(context).pop();
                         },
                   child: prov.isSaving
                       ? const CircularProgressIndicator()


### PR DESCRIPTION
## Summary
- include `restricted` and `showInLeaderboard` flags in device session snapshots
- send leaderboard flags when building and saving snapshots
- navigate back to the gym screen after a successful session save

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c81797c0f08320804a73396ae6c6ff