### PR TITLE
Close device keypad instantly when leaving page

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -118,12 +118,12 @@ class _DeviceScreenState extends State<DeviceScreen> {
     });
   }
 
-  void _closeKeyboard({bool silently = false}) {
+  void _closeKeyboard({bool silently = false, bool instant = false}) {
     FocusManager.instance.primaryFocus?.unfocus();
     if (silently) {
-      _keypadController?.close(notify: false);
+      _keypadController?.close(notify: false, immediate: instant);
     } else {
-      _keypadController?.close();
+      _keypadController?.close(immediate: instant);
     }
   }
 
@@ -300,7 +300,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
               Expanded(
                 child: OutlinedButton(
                   onPressed: () {
-                    _closeKeyboard();
+                    _closeKeyboard(instant: true);
                     Navigator.pop(context);
                   },
                   child: Text(loc.cancelButton),
@@ -413,7 +413,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(content: Text(message)),
                           );
-                          _closeKeyboard();
+                          _closeKeyboard(instant: true);
                           Navigator.of(context).popUntil((route) {
                             final name = route.settings.name;
                             return name == AppRouter.home || route.isFirst;
@@ -437,7 +437,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
 
   @override
   void dispose() {
-    _closeKeyboard();
+    _closeKeyboard(instant: true);
     _scrollController.dispose();
     super.dispose();
   }
@@ -506,7 +506,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
               icon: const Icon(Icons.history),
               tooltip: 'Verlauf',
               onPressed: () {
-                _closeKeyboard();
+                _closeKeyboard(instant: true);
                 final deviceProv = context.read<DeviceProvider>();
                 String? exerciseName;
                 if (deviceProv.device?.isMulti ?? false) {

--- a/test/ui/overlay_numeric_keypad_test.dart
+++ b/test/ui/overlay_numeric_keypad_test.dart
@@ -74,6 +74,30 @@ void main() {
     expect(controller.isOpen, false);
   });
 
+  testWidgets('close with immediate flag removes overlay without delay',
+      (tester) async {
+    final controller = OverlayNumericKeypadController();
+    final textCtrl = TextEditingController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OverlayNumericKeypadHost(
+          controller: controller,
+          child: TextField(controller: textCtrl),
+        ),
+      ),
+    );
+
+    controller.openFor(textCtrl);
+    await tester.pumpAndSettle();
+    expect(find.byType(OverlayNumericKeypad), findsOneWidget);
+
+    controller.close(immediate: true);
+    await tester.pump();
+
+    expect(find.byType(OverlayNumericKeypad), findsNothing);
+  });
+
   testWidgets('allowDecimal parameter sets controller flag', (tester) async {
     final controller = OverlayNumericKeypadController();
     final textCtrl = TextEditingController();


### PR DESCRIPTION
## Summary
- allow the device screen to request an instant keypad dismissal when navigation occurs
- teach the overlay keypad host to skip its closing animation when the controller asks for an immediate close and use that for back navigation
- cover the new behavior with a widget test that verifies the overlay disappears without delay

## Testing
- `flutter test test/ui/overlay_numeric_keypad_test.dart` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c08ed848832095daf3ed3f26c471