### PR TITLE
Cache keypad controller for safe disposal

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -53,6 +53,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
   final _scrollController = ScrollController();
   final List<GlobalKey<SetCardState>> _setKeys = [];
   final _pagerKey = GlobalKey<DevicePagerState>();
+  OverlayNumericKeypadController? _keypadController;
 
   @override
   void initState() {
@@ -80,6 +81,12 @@ class _DeviceScreenState extends State<DeviceScreen> {
       _dlog('loadDevice() → done');
       setState(() {});
     });
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _keypadController ??= context.read<OverlayNumericKeypadController>();
   }
 
   void _addSet() {
@@ -113,7 +120,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
 
   void _closeKeyboard() {
     FocusManager.instance.primaryFocus?.unfocus();
-    context.read<OverlayNumericKeypadController>().close();
+    _keypadController?.close();
   }
 
   Widget _buildEditablePage(


### PR DESCRIPTION
## Summary
- cache the overlay numeric keypad controller once the widget tree is ready
- reuse the cached controller when closing the keyboard, preventing provider lookups during dispose

## Testing
- flutter analyze *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8aa8c860c8320848d274dcccea1ad