### PR TITLE
Allow members to delete their own training sessions

### DIFF
--- a/firestore-tests/training_details_rules.test.js
+++ b/firestore-tests/training_details_rules.test.js
@@ -31,6 +31,18 @@ describe('Training details rules', () => {
       await db
         .collection('gyms')
         .doc(gym)
+        .collection('users')
+        .doc('owner')
+        .set({ role: 'member' });
+      await db
+        .collection('gyms')
+        .doc(gym)
+        .collection('users')
+        .doc('friend')
+        .set({ role: 'member' });
+      await db
+        .collection('gyms')
+        .doc(gym)
         .collection('devices')
         .doc('dev1')
         .collection('exercises')
@@ -57,6 +69,7 @@ describe('Training details rules', () => {
 
   const friendCtx = () => testEnv.authenticatedContext('friend');
   const strangerCtx = () => testEnv.authenticatedContext('stranger');
+  const ownerCtx = () => testEnv.authenticatedContext('owner');
 
   it('allows friend to read device', async () => {
     const db = friendCtx().firestore();
@@ -124,5 +137,173 @@ describe('Training details rules', () => {
       .collection('sessions')
       .doc('newSession');
     await assertFails(ref.set({ userId: 'friend' }));
+  });
+
+  it('allows owner to delete own log entry', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const db = context.firestore();
+      await db
+        .collection('gyms')
+        .doc('Club Aktiv')
+        .collection('devices')
+        .doc('dev1')
+        .collection('logs')
+        .doc('log1')
+        .set({
+          userId: 'owner',
+          sessionId: 's1',
+          timestamp: new Date(),
+        });
+    });
+
+    const db = ownerCtx().firestore();
+    const ref = db
+      .collection('gyms')
+      .doc('Club Aktiv')
+      .collection('devices')
+      .doc('dev1')
+      .collection('logs')
+      .doc('log1');
+    await assertSucceeds(ref.delete());
+  });
+
+  it('denies friend from deleting owners log entry', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const db = context.firestore();
+      await db
+        .collection('gyms')
+        .doc('Club Aktiv')
+        .collection('devices')
+        .doc('dev1')
+        .collection('logs')
+        .doc('log1')
+        .set({
+          userId: 'owner',
+          sessionId: 's1',
+          timestamp: new Date(),
+        });
+    });
+
+    const db = friendCtx().firestore();
+    const ref = db
+      .collection('gyms')
+      .doc('Club Aktiv')
+      .collection('devices')
+      .doc('dev1')
+      .collection('logs')
+      .doc('log1');
+    await assertFails(ref.delete());
+  });
+
+  it('allows owner to delete own session snapshot', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const db = context.firestore();
+      await db
+        .collection('gyms')
+        .doc('Club Aktiv')
+        .collection('devices')
+        .doc('dev1')
+        .collection('sessions')
+        .doc('s1')
+        .set({ userId: 'owner' });
+    });
+
+    const db = ownerCtx().firestore();
+    const ref = db
+      .collection('gyms')
+      .doc('Club Aktiv')
+      .collection('devices')
+      .doc('dev1')
+      .collection('sessions')
+      .doc('s1');
+    await assertSucceeds(ref.delete());
+  });
+
+  it('denies friend from deleting owners session snapshot', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const db = context.firestore();
+      await db
+        .collection('gyms')
+        .doc('Club Aktiv')
+        .collection('devices')
+        .doc('dev1')
+        .collection('sessions')
+        .doc('s1')
+        .set({ userId: 'owner' });
+    });
+
+    const db = friendCtx().firestore();
+    const ref = db
+      .collection('gyms')
+      .doc('Club Aktiv')
+      .collection('devices')
+      .doc('dev1')
+      .collection('sessions')
+      .doc('s1');
+    await assertFails(ref.delete());
+  });
+
+  it('allows owner to delete leaderboard markers', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const db = context.firestore();
+      const base = db
+        .collection('gyms')
+        .doc('Club Aktiv')
+        .collection('devices')
+        .doc('dev1')
+        .collection('leaderboard')
+        .doc('owner');
+      await base.set({ userId: 'owner', xp: 10, level: 1 });
+      await base.collection('sessions').doc('s1').set({ createdAt: new Date() });
+      await base.collection('days').doc('2025-09-16').set({ sessionCount: 1 });
+      await base
+        .collection('exercises')
+        .doc('ex1-2025-09-16')
+        .set({ sessionId: 's1' });
+    });
+
+    const db = ownerCtx().firestore();
+    const base = db
+      .collection('gyms')
+      .doc('Club Aktiv')
+      .collection('devices')
+      .doc('dev1')
+      .collection('leaderboard')
+      .doc('owner');
+    await assertSucceeds(base.collection('sessions').doc('s1').delete());
+    await assertSucceeds(base.collection('days').doc('2025-09-16').delete());
+    await assertSucceeds(base.collection('exercises').doc('ex1-2025-09-16').delete());
+  });
+
+  it('denies friend from deleting owners leaderboard markers', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const db = context.firestore();
+      const base = db
+        .collection('gyms')
+        .doc('Club Aktiv')
+        .collection('devices')
+        .doc('dev1')
+        .collection('leaderboard')
+        .doc('owner');
+      await base.set({ userId: 'owner', xp: 10, level: 1 });
+      await base.collection('sessions').doc('s1').set({ createdAt: new Date() });
+      await base.collection('days').doc('2025-09-16').set({ sessionCount: 1 });
+      await base
+        .collection('exercises')
+        .doc('ex1-2025-09-16')
+        .set({ sessionId: 's1' });
+    });
+
+    const db = friendCtx().firestore();
+    const base = db
+      .collection('gyms')
+      .doc('Club Aktiv')
+      .collection('devices')
+      .doc('dev1')
+      .collection('leaderboard')
+      .doc('owner');
+    await assertFails(base.collection('sessions').doc('s1').delete());
+    await assertFails(base.collection('days').doc('2025-09-16').delete());
+    await assertFails(base.collection('exercises').doc('ex1-2025-09-16').delete());
   });
 });

--- a/firestore.rules
+++ b/firestore.rules
@@ -313,7 +313,8 @@ service cloud.firestore {
         match /logs/{logId} {
           allow create: if requestOwnerInGym(gymId);
           allow read: if resourceOwnerOrAdmin(gymId);
-          allow update, delete: if false;
+          allow delete: if resourceOwnerOrAdmin(gymId);
+          allow update: if false;
         }
 
         // Session snapshots per user (read owner/admin; write owner-only)
@@ -321,7 +322,8 @@ service cloud.firestore {
           allow create: if requestOwnerInGym(gymId);
           allow read: if resourceOwnerOrAdmin(gymId) ||
                        isFriend(resource.data.userId, request.auth.uid);
-          allow update, delete: if false;
+          allow delete: if resourceOwnerOrAdmin(gymId);
+          allow update: if false;
         }
 
         // Per-user notes for device
@@ -334,23 +336,27 @@ service cloud.firestore {
           allow read: if ownerOrAdmin(gymId, userId);
           allow create, update: if ownerOrAdmin(gymId, userId) &&
                                 request.resource.data.userId == userId;
+          allow delete: if ownerOrAdmin(gymId, userId);
 
           // Daily markers
           match /days/{dayKey} {
             allow read: if ownerOrAdmin(gymId, userId);
             allow create: if ownerOrAdmin(gymId, userId);
+            allow delete: if ownerOrAdmin(gymId, userId);
           }
 
           // Session markers
           match /sessions/{sessionId} {
             allow read: if ownerOrAdmin(gymId, userId);
             allow create: if ownerOrAdmin(gymId, userId);
+            allow delete: if ownerOrAdmin(gymId, userId);
           }
 
           // Exercise markers for multi-exercise tracking
           match /exercises/{exerciseId} {
             allow read: if ownerOrAdmin(gymId, userId);
             allow create: if ownerOrAdmin(gymId, userId);
+            allow delete: if ownerOrAdmin(gymId, userId);
           }
         }
 


### PR DESCRIPTION
## Summary
- allow authenticated gym members to delete their own device logs, session snapshots, and leaderboard markers in Firestore rules
- extend training details security tests to cover owner vs. non-owner deletion scenarios

## Testing
- npm run rules-test *(fails: Firestore emulator download is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c89f1e63c48320a991f679db1a7715