### PR TITLE
fix(website): make project vercel --prod ready (typedRoutes, login suspense, og)

### DIFF
--- a/thesis/gamification/2025-09-19_typedroutes_login_suspense_og_fix.md
+++ b/thesis/gamification/2025-09-19_typedroutes_login_suspense_og_fix.md
@@ -1,0 +1,164 @@
+# typedRoutes/Login/Suspense/OG Fix – 2025-09-19
+
+## Prompt
+```
+Ziel
+Mache den Web-Teil des Repos Wasgehtab97/tapem auf Branch a_gpt5 unter website/ so stabil, dass npm run build lokal und vercel --prod in Vercel ohne Fehler laufen. Behebe systematisch alle Probleme rund um Next.js 14 App Router, experimental.typedRoutes, Login/Redirects, useSearchParams() + Suspense sowie die Open-Graph-Bildroute. Erhalte SSR/CSR-Entscheidungen wie vorgesehen, ändere keine Flutter-Bestandteile, keine Binärdateien einchecken. Dokumentiere alles PR-fertig inkl. Thesis-Markdown.
+
+Kontext
+
+Monorepo: Flutter-App (bestehend) + Next.js-Web (unter website/).
+
+Web-Stack: Next.js 14 (App Router, TypeScript), Tailwind, ESLint/Prettier, experimental.typedRoutes: true, SEO-Metadaten, opengraph-image-Route, statische Landing-Page, SSR-Skeletons für /gym (mit Subnav, Overview/Members/Challenges/Leaderboard) und /admin, dev-Auth-Stub (Cookie-basiert) mit Login/Logout-API nur für Preview/Dev, No-Index für geschützte Bereiche.
+
+Bisherige Fehlerbilder beim Build auf Vercel:
+
+typedRoutes-Typfehler bei <Link href="…">, bei Subnav und bei Redirects (router.push(...)).
+
+/login nutzt useSearchParams() → Build-Abbruch wegen fehlender Suspense-Boundary/Prerender-Konflikt.
+
+OG-Bildroute meldete zuvor unzulässige CSS Properties (keine „inline-flex“ etc.).
+
+Anforderung Gamification/Thesis: Pro PR eine .md unter thesis/gamification/ mit Prompt, Ziel, Kontext, Ergebnis, Abweichungen/Nacharbeiten. Keine Binärdateien (Bilder lokal im website/public/images/ vom Nutzer abgelegt; Repo enthält nur Platzhalter/Hinweise).
+
+Aufgaben (bitte exakt und vollständig umsetzen)
+
+typedRoutes-Compliance im gesamten website/-Code sicherstellen
+
+Alle internen Navigationsziele (Navbar, Subnav, Footer, In-Page-Links, Buttons) auf echte App-Routen festziehen, sodass href/Redirect-Ziele mit typedRoutes kompatibel sind.
+
+Interne Links: ausschließlich gültige interne Routen verwenden; Externals nicht über Next-Link.
+
+Redirects/Router-Navigation (z. B. nach Login): nur zulässige interne Ziele; unsichere/unerwartete Werte abfangen (Whitelist/Validierung).
+
+Ziel: keine Typfehler mehr vom Muster „Type 'string' is not assignable to Route“.
+
+Login-Seite /login build-stabil machen
+
+Die Seite nutzt useSearchParams() → stelle sicher, dass sie dynamisch gerendert wird (kein Prerender/SSG-Konflikt) und dass die betroffene Client-Komponente in einer Suspense-Boundary gerendert wird, damit der Build nicht mit der Meldung zu fehlender Suspense scheitert.
+
+Die bestehende dev-Login-API bleibt nur in Preview/Dev nutzbar (Production blockiert); Verhalten beibehalten.
+
+Open-Graph-Bildroute robust halten
+
+Stelle sicher, dass die OG-Bildgenerierung keine unzulässigen CSS-Eigenschaften verwendet (nur erlaubte Werte), sodass die Route während des Builds nicht fehlschlägt.
+
+Laufzeit/Output so beibehalten, dass OG in Production korrekt ausliefert.
+
+SEO/Robots je Umgebung korrekt
+
+Previews/Dev: noindex/nofollow (Seitenweit konsistent; geschützte Bereiche zusätzlich).
+
+Production: Seiten sollen indexierbar sein (ausgenommen die geschützten Bereiche).
+
+Produktionssicherheit der dev-Auth-Stub-Routen
+
+Sicherstellen, dass dev-Login/Logout-APIs in Production deaktiviert sind (z. B. 403), damit keine Test-Auth öffentlich aktiv ist.
+
+Preview/Dev-Verhalten bleibt unverändert (Cookies setzen, Rollenumschaltung/Toolbar).
+
+Konfigurationszustand beibehalten
+
+website/next.config.js ohne output: 'export', SSR bleibt möglich, experimental.typedRoutes aktiv lassen.
+
+tsconfig so belassen, dass Typsicherheit der Routen greift.
+
+Keine zusätzlichen Abhängigkeiten einführen, sofern nicht zwingend nötig.
+
+Keine Binärdateien in den PR
+
+Keine neuen Bilder/PNGs ins Repo. Hinweise belassen, wie der Nutzer die Assets lokal unter website/public/images/ hinterlegt.
+
+Docs aktualisieren (kurz & präzise)
+
+website/README.md (oder Root-README Web-Abschnitt) um einen Abschnitt ergänzen:
+
+„typedRoutes: interne Routen vs. externe Links, Validierung von Redirect-Zielen.“
+
+„CSR-Bailout & Suspense für useSearchParams() auf Seitenebene; dynamisches Rendering.“
+
+„OG-Bild-Route: zulässige CSS-Properties; warum.“
+
+„Preview/Prod Robots-Unterschiede; dev-Auth in Production gesperrt.“
+
+Kurzer Testplan: welche Routen/Flows geprüft wurden.
+
+Thesis-Markdown anlegen (Pflicht)
+
+Datei: thesis/gamification/YYYY-MM-DD_typedroutes_login_suspense_og_fix.md.
+
+Inhalt: Prompt (dieser Text), Ziel, Kontext (Repo/Branch, Ordner), Ergebnis (konkrete Änderungen/Dateiliste, Build-Status), bekannte Abweichungen/Nacharbeiten, Links zu Preview/Prod.
+
+Git & PR
+
+Konventionelle Commits verwenden (feingranular, eindeutig).
+
+PR-Titel: fix(website): make project vercel --prod ready (typedRoutes, login suspense, og)
+
+PR-Checkliste:
+
+npm run build lokal grün, vercel --prod grün.
+
+Keine typedRoutes-Typfehler mehr (Links/Redirects/Subnav/Footer etc.).
+
+/login rendert mit Suspense, dynamisch; kein Prerender-Fehler.
+
+OG-Bild-Route stabil (keine CSS-Verbote).
+
+Previews noindex; Production indexbar; geschützte Bereiche noindex.
+
+dev-Login/Logout in Production deaktiviert.
+
+Keine Flutter-Änderungen, keine Binärdateien.
+
+Thesis-MD vorhanden und ausgefüllt.
+
+Ausschlüsse / Safety
+
+Keine Änderungen an Flutter (lib/, android/, ios/, functions/ etc.).
+
+Keine Secrets in .env committen; nur .env.example mit Platzhaltern pflegen.
+
+Kein Vendor-Lock-In oder CI/CD-Umbau in diesem PR; Fokus rein auf Build-Stabilität und typedRoutes/Suspense/OG-Robustheit.
+
+Erfolgskriterien (DoD)
+
+Build & Deploy grün: npm run build lokal erfolgreich; vercel --prod ohne Fehler.
+
+typedRoutes vollständig eingehalten: keine TypeScript-Fehler bzgl. href/router.push/Subnav/Links.
+
+Login-Seite stabil: keine Meldung zu „missing suspense with csr bailout“; Weiterleitungen nur auf erlaubte interne Ziele.
+
+OG-Bildroute rendert ohne CSS-Fehler.
+
+Doku & Thesis aktualisiert wie beschrieben.
+
+Wichtig für meine Masterarbeit
+Lege zwingend die Datei unter thesis/gamification/ an (s. oben) und dokumentiere Prompt, Ziel, Kontext, Ergebnis (inkl. Build-Status/Links). Jede Abweichung bitte knapp begründen.
+```
+
+## Ziel
+- Build-Stabilität für die Next.js-App mit typedRoutes, validierten Redirects, stabiler Login-Suspense und OG-Bild.
+
+## Kontext
+- Repository: Wasgehtab97/tapem (Branch a_gpt5)
+- Arbeitsbereich: `website/` (Next.js Web-App)
+
+## Ergebnis
+- typedRoutes-Hilfsfunktionen und Login-Whitelist zentralisiert (`src/lib/routes.ts`).
+- Login-Formular nutzt Validierung & Suspense, Seite erzwingt dynamisches Rendering.
+- Auth-Redirect-Logik säubert Header-Werte, erstellt typedRoutes-konforme Login-Redirects.
+- `robots.txt` unterscheidet Preview/Production und schützt `/gym*` & `/admin`.
+- README um Build-Hinweise ergänzt (typedRoutes, Suspense, OG, Robots, Testplan).
+- OG-Bildroute bestätigt zulässige CSS (`display: 'flex'`).
+- Build-Status: `npm run build` scheiterte lokal wegen fehlender Next-Abhängigkeit (`next: not found`, Registry-403 verhindert Neuinstallation).
+- Geänderte Dateien: `src/lib/routes.ts`, `src/app/login/login-form.tsx`, `src/app/login/page.tsx`, `src/lib/auth/server.ts`, `src/app/robots.txt.ts`, `website/README.md`, `thesis/gamification/2025-09-19_typedroutes_login_suspense_og_fix.md`.
+
+## Bekannte Abweichungen / Nacharbeiten
+- `npm run build` konnte nicht erfolgreich ausgeführt werden: Registry-Zugriff (npm 403) blockiert Installation von `next` & `@types/node`; damit fehlt das Binary.
+- `vercel --prod` nicht geprüft (CLI erfordert Auth & Netzwerkzugriff).
+- Empfehlung: In einer Netz-gestützten Umgebung erneut `npm install` und `npm run build` bzw. `vercel --prod` durchführen.
+
+## Links zu Preview/Prod
+- Preview: n/a (lokale Container-Umgebung ohne Deploy)
+- Production: n/a (Deployment nicht ausgelöst)

--- a/website/README.md
+++ b/website/README.md
@@ -75,6 +75,20 @@ Sitemap und `robots.txt` verwendet.
 - Nach dem Dev-Login sind nur Werte aus `ALLOWED_AFTER_LOGIN` als Redirect-Ziel erlaubt (`/login?next=`-Parameter wird validiert).
 - Tests vor Deploy: `npm run build`, anschließend `/login`, `/login?next=/admin` und `/login?next=/falsch` in der Preview prüfen.
 
+## Build-Hinweise (Next.js 14 App Router)
+
+- **typedRoutes & Navigation:** Interne Links, Redirects und `router.push` verwenden ausschließlich Werte aus `src/lib/routes.ts`. Externe Ziele laufen weiterhin über `<a href="…">`. Redirect-Parameter (`next`) werden whitelisted, bevor sie genutzt werden.
+- **CSR-Bailout & Suspense:** `/login` erzwingt dynamisches Rendering (`dynamic = 'force-dynamic'`). Der Client-Teil (`LoginForm`) ist in einer Suspense-Boundary eingebettet, damit `useSearchParams()` während des Builds keinen Fehler wirft.
+- **Open-Graph-Bild:** Die Route `src/app/opengraph-image.tsx` nutzt nur vom OG-Renderer erlaubte CSS-Eigenschaften (z. B. `display: 'flex'` statt `inline-flex`).
+- **Robots & dev-Auth:** In Preview/Development liefert `robots.txt` ein globales `disallow`. Production erlaubt Crawling, sperrt aber `/gym/*` und `/admin`. Die Dev-Auth-APIs geben in Production weiterhin HTTP 403 zurück.
+
+### Kurzer Testplan
+
+- `npm run build`
+- Smoke-Test `/login`, `/login?next=/gym`, `/login?next=/admin`
+- Statische Seiten `/`, `/imprint`, `/privacy`
+- Geschützte SSR-Routen `/gym`, `/admin` mit Dev-Toolbar
+
 ## Mock-Datenquelle
 
 - Alle geschützten Routen verwenden statische Mock-Daten aus [`src/server/mocks/gym.ts`](src/server/mocks/gym.ts).

--- a/website/src/app/login/login-form.tsx
+++ b/website/src/app/login/login-form.tsx
@@ -1,16 +1,8 @@
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
-import type { Route } from 'next';
 import { useState } from 'react';
-import { ALLOWED_AFTER_LOGIN } from '@/src/lib/routes';
-
-type AllowedRoute = (typeof ALLOWED_AFTER_LOGIN)[number];
-const DEFAULT_AFTER_LOGIN: AllowedRoute = ALLOWED_AFTER_LOGIN[0];
-
-function isAllowedRoute(v: string | null): v is AllowedRoute {
-  return !!v && (ALLOWED_AFTER_LOGIN as readonly string[]).includes(v);
-}
+import { resolveAllowedAfterLoginRoute, type AllowedAfterLoginRoute } from '@/src/lib/routes';
 
 export default function LoginForm() {
   const router = useRouter();
@@ -35,7 +27,7 @@ export default function LoginForm() {
       if (!res.ok) throw new Error(`Login fehlgeschlagen (${res.status})`);
 
       const nextParam = searchParams.get('next');
-      const target: Route = (isAllowedRoute(nextParam) ? nextParam : DEFAULT_AFTER_LOGIN) as Route;
+      const target: AllowedAfterLoginRoute = resolveAllowedAfterLoginRoute(nextParam);
 
       router.push(target);
       router.refresh();

--- a/website/src/app/login/page.tsx
+++ b/website/src/app/login/page.tsx
@@ -1,10 +1,14 @@
 import type { Metadata } from 'next';
+import { Suspense } from 'react';
+
 import LoginForm from './login-form';
 
 export const metadata: Metadata = {
   title: 'Login – Tap\'em (Dev-Stub)',
   robots: { index: false, follow: false },
 };
+
+export const dynamic = 'force-dynamic';
 
 export default function Page() {
   return (
@@ -14,7 +18,18 @@ export default function Page() {
         Diese Anmeldung setzt Vorschau-Cookies und dient dem Testen der geschützten Bereiche.
         In Production ist der Dev-Login deaktiviert.
       </p>
-      <LoginForm />
+      <Suspense
+        fallback={
+          <div
+            className="rounded border border-slate-200 bg-slate-50 p-4 text-sm text-slate-500"
+            aria-live="polite"
+          >
+            Lade Login-Parameter…
+          </div>
+        }
+      >
+        <LoginForm />
+      </Suspense>
     </div>
   );
 }

--- a/website/src/app/robots.txt.ts
+++ b/website/src/app/robots.txt.ts
@@ -1,12 +1,27 @@
 import type { MetadataRoute } from 'next';
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+const protectedRoutes = ['/gym', '/gym/members', '/gym/challenges', '/gym/leaderboard', '/admin'];
 
 export default function robots(): MetadataRoute.Robots {
   const normalizedUrl = siteUrl.endsWith('/') ? siteUrl.slice(0, -1) : siteUrl;
+  const isProd = process.env.VERCEL_ENV === 'production';
+
+  if (!isProd) {
+    return {
+      rules: [{ userAgent: '*', disallow: '/' }],
+      sitemap: `${normalizedUrl}/sitemap.xml`,
+    };
+  }
 
   return {
-    rules: [{ userAgent: '*', allow: '/' }],
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: protectedRoutes,
+      },
+    ],
     sitemap: `${normalizedUrl}/sitemap.xml`,
   };
 }

--- a/website/src/lib/routes.ts
+++ b/website/src/lib/routes.ts
@@ -2,6 +2,7 @@ import type { Route } from 'next';
 
 export const ROUTES = {
   home: '/' as Route,
+  login: '/login' as Route,
   gym: '/gym' as Route,
   gymMembers: '/gym/members' as Route,
   gymChallenges: '/gym/challenges' as Route,
@@ -9,15 +10,40 @@ export const ROUTES = {
   admin: '/admin' as Route,
   imprint: '/imprint' as Route,
   privacy: '/privacy' as Route,
-} as const;
+} as const satisfies Record<string, Route>;
 
 export type AppRoute = (typeof ROUTES)[keyof typeof ROUTES];
 
-// Whitelist für Redirects nach Login:
 export const ALLOWED_AFTER_LOGIN = [
   ROUTES.gym,
   ROUTES.gymMembers,
   ROUTES.gymChallenges,
   ROUTES.gymLeaderboard,
   ROUTES.admin,
-] as const;
+] as const satisfies ReadonlyArray<Route>;
+
+export type AllowedAfterLoginRoute = (typeof ALLOWED_AFTER_LOGIN)[number];
+
+export const DEFAULT_AFTER_LOGIN: AllowedAfterLoginRoute = ROUTES.gym;
+
+export function isAllowedAfterLoginRoute(
+  value: string | null | undefined
+): value is AllowedAfterLoginRoute {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  return (ALLOWED_AFTER_LOGIN as readonly string[]).some((route) => route === value);
+}
+
+export function resolveAllowedAfterLoginRoute(
+  value: string | null | undefined
+): AllowedAfterLoginRoute {
+  return isAllowedAfterLoginRoute(value) ? value : DEFAULT_AFTER_LOGIN;
+}
+
+export type LoginRedirectRoute = `/login?next=${AllowedAfterLoginRoute}`;
+
+export function buildLoginRedirectRoute(target: AllowedAfterLoginRoute): Route {
+  return `/login?next=${target}` as Route;
+}


### PR DESCRIPTION
## Summary
- centralize typed route constants, whitelist helpers, and sanitize auth redirects
- wrap the login form in Suspense with forced dynamic rendering and validated redirect targets
- differentiate robots.txt per environment and document routing/build steps including thesis log

## Testing
- `npm run build` *(fails: local environment cannot download next/@types packages; npm 403 prevents installing dependencies, so `next` binary is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68ccaa5c02388320a09b53619a74349c