### PR TITLE
fix(device): use outline style for save button

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -5,7 +5,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
-import 'package:tapem/core/widgets/brand_primary_button.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
 import 'package:tapem/l10n/app_localizations.dart';
@@ -298,7 +297,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
               ),
               const SizedBox(width: 12),
               Expanded(
-                child: BrandPrimaryButton(
+                child: OutlinedButton(
                   onPressed: prov.hasSessionToday || prov.isSaving
                       ? null
                       : () async {
@@ -405,7 +404,11 @@ class _DeviceScreenState extends State<DeviceScreen> {
                           );
                         },
                   child: prov.isSaving
-                      ? const CircularProgressIndicator()
+                      ? const SizedBox(
+                          width: 24,
+                          height: 24,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
                       : Text(loc.saveButton),
                 ),
               ),

--- a/thesis/documentation/DOC-20250915-device-save-button-outline.md
+++ b/thesis/documentation/DOC-20250915-device-save-button-outline.md
@@ -1,0 +1,15 @@
+## Aufgabe
+
+Speicher-Button auf der Geräte-Seite optisch an das Outline-Design der App
+angleichen.
+
+## Ziel
+
+Der Speichern-Button soll wie die anderen Buttons und Karten den Outline-Stil
+verwenden, um ein einheitliches Erscheinungsbild sicherzustellen.
+
+## Kontext
+
+Zuvor nutzte der Speichern-Button einen eigenen Gradient-Stil. Für ein
+konsistentes Design wurde er durch einen `OutlinedButton` ersetzt.
+


### PR DESCRIPTION
## Summary
- style DeviceScreen save button with OutlinedButton to match app outline theme
- add thesis documentation entry summarizing task, goal, and context

## Testing
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68c832335dbc83208b13716355594481