### PR TITLE
Silence keypad close notifications during dispose

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -118,9 +118,13 @@ class _DeviceScreenState extends State<DeviceScreen> {
     });
   }
 
-  void _closeKeyboard() {
+  void _closeKeyboard({bool silently = false}) {
     FocusManager.instance.primaryFocus?.unfocus();
-    _keypadController?.close();
+    if (silently) {
+      _keypadController?.close(notify: false);
+    } else {
+      _keypadController?.close();
+    }
   }
 
   Widget _buildEditablePage(
@@ -433,7 +437,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
 
   @override
   void dispose() {
-    _closeKeyboard();
+    _closeKeyboard(silently: true);
     _scrollController.dispose();
     super.dispose();
   }

--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -82,12 +82,12 @@ class OverlayNumericKeypadController extends ChangeNotifier {
     }
   }
 
-  void close() {
+  void close({bool notify = true}) {
     if (!_isOpen) return;
     _isOpen = false;
     _contentHeight = 0.0;
     _klog('close()');
-    notifyListeners();
+    if (notify) notifyListeners();
   }
 
   void _updateContentHeight(double height) {


### PR DESCRIPTION
## Summary
- allow OverlayNumericKeypadController.close to skip emitting notifications when the keypad is torn down
- close the device keypad silently during DeviceScreen disposal to avoid notifying while the widget tree is locked

## Testing
- flutter analyze *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8aca619388320ad6df54294ad5d46