### PR TITLE
Use brand outline styling for gym device cards

### DIFF
--- a/lib/ui/devices/device_card.dart
+++ b/lib/ui/devices/device_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:tapem/core/widgets/brand_outline.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/features/device/presentation/widgets/muscle_chips.dart';
 import 'package:tapem/l10n/app_localizations.dart';
@@ -26,102 +27,92 @@ class DeviceCard extends StatelessWidget {
     return Semantics(
       label: '${device.name}, ${brand.isNotEmpty ? '$brand, ' : ''}ID $idText',
       button: true,
-      child: Material(
-        color: theme.colorScheme.surfaceVariant,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(14),
-          side: BorderSide(color: theme.colorScheme.primary),
-        ),
-        child: InkWell(
-          borderRadius: BorderRadius.circular(14),
-          onTap: () => onTap?.call(),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        device.name,
+      child: BrandOutline(
+        onTap: onTap,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    device.name,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.titleMedium,
+                  ),
+                  if (brand.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Text(
+                        brand,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.titleMedium,
-                      ),
-                      if (brand.isNotEmpty)
-                        Padding(
-                          padding: const EdgeInsets.only(top: 4),
-                          child: Text(
-                            brand,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: theme.colorScheme.onSurfaceVariant,
-                            ),
-                          ),
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
                         ),
-                    ],
-                  ),
-                ),
-                const SizedBox(width: 12),
-                ConstrainedBox(
-                  constraints: const BoxConstraints(minWidth: 120, maxWidth: 180),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.end,
-                    children: [
-                      Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Text('ID: $idText', style: theme.textTheme.labelSmall),
-                          if (onAssignMuscles != null || onResetMuscles != null)
-                            PopupMenuButton<_Menu>(
-                              tooltip: loc.assignMuscleGroups,
-                              onSelected: (v) {
-                                switch (v) {
-                                  case _Menu.assign:
-                                    onAssignMuscles?.call();
-                                    break;
-                                  case _Menu.reset:
-                                    onResetMuscles?.call();
-                                    break;
-                                }
-                              },
-                              itemBuilder: (ctx) => [
-                                if (onAssignMuscles != null)
-                                  PopupMenuItem(
-                                    value: _Menu.assign,
-                                    child: Text(loc.assignMuscleGroups),
-                                  ),
-                                if (onResetMuscles != null)
-                                  PopupMenuItem(
-                                    value: _Menu.reset,
-                                    child: Text(loc.resetMuscleGroups),
-                                  ),
-                              ],
-                            ),
-                        ],
                       ),
-                      if (!device.isMulti &&
-                          (device.primaryMuscleGroups.isNotEmpty ||
-                              device.secondaryMuscleGroups.isNotEmpty))
-                        Padding(
-                          padding: const EdgeInsets.only(top: 6),
-                          child: Align(
-                            alignment: Alignment.centerRight,
-                            child: MuscleChips(
-                              primaryIds: device.primaryMuscleGroups,
-                              secondaryIds: device.secondaryMuscleGroups,
-                            ),
-                          ),
-                        ),
-                    ],
-                  ),
-                ),
-              ],
+                    ),
+                ],
+              ),
             ),
-          ),
+            const SizedBox(width: 12),
+            ConstrainedBox(
+              constraints: const BoxConstraints(minWidth: 120, maxWidth: 180),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text('ID: $idText', style: theme.textTheme.labelSmall),
+                      if (onAssignMuscles != null || onResetMuscles != null)
+                        PopupMenuButton<_Menu>(
+                          tooltip: loc.assignMuscleGroups,
+                          onSelected: (v) {
+                            switch (v) {
+                              case _Menu.assign:
+                                onAssignMuscles?.call();
+                                break;
+                              case _Menu.reset:
+                                onResetMuscles?.call();
+                                break;
+                            }
+                          },
+                          itemBuilder: (ctx) => [
+                            if (onAssignMuscles != null)
+                              PopupMenuItem(
+                                value: _Menu.assign,
+                                child: Text(loc.assignMuscleGroups),
+                              ),
+                            if (onResetMuscles != null)
+                              PopupMenuItem(
+                                value: _Menu.reset,
+                                child: Text(loc.resetMuscleGroups),
+                              ),
+                          ],
+                        ),
+                    ],
+                  ),
+                  if (!device.isMulti &&
+                      (device.primaryMuscleGroups.isNotEmpty ||
+                          device.secondaryMuscleGroups.isNotEmpty))
+                    Padding(
+                      padding: const EdgeInsets.only(top: 6),
+                      child: Align(
+                        alignment: Alignment.centerRight,
+                        child: MuscleChips(
+                          primaryIds: device.primaryMuscleGroups,
+                          secondaryIds: device.secondaryMuscleGroups,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/test/ui/gym/device_card_test.dart
+++ b/test/ui/gym/device_card_test.dart
@@ -1,22 +1,25 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
-import 'package:tapem/features/device/domain/models/device.dart';
-import 'package:tapem/ui/devices/device_card.dart';
-import 'package:tapem/features/device/presentation/widgets/muscle_chips.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
+import 'package:tapem/core/theme/brand_on_colors.dart';
+import 'package:tapem/features/device/domain/models/device.dart';
+import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
+import 'package:tapem/features/device/domain/repositories/device_repository.dart';
+import 'package:tapem/features/device/domain/usecases/set_device_muscle_groups_usecase.dart';
+import 'package:tapem/features/device/domain/usecases/update_device_muscle_groups_usecase.dart';
+import 'package:tapem/features/device/presentation/widgets/muscle_chips.dart';
+import 'package:tapem/features/history/domain/models/workout_log.dart';
+import 'package:tapem/features/history/domain/usecases/get_history_for_device.dart';
 import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
 import 'package:tapem/features/muscle_group/domain/repositories/muscle_group_repository.dart';
+import 'package:tapem/features/muscle_group/domain/usecases/delete_muscle_group.dart';
 import 'package:tapem/features/muscle_group/domain/usecases/get_muscle_groups_for_gym.dart';
 import 'package:tapem/features/muscle_group/domain/usecases/save_muscle_group.dart';
-import 'package:tapem/features/muscle_group/domain/usecases/delete_muscle_group.dart';
-import 'package:tapem/features/history/domain/usecases/get_history_for_device.dart';
-import 'package:tapem/features/history/domain/models/workout_log.dart';
-import 'package:tapem/features/device/domain/repositories/device_repository.dart';
-import 'package:tapem/features/device/domain/usecases/update_device_muscle_groups_usecase.dart';
-import 'package:tapem/features/device/domain/usecases/set_device_muscle_groups_usecase.dart';
-import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+import 'package:tapem/ui/devices/device_card.dart';
 
 class _DummyMuscleGroupRepo implements MuscleGroupRepository {
   @override
@@ -98,12 +101,33 @@ MuscleGroupProvider _makeProvider() {
   );
 }
 
+ThemeData _buildTheme() {
+  return ThemeData(extensions: [
+    AppBrandTheme.defaultTheme(),
+    const BrandOnColors(
+      onPrimary: Colors.black,
+      onSecondary: Colors.black,
+      onGradient: Colors.black,
+      onCta: Colors.black,
+    ),
+  ]);
+}
+
+Widget _wrapWithMaterialApp(Widget child) {
+  return MaterialApp(
+    theme: _buildTheme(),
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: child,
+  );
+}
+
 void main() {
   testWidgets('renders name, brand and id', (tester) async {
     final device = Device(uid: '1', id: 1, name: 'Bench', description: 'Eleiko');
     await tester.pumpWidget(
-      MaterialApp(
-        home: ChangeNotifierProvider(
+      _wrapWithMaterialApp(
+        ChangeNotifierProvider(
           create: (_) => _makeProvider(),
           child: DeviceCard(device: device),
         ),
@@ -124,8 +148,8 @@ void main() {
       secondaryMuscleGroups: const ['back'],
     );
     await tester.pumpWidget(
-      MaterialApp(
-        home: ChangeNotifierProvider(
+      _wrapWithMaterialApp(
+        ChangeNotifierProvider(
           create: (_) => _makeProvider(),
           child: DeviceCard(device: device),
         ),
@@ -144,8 +168,8 @@ void main() {
       primaryMuscleGroups: const ['chest'],
     );
     await tester.pumpWidget(
-      MaterialApp(
-        home: ChangeNotifierProvider(
+      _wrapWithMaterialApp(
+        ChangeNotifierProvider(
           create: (_) => _makeProvider(),
           child: DeviceCard(device: device),
         ),
@@ -164,8 +188,8 @@ void main() {
       secondaryMuscleGroups: const ['back'],
     );
     await tester.pumpWidget(
-      MaterialApp(
-        home: ChangeNotifierProvider(
+      _wrapWithMaterialApp(
+        ChangeNotifierProvider(
           create: (_) => _makeProvider(),
           child: DeviceCard(device: device),
         ),


### PR DESCRIPTION
## Summary
- wrap gym device cards with the shared BrandOutline to display the gradient outline from the active theme
- adjust the device card widget tests to load the brand theme extension and app localizations during rendering

## Testing
- not run (Flutter CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c87210764483209efe7191281da200