### PR TITLE
Close overlay keypad when leaving device screen

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -437,7 +437,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
 
   @override
   void dispose() {
-    _closeKeyboard(silently: true);
+    _closeKeyboard();
     _scrollController.dispose();
     super.dispose();
   }


### PR DESCRIPTION
## Summary
- ensure the device screen notifies the overlay keypad controller during dispose so the keypad closes when leaving the page

## Testing
- flutter test test/ui/overlay_numeric_keypad_test.dart *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8bd7edb6c83208899798cda9ec31c