### PR TITLE
Fix missing Timer import for numeric keypad overlay

### DIFF
--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -1,6 +1,7 @@
 // lib/ui/numeric_keypad/overlay_numeric_keypad.dart
 // Geometry-driven numeric keypad with de-duped height notifications + logging.
 
+import 'dart:async';
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';


### PR DESCRIPTION
## Summary
- add the missing `dart:async` import so the overlay numeric keypad can use `Timer`

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8c9ccc7288320b019e2afa9145416