### PR TITLE
Allow deleting training sessions from details view

### DIFF
--- a/lib/features/device/data/sources/firestore_device_source.dart
+++ b/lib/features/device/data/sources/firestore_device_source.dart
@@ -147,4 +147,19 @@ class FirestoreDeviceSource {
     if (!snap.exists) return null;
     return DeviceSessionSnapshot.fromJson(snap.data()!);
   }
+
+  Future<void> deleteSessionSnapshot({
+    required String gymId,
+    required String deviceId,
+    required String sessionId,
+  }) async {
+    final ref = _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('devices')
+        .doc(deviceId)
+        .collection('sessions')
+        .doc(sessionId);
+    await ref.delete();
+  }
 }

--- a/lib/features/rank/domain/services/level_service.dart
+++ b/lib/features/rank/domain/services/level_service.dart
@@ -21,4 +21,50 @@ class LevelService {
     }
     return LevelInfo(level: level, xp: totalXp);
   }
+
+  LevelInfo removeXp(LevelInfo info, int delta) {
+    if (delta <= 0) return info;
+    var level = info.level;
+    if (level > maxLevel) {
+      level = maxLevel;
+    }
+    var xp = info.xp;
+    var remaining = delta;
+
+    while (remaining > 0) {
+      if (xp >= remaining) {
+        xp -= remaining;
+        remaining = 0;
+      } else {
+        remaining -= xp;
+        if (level > 1) {
+          level -= 1;
+          xp = xpPerLevel;
+        } else {
+          xp = 0;
+          remaining = 0;
+        }
+      }
+
+      if (level == maxLevel && xp < 0) {
+        xp = 0;
+      }
+      if (level <= 1 && xp <= 0) {
+        xp = 0;
+        remaining = 0;
+      }
+    }
+
+    if (xp >= xpPerLevel) {
+      xp = xpPerLevel - 1;
+    }
+    if (level < 1) {
+      level = 1;
+    }
+    if (level >= maxLevel && xp < 0) {
+      xp = 0;
+    }
+
+    return LevelInfo(level: level, xp: xp);
+  }
 }

--- a/lib/features/training_details/data/session_meta_source.dart
+++ b/lib/features/training_details/data/session_meta_source.dart
@@ -37,6 +37,21 @@ class SessionMetaSource {
     return doc.data();
   }
 
+  Future<void> deleteMeta({
+    required String gymId,
+    required String uid,
+    required String sessionId,
+  }) async {
+    await _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('users')
+        .doc(uid)
+        .collection('session_meta')
+        .doc(sessionId)
+        .delete();
+  }
+
   Future<Map<String, dynamic>?> getMetaByDayKey({
     required String gymId,
     required String uid,

--- a/lib/features/training_details/domain/repositories/session_repository.dart
+++ b/lib/features/training_details/domain/repositories/session_repository.dart
@@ -5,4 +5,10 @@ abstract class SessionRepository {
     required String userId,
     required DateTime date,
   });
+
+  Future<void> deleteSession({
+    required String gymId,
+    required String userId,
+    required Session session,
+  });
 }

--- a/lib/features/training_details/domain/usecases/delete_session.dart
+++ b/lib/features/training_details/domain/usecases/delete_session.dart
@@ -1,0 +1,19 @@
+import '../models/session.dart';
+import '../repositories/session_repository.dart';
+
+class DeleteSession {
+  final SessionRepository _repository;
+  DeleteSession(this._repository);
+
+  Future<void> execute({
+    required String gymId,
+    required String userId,
+    required Session session,
+  }) {
+    return _repository.deleteSession(
+      gymId: gymId,
+      userId: userId,
+      session: session,
+    );
+  }
+}

--- a/lib/features/training_details/presentation/widgets/day_sessions_overview.dart
+++ b/lib/features/training_details/presentation/widgets/day_sessions_overview.dart
@@ -5,8 +5,13 @@ import 'package:tapem/core/logging/elog.dart';
 
 class DaySessionsOverview extends StatelessWidget {
   final List<Session> sessions;
-  const DaySessionsOverview({Key? key, required this.sessions})
-    : super(key: key);
+  final void Function(Session session)? onSessionLongPress;
+
+  const DaySessionsOverview({
+    Key? key,
+    required this.sessions,
+    this.onSessionLongPress,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -29,10 +34,16 @@ class DaySessionsOverview extends StatelessWidget {
                   });
                   return SizedBox(
                     width: cardWidth,
-                    child: SessionExerciseCard(
-                      title: session.deviceName,
-                      subtitle: session.deviceDescription,
-                      sets: session.sets,
+                    child: GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onLongPress: onSessionLongPress != null
+                          ? () => onSessionLongPress!(session)
+                          : null,
+                      child: SessionExerciseCard(
+                        title: session.deviceName,
+                        subtitle: session.deviceDescription,
+                        sets: session.sets,
+                      ),
                     ),
                   );
                 },

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -723,4 +723,14 @@
   ,"assign_failed_snackbar": "Zuweisung fehlgeschlagen"
   ,"removed_snackbar": "Entfernt"
   ,"no_permission_symbols": "Keine Berechtigung zum Anzeigen der Symbole"
+  ,"trainingDetailsDeleteSessionTitle": "Session löschen"
+  ,"@trainingDetailsDeleteSessionTitle": {"description": "Titel des Dialogs zum Löschen einer Training-Session."}
+  ,"trainingDetailsDeleteSessionMessage": "Möchtest du diese Session wirklich löschen? Alle zugehörigen Daten werden entfernt."
+  ,"@trainingDetailsDeleteSessionMessage": {"description": "Beschreibungstext, dass beim Löschen einer Session alle Daten entfernt werden."}
+  ,"trainingDetailsDeleteSessionConfirm": "Session löschen"
+  ,"@trainingDetailsDeleteSessionConfirm": {"description": "Beschriftung der Bestätigungsschaltfläche zum Löschen einer Session."}
+  ,"trainingDetailsDeleteSessionSuccess": "Session gelöscht."
+  ,"@trainingDetailsDeleteSessionSuccess": {"description": "Snackbar-Text nach erfolgreichem Löschen einer Session."}
+  ,"trainingDetailsDeleteSessionError": "Session konnte nicht gelöscht werden."
+  ,"@trainingDetailsDeleteSessionError": {"description": "Snackbar-Text, wenn das Löschen einer Session fehlgeschlagen ist."}
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -721,4 +721,14 @@
   ,"assign_failed_snackbar": "Assignment failed"
   ,"removed_snackbar": "Removed"
   ,"no_permission_symbols": "No permission to view symbols"
+  ,"trainingDetailsDeleteSessionTitle": "Delete session"
+  ,"@trainingDetailsDeleteSessionTitle": {"description": "Title for the dialog that confirms deleting a training session."}
+  ,"trainingDetailsDeleteSessionMessage": "Do you really want to delete this session? All related data will be removed."
+  ,"@trainingDetailsDeleteSessionMessage": {"description": "Body text explaining that deleting a session removes all associated data."}
+  ,"trainingDetailsDeleteSessionConfirm": "Delete session"
+  ,"@trainingDetailsDeleteSessionConfirm": {"description": "Confirmation button label for deleting a training session."}
+  ,"trainingDetailsDeleteSessionSuccess": "Session deleted."
+  ,"@trainingDetailsDeleteSessionSuccess": {"description": "Snackbar text shown after a session was deleted."}
+  ,"trainingDetailsDeleteSessionError": "Could not delete the session."
+  ,"@trainingDetailsDeleteSessionError": {"description": "Snackbar text shown when deleting a session failed."}
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1546,6 +1546,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No permission to view symbols'**
   String get no_permission_symbols;
+
+  /// Title for the dialog that confirms deleting a training session.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete session'**
+  String get trainingDetailsDeleteSessionTitle;
+
+  /// Body text explaining that deleting a session removes all associated data.
+  ///
+  /// In en, this message translates to:
+  /// **'Do you really want to delete this session? All related data will be removed.'**
+  String get trainingDetailsDeleteSessionMessage;
+
+  /// Confirmation button label for deleting a training session.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete session'**
+  String get trainingDetailsDeleteSessionConfirm;
+
+  /// Snackbar text shown after a session was deleted.
+  ///
+  /// In en, this message translates to:
+  /// **'Session deleted.'**
+  String get trainingDetailsDeleteSessionSuccess;
+
+  /// Snackbar text shown when deleting a session failed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not delete the session.'**
+  String get trainingDetailsDeleteSessionError;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -763,4 +763,21 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get no_permission_symbols => 'Keine Berechtigung zum Anzeigen der Symbole';
+
+  @override
+  String get trainingDetailsDeleteSessionTitle => 'Session löschen';
+
+  @override
+  String get trainingDetailsDeleteSessionMessage =>
+      'Möchtest du diese Session wirklich löschen? Alle zugehörigen Daten werden entfernt.';
+
+  @override
+  String get trainingDetailsDeleteSessionConfirm => 'Session löschen';
+
+  @override
+  String get trainingDetailsDeleteSessionSuccess => 'Session gelöscht.';
+
+  @override
+  String get trainingDetailsDeleteSessionError =>
+      'Session konnte nicht gelöscht werden.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -763,4 +763,21 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get no_permission_symbols => 'No permission to view symbols';
+
+  @override
+  String get trainingDetailsDeleteSessionTitle => 'Delete session';
+
+  @override
+  String get trainingDetailsDeleteSessionMessage =>
+      'Do you really want to delete this session? All related data will be removed.';
+
+  @override
+  String get trainingDetailsDeleteSessionConfirm => 'Delete session';
+
+  @override
+  String get trainingDetailsDeleteSessionSuccess => 'Session deleted.';
+
+  @override
+  String get trainingDetailsDeleteSessionError =>
+      'Could not delete the session.';
 }


### PR DESCRIPTION
## Summary
- add a long-press delete action on training details sessions with a localized confirmation dialog
- remove session logs, metadata, snapshots, and awarded XP via a new delete use case
- extend Firestore XP source with reverse operations and add localization strings for the new flow

## Testing
- Not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c89783b17c83208c88126550bcbcb9