### PR TITLE
Close overlay keypad immediately on outside tap

### DIFF
--- a/test/ui/overlay_numeric_keypad_test.dart
+++ b/test/ui/overlay_numeric_keypad_test.dart
@@ -117,7 +117,8 @@ void main() {
     expect(controller.allowDecimal, false);
   });
 
-  testWidgets('outside tap triggers button and closes keypad', (tester) async {
+  testWidgets('outside tap triggers button and closes keypad immediately',
+      (tester) async {
     final controller = OverlayNumericKeypadController();
     bool pressed = false;
     final textCtrl = TextEditingController();
@@ -148,7 +149,12 @@ void main() {
     await tester.pumpAndSettle();
     expect(controller.isOpen, true);
 
-    await tester.tap(find.text('Add'));
+    final gesture =
+        await tester.startGesture(tester.getCenter(find.text('Add')));
+    await tester.pump();
+    expect(controller.isOpen, false);
+
+    await gesture.up();
     await tester.pumpAndSettle();
 
     expect(pressed, true);


### PR DESCRIPTION
## Summary
- close the overlay keypad instantly when pointer events occur outside the keypad surface
- add a shared handler that reacts on pointer down/up events and skips the hide animation
- adjust the overlay keypad widget test to assert the immediate closing behaviour

## Testing
- Attempted `flutter test test/ui/overlay_numeric_keypad_test.dart` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d4df03e483209df8dfcd9fe56cda