### PR TITLE
Implement Firebase admin login flow

### DIFF
--- a/website/.env.example
+++ b/website/.env.example
@@ -3,15 +3,24 @@ NEXT_PUBLIC_MARKETING_HOST=localhost:3000
 NEXT_PUBLIC_PORTAL_HOST=portal.localhost:3000
 NEXT_PUBLIC_ADMIN_HOST=admin.localhost:3000
 
-# Firebase (später)
+# Firebase (Client)
 NEXT_PUBLIC_FIREBASE_API_KEY=
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=
 NEXT_PUBLIC_FIREBASE_PROJECT_ID=
 NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
 NEXT_PUBLIC_FIREBASE_APP_ID=
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=
 
-# Firebase Admin (serverseitig, nicht in den Client bundlen)
+# Firebase Admin (Server, nicht in den Client bundlen)
+# Bevorzugt: Base64-kodiertes Service-Account-JSON (Preview/Production)
+FIREBASE_SERVICE_ACCOUNT=
+
+# Optional für lokale Entwicklung (wird ignoriert, wenn FIREBASE_SERVICE_ACCOUNT gesetzt ist)
 FIREBASE_PROJECT_ID=
 FIREBASE_CLIENT_EMAIL=
 FIREBASE_PRIVATE_KEY=""
+
+# Admin Auth
+# Kommagetrennte Liste erlaubter Admin-E-Mails (optional, Preview/Production)
+ADMIN_ALLOWLIST=

--- a/website/src/app/(admin)/admin/login/page.tsx
+++ b/website/src/app/(admin)/admin/login/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+
+import AdminLoginForm from '@/src/components/admin/admin-login-form';
+import { getDeploymentStage } from '@/src/config/sites';
+import { getDevUserFromCookies } from '@/src/lib/auth/server';
+import { ADMIN_ROUTES } from '@/src/lib/routes';
+import { getAdminUserFromSession } from '@/src/server/auth/session';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: "Tap'em Admin – Anmeldung",
+  robots: { index: false, follow: false },
+};
+
+export default async function AdminLoginPage() {
+  const sessionUser = await getAdminUserFromSession();
+  if (sessionUser) {
+    redirect(ADMIN_ROUTES.dashboard.href);
+  }
+
+  const stage = getDeploymentStage();
+  if (stage !== 'production') {
+    const devUser = getDevUserFromCookies();
+    if (devUser?.role === 'admin') {
+      redirect(ADMIN_ROUTES.dashboard.href);
+    }
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-md flex-col gap-8 px-6 py-16">
+      <header className="space-y-2 text-center">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+          Nur für Administrator:innen
+        </p>
+        <h1 className="text-3xl font-semibold text-slate-900">Anmeldung</h1>
+        <p className="text-sm text-slate-600">
+          Melde dich mit deiner Tap&apos;em Admin-E-Mail an. Nach erfolgreicher Authentifizierung wird ein sicheres
+          Session-Cookie gesetzt.
+        </p>
+      </header>
+      <AdminLoginForm />
+      <p className="text-xs text-slate-500">
+        Bei Problemen kontaktiere bitte das Core-Team. Die Anmeldung nutzt Firebase Authentication mit E-Mail und Passwort.
+      </p>
+    </div>
+  );
+}

--- a/website/src/app/(admin)/layout.tsx
+++ b/website/src/app/(admin)/layout.tsx
@@ -2,20 +2,15 @@ import type { Metadata } from 'next';
 import { headers } from 'next/headers';
 import { ReactNode } from 'react';
 
+import AdminShell from '@/src/components/layout/admin-shell';
 import { buildSiteMetadata, getSiteConfig } from '@/src/config/sites';
-
-import '../styles/globals.css';
 
 export async function generateMetadata(): Promise<Metadata> {
   const headerList = headers();
   const host = headerList.get('host');
-  return buildSiteMetadata(getSiteConfig('marketing'), host);
+  return buildSiteMetadata(getSiteConfig('admin'), host);
 }
 
-export default function RootLayout({ children }: { children: ReactNode }) {
-  return (
-    <html lang="de" suppressHydrationWarning className="h-full">
-      <body className="bg-page text-page">{children}</body>
-    </html>
-  );
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return <AdminShell>{children}</AdminShell>;
 }

--- a/website/src/app/(marketing)/layout.tsx
+++ b/website/src/app/(marketing)/layout.tsx
@@ -2,9 +2,8 @@ import type { Metadata } from 'next';
 import { headers } from 'next/headers';
 import { ReactNode } from 'react';
 
+import MarketingShell from '@/src/components/layout/marketing-shell';
 import { buildSiteMetadata, getSiteConfig } from '@/src/config/sites';
-
-import '../styles/globals.css';
 
 export async function generateMetadata(): Promise<Metadata> {
   const headerList = headers();
@@ -12,10 +11,6 @@ export async function generateMetadata(): Promise<Metadata> {
   return buildSiteMetadata(getSiteConfig('marketing'), host);
 }
 
-export default function RootLayout({ children }: { children: ReactNode }) {
-  return (
-    <html lang="de" suppressHydrationWarning className="h-full">
-      <body className="bg-page text-page">{children}</body>
-    </html>
-  );
+export default function MarketingLayout({ children }: { children: ReactNode }) {
+  return <MarketingShell>{children}</MarketingShell>;
 }

--- a/website/src/app/(portal)/layout.tsx
+++ b/website/src/app/(portal)/layout.tsx
@@ -2,20 +2,15 @@ import type { Metadata } from 'next';
 import { headers } from 'next/headers';
 import { ReactNode } from 'react';
 
+import PortalShell from '@/src/components/layout/portal-shell';
 import { buildSiteMetadata, getSiteConfig } from '@/src/config/sites';
-
-import '../styles/globals.css';
 
 export async function generateMetadata(): Promise<Metadata> {
   const headerList = headers();
   const host = headerList.get('host');
-  return buildSiteMetadata(getSiteConfig('marketing'), host);
+  return buildSiteMetadata(getSiteConfig('portal'), host);
 }
 
-export default function RootLayout({ children }: { children: ReactNode }) {
-  return (
-    <html lang="de" suppressHydrationWarning className="h-full">
-      <body className="bg-page text-page">{children}</body>
-    </html>
-  );
+export default function PortalLayout({ children }: { children: ReactNode }) {
+  return <PortalShell>{children}</PortalShell>;
 }

--- a/website/src/app/(portal)/login/page.tsx
+++ b/website/src/app/(portal)/login/page.tsx
@@ -1,77 +1,14 @@
 import type { Metadata } from 'next';
-import { headers } from 'next/headers';
-import { redirect } from 'next/navigation';
 import { Suspense } from 'react';
-
-import AdminLoginForm from '@/src/components/admin/admin-login-form';
-import { findSiteByHost, getDeploymentStage, getSiteConfig, type SiteConfig } from '@/src/config/sites';
-import { ADMIN_ROUTES } from '@/src/lib/routes';
-import { getDevUserFromCookies } from '@/src/lib/auth/server';
-import { getAdminUserFromSession } from '@/src/server/auth/session';
 
 import LoginForm from './login-form';
 
-type LoginSite = Extract<SiteConfig['key'], 'portal' | 'admin'>;
+export const metadata: Metadata = {
+  title: "Login – Tap'em (Dev-Stub)",
+  robots: { index: false, follow: false },
+};
 
-function resolveLoginSite(): LoginSite {
-  const host = headers().get('host');
-  const site = findSiteByHost(host) ?? getSiteConfig('portal');
-  return site.key === 'admin' ? 'admin' : 'portal';
-}
-
-export const dynamic = 'force-dynamic';
-
-export async function generateMetadata(): Promise<Metadata> {
-  const site = resolveLoginSite();
-
-  if (site === 'admin') {
-    return {
-      title: "Tap'em Admin – Anmeldung",
-      robots: { index: false, follow: false },
-    } satisfies Metadata;
-  }
-
-  return {
-    title: "Login – Tap'em (Dev-Stub)",
-    robots: { index: false, follow: false },
-  } satisfies Metadata;
-}
-
-export default async function Page() {
-  const site = resolveLoginSite();
-
-  if (site === 'admin') {
-    const sessionUser = await getAdminUserFromSession();
-    if (sessionUser) {
-      redirect(ADMIN_ROUTES.dashboard.href);
-    }
-
-    const stage = getDeploymentStage();
-    if (stage !== 'production') {
-      const devUser = getDevUserFromCookies();
-      if (devUser?.role === 'admin') {
-        redirect(ADMIN_ROUTES.dashboard.href);
-      }
-    }
-
-    return (
-      <div className="mx-auto flex w-full max-w-md flex-col gap-8 px-6 py-16">
-        <header className="space-y-2 text-center">
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Nur für Administrator:innen</p>
-          <h1 className="text-3xl font-semibold text-slate-900">Anmeldung</h1>
-          <p className="text-sm text-slate-600">
-            Melde dich mit deiner Tap&apos;em Admin-E-Mail an. Nach erfolgreicher Authentifizierung wird ein
-            sicheres Session-Cookie gesetzt.
-          </p>
-        </header>
-        <AdminLoginForm />
-        <p className="text-xs text-slate-500">
-          Bei Problemen kontaktiere bitte das Core-Team. Die Anmeldung nutzt Firebase Authentication mit E-Mail und Passwort.
-        </p>
-      </div>
-    );
-  }
-
+export default function Page() {
   return (
     <div className="mx-auto w-full max-w-xl space-y-6 px-6 py-16">
       <h1 className="text-2xl font-semibold">Anmelden (Dev-Stub)</h1>

--- a/website/src/app/api/dev/login/route.ts
+++ b/website/src/app/api/dev/login/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from 'next/server';
 
 import { findSiteByHost, normalizeHost } from '@/src/config/sites';
+import { DEV_ROLE_COOKIE } from '@/src/lib/auth/constants';
 import type { Role } from '@/src/lib/auth/types';
 
-const ROLE_COOKIE = 'tapem_role';
+const ROLE_COOKIE = DEV_ROLE_COOKIE;
 const EMAIL_COOKIE = 'tapem_email';
 const MAX_AGE = 60 * 60 * 24 * 7; // 7 Tage
 const ROLES: Role[] = ['admin', 'owner', 'operator'];

--- a/website/src/app/api/dev/logout/route.ts
+++ b/website/src/app/api/dev/logout/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
 
 import { findSiteByHost, normalizeHost } from '@/src/config/sites';
+import { DEV_ROLE_COOKIE } from '@/src/lib/auth/constants';
 
-const ROLE_COOKIE = 'tapem_role';
+const ROLE_COOKIE = DEV_ROLE_COOKIE;
 const EMAIL_COOKIE = 'tapem_email';
 
 function resolveCookieDomain(request: Request): string | undefined {

--- a/website/src/app/robots.txt.ts
+++ b/website/src/app/robots.txt.ts
@@ -3,7 +3,16 @@ import { headers } from 'next/headers';
 
 import { buildMetadataBase, findSiteByHost, getSiteConfig } from '@/src/config/sites';
 
-const MARKETING_DISALLOW = ['/login', '/gym', '/gym/members', '/gym/challenges', '/gym/leaderboard', '/admin'];
+const MARKETING_DISALLOW = [
+  '/login',
+  '/gym',
+  '/gym/members',
+  '/gym/challenges',
+  '/gym/leaderboard',
+  '/admin',
+  '/admin/login',
+  '/admin/logout',
+];
 
 export default function robots(): MetadataRoute.Robots {
   const headerList = headers();

--- a/website/src/components/admin/admin-login-form.tsx
+++ b/website/src/components/admin/admin-login-form.tsx
@@ -23,7 +23,7 @@ type StatusState =
   | { state: 'error'; message: string };
 
 async function postAdminSession(idToken: string) {
-  const response = await fetch('/api/admin/session', {
+  const response = await fetch('/api/admin/auth/session', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ idToken }),

--- a/website/src/components/layout/marketing-shell.tsx
+++ b/website/src/components/layout/marketing-shell.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link';
 import { ReactNode } from 'react';
 
-import { buildSiteUrl, getDeploymentStage } from '@/src/config/sites';
-import { MARKETING_ROUTES, PORTAL_ROUTES } from '@/src/lib/routes';
+import { getDeploymentStage } from '@/src/config/sites';
+import { ADMIN_ROUTES, MARKETING_ROUTES } from '@/src/lib/routes';
 import { ThemeToggle } from '@/src/components/theme-toggle';
 
 const marketingNav = [
@@ -13,7 +13,6 @@ const marketingNav = [
 ] as const;
 
 export default function MarketingShell({ children }: { children: ReactNode }) {
-  const portalLoginUrl = buildSiteUrl('portal', PORTAL_ROUTES.login.href);
   const stage = getDeploymentStage();
   const showPreviewLabel = stage !== 'production';
 
@@ -37,12 +36,12 @@ export default function MarketingShell({ children }: { children: ReactNode }) {
           </nav>
 
           <div className="flex items-center gap-3">
-            <a
-              href={portalLoginUrl}
+            <Link
+              href={ADMIN_ROUTES.login.href}
               className="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-lg shadow-primary/30 transition hover:bg-primary/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
             >
               Für Studios: Login
-            </a>
+            </Link>
             <ThemeToggle />
           </div>
         </div>

--- a/website/src/lib/auth/constants.ts
+++ b/website/src/lib/auth/constants.ts
@@ -1,0 +1,3 @@
+export const ADMIN_SESSION_COOKIE = '__Secure-tapem-admin-session';
+
+export const DEV_ROLE_COOKIE = 'tapem_role';

--- a/website/src/lib/auth/types.ts
+++ b/website/src/lib/auth/types.ts
@@ -15,5 +15,5 @@ export type AuthenticatedUser = {
   displayName?: string | null;
   source: AuthenticatedUserSource;
   claims?: Record<string, unknown>;
-  roleSource?: 'claim' | 'profile';
+  roleSource?: 'claim' | 'profile' | 'allowlist';
 };

--- a/website/src/lib/routes.ts
+++ b/website/src/lib/routes.ts
@@ -51,10 +51,9 @@ const PORTAL_ROUTE_LIST = Object.values(
 ) as readonly PortalRouteDefinition[];
 
 export const ADMIN_ROUTES = {
-  home: defineRoute('admin', '/' as Route),
   dashboard: defineRoute('admin', '/admin' as Route),
-  login: defineRoute('admin', '/login' as Route),
-  logout: defineRoute('admin', '/logout' as Route),
+  login: defineRoute('admin', '/admin/login' as Route),
+  logout: defineRoute('admin', '/admin/logout' as Route),
 } as const;
 
 export type AdminRouteDefinition =
@@ -133,7 +132,6 @@ const ADMIN_PUBLIC_PATHS = buildPathSet([
 ]);
 
 const ADMIN_PROTECTED_PATHS = buildPathSet([
-  ADMIN_ROUTES.home.href,
   ADMIN_ROUTES.dashboard.href,
 ]);
 
@@ -230,8 +228,15 @@ export function safeAfterLoginRoute(
   });
 }
 
-export function buildLoginRedirectRoute(target: AfterLoginRoute): Route {
+export function buildPortalLoginRedirectRoute(target: AfterLoginRoute): Route {
   return `${PORTAL_ROUTES.login.href}?next=${target}` as Route;
+}
+
+type AdminAfterLoginRouteDefinition = typeof ADMIN_ROUTES.dashboard;
+export type AdminAfterLoginRoute = AdminAfterLoginRouteDefinition['href'];
+
+export function buildAdminLoginRedirectRoute(target: AdminAfterLoginRoute): Route {
+  return `${ADMIN_ROUTES.login.href}?next=${target}` as Route;
 }
 
 export function normalizePathname(pathname: string): string {

--- a/website/src/server/firebase/admin.ts
+++ b/website/src/server/firebase/admin.ts
@@ -15,12 +15,70 @@ export class FirebaseAdminConfigError extends Error {
 
 let cachedAdminApp: App | null = null;
 
-function getRequiredEnv(key: 'FIREBASE_PROJECT_ID' | 'FIREBASE_CLIENT_EMAIL' | 'FIREBASE_PRIVATE_KEY'): string {
-  const value = process.env[key];
-  if (!value || value.length === 0) {
-    throw new FirebaseAdminConfigError(`Missing required server environment variable: ${key}`);
+type ServiceAccountConfig = {
+  projectId: string;
+  clientEmail: string;
+  privateKey: string;
+};
+
+function normalizePrivateKey(value: string): string {
+  return value.replace(/\r?\n/g, '\n');
+}
+
+function parseServiceAccountJson(encoded: string): ServiceAccountConfig {
+  try {
+    const json = Buffer.from(encoded, 'base64').toString('utf8');
+    const parsed = JSON.parse(json) as {
+      project_id?: string;
+      client_email?: string;
+      private_key?: string;
+    };
+
+    const projectId = parsed.project_id?.trim();
+    const clientEmail = parsed.client_email?.trim();
+    const privateKey = parsed.private_key;
+
+    if (!projectId || !clientEmail || !privateKey) {
+      throw new FirebaseAdminConfigError(
+        'FIREBASE_SERVICE_ACCOUNT is missing required fields (project_id, client_email, private_key).'
+      );
+    }
+
+    return {
+      projectId,
+      clientEmail,
+      privateKey: normalizePrivateKey(privateKey),
+    };
+  } catch (error) {
+    if (error instanceof FirebaseAdminConfigError) {
+      throw error;
+    }
+
+    throw new FirebaseAdminConfigError('FIREBASE_SERVICE_ACCOUNT could not be parsed.');
   }
-  return value;
+}
+
+function readServiceAccountConfig(): ServiceAccountConfig {
+  const encoded = process.env.FIREBASE_SERVICE_ACCOUNT;
+  if (encoded && encoded.trim().length > 0) {
+    return parseServiceAccountJson(encoded.trim());
+  }
+
+  const projectId = process.env.FIREBASE_PROJECT_ID?.trim();
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL?.trim();
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY;
+
+  if (projectId && clientEmail && privateKey) {
+    return {
+      projectId,
+      clientEmail,
+      privateKey: normalizePrivateKey(privateKey),
+    };
+  }
+
+  throw new FirebaseAdminConfigError(
+    'Firebase Admin SDK configuration is missing. Set FIREBASE_SERVICE_ACCOUNT (Base64) or FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, FIREBASE_PRIVATE_KEY.'
+  );
 }
 
 function initializeAdminApp(): App {
@@ -34,9 +92,7 @@ function initializeAdminApp(): App {
     return cachedAdminApp;
   }
 
-  const projectId = getRequiredEnv('FIREBASE_PROJECT_ID');
-  const clientEmail = getRequiredEnv('FIREBASE_CLIENT_EMAIL');
-  const privateKey = getRequiredEnv('FIREBASE_PRIVATE_KEY').replace(/\\n/g, '\n');
+  const { projectId, clientEmail, privateKey } = readServiceAccountConfig();
 
   cachedAdminApp = initializeApp(
     {


### PR DESCRIPTION
## Summary
- add a dedicated `/admin/login` page and session endpoint that issues HTTP-only cookies after Firebase authentication, including allowlist-aware verification via the Admin SDK
- update admin route definitions and middleware to validate session cookies through the new API, redirect unauthenticated users, and surface a typed CTA from the marketing shell
- introduce per-route-group layouts so marketing, portal, and admin sections render the correct shells and metadata without host switching
- enhance the admin login form to call the new `/api/admin/auth/session` endpoint and normalise post-login redirects
- refresh Firebase configuration docs and environment templates for the Base64 service account and optional admin allowlist

## Testing
- `npm run build` *(fails: `next` not found because npm dependencies are not installed in the sandbox)*
- `npm install` *(fails: registry returns 403 for `firebase`)*

## Environment
- set `FIREBASE_SERVICE_ACCOUNT` (Base64 JSON) plus client `NEXT_PUBLIC_FIREBASE_*` keys
- optionally configure `ADMIN_ALLOWLIST` for fallback admin access without a custom claim

## Follow-ups
- provision real admin/portal subdomains and expand role-based dashboards when infrastructure is ready

------
https://chatgpt.com/codex/tasks/task_e_68cdf3d912a483208ef42bff73ef287b