### PR TITLE
fix(website): make project vercel --prod ready (typedRoutes, login redirect, og)

### DIFF
--- a/thesis/gamification/2025-09-19_typedroutes_login_nav_fix.md
+++ b/thesis/gamification/2025-09-19_typedroutes_login_nav_fix.md
@@ -1,88 +1,211 @@
 # typedroutes_login_nav_fix
 
 ## Prompt
+```
+Ziel:
+Im Repo Wasgehtab97/tapem, Branch a_gpt5, den Web-Teil unter website/ so anpassen, dass npm run build lokal und vercel --prod in Vercel ohne TypeScript-Fehler durchlaufen.
+Besonders: Next.js experimental.typedRoutes fehlerfrei machen (keine string-hrefs), Login-Redirect typisiert & sicher, OG-Bild kompatibles CSS, keine Binärdateien. Flutter-Ordner nicht ändern.
 
-Ziel: Im Repo Wasgehtab97/tapem, Branch a_gpt5, die Next.js-Webapp unter website/ so fixen, dass vercel --prod ohne TypeScript-Fehler baut.
-Fehlerbilder:
+Rahmenbedingungen (bitte strikt einhalten)
 
-layout.tsx: typedRoutes verlangt Route für href, bisher werden Strings gereicht.
+Nur unter website/ arbeiten (außer README/Thesis).
 
-login-form.tsx: router.push(nextPath || '/gym') → nextPath ist generischer String; bei typedRoutes muss es ein Route sein.
+Keine Änderungen in Flutter-Dateien (lib/, android/, ios/, functions/ etc.).
 
-login/page.tsx: <LoginForm nextPath={...} /> → LoginForm hat keinen solchen Prop.
-Nebenbedingung: Keine Flutter-Files ändern; keine Binärdateien; konventionelle Commits; Thesis-.md anlegen.
+Keine Binärdateien (keine PNG/JPG/WebP/ICO).
 
-Anforderungen (bitte exakt umsetzen)
+Konventionelle Commits verwenden.
 
-Navigation typisieren (typedRoutes-safe)
+Thesis-Doku je PR in thesis/gamification/ anlegen (siehe unten).
 
-Datei: website/src/app/layout.tsx
+Aufgaben – Schritt für Schritt
+1) Zentrale, getypte Routen definieren (einmalig)
 
-Import ergänzen: import type { Route } from 'next';
-
-Navigationsliste strikt typisieren:
-
-const navLinks: Array<{ href: Route; label: string }> = [
-  { href: '/', label: 'Home' },
-  { href: '/gym', label: 'Gym' },
-  { href: '/admin', label: 'Admin' },
-];
-
-
-Link-Rendering unverändert lassen (jetzt fehlerfrei, weil href vom Typ Route ist).
-
-Bonus (beibehalten): robots abhängig von process.env.VERCEL_ENV (Preview = noindex, Prod = index). Falls das schon implementiert ist, nicht anfassen.
-
-Login-Redirect typed & sicher (Whitelist)
-
-Datei: website/src/app/login/login-form.tsx
-
-Ohne Props arbeiten (kein nextPath Prop). Die Komponente liest next selbst via useSearchParams.
-
-Oben ergänzen:
+Datei: website/src/lib/routes.ts (neu)
 
 import type { Route } from 'next';
 
-const ALLOWED_AFTER_LOGIN = [
-  '/gym',
-  '/gym/members',
-  '/gym/challenges',
-  '/gym/leaderboard',
-  '/admin',
+export const ROUTES = {
+  home: '/' as Route,
+  gym: '/gym' as Route,
+  gymMembers: '/gym/members' as Route,
+  gymChallenges: '/gym/challenges' as Route,
+  gymLeaderboard: '/gym/leaderboard' as Route,
+  admin: '/admin' as Route,
+  imprint: '/imprint' as Route,
+  privacy: '/privacy' as Route,
+} as const;
+
+export type AppRoute = (typeof ROUTES)[keyof typeof ROUTES];
+
+// Whitelist für Redirects nach Login:
+export const ALLOWED_AFTER_LOGIN = [
+  ROUTES.gym,
+  ROUTES.gymMembers,
+  ROUTES.gymChallenges,
+  ROUTES.gymLeaderboard,
+  ROUTES.admin,
 ] as const;
+
+2) layout.tsx – Nav typedRoutes-sicher + Preview noindex (falls noch nicht)
+
+Datei: website/src/app/layout.tsx
+
+Route importieren: import type { Route } from 'next';
+
+Nav liste typisieren oder ROUTES verwenden:
+
+import { ROUTES } from '@/src/lib/routes';
+
+const navLinks: Array<{ href: Route; label: string }> = [
+  { href: ROUTES.home, label: 'Home' },
+  { href: ROUTES.gym, label: 'Gym' },
+  { href: ROUTES.admin, label: 'Admin' },
+];
+
+
+<Link href={link.href}> unverändert lassen (jetzt typ-sicher).
+
+metadata.robots: In Preview/Dev noindex, in Prod index (falls noch nicht vorhanden: umsetzen).
+
+3) Gym-Subnav typedRoutes-sicher
+
+Datei: website/src/components/gym-subnav.tsx (ersetzen)
+
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import type { Route } from 'next';
+import { ROUTES } from '@/src/lib/routes';
+
+const items = [
+  { href: ROUTES.gym, label: 'Übersicht' },
+  { href: ROUTES.gymMembers, label: 'Mitglieder' },
+  { href: ROUTES.gymChallenges, label: 'Challenges' },
+  { href: ROUTES.gymLeaderboard, label: 'Rangliste' },
+] satisfies ReadonlyArray<{ href: Route; label: string }>;
+
+export default function GymSubnav() {
+  const pathname = usePathname();
+
+  return (
+    <nav aria-label="Gym-Untermenü" className="flex flex-wrap gap-2">
+      {items.map((item) => {
+        const isActive = pathname === item.href;
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={
+              'rounded-full border px-4 py-2 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900 ' +
+              (isActive
+                ? 'border-slate-900 bg-slate-900 text-white'
+                : 'border-slate-300 text-slate-700 hover:bg-slate-100')
+            }
+            aria-current={isActive ? 'page' : undefined}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+4) Login-Form: typed Redirect + Open-Redirect-Schutz
+
+Datei: website/src/app/login/login-form.tsx (ersetzen)
+
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import type { Route } from 'next';
+import { useState } from 'react';
+import { ALLOWED_AFTER_LOGIN } from '@/src/lib/routes';
+
 type AllowedRoute = (typeof ALLOWED_AFTER_LOGIN)[number];
-const DEFAULT_AFTER_LOGIN: AllowedRoute = '/gym';
+const DEFAULT_AFTER_LOGIN: AllowedRoute = ALLOWED_AFTER_LOGIN[0];
 
 function isAllowedRoute(v: string | null): v is AllowedRoute {
   return !!v && (ALLOWED_AFTER_LOGIN as readonly string[]).includes(v);
 }
 
+export default function LoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
 
-Beim Redirect:
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-const nextParam = searchParams.get('next');
-const target: Route = (isAllowedRoute(nextParam) ? nextParam : DEFAULT_AFTER_LOGIN) as Route;
-router.push(target);
-router.refresh();
+  async function onSubmit(formData: FormData) {
+    setError(null);
+    setSubmitting(true);
 
+    try {
+      const email = (formData.get('email') as string | null) ?? '';
+      const role = (formData.get('role') as string | null) ?? 'owner';
 
-Keine Prop-Definition für LoginForm hinzufügen (reinlesen via useSearchParams).
+      const res = await fetch('/api/dev/login', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ email, role }),
+      });
+      if (!res.ok) throw new Error(`Login fehlgeschlagen (${res.status})`);
 
-Login-Page Prop entfernen
+      const nextParam = searchParams.get('next');
+      const target: Route = (isAllowedRoute(nextParam) ? nextParam : DEFAULT_AFTER_LOGIN) as Route;
 
-Datei: website/src/app/login/page.tsx
+      router.push(target);
+      router.refresh();
+    } catch (e: any) {
+      setError(e?.message ?? 'Unbekannter Fehler beim Login.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
 
-Kein nextPath mehr berechnen/weiterreichen.
+  return (
+    <form action={onSubmit} className="max-w-md space-y-4">
+      <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+        <strong>Dev-Login (Stub):</strong> Nur für Preview/Entwicklung. In Production deaktiviert.
+      </div>
 
-<LoginForm /> ohne Props rendern.
+      <div className="space-y-1">
+        <label htmlFor="email" className="block text-sm font-medium text-slate-700">E-Mail (optional)</label>
+        <input id="email" name="email" type="email" placeholder="you@example.com"
+          className="w-full rounded border border-slate-300 px-3 py-2 text-sm outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900" />
+      </div>
 
-Beispiel (wenn eine schlanke Page gebraucht wird):
+      <div className="space-y-1">
+        <label htmlFor="role" className="block text-sm font-medium text-slate-700">Rolle</label>
+        <select id="role" name="role" defaultValue="owner"
+          className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900">
+          <option value="owner">owner</option>
+          <option value="operator">operator</option>
+          <option value="admin">admin</option>
+        </select>
+      </div>
+
+      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+
+      <button type="submit" disabled={submitting}
+        className="inline-flex items-center justify-center rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800 disabled:opacity-50">
+        {submitting ? 'Anmelden…' : 'Anmelden'}
+      </button>
+    </form>
+  );
+}
+
+5) Login-Page: Prop entfernen
+
+Datei: website/src/app/login/page.tsx (ersetzen)
 
 import type { Metadata } from 'next';
 import LoginForm from './login-form';
 
 export const metadata: Metadata = {
-  title: 'Login – Tap’em (Dev-Stub)',
+  title: 'Login – Tap'em (Dev-Stub)',
   robots: { index: false, follow: false },
 };
 
@@ -91,7 +214,7 @@ export default function Page() {
     <div className="space-y-6">
       <h1 className="text-2xl font-semibold">Anmelden (Dev-Stub)</h1>
       <p className="text-sm text-slate-600">
-        Diese Anmeldung setzt nur Vorschau-Cookies und dient dem Testen der geschützten Bereiche.
+        Diese Anmeldung setzt Vorschau-Cookies und dient dem Testen der geschützten Bereiche.
         In Production ist der Dev-Login deaktiviert.
       </p>
       <LoginForm />
@@ -99,107 +222,115 @@ export default function Page() {
   );
 }
 
-
-(Nur falls vorhanden) OG-Bild CSS konsistent halten
+6) OG-Bild kompatibel (falls noch nicht)
 
 Datei: website/src/app/opengraph-image.tsx
 
-Stelle sicher, dass kein display: inline-flex verwendet wird. Nur erlaubte Werte wie display: 'flex'.
+Sicherstellen: kein display: 'inline-flex', stattdessen display: 'flex'.
 
-Falls bereits korrigiert: nicht ändern.
+Nur einfache Inline-Styles verwenden (keine Tailwind-Klassen in @vercel/og).
 
-tsconfig / next.config
+7) Externe Links richtig verwenden
 
-website/next.config.js: experimental.typedRoutes bleibt aktiv (nicht entfernen).
+Suche und ersetze in website/src/**:
 
-website/tsconfig.json: nichts ändern, außer es ist nötig, um die obigen Typen zu erkennen (meist nicht notwendig).
+Für externe URLs (https://…) kein next/link, sondern <a href="…" target="_blank" rel="noreferrer noopener">…</a>.
 
-Docs & Thesis
+Für interne Routen nur Route-typisierte Werte (aus ROUTES).
 
-README.md (Root oder website/README.md) – kurzer Abschnitt „typedRoutes Fix“:
+8) Dev-Login-API in Produktion sperren (Safety)
 
-Warum Route nötig ist,
+Dateien: website/src/app/api/dev/login/route.ts, .../logout/route.ts
 
-Whitelist-Konzept nach Login,
+Ganz oben:
 
-QA-Schritte (siehe unten).
+if (process.env.VERCEL_ENV === 'production') {
+  return new Response('dev login disabled in production', { status: 403 });
+}
 
-Thesis-Markdown anlegen:
-Datei: thesis/gamification/YYYY-MM-DD_typedroutes_login_nav_fix.md
-Inhalt: Prompt (dieser Text), Ziel, Kontext (Repo/Branch), Ergebnis (Dateiliste), Screens/Links (optional), Abweichungen/Nacharbeiten.
 
-Git & PR
+(Logout darf optional 204 zurückgeben ohne 403 – egal für Build, aber klarer.)
 
-Konventionelle Commits (Beispiel unten).
+9) .env.example belassen/ergänzen (keine Secrets)
 
-PR-Titel: fix(website): typedRoutes-safe nav and login redirect (no binaries)
+Datei: website/.env.example – nur Platzhalter (Firebase später).
 
-PR-Checkliste:
+10) Doku & Thesis
 
-Build lokal und auf Vercel grün,
+website/README.md: Abschnitt „typedRoutes & Login-Whitelist“ mit kurzen Prüfhinweisen.
 
-layout.tsx nutzt Route-typisierte Nav,
+thesis/gamification/YYYY-MM-DD_typedroutes_login_nav_fix.md (neu)
+Inhalt: Prompt (dieser Text), Ziel, Kontext (Repo/Branch), Ergebnis (Dateiliste), Links/Screens (optional), Abweichungen.
 
-login-form.tsx nutzt Whitelist + Route Redirect,
+11) Fallback (nur wenn nötig)
 
-login/page.tsx ohne nextPath Prop,
+Falls trotz obiger Korrekturen noch einzelne Drittstellen Probleme machen:
 
-Keine Flutter-Änderungen, keine Binärdateien, Thesis-.md vorhanden.
+In website/next.config.js vorübergehend:
 
-Erwartete Commits (Beispiele)
+experimental: { typedRoutes: false }
 
-fix(website): type-safe nav links for Next.js typedRoutes
 
-fix(website): typedRoutes-safe login redirect with allowed route whitelist
+Nicht standardmäßig setzen – nur falls absolut nötig. Standard bleibt true.
 
-fix(website): remove invalid LoginForm prop usage
+Qualität / Checks
 
-docs(website): explain typedRoutes and login whitelist
+npm run build lokal: grün.
+
+vercel --prod: grün.
+
+Manuell testen:
+
+Navbar Links + Gym-Subnav klicken.
+
+/login → Login als owner → /gym.
+
+/login?next=/admin → Login als admin → /admin.
+
+/login?next=/falsch → Redirect auf /gym (Whitelist).
+
+Commits (Beispiele)
+
+fix(website): introduce typed route constants and safe internal links
+
+fix(website): typedRoutes-safe login redirect with whitelist
+
+fix(website): type-safe gym subnav
+
+fix(website): vercel/og css compatibility
+
+docs(website): add typedRoutes and verification notes
 
 docs(thesis): add typedroutes_login_nav_fix log
 
-Tests / Abnahme
+PR
 
-npm run build lokal ohne Fehler.
-
-vercel --prod erfolgreich (Production URL liefert Seite).
-
-Manuell prüfen:
-
-Navbar-Links funktionieren.
-
-/login → Login als owner → Redirect /gym.
-
-/login?next=/admin → als admin → Redirect /admin.
-
-/login?next=/oops → Redirect /gym (Whitelist greift).
-
-(Falls OG-Route existiert) /opengraph-image rendert ohne CSS-Fehler.
-
-Wichtig (Masterarbeit/Gamification): Erstelle im PR zwingend die Datei thesis/gamification/YYYY-MM-DD_typedroutes_login_nav_fix.md mit Prompt, Ziel, Kontext, Ergebnis. Keine Binärdateien in den PR aufnehmen.
+Titel: fix(website): make project vercel --prod ready (typedRoutes, login redirect, og)
+Checkliste: Build/Deploy grün, interne Links typisiert, Login-Redirect whitelisted, OG-Route kompatibel, keine Binaries, Flutter unberührt, Thesis-MD vorhanden.
+```
 
 ## Ziel
-
-- typedRoutes-Fehler in Navigation und Login beseitigen.
-- Redirect nach Dev-Login über Whitelist absichern.
-- Dokumentation & Thesis-Eintrag ergänzen.
+- Typed Routes konsolidieren, Login-Redirect absichern und Build-Kompatibilität für Next.js/Vercel sicherstellen.
 
 ## Kontext
-
 - Repository: Wasgehtab97/tapem
 - Branch: a_gpt5
+- Fokus: `website/` (Next.js-App) und begleitende Thesis-Notiz
 
 ## Ergebnis
+- `website/src/lib/routes.ts`
+- `website/src/app/layout.tsx`
+- `website/src/components/gym-subnav.tsx`
+- `website/src/app/login/login-form.tsx`
+- `website/src/app/login/page.tsx`
+- `website/src/app/page.tsx`
+- `website/src/app/api/dev/login/route.ts`
+- `website/src/app/api/dev/logout/route.ts`
+- `website/README.md`
+- `thesis/gamification/2025-09-19_typedroutes_login_nav_fix.md`
 
-- website/src/app/login/page.tsx
-- website/src/app/login/login-form.tsx
-- README.md
-- thesis/gamification/2025-09-19_typedroutes_login_nav_fix.md
-
-## Screens/Links
-
+## Links/Screens
 - n/a
 
-## Abweichungen/Nacharbeiten
-
-- Keine.
+## Abweichungen
+- Keine

--- a/website/README.md
+++ b/website/README.md
@@ -69,6 +69,12 @@ Sitemap und `robots.txt` verwendet.
 - In Development & Preview blendet die Top-Navigation eine Dev-Toolbar ein. Damit können Rollen ohne Seitenwechsel gewechselt werden.
 - In Production verweigern die API-Routen den Aufruf mit `403` (_dev login disabled in production_).
 
+## typedRoutes & Login-Whitelist
+
+- Zentrale Routen werden in [`src/lib/routes.ts`](src/lib/routes.ts) als `Route`-Typen gepflegt; Link-Komponenten verwenden ausschließlich diese Konstanten.
+- Nach dem Dev-Login sind nur Werte aus `ALLOWED_AFTER_LOGIN` als Redirect-Ziel erlaubt (`/login?next=`-Parameter wird validiert).
+- Tests vor Deploy: `npm run build`, anschließend `/login`, `/login?next=/admin` und `/login?next=/falsch` in der Preview prüfen.
+
 ## Mock-Datenquelle
 
 - Alle geschützten Routen verwenden statische Mock-Daten aus [`src/server/mocks/gym.ts`](src/server/mocks/gym.ts).

--- a/website/src/app/api/dev/login/route.ts
+++ b/website/src/app/api/dev/login/route.ts
@@ -7,10 +7,6 @@ const EMAIL_COOKIE = 'tapem_email';
 const MAX_AGE = 60 * 60 * 24 * 7; // 7 Tage
 const ROLES: Role[] = ['admin', 'owner', 'operator'];
 
-function isProduction() {
-  return process.env.VERCEL_ENV === 'production';
-}
-
 function parseRole(value: unknown): Role | undefined {
   if (typeof value === 'string' && ROLES.includes(value as Role)) {
     return value as Role;
@@ -20,8 +16,8 @@ function parseRole(value: unknown): Role | undefined {
 }
 
 export async function POST(request: Request) {
-  if (isProduction()) {
-    return new NextResponse('dev login disabled in production', { status: 403 });
+  if (process.env.VERCEL_ENV === 'production') {
+    return new Response('dev login disabled in production', { status: 403 });
   }
 
   const contentType = request.headers.get('content-type') ?? '';

--- a/website/src/app/api/dev/logout/route.ts
+++ b/website/src/app/api/dev/logout/route.ts
@@ -3,13 +3,9 @@ import { NextResponse } from 'next/server';
 const ROLE_COOKIE = 'tapem_role';
 const EMAIL_COOKIE = 'tapem_email';
 
-function isProduction() {
-  return process.env.VERCEL_ENV === 'production';
-}
-
 export async function POST() {
-  if (isProduction()) {
-    return new NextResponse('dev login disabled in production', { status: 403 });
+  if (process.env.VERCEL_ENV === 'production') {
+    return new Response('dev login disabled in production', { status: 403 });
   }
 
   const response = new NextResponse(null, { status: 204 });

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { ReactNode } from 'react';
 
 import { getDevUserFromCookies } from '@/src/lib/auth/server';
 import type { Role } from '@/src/lib/auth/types';
+import { ROUTES } from '@/src/lib/routes';
 import DevToolbar from '@/src/components/dev-toolbar';
 
 import '../styles/globals.css';
@@ -16,9 +17,9 @@ const isProd = process.env.VERCEL_ENV === 'production';
  * Navigation: mit typedRoutes typisiert, damit href exakt existierende interne Routen sind.
  */
 const navLinks: Array<{ href: Route; label: string }> = [
-  { href: '/', label: 'Home' },
-  { href: '/gym', label: 'Gym' },
-  { href: '/admin', label: 'Admin' },
+  { href: ROUTES.home, label: 'Home' },
+  { href: ROUTES.gym, label: 'Gym' },
+  { href: ROUTES.admin, label: 'Admin' },
 ];
 
 export const metadata: Metadata = {
@@ -75,7 +76,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-4">
               <div className="flex flex-1 items-center gap-8">
                 <Link
-                  href="/"
+                  href={ROUTES.home}
                   className="text-base font-semibold text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900"
                 >
                   Tap&apos;em

--- a/website/src/app/login/login-form.tsx
+++ b/website/src/app/login/login-form.tsx
@@ -3,18 +3,10 @@
 import { useRouter, useSearchParams } from 'next/navigation';
 import type { Route } from 'next';
 import { useState } from 'react';
-
-// Whitelist der erlaubten Zielrouten nach Login (bei Bedarf erweitern)
-const ALLOWED_AFTER_LOGIN = [
-  '/gym',
-  '/gym/members',
-  '/gym/challenges',
-  '/gym/leaderboard',
-  '/admin',
-] as const;
+import { ALLOWED_AFTER_LOGIN } from '@/src/lib/routes';
 
 type AllowedRoute = (typeof ALLOWED_AFTER_LOGIN)[number];
-const DEFAULT_AFTER_LOGIN: AllowedRoute = '/gym';
+const DEFAULT_AFTER_LOGIN: AllowedRoute = ALLOWED_AFTER_LOGIN[0];
 
 function isAllowedRoute(v: string | null): v is AllowedRoute {
   return !!v && (ALLOWED_AFTER_LOGIN as readonly string[]).includes(v);
@@ -35,18 +27,13 @@ export default function LoginForm() {
       const email = (formData.get('email') as string | null) ?? '';
       const role = (formData.get('role') as string | null) ?? 'owner';
 
-      // Dev-Login-API (setzt Cookies). In Production sollte diese Route 403 liefern.
       const res = await fetch('/api/dev/login', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ email, role }),
       });
+      if (!res.ok) throw new Error(`Login fehlgeschlagen (${res.status})`);
 
-      if (!res.ok) {
-        throw new Error(`Login fehlgeschlagen (${res.status})`);
-      }
-
-      // Zielroute bestimmen (nur Whitelist zulassen)
       const nextParam = searchParams.get('next');
       const target: Route = (isAllowedRoute(nextParam) ? nextParam : DEFAULT_AFTER_LOGIN) as Route;
 
@@ -66,28 +53,15 @@ export default function LoginForm() {
       </div>
 
       <div className="space-y-1">
-        <label htmlFor="email" className="block text-sm font-medium text-slate-700">
-          E-Mail (optional)
-        </label>
-        <input
-          id="email"
-          name="email"
-          type="email"
-          placeholder="you@example.com"
-          className="w-full rounded border border-slate-300 px-3 py-2 text-sm outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900"
-        />
+        <label htmlFor="email" className="block text-sm font-medium text-slate-700">E-Mail (optional)</label>
+        <input id="email" name="email" type="email" placeholder="you@example.com"
+          className="w-full rounded border border-slate-300 px-3 py-2 text-sm outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900" />
       </div>
 
       <div className="space-y-1">
-        <label htmlFor="role" className="block text-sm font-medium text-slate-700">
-          Rolle
-        </label>
-        <select
-          id="role"
-          name="role"
-          defaultValue="owner"
-          className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900"
-        >
+        <label htmlFor="role" className="block text-sm font-medium text-slate-700">Rolle</label>
+        <select id="role" name="role" defaultValue="owner"
+          className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900">
           <option value="owner">owner</option>
           <option value="operator">operator</option>
           <option value="admin">admin</option>
@@ -96,11 +70,8 @@ export default function LoginForm() {
 
       {error ? <p className="text-sm text-red-600">{error}</p> : null}
 
-      <button
-        type="submit"
-        disabled={submitting}
-        className="inline-flex items-center justify-center rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800 disabled:opacity-50"
-      >
+      <button type="submit" disabled={submitting}
+        className="inline-flex items-center justify-center rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800 disabled:opacity-50">
         {submitting ? 'Anmelden…' : 'Anmelden'}
       </button>
     </form>

--- a/website/src/app/login/page.tsx
+++ b/website/src/app/login/page.tsx
@@ -11,8 +11,8 @@ export default function Page() {
     <div className="space-y-6">
       <h1 className="text-2xl font-semibold">Anmelden (Dev-Stub)</h1>
       <p className="text-sm text-slate-600">
-        Diese Anmeldung setzt nur Vorschau-Cookies und dient dem Testen der geschützten Bereiche. In Production ist der
-        Dev-Login deaktiviert.
+        Diese Anmeldung setzt Vorschau-Cookies und dient dem Testen der geschützten Bereiche.
+        In Production ist der Dev-Login deaktiviert.
       </p>
       <LoginForm />
     </div>

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -4,6 +4,8 @@ import path from 'node:path';
 import Image from 'next/image';
 import Link from 'next/link';
 
+import { ROUTES } from '@/src/lib/routes';
+
 import { ThemeToggle } from '../components/theme-toggle';
 
 export const dynamic = 'force-static';
@@ -172,22 +174,22 @@ export default function HomePage() {
     <div className="flex min-h-screen flex-col bg-white text-slate-900 dark:bg-slate-950 dark:text-slate-100">
       <header className="border-b border-slate-200 bg-white/80 backdrop-blur dark:border-slate-800 dark:bg-slate-950/80">
         <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4" aria-label="Top navigation">
-          <Link href="#hero" className="text-lg font-semibold">
+          <a href="#hero" className="text-lg font-semibold">
             Tap'em
-          </Link>
+          </a>
           <nav className="hidden items-center gap-6 text-sm font-medium md:flex" aria-label="Hauptnavigation">
-            <Link className="hover:text-primary" href="#features">
+            <a className="hover:text-primary" href="#features">
               Features
-            </Link>
-            <Link className="hover:text-primary" href="#how-it-works">
+            </a>
+            <a className="hover:text-primary" href="#how-it-works">
               So funktioniert's
-            </Link>
-            <Link className="hover:text-primary" href="#faq">
+            </a>
+            <a className="hover:text-primary" href="#faq">
               FAQ
-            </Link>
-            <Link className="hover:text-primary" href="#contact">
+            </a>
+            <a className="hover:text-primary" href="#contact">
               Kontakt
-            </Link>
+            </a>
           </nav>
           <ThemeToggle />
         </div>
@@ -206,18 +208,18 @@ export default function HomePage() {
                 effizientere Abläufe und motivierte Mitglieder.
               </p>
               <div className="flex flex-col gap-3 sm:flex-row">
-                <Link
+                <a
                   href="#features"
                   className="rounded-full bg-primary px-6 py-3 text-center text-sm font-semibold text-primary-foreground shadow-lg shadow-primary/30 transition hover:bg-primary/90"
                 >
                   Mehr erfahren
-                </Link>
-                <Link
+                </a>
+                <a
                   href="#contact"
                   className="rounded-full border border-slate-300 px-6 py-3 text-center text-sm font-semibold transition hover:border-primary hover:text-primary dark:border-slate-700"
                 >
                   Für Studios: Demo anfragen
-                </Link>
+                </a>
               </div>
               <dl className="grid grid-cols-1 gap-6 text-slate-600 dark:text-slate-300 sm:grid-cols-3">
                 <div>
@@ -374,12 +376,12 @@ export default function HomePage() {
               Teile uns Studio-Größe, bestehende Systeme und gewünschte Features mit. Wir melden uns mit
               einem individuellen Onboarding-Plan.
             </p>
-            <Link
+            <a
               href="mailto:team@tapem.app"
               className="mt-6 inline-flex items-center justify-center rounded-full bg-secondary px-6 py-3 text-sm font-semibold text-secondary-foreground shadow-lg shadow-secondary/30 transition hover:bg-secondary/90"
             >
               Kontakt aufnehmen
-            </Link>
+            </a>
           </div>
         </section>
       </main>
@@ -389,13 +391,13 @@ export default function HomePage() {
           <p>&copy; {new Date().getFullYear()} Tap&apos;em. Alle Rechte vorbehalten.</p>
           <div className="flex gap-6">
             <Link
-              href="/imprint"
+              href={ROUTES.imprint}
               className="font-medium text-slate-700 transition hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:text-slate-200"
             >
               Impressum
             </Link>
             <Link
-              href="/privacy"
+              href={ROUTES.privacy}
               className="font-medium text-slate-700 transition hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:text-slate-200"
             >
               Datenschutz

--- a/website/src/components/gym-subnav.tsx
+++ b/website/src/components/gym-subnav.tsx
@@ -2,20 +2,22 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import type { Route } from 'next';
+import { ROUTES } from '@/src/lib/routes';
 
-const navItems = [
-  { href: '/gym', label: 'Übersicht' },
-  { href: '/gym/members', label: 'Mitglieder' },
-  { href: '/gym/challenges', label: 'Challenges' },
-  { href: '/gym/leaderboard', label: 'Leaderboard' },
-];
+const items = [
+  { href: ROUTES.gym, label: 'Übersicht' },
+  { href: ROUTES.gymMembers, label: 'Mitglieder' },
+  { href: ROUTES.gymChallenges, label: 'Challenges' },
+  { href: ROUTES.gymLeaderboard, label: 'Rangliste' },
+] satisfies ReadonlyArray<{ href: Route; label: string }>;
 
 export default function GymSubnav() {
   const pathname = usePathname();
 
   return (
-    <nav aria-label="Gym Navigation" className="flex flex-wrap gap-2 text-sm font-medium text-slate-700">
-      {navItems.map((item) => {
+    <nav aria-label="Gym-Untermenü" className="flex flex-wrap gap-2">
+      {items.map((item) => {
         const isActive = pathname === item.href;
         return (
           <Link
@@ -25,7 +27,7 @@ export default function GymSubnav() {
               'rounded-full border px-4 py-2 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900 ' +
               (isActive
                 ? 'border-slate-900 bg-slate-900 text-white'
-                : 'border-slate-200 bg-white text-slate-700 hover:border-slate-900/60 hover:bg-slate-100')
+                : 'border-slate-300 text-slate-700 hover:bg-slate-100')
             }
             aria-current={isActive ? 'page' : undefined}
           >

--- a/website/src/lib/routes.ts
+++ b/website/src/lib/routes.ts
@@ -1,0 +1,23 @@
+import type { Route } from 'next';
+
+export const ROUTES = {
+  home: '/' as Route,
+  gym: '/gym' as Route,
+  gymMembers: '/gym/members' as Route,
+  gymChallenges: '/gym/challenges' as Route,
+  gymLeaderboard: '/gym/leaderboard' as Route,
+  admin: '/admin' as Route,
+  imprint: '/imprint' as Route,
+  privacy: '/privacy' as Route,
+} as const;
+
+export type AppRoute = (typeof ROUTES)[keyof typeof ROUTES];
+
+// Whitelist für Redirects nach Login:
+export const ALLOWED_AFTER_LOGIN = [
+  ROUTES.gym,
+  ROUTES.gymMembers,
+  ROUTES.gymChallenges,
+  ROUTES.gymLeaderboard,
+  ROUTES.admin,
+] as const;


### PR DESCRIPTION
## Summary
- add central `Route`-typed constants and reuse them in navigation and gym subnav
- secure the login redirect flow with a whitelist and production guards for the dev auth endpoints
- adjust internal/external links, extend documentation, and record the thesis log entry

## Testing
- `npm run build` *(fails: Next.js binary missing because npm install was blocked with 403 from registry)*

## Checklist
- [ ] Build/Deploy grün *(registry.npmjs.org returned 403 for @types/node; install and build could not complete in container)*
- [x] Interne Links typisiert
- [x] Login-Redirect whitelisted
- [x] OG-Route kompatibel
- [x] Keine Binaries
- [x] Flutter unberührt
- [x] Thesis-MD vorhanden

------
https://chatgpt.com/codex/tasks/task_e_68cca44154e083209036f353e7963bd3