### PR TITLE
Navigate back to gym after session save

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -393,15 +393,20 @@ class _DeviceScreenState extends State<DeviceScreen> {
                             if (sessionId != null) 'sessionId': sessionId,
                             'result': 'ok',
                           });
+                          if (!mounted) {
+                            return;
+                          }
+                          final message = prov.device!.isMulti
+                              ? loc.multiDeviceSessionSaved
+                              : loc.sessionSaved;
                           ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(
-                              content: Text(
-                                prov.device!.isMulti
-                                    ? loc.multiDeviceSessionSaved
-                                    : loc.sessionSaved,
-                              ),
-                            ),
+                            SnackBar(content: Text(message)),
                           );
+                          _closeKeyboard();
+                          Navigator.of(context).popUntil((route) {
+                            final name = route.settings.name;
+                            return name == AppRouter.home || route.isFirst;
+                          });
                         },
                   child: prov.isSaving
                       ? const SizedBox(


### PR DESCRIPTION
## Summary
- return early if the device screen is unmounted after saving
- show the session saved message and close the keypad before leaving
- pop back to the home/gym view once a session is stored successfully

## Testing
- `flutter test` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c886d5aebc83208c68238309043c34