### PR TITLE
Fix TypeScript module resolution and firebase admin emulator setup

### DIFF
--- a/website/middleware.ts
+++ b/website/middleware.ts
@@ -1,9 +1,9 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
-import { getDeploymentStage } from '@/src/config/sites';
-import { ADMIN_SESSION_COOKIE, DEV_ROLE_COOKIE } from '@/src/lib/auth/constants';
-import type { Role } from '@/src/lib/auth/types';
+import { getDeploymentStage } from '@/config/sites';
+import { ADMIN_SESSION_COOKIE, DEV_ROLE_COOKIE } from '@/lib/auth/constants';
+import type { Role } from '@/lib/auth/types';
 import {
   ADMIN_ROUTES,
   DEFAULT_AFTER_LOGIN,
@@ -14,8 +14,8 @@ import {
   isPortalPath,
   isPortalProtectedPath,
   safeAfterLoginRoute,
-} from '@/src/lib/routes';
-import { isDevPreviewRoleSwitchesEnabled } from '@/src/lib/env';
+} from '@/lib/routes';
+import { isDevPreviewRoleSwitchesEnabled } from '@/lib/env';
 
 const PORTAL_ALLOWED_ROLES: Role[] = ['admin', 'owner', 'operator'];
 const ADMIN_SESSION_API_PATH = '/api/auth/me';

--- a/website/src/app/(admin)/admin/login/page.tsx
+++ b/website/src/app/(admin)/admin/login/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata, Viewport } from 'next';
 import { redirect } from 'next/navigation';
 
-import AdminLoginForm from '@/src/components/admin/admin-login-form';
-import { SITE_THEME_COLORS, getDeploymentStage } from '@/src/config/sites';
-import { getDevUserFromCookies } from '@/src/lib/auth/server';
-import { ADMIN_ROUTES } from '@/src/lib/routes';
-import { getAdminUserFromSession } from '@/src/server/auth/session';
+import AdminLoginForm from '@/components/admin/admin-login-form';
+import { SITE_THEME_COLORS, getDeploymentStage } from '@/config/sites';
+import { getDevUserFromCookies } from '@/lib/auth/server';
+import { ADMIN_ROUTES } from '@/lib/routes';
+import { getAdminUserFromSession } from '@/server/auth/session';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/website/src/app/(admin)/admin/logout/route.ts
+++ b/website/src/app/(admin)/admin/logout/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 
-import { MARKETING_ROUTES } from '@/src/lib/routes';
-import { revokeAdminSessionCookie } from '@/src/server/auth/session';
-import { ADMIN_SESSION_COOKIE_NAME, buildAdminSessionCookie } from '@/src/server/auth/cookies';
+import { MARKETING_ROUTES } from '@/lib/routes';
+import { revokeAdminSessionCookie } from '@/server/auth/session';
+import { ADMIN_SESSION_COOKIE_NAME, buildAdminSessionCookie } from '@/server/auth/cookies';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/website/src/app/(admin)/admin/page.tsx
+++ b/website/src/app/(admin)/admin/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next';
 
-import { requireRole } from '@/src/lib/auth/server';
-import { ADMIN_ROUTES } from '@/src/lib/routes';
-import { fetchAdminDashboardData } from '@/src/server/admin/dashboard-data';
+import { requireRole } from '@/lib/auth/server';
+import { ADMIN_ROUTES } from '@/lib/routes';
+import { fetchAdminDashboardData } from '@/server/admin/dashboard-data';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/website/src/app/(admin)/layout.tsx
+++ b/website/src/app/(admin)/layout.tsx
@@ -2,8 +2,8 @@ import type { Metadata, Viewport } from 'next';
 import { headers } from 'next/headers';
 import { ReactNode } from 'react';
 
-import AdminShell from '@/src/components/layout/admin-shell';
-import { SITE_THEME_COLORS, buildSiteMetadata, getSiteConfig } from '@/src/config/sites';
+import AdminShell from '@/components/layout/admin-shell';
+import { SITE_THEME_COLORS, buildSiteMetadata, getSiteConfig } from '@/config/sites';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/website/src/app/(marketing)/layout.tsx
+++ b/website/src/app/(marketing)/layout.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from 'next';
 import { headers } from 'next/headers';
 import { ReactNode } from 'react';
 
-import MarketingShell from '@/src/components/layout/marketing-shell';
-import { buildSiteMetadata, getSiteConfig } from '@/src/config/sites';
+import MarketingShell from '@/components/layout/marketing-shell';
+import { buildSiteMetadata, getSiteConfig } from '@/config/sites';
 
 export async function generateMetadata(): Promise<Metadata> {
   const headerList = headers();

--- a/website/src/app/(portal)/gym/challenges/page.tsx
+++ b/website/src/app/(portal)/gym/challenges/page.tsx
@@ -1,5 +1,5 @@
-import { requireRole } from '@/src/lib/auth/server';
-import { gymChallengesMock } from '@/src/server/mocks/gym';
+import { requireRole } from '@/lib/auth/server';
+import { gymChallengesMock } from '@/server/mocks/gym';
 
 export default async function GymChallengesPage() {
   await requireRole(['owner', 'operator', 'admin']);

--- a/website/src/app/(portal)/gym/layout.tsx
+++ b/website/src/app/(portal)/gym/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { ReactNode } from 'react';
 
-import GymSubnav from '@/src/components/gym-subnav';
+import GymSubnav from '@/components/gym-subnav';
 
 export const metadata: Metadata = {
   robots: {

--- a/website/src/app/(portal)/gym/leaderboard/page.tsx
+++ b/website/src/app/(portal)/gym/leaderboard/page.tsx
@@ -1,5 +1,5 @@
-import { requireRole } from '@/src/lib/auth/server';
-import { gymLeaderboardMock } from '@/src/server/mocks/gym';
+import { requireRole } from '@/lib/auth/server';
+import { gymLeaderboardMock } from '@/server/mocks/gym';
 
 export default async function GymLeaderboardPage() {
   await requireRole(['owner', 'operator', 'admin']);

--- a/website/src/app/(portal)/gym/members/page.tsx
+++ b/website/src/app/(portal)/gym/members/page.tsx
@@ -1,5 +1,5 @@
-import { requireRole } from '@/src/lib/auth/server';
-import { gymMembersMock } from '@/src/server/mocks/gym';
+import { requireRole } from '@/lib/auth/server';
+import { gymMembersMock } from '@/server/mocks/gym';
 
 export default async function GymMembersPage() {
   await requireRole(['owner', 'operator', 'admin']);

--- a/website/src/app/(portal)/gym/page.tsx
+++ b/website/src/app/(portal)/gym/page.tsx
@@ -1,5 +1,5 @@
-import { requireRole } from '@/src/lib/auth/server';
-import { gymChallengesMock, gymLeaderboardMock, gymOverviewKpis } from '@/src/server/mocks/gym';
+import { requireRole } from '@/lib/auth/server';
+import { gymChallengesMock, gymLeaderboardMock, gymOverviewKpis } from '@/server/mocks/gym';
 
 export default async function GymOverviewPage() {
   const { user } = await requireRole(['owner', 'operator', 'admin']);

--- a/website/src/app/(portal)/layout.tsx
+++ b/website/src/app/(portal)/layout.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from 'next';
 import { headers } from 'next/headers';
 import { ReactNode } from 'react';
 
-import PortalShell from '@/src/components/layout/portal-shell';
-import { buildSiteMetadata, getSiteConfig } from '@/src/config/sites';
+import PortalShell from '@/components/layout/portal-shell';
+import { buildSiteMetadata, getSiteConfig } from '@/config/sites';
 
 export async function generateMetadata(): Promise<Metadata> {
   const headerList = headers();

--- a/website/src/app/(portal)/login/login-form.tsx
+++ b/website/src/app/(portal)/login/login-form.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
-import { safeAfterLoginRoute, type AfterLoginRoute } from '@/src/lib/routes';
+import { safeAfterLoginRoute, type AfterLoginRoute } from '@/lib/routes';
 
 export default function LoginForm() {
   const router = useRouter();

--- a/website/src/app/401/page.tsx
+++ b/website/src/app/401/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next';
 import { headers } from 'next/headers';
 
-import { buildSiteUrl, findSiteByHost, getSiteConfig, type SiteConfig } from '@/src/config/sites';
-import { MARKETING_ROUTES, PORTAL_ROUTES, ADMIN_ROUTES } from '@/src/lib/routes';
+import { buildSiteUrl, findSiteByHost, getSiteConfig, type SiteConfig } from '@/config/sites';
+import { MARKETING_ROUTES, PORTAL_ROUTES, ADMIN_ROUTES } from '@/lib/routes';
 
 export const metadata: Metadata = {
   title: 'Anmeldung erforderlich – Tap\'em',

--- a/website/src/app/403/page.tsx
+++ b/website/src/app/403/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next';
 import { headers } from 'next/headers';
 
-import { findSiteByHost, getSiteConfig, type SiteConfig } from '@/src/config/sites';
-import { ADMIN_ROUTES, MARKETING_ROUTES, PORTAL_ROUTES } from '@/src/lib/routes';
+import { findSiteByHost, getSiteConfig, type SiteConfig } from '@/config/sites';
+import { ADMIN_ROUTES, MARKETING_ROUTES, PORTAL_ROUTES } from '@/lib/routes';
 
 export const metadata: Metadata = {
   title: 'Kein Zugriff – Tap\'em',

--- a/website/src/app/404/page.tsx
+++ b/website/src/app/404/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next';
 import { headers } from 'next/headers';
 
-import { buildSiteUrl, findSiteByHost, getSiteConfig, type SiteConfig } from '@/src/config/sites';
-import { ADMIN_ROUTES, MARKETING_ROUTES, PORTAL_ROUTES } from '@/src/lib/routes';
+import { buildSiteUrl, findSiteByHost, getSiteConfig, type SiteConfig } from '@/config/sites';
+import { ADMIN_ROUTES, MARKETING_ROUTES, PORTAL_ROUTES } from '@/lib/routes';
 
 export const metadata: Metadata = {
   title: 'Nicht gefunden – Tap\'em',

--- a/website/src/app/api/auth/login/route.ts
+++ b/website/src/app/api/auth/login/route.ts
@@ -1,14 +1,14 @@
 import { NextResponse } from 'next/server';
 
-import { ADMIN_SESSION_MAX_AGE_SECONDS, buildAdminSessionCookie } from '@/src/server/auth/cookies';
+import { ADMIN_SESSION_MAX_AGE_SECONDS, buildAdminSessionCookie } from '@/server/auth/cookies';
 import {
   AdminRoleRequiredError,
   createAdminSession,
-} from '@/src/server/auth/session';
+} from '@/server/auth/session';
 import {
   FirebaseAdminConfigError,
   assertFirebaseAdminReady,
-} from '@/src/server/firebase/admin';
+} from '@/server/firebase/admin';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/website/src/app/api/auth/logout/route.ts
+++ b/website/src/app/api/auth/logout/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 
-import { ADMIN_SESSION_COOKIE_NAME, buildAdminSessionCookie } from '@/src/server/auth/cookies';
-import { revokeAdminSessionCookie } from '@/src/server/auth/session';
-import { assertFirebaseAdminReady } from '@/src/server/firebase/admin';
+import { ADMIN_SESSION_COOKIE_NAME, buildAdminSessionCookie } from '@/server/auth/cookies';
+import { revokeAdminSessionCookie } from '@/server/auth/session';
+import { assertFirebaseAdminReady } from '@/server/firebase/admin';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/website/src/app/api/auth/me/route.ts
+++ b/website/src/app/api/auth/me/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 
-import { getAdminUserFromSession } from '@/src/server/auth/session';
-import { assertFirebaseAdminReady } from '@/src/server/firebase/admin';
+import { getAdminUserFromSession } from '@/server/auth/session';
+import { assertFirebaseAdminReady } from '@/server/firebase/admin';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/website/src/app/api/dev/login/route.ts
+++ b/website/src/app/api/dev/login/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
 
-import { findSiteByHost, normalizeHost } from '@/src/config/sites';
-import { DEV_ROLE_COOKIE } from '@/src/lib/auth/constants';
-import { isDevPreviewRoleSwitchesEnabled } from '@/src/lib/env';
-import type { Role } from '@/src/lib/auth/types';
+import { findSiteByHost, normalizeHost } from '@/config/sites';
+import { DEV_ROLE_COOKIE } from '@/lib/auth/constants';
+import { isDevPreviewRoleSwitchesEnabled } from '@/lib/env';
+import type { Role } from '@/lib/auth/types';
 
 const ROLE_COOKIE = DEV_ROLE_COOKIE;
 const EMAIL_COOKIE = 'tapem_email';

--- a/website/src/app/api/dev/logout/route.ts
+++ b/website/src/app/api/dev/logout/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 
-import { findSiteByHost, normalizeHost } from '@/src/config/sites';
-import { DEV_ROLE_COOKIE } from '@/src/lib/auth/constants';
-import { isDevPreviewRoleSwitchesEnabled } from '@/src/lib/env';
+import { findSiteByHost, normalizeHost } from '@/config/sites';
+import { DEV_ROLE_COOKIE } from '@/lib/auth/constants';
+import { isDevPreviewRoleSwitchesEnabled } from '@/lib/env';
 
 const ROLE_COOKIE = DEV_ROLE_COOKIE;
 const EMAIL_COOKIE = 'tapem_email';

--- a/website/src/app/api/health/firebase-admin/route.ts
+++ b/website/src/app/api/health/firebase-admin/route.ts
@@ -6,7 +6,7 @@ import {
   assertFirebaseAdminReady,
   getFirebaseAdminApp,
   getFirebaseAdminConfigSummary,
-} from '@/src/server/firebase/admin';
+} from '@/server/firebase/admin';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata, Viewport } from 'next';
 import { headers } from 'next/headers';
 import { ReactNode } from 'react';
 
-import { SITE_THEME_COLORS, buildSiteMetadata, getSiteConfig } from '@/src/config/sites';
+import { SITE_THEME_COLORS, buildSiteMetadata, getSiteConfig } from '@/config/sites';
 
 import '../styles/globals.css';
 

--- a/website/src/app/robots.txt.ts
+++ b/website/src/app/robots.txt.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from 'next';
 import { headers } from 'next/headers';
 
-import { buildMetadataBase, findSiteByHost, getSiteConfig } from '@/src/config/sites';
+import { buildMetadataBase, findSiteByHost, getSiteConfig } from '@/config/sites';
 
 const MARKETING_DISALLOW = [
   '/login',

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from 'next';
 import { headers } from 'next/headers';
 
-import { buildMetadataBase, findSiteByHost, getSiteConfig } from '@/src/config/sites';
+import { buildMetadataBase, findSiteByHost, getSiteConfig } from '@/config/sites';
 
 const MARKETING_SITEMAP_PATHS = [
   { path: '/', priority: 1, changeFrequency: 'monthly' as const },

--- a/website/src/components/admin/admin-login-form.tsx
+++ b/website/src/components/admin/admin-login-form.tsx
@@ -8,8 +8,8 @@ import {
   FirebaseClientConfigError,
   getFirebaseAuth,
   isFirebaseClientConfigured,
-} from '@/src/lib/firebase/client';
-import { ADMIN_ROUTES, DEFAULT_AFTER_LOGIN, safeAfterLoginRoute } from '@/src/lib/routes';
+} from '@/lib/firebase/client';
+import { ADMIN_ROUTES, DEFAULT_AFTER_LOGIN, safeAfterLoginRoute } from '@/lib/routes';
 
 type FormState = {
   email: string;

--- a/website/src/components/dev-toolbar.tsx
+++ b/website/src/components/dev-toolbar.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 
-import type { Role } from '@/src/lib/auth/types';
+import type { Role } from '@/lib/auth/types';
 
 const quickRoles: Role[] = ['owner', 'operator', 'admin'];
 

--- a/website/src/components/gym-subnav.tsx
+++ b/website/src/components/gym-subnav.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
-import { PORTAL_ROUTES, type PortalRouteDefinition } from '@/src/lib/routes';
+import { PORTAL_ROUTES, type PortalRouteDefinition } from '@/lib/routes';
 
 const items = [
   { route: PORTAL_ROUTES.gym, label: 'Übersicht' },

--- a/website/src/components/layout/admin-shell.tsx
+++ b/website/src/components/layout/admin-shell.tsx
@@ -1,13 +1,13 @@
 import Link from 'next/link';
 import { ReactNode } from 'react';
 
-import DevToolbar from '@/src/components/dev-toolbar';
-import { getDeploymentStage } from '@/src/config/sites';
-import { getDevUserFromCookies } from '@/src/lib/auth/server';
-import type { AuthenticatedUser, Role } from '@/src/lib/auth/types';
-import { ADMIN_ROUTES, type AdminRouteDefinition } from '@/src/lib/routes';
-import { isDevPreviewRoleSwitchesEnabled } from '@/src/lib/env';
-import { getAdminUserFromSession } from '@/src/server/auth/session';
+import DevToolbar from '@/components/dev-toolbar';
+import { getDeploymentStage } from '@/config/sites';
+import { getDevUserFromCookies } from '@/lib/auth/server';
+import type { AuthenticatedUser, Role } from '@/lib/auth/types';
+import { ADMIN_ROUTES, type AdminRouteDefinition } from '@/lib/routes';
+import { isDevPreviewRoleSwitchesEnabled } from '@/lib/env';
+import { getAdminUserFromSession } from '@/server/auth/session';
 
 type NavigationItem = {
   label: string;

--- a/website/src/components/layout/marketing-shell.tsx
+++ b/website/src/components/layout/marketing-shell.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
 import { ReactNode } from 'react';
 
-import { getDeploymentStage } from '@/src/config/sites';
-import { ADMIN_ROUTES, MARKETING_ROUTES } from '@/src/lib/routes';
-import { ThemeToggle } from '@/src/components/theme-toggle';
+import { getDeploymentStage } from '@/config/sites';
+import { ADMIN_ROUTES, MARKETING_ROUTES } from '@/lib/routes';
+import { ThemeToggle } from '@/components/theme-toggle';
 
 const marketingNav = [
   { label: 'Features', href: '/#features' },

--- a/website/src/components/layout/portal-shell.tsx
+++ b/website/src/components/layout/portal-shell.tsx
@@ -1,11 +1,11 @@
 import Link from 'next/link';
 import { ReactNode } from 'react';
 
-import { getDeploymentStage } from '@/src/config/sites';
-import DevToolbar from '@/src/components/dev-toolbar';
-import { getDevUserFromCookies } from '@/src/lib/auth/server';
-import type { Role } from '@/src/lib/auth/types';
-import { PORTAL_ROUTES, type PortalRouteDefinition } from '@/src/lib/routes';
+import { getDeploymentStage } from '@/config/sites';
+import DevToolbar from '@/components/dev-toolbar';
+import { getDevUserFromCookies } from '@/lib/auth/server';
+import type { Role } from '@/lib/auth/types';
+import { PORTAL_ROUTES, type PortalRouteDefinition } from '@/lib/routes';
 
 const portalNav = [
   { route: PORTAL_ROUTES.gym, label: 'Dashboard' },

--- a/website/src/config/sites.ts
+++ b/website/src/config/sites.ts
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, ThemeColorDescriptor } from 'next';
 
 export type SiteKey = 'marketing' | 'portal' | 'admin';
 
@@ -50,10 +50,10 @@ const SITE_CONFIGS: Record<SiteKey, SiteConfig> = {
   },
 };
 
-export const SITE_THEME_COLORS = [
+export const SITE_THEME_COLORS: ThemeColorDescriptor[] = [
   { media: '(prefers-color-scheme: light)', color: '#f1f5f9' },
   { media: '(prefers-color-scheme: dark)', color: '#020617' },
-] as const;
+];
 
 const HOST_LOOKUP = new Map<string, SiteConfig>();
 

--- a/website/src/lib/auth/constants.ts
+++ b/website/src/lib/auth/constants.ts
@@ -1,3 +1,3 @@
-export { ADMIN_SESSION_COOKIE_NAME as ADMIN_SESSION_COOKIE } from '@/src/server/auth/cookies';
+export { ADMIN_SESSION_COOKIE_NAME as ADMIN_SESSION_COOKIE } from '@/server/auth/cookies';
 
 export const DEV_ROLE_COOKIE = 'tapem_role';

--- a/website/src/lib/auth/server.ts
+++ b/website/src/lib/auth/server.ts
@@ -3,9 +3,9 @@ import 'server-only';
 import { cookies, headers } from 'next/headers';
 import { notFound, redirect } from 'next/navigation';
 
-import { DEV_ROLE_COOKIE } from '@/src/lib/auth/constants';
-import { getDeploymentStage } from '@/src/config/sites';
-import { isDevPreviewRoleSwitchesEnabled } from '@/src/lib/env';
+import { DEV_ROLE_COOKIE } from '@/lib/auth/constants';
+import { getDeploymentStage } from '@/config/sites';
+import { isDevPreviewRoleSwitchesEnabled } from '@/lib/env';
 import {
   ADMIN_ROUTES,
   DEFAULT_AFTER_LOGIN,
@@ -15,10 +15,10 @@ import {
   safeAfterLoginRoute,
   type AfterLoginRoute,
   type AdminAfterLoginRoute,
-} from '@/src/lib/routes';
+} from '@/lib/routes';
 import {
   getAdminUserFromSession,
-} from '@/src/server/auth/session';
+} from '@/server/auth/session';
 
 import type { AuthenticatedUser, DevUser, Role } from './types';
 

--- a/website/src/lib/routes.ts
+++ b/website/src/lib/routes.ts
@@ -1,6 +1,6 @@
 import type { Route } from 'next';
 
-import type { SiteKey } from '@/src/config/sites';
+import type { SiteKey } from '@/config/sites';
 
 type RouteDefinition<Site extends SiteKey, Path extends Route> = {
   readonly site: Site;

--- a/website/src/server/admin/dashboard-data.ts
+++ b/website/src/server/admin/dashboard-data.ts
@@ -2,7 +2,7 @@ import 'server-only';
 
 import { Timestamp } from 'firebase-admin/firestore';
 
-import { getFirebaseAdminFirestore } from '@/src/server/firebase/admin';
+import { getFirebaseAdminFirestore } from '@/server/firebase/admin';
 
 export type AdminKpiMetric = {
   id: string;
@@ -117,7 +117,7 @@ async function computeMetric({ id, label, run, fallback }: MetricComputation): P
           warning: {
             metricId: id,
             message: messageParts.join(' '),
-            indexUrl,
+            indexUrl: indexUrl ?? undefined,
           },
         };
       } catch (fallbackError) {

--- a/website/src/server/auth/cookies.ts
+++ b/website/src/server/auth/cookies.ts
@@ -1,4 +1,4 @@
-import { getDeploymentStage, getSiteConfig, normalizeHost } from '@/src/config/sites';
+import { getDeploymentStage, getSiteConfig, normalizeHost } from '@/config/sites';
 
 export const ADMIN_SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 7; // 7 Tage
 

--- a/website/src/server/auth/session.ts
+++ b/website/src/server/auth/session.ts
@@ -3,10 +3,10 @@ import 'server-only';
 import { cookies } from 'next/headers';
 import type { DecodedIdToken } from 'firebase-admin/auth';
 
-import { ADMIN_SESSION_COOKIE } from '@/src/lib/auth/constants';
-import type { AuthenticatedUser, Role } from '@/src/lib/auth/types';
-import { getFirebaseAdminAuth, getFirebaseAdminFirestore } from '@/src/server/firebase/admin';
-import { ADMIN_SESSION_MAX_AGE_SECONDS } from '@/src/server/auth/cookies';
+import { ADMIN_SESSION_COOKIE } from '@/lib/auth/constants';
+import type { AuthenticatedUser, Role } from '@/lib/auth/types';
+import { getFirebaseAdminAuth, getFirebaseAdminFirestore } from '@/server/firebase/admin';
+import { ADMIN_SESSION_MAX_AGE_SECONDS } from '@/server/auth/cookies';
 
 export class AdminRoleRequiredError extends Error {
   constructor(message: string) {

--- a/website/src/server/firebase/admin.ts
+++ b/website/src/server/firebase/admin.ts
@@ -267,10 +267,19 @@ function ensureServices(): { app: App; auth: Auth; firestore: Firestore } {
   if (emulatorConfig && !state.emulatorConfigured && state.auth && state.firestore) {
     logDebug('Verbinde Firebase Admin SDK mit Emulatoren', emulatorConfig);
     state.firestore.settings({ host: emulatorConfig.firestoreHost, ssl: false });
-    const authHost = emulatorConfig.authHost.startsWith('http')
+    const authHostUrl = emulatorConfig.authHost.startsWith('http')
       ? emulatorConfig.authHost
       : `http://${emulatorConfig.authHost}`;
-    state.auth.useEmulator(authHost);
+    const normalizedAuthHost = (() => {
+      try {
+        return new URL(authHostUrl).host;
+      } catch {
+        return emulatorConfig.authHost;
+      }
+    })();
+    if (process.env.FIREBASE_AUTH_EMULATOR_HOST !== normalizedAuthHost) {
+      process.env.FIREBASE_AUTH_EMULATOR_HOST = normalizedAuthHost;
+    }
     state.emulatorConfigured = true;
   }
 

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -13,12 +13,11 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["node"],
+    "types": ["node", "react", "react-dom", "next"],
     "baseUrl": ".",
     "plugins": [{ "name": "next" }],
     "paths": {
-      "@/*": ["./*"],
-      "@/src/*": ["./src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary
- map the `@/` alias directly to `src/` in `tsconfig.json` and update all imports to match while ensuring Next/React type packages are loaded
- give the shared theme color metadata an explicit `ThemeColorDescriptor[]` type and avoid storing `null` in optional admin dashboard warning links
- swap the deprecated `Auth.useEmulator` call for logic that normalizes and applies `FIREBASE_AUTH_EMULATOR_HOST` when the emulator is enabled

## Testing
- `npm ci` *(terminated after running for >10 minutes without completing)*

------
https://chatgpt.com/codex/tasks/task_e_68cf35a6a39483208efe063974b48283