### PR TITLE
Ensure overlay keypad closes when leaving device screen

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -539,7 +539,13 @@ class _DeviceScreenState extends State<DeviceScreen> {
       );
     }
 
-    return scaffold;
+    return WillPopScope(
+      onWillPop: () async {
+        _closeKeyboard();
+        return true;
+      },
+      child: scaffold,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- wrap the device screen scaffold in a WillPopScope so the overlay keypad closes before the route pops

## Testing
- flutter test *(fails: Flutter SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e78bb2f8832083b1c632c32926a4