### PR TITLE
Keep overlay keypad persistent on device screen

### DIFF
--- a/lib/features/admin/presentation/screens/challenge_admin_screen.dart
+++ b/lib/features/admin/presentation/screens/challenge_admin_screen.dart
@@ -141,6 +141,7 @@ class _ChallengeAdminScreenState extends State<ChallengeAdminScreen> {
               controller: _setCtrl,
               keyboardType: TextInputType.none,
               readOnly: true,
+              enableInteractiveSelection: false,
               autofocus: false,
               onTap: () => context
                   .read<OverlayNumericKeypadController>()
@@ -152,6 +153,7 @@ class _ChallengeAdminScreenState extends State<ChallengeAdminScreen> {
               controller: _xpCtrl,
               keyboardType: TextInputType.none,
               readOnly: true,
+              enableInteractiveSelection: false,
               autofocus: false,
               onTap: () => context
                   .read<OverlayNumericKeypadController>()

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -86,7 +86,9 @@ class _DeviceScreenState extends State<DeviceScreen> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _keypadController ??= context.read<OverlayNumericKeypadController>();
+    final keypad = context.read<OverlayNumericKeypadController>();
+    _keypadController ??= keypad;
+    keypad.setOutsideTapMode(OutsideTapMode.none);
   }
 
   void _addSet() {
@@ -437,6 +439,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
 
   @override
   void dispose() {
+    _keypadController?.setOutsideTapMode(OutsideTapMode.closeAfterTap);
     _closeKeyboard(instant: true);
     _scrollController.dispose();
     super.dispose();
@@ -507,6 +510,8 @@ class _DeviceScreenState extends State<DeviceScreen> {
               tooltip: 'Verlauf',
               onPressed: () {
                 _closeKeyboard(instant: true);
+                _keypadController
+                    ?.setOutsideTapMode(OutsideTapMode.closeAfterTap);
                 final deviceProv = context.read<DeviceProvider>();
                 String? exerciseName;
                 if (deviceProv.device?.isMulti ?? false) {
@@ -519,19 +524,25 @@ class _DeviceScreenState extends State<DeviceScreen> {
                       )
                       .name;
                 }
-                Navigator.of(context).pushNamed(
-                  AppRouter.history,
-                  arguments: {
-                    'deviceId': widget.deviceId,
-                    'deviceName': deviceProv.device?.name ?? widget.deviceId,
-                    'deviceDescription': deviceProv.device?.description,
-                    'isMulti': deviceProv.device?.isMulti ?? false,
-                    if (deviceProv.device?.isMulti ?? false)
-                      'exerciseId': widget.exerciseId,
-                    if (deviceProv.device?.isMulti ?? false)
-                      'exerciseName': exerciseName,
-                  },
-                );
+                Navigator.of(context)
+                    .pushNamed(
+                      AppRouter.history,
+                      arguments: {
+                        'deviceId': widget.deviceId,
+                        'deviceName':
+                            deviceProv.device?.name ?? widget.deviceId,
+                        'deviceDescription': deviceProv.device?.description,
+                        'isMulti': deviceProv.device?.isMulti ?? false,
+                        if (deviceProv.device?.isMulti ?? false)
+                          'exerciseId': widget.exerciseId,
+                        if (deviceProv.device?.isMulti ?? false)
+                          'exerciseName': exerciseName,
+                      },
+                    )
+                    .then((_) {
+                  if (!mounted) return;
+                  _keypadController?.setOutsideTapMode(OutsideTapMode.none);
+                });
               },
             ),
           ],
@@ -685,6 +696,7 @@ class _PlannedTableState extends State<_PlannedTable> {
                           isDense: true,
                         ),
                         readOnly: true,
+                        enableInteractiveSelection: false,
                         keyboardType: TextInputType.none,
                         autofocus: false,
                         onTap: () {
@@ -709,6 +721,7 @@ class _PlannedTableState extends State<_PlannedTable> {
                           isDense: true,
                         ),
                         readOnly: true,
+                        enableInteractiveSelection: false,
                         keyboardType: TextInputType.none,
                         autofocus: false,
                         onTap: () {

--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -397,9 +397,15 @@ class SetCardState extends State<SetCard> {
                                 }
                               }
                             }
-                            context
-                                .read<OverlayNumericKeypadController>()
-                                .close();
+                            final allChecked = sets.every((set) {
+                              final doneVal = set['done'];
+                              return doneVal == true || doneVal == 'true';
+                            });
+                            if (allChecked) {
+                              context
+                                  .read<OverlayNumericKeypadController>()
+                                  .close();
+                            }
                           }
                         },
                 ),
@@ -437,6 +443,7 @@ class SetCardState extends State<SetCard> {
                       ),
                       enabled: !widget.readOnly,
                       readOnly: true,
+                      enableInteractiveSelection: false,
                       keyboardType: TextInputType.none,
                       validator: _validateDrop,
                       onTap: done || widget.readOnly
@@ -456,6 +463,7 @@ class SetCardState extends State<SetCard> {
                       ),
                       enabled: !widget.readOnly,
                       readOnly: true,
+                      enableInteractiveSelection: false,
                       keyboardType: TextInputType.none,
                       validator: _validateDrop,
                       onTap: done || widget.readOnly
@@ -602,6 +610,7 @@ class _InputPill extends StatelessWidget {
           focusNode: focusNode,
           enabled: !readOnly,
           readOnly: true,
+          enableInteractiveSelection: false,
           onTap: readOnly ? null : onTap,
           keyboardType: TextInputType.none,
           decoration: InputDecoration(

--- a/lib/features/training_plan/presentation/screens/plan_editor_screen.dart
+++ b/lib/features/training_plan/presentation/screens/plan_editor_screen.dart
@@ -463,6 +463,7 @@ class _PlanEntryEditorState extends State<_PlanEntryEditor> {
                       isDense: true,
                     ),
                     readOnly: true,
+                    enableInteractiveSelection: false,
                     keyboardType: TextInputType.none,
                     onTap: () => context
                         .read<OverlayNumericKeypadController>()
@@ -479,6 +480,7 @@ class _PlanEntryEditorState extends State<_PlanEntryEditor> {
                       isDense: true,
                     ),
                     readOnly: true,
+                    enableInteractiveSelection: false,
                     keyboardType: TextInputType.none,
                     onTap: () => context
                         .read<OverlayNumericKeypadController>()
@@ -495,6 +497,7 @@ class _PlanEntryEditorState extends State<_PlanEntryEditor> {
                       isDense: true,
                     ),
                     readOnly: true,
+                    enableInteractiveSelection: false,
                     keyboardType: TextInputType.none,
                     onTap: () => context
                         .read<OverlayNumericKeypadController>()

--- a/lib/features/training_plan/presentation/screens/plan_overview_screen.dart
+++ b/lib/features/training_plan/presentation/screens/plan_overview_screen.dart
@@ -187,6 +187,7 @@ class _PlanOverviewScreenState extends State<PlanOverviewScreen> {
                           ),
                           keyboardType: TextInputType.none,
                           readOnly: true,
+                          enableInteractiveSelection: false,
                           autofocus: false,
                           onTap: () => context
                               .read<OverlayNumericKeypadController>()

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -462,7 +462,6 @@ class MyApp extends StatelessWidget {
         app = DynamicLinkListener(child: app);
         return OverlayNumericKeypadHost(
           controller: keypad,
-          outsideTapMode: OutsideTapMode.closeAfterTap,
           child: app,
         );
       },

--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -53,10 +53,12 @@ class OverlayNumericKeypadController extends ChangeNotifier {
   bool _pendingHeightNotify = false;
   bool _instantCloseRequested = false;
   bool _deferredNotifyScheduled = false;
+  OutsideTapMode _outsideTapMode = OutsideTapMode.closeAfterTap;
 
   bool get isOpen => _isOpen;
   TextEditingController? get target => _target;
   double get keypadContentHeight => _isOpen ? _contentHeight : 0.0;
+  OutsideTapMode get outsideTapMode => _outsideTapMode;
 
   bool consumeInstantClose() {
     final shouldCloseInstantly = _instantCloseRequested;
@@ -134,6 +136,12 @@ class OverlayNumericKeypadController extends ChangeNotifier {
       }
     });
   }
+
+  void setOutsideTapMode(OutsideTapMode mode) {
+    if (_outsideTapMode == mode) return;
+    _outsideTapMode = mode;
+    notifyListeners();
+  }
 }
 
 enum OutsideTapMode { none, closeAfterTap }
@@ -143,7 +151,6 @@ class OverlayNumericKeypadHost extends StatefulWidget {
   final Widget child;
   final NumericKeypadTheme theme;
   final bool interceptAndroidBack;
-  final OutsideTapMode outsideTapMode;
 
   const OverlayNumericKeypadHost({
     super.key,
@@ -151,7 +158,6 @@ class OverlayNumericKeypadHost extends StatefulWidget {
     required this.child,
     this.theme = const NumericKeypadTheme(),
     this.interceptAndroidBack = true,
-    this.outsideTapMode = OutsideTapMode.none,
   });
 
   @override
@@ -177,7 +183,8 @@ class _OverlayNumericKeypadHostState extends State<OverlayNumericKeypadHost>
       'outsideTap ${event.runtimeType} at ${event.position} insideKeypad=$inside',
     );
 
-    if (widget.outsideTapMode == OutsideTapMode.closeAfterTap && !inside) {
+    if (widget.controller.outsideTapMode == OutsideTapMode.closeAfterTap &&
+        !inside) {
       widget.controller.close(immediate: true);
     }
   }
@@ -208,6 +215,7 @@ class _OverlayNumericKeypadHostState extends State<OverlayNumericKeypadHost>
     return AnimatedBuilder(
       animation: widget.controller,
       builder: (context, _) {
+        final outsideTapMode = widget.controller.outsideTapMode;
         final keypad = widget.controller.isOpen
             ? OverlayNumericKeypad(
                 key: const ValueKey('overlay_numeric_keypad'),
@@ -221,7 +229,7 @@ class _OverlayNumericKeypadHostState extends State<OverlayNumericKeypadHost>
           children: [
             child,
             if (widget.controller.isOpen &&
-                widget.outsideTapMode != OutsideTapMode.none)
+                outsideTapMode != OutsideTapMode.none)
               Positioned.fill(
                 child: Listener(
                   behavior: HitTestBehavior.translucent,


### PR DESCRIPTION
## Summary
- add controller-managed outside tap handling for the overlay keypad and keep it open while the device screen is active
- disable system text selection on numeric keypad fields to avoid the system context menu assertion and keep the keypad from closing while switching fields
- only close the keypad automatically after all sets are checked and restore default outside-tap behaviour when leaving the device screen

## Testing
- `flutter analyze` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ddb650608320ac9c5c0327686b4c