### PR TITLE
Remove device description from device screen

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -156,15 +156,6 @@ class _DeviceScreenState extends State<DeviceScreen> {
                   physics: const AlwaysScrollableScrollPhysics(),
                   padding: EdgeInsets.fromLTRB(16, 16, 16, bottomPad),
                   children: [
-                    if (prov.device!.description.isNotEmpty) ...[
-                      Text(
-                        prov.device!.description,
-                        style: TextStyle(
-                          color: Theme.of(context).colorScheme.onSurface,
-                        ),
-                      ),
-                      const SizedBox(height: 16),
-                    ],
                     if (plannedEntry != null)
                       _PlannedTable(entry: plannedEntry)
                     else ...[


### PR DESCRIPTION
## Summary
- remove the device description text from the device screen so only the session content remains

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c340f8048320845b55c44bfb21c6