### PR TITLE
Allow owners to delete legacy log entries

### DIFF
--- a/firestore-tests/training_details_rules.test.js
+++ b/firestore-tests/training_details_rules.test.js
@@ -195,6 +195,54 @@ describe('Training details rules', () => {
     await assertFails(ref.delete());
   });
 
+  it('allows owner to delete fallback log entry', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const db = context.firestore();
+      await db
+        .collection('legacyDevices')
+        .doc('dev1')
+        .collection('logs')
+        .doc('log1')
+        .set({
+          userId: 'owner',
+          sessionId: 'legacySession',
+          timestamp: new Date(),
+        });
+    });
+
+    const db = ownerCtx().firestore();
+    const ref = db
+      .collection('legacyDevices')
+      .doc('dev1')
+      .collection('logs')
+      .doc('log1');
+    await assertSucceeds(ref.delete());
+  });
+
+  it('denies friend from deleting fallback log entry', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const db = context.firestore();
+      await db
+        .collection('legacyDevices')
+        .doc('dev1')
+        .collection('logs')
+        .doc('log1')
+        .set({
+          userId: 'owner',
+          sessionId: 'legacySession',
+          timestamp: new Date(),
+        });
+    });
+
+    const db = friendCtx().firestore();
+    const ref = db
+      .collection('legacyDevices')
+      .doc('dev1')
+      .collection('logs')
+      .doc('log1');
+    await assertFails(ref.delete());
+  });
+
   it('allows owner to delete own session snapshot', async () => {
     await testEnv.withSecurityRulesDisabled(async (context) => {
       const db = context.firestore();

--- a/firestore.rules
+++ b/firestore.rules
@@ -105,6 +105,8 @@ service cloud.firestore {
       allow read: if isAuthed() &&
         (resource.data.userId == request.auth.uid ||
          isFriend(resource.data.userId, request.auth.uid));
+      allow delete: if isAuthed() &&
+        resource.data.userId == request.auth.uid;
     }
 
     // ─────────────────────────


### PR DESCRIPTION
## Summary
- allow authenticated members to delete their own documents in any `logs` collection when the entry belongs to them
- add regression coverage that owners can remove fallback log entries while non-owners remain blocked

## Testing
- ⚠️ `npx firebase emulators:exec --only firestore "npm run rules-test"` *(fails: emulator download blocked with HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a503de4c8320b464b525dda92ccd