### PR TITLE
Add compatibility path alias for legacy @/src imports

### DIFF
--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -17,7 +17,8 @@
     "baseUrl": ".",
     "plugins": [{ "name": "next" }],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@/src/*": ["./src/*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary
- add a backwards-compatible TypeScript path alias so `@/src/*` imports resolve to the shared source directory

## Testing
- npm run lint *(fails: unable to install npm dependencies because registry access returns 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf473121c083209c75b7835821ab12