### PR TITLE
Ensure isCardio flag saved in session snapshots

### DIFF
--- a/lib/features/device/domain/models/device_session_snapshot.dart
+++ b/lib/features/device/domain/models/device_session_snapshot.dart
@@ -70,7 +70,7 @@ class DeviceSessionSnapshot {
         'sets': sets.map((s) => s.toJson()).toList(),
         'renderVersion': renderVersion,
         'uiHints': uiHints,
-        if (isCardio) 'isCardio': true,
+        'isCardio': isCardio,
         if (mode != null) 'mode': mode,
         if (durationSec != null) 'durationSec': durationSec,
         if (speedKmH != null) 'speedKmH': speedKmH,

--- a/test/features/device/domain/models/device_session_snapshot_test.dart
+++ b/test/features/device/domain/models/device_session_snapshot_test.dart
@@ -44,7 +44,7 @@ void main() {
     expect(decoded.durationSec, 90);
   });
 
-  test('toJson omits isCardio when false', () {
+  test('toJson includes isCardio when false', () {
     final snapshot = DeviceSessionSnapshot(
       sessionId: 's2',
       deviceId: 'd1',
@@ -53,6 +53,6 @@ void main() {
       sets: const [],
     );
     final json = snapshot.toJson();
-    expect(json.containsKey('isCardio'), false);
+    expect(json['isCardio'], isFalse);
   });
 }


### PR DESCRIPTION
## Summary
- Always include `isCardio` in session snapshot JSON to satisfy Firestore rules
- Update snapshot test to expect `isCardio` flag when false

## Testing
- ⚠️ `flutter test` *(flutter: command not found)*
- ⚠️ `git clone https://github.com/flutter/flutter.git -b stable --depth 1 /opt/flutter` *(CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c81cf70ef48320a731248f43dc7220