### PR TITLE
feat: unify global theme handling across segments

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -39,6 +39,13 @@ npm run build
 npm start
 ```
 
+## Theme (Dark/Light/System)
+
+- Die Auswahl wird clientseitig unter `localStorage['tapem-theme']` gespeichert und kann `light`, `dark` oder `system` enthalten.
+- Ein Best-Effort-Hint für SSR liegt als Cookie `tapem-theme` vor und speichert den zuletzt gerenderten Modus (`light` oder `dark`).
+- `src/components/theme-script.tsx` setzt vor der Hydration die passende `data-theme`-Klasse auf `<html>` und synchronisiert das Cookie.
+- Gemeinsame Tokens wie `bg-page`, `bg-card`, `text-page`, `text-muted` etc. stammen aus `src/styles/globals.css` und werden in allen Segmenten verwendet.
+
 ## Umgebungskonfiguration
 
 `.env.example` enthält optionale Host-Overrides für lokale Tests:

--- a/website/src/app/(admin)/admin/login/page.tsx
+++ b/website/src/app/(admin)/admin/login/page.tsx
@@ -44,15 +44,15 @@ export default async function Page() {
   return (
     <div className="mx-auto grid max-w-lg gap-6 py-10">
       {info && (
-        <div className="rounded-md border border-emerald-400 bg-emerald-100/10 p-3 text-emerald-200">
+        <div className="rounded-md border border-emerald-400 bg-emerald-100/10 p-3 text-emerald-200 dark:border-emerald-500/60 dark:bg-emerald-500/10 dark:text-emerald-200">
           Verbunden mit Projekt <b>{info.projectId}</b> · Modus <b>{info.mode}</b> · Service Account{' '}
           {info.usesServiceAccount ? 'aktiv' : 'inaktiv'}
         </div>
       )}
       <h1 className="text-2xl font-semibold">Anmeldung</h1>
       <AdminLoginForm />
-      <p className="text-sm opacity-60">Bei Problemen: Core-Team kontaktieren.</p>
-      <p className="text-xs opacity-40">
+      <p className="text-sm text-muted">Bei Problemen: Core-Team kontaktieren.</p>
+      <p className="text-xs text-muted">
         <Link href={MARKETING_ROUTES.home.href}>Zurück</Link>
       </p>
     </div>

--- a/website/src/app/(admin)/admin/page.tsx
+++ b/website/src/app/(admin)/admin/page.tsx
@@ -54,7 +54,7 @@ function ActivityChart({
     >
       <title>Check-ins der letzten 14 Tage</title>
       <desc>Visualisierung der täglichen Check-ins über zwei Wochen.</desc>
-      <line x1={0} y1={chartHeight} x2={chartWidth} y2={chartHeight} stroke="#CBD5F5" strokeWidth={1} />
+      <line x1={0} y1={chartHeight} x2={chartWidth} y2={chartHeight} stroke="var(--page-border)" strokeWidth={1} />
       {points.map((point, index) => {
         const value = point.totalCheckIns;
         const barHeight = max > 0 ? Math.round((value / max) * (chartHeight - 16)) : 0;
@@ -74,7 +74,7 @@ function ActivityChart({
               x={x + barWidth / 2}
               y={chartHeight + 16}
               textAnchor="middle"
-              className="fill-slate-500 text-[10px]"
+              className="fill-[var(--page-muted)] text-[10px]"
             >
               {dayFormatter.format(new Date(point.date))}
             </text>
@@ -82,7 +82,7 @@ function ActivityChart({
               x={x + barWidth / 2}
               y={y - 6}
               textAnchor="middle"
-              className="fill-slate-600 text-[10px]"
+              className="fill-[var(--page-muted)] text-[10px]"
             >
               {value}
             </text>
@@ -117,20 +117,20 @@ export default async function AdminPage() {
     <div className="mx-auto w-full max-w-6xl space-y-12 px-6 py-16">
       <section className="space-y-3">
         <header>
-          <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">Admin Monitoring</p>
-          <h1 className="mt-1 text-3xl font-semibold text-slate-900">Hallo {user.email}</h1>
-          <p className="mt-2 max-w-3xl text-sm text-slate-600">
+          <p className="text-sm font-semibold uppercase tracking-wide text-muted">Admin Monitoring</p>
+          <h1 className="mt-1 text-3xl font-semibold text-page">Hallo {user.email}</h1>
+          <p className="mt-2 max-w-3xl text-sm text-muted">
             Dieses Dashboard fasst Kernmetriken aus Firestore zusammen und zeigt einen aktuellen Ereignis-Stream.
             Alle Serverabfragen werden ausschließlich über das Firebase Admin SDK ausgeführt.
           </p>
         </header>
         {dashboard.metrics.error ? (
-          <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-500/60 dark:bg-amber-500/10 dark:text-amber-200">
             {dashboard.metrics.error}
           </div>
         ) : null}
         {dashboard.metrics.warnings.length > 0 ? (
-          <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-xs text-amber-800">
+          <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-xs text-amber-800 dark:border-amber-500/60 dark:bg-amber-500/10 dark:text-amber-200">
             <p className="font-semibold">Hinweis:</p>
             <ul className="mt-1 space-y-1">
               {dashboard.metrics.warnings.map((warning) => (
@@ -154,26 +154,26 @@ export default async function AdminPage() {
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {dashboard.metrics.items.map((metric) => (
             <article key={metric.id} className="rounded-lg border border-subtle bg-card p-5 shadow-sm">
-              <p className="text-sm font-medium text-slate-600">{metric.label}</p>
-              <p className="mt-2 text-2xl font-semibold text-slate-900">{formatNumber(metric.value)}</p>
-              <p className="mt-1 text-xs text-slate-500">{metricHelpers[metric.id] ?? ''}</p>
+              <p className="text-sm font-medium text-muted">{metric.label}</p>
+              <p className="mt-2 text-2xl font-semibold text-page">{formatNumber(metric.value)}</p>
+              <p className="mt-1 text-xs text-muted">{metricHelpers[metric.id] ?? ''}</p>
             </article>
           ))}
         </div>
-        <p className="text-xs text-slate-400">
+        <p className="text-xs text-muted">
           Stand: {formatDateTime(dashboard.metrics.generatedAt)} · Datenquelle: Firestore (Tap&apos;em Projekt)
         </p>
       </section>
 
       <section className="space-y-4 rounded-lg border border-subtle bg-card p-6 shadow-sm">
         <header className="space-y-1">
-          <h2 className="text-xl font-semibold text-slate-900">Check-in Verlauf (14 Tage)</h2>
-          <p className="text-sm text-slate-600">
+          <h2 className="text-xl font-semibold text-page">Check-in Verlauf (14 Tage)</h2>
+          <p className="text-sm text-muted">
             Zeigt die Anzahl verarbeiteter Check-ins über alle Gyms. Grundlage ist der Logs-CollectionGroup in Firestore.
           </p>
         </header>
         {dashboard.activity.error ? (
-          <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-500/60 dark:bg-amber-500/10 dark:text-amber-200">
             {dashboard.activity.error}
           </div>
         ) : null}
@@ -182,13 +182,13 @@ export default async function AdminPage() {
 
       <section className="space-y-4 rounded-lg border border-subtle bg-card p-6 shadow-sm">
         <header className="space-y-1">
-          <h2 className="text-xl font-semibold text-slate-900">Letzte Ereignisse</h2>
-          <p className="text-sm text-slate-600">
+          <h2 className="text-xl font-semibold text-page">Letzte Ereignisse</h2>
+          <p className="text-sm text-muted">
             Aktuelle Logs aus den Gym-Geräten. Zeigt Typ, Quelle und Beschreibung der Aktivität.
           </p>
         </header>
         {dashboard.events.error ? (
-          <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-500/60 dark:bg-amber-500/10 dark:text-amber-200">
             {dashboard.events.error}
           </div>
         ) : null}
@@ -198,42 +198,42 @@ export default async function AdminPage() {
           </div>
         ) : (
           <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-slate-200">
+            <table className="min-w-full divide-y divide-[color:var(--page-border)]">
               <thead className="bg-card-muted">
                 <tr>
-                  <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
                     Zeitstempel
                   </th>
-                  <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
                     Gym / Gerät
                   </th>
-                  <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
                     Typ
                   </th>
-                  <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
                     Details
                   </th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-slate-200">
+              <tbody className="divide-y divide-[color:var(--page-border)]">
                 {dashboard.events.items.map((event) => (
                   <tr key={`${event.id}-${event.timestamp.toISOString()}`} className="hover:bg-card-muted">
-                    <td className="whitespace-nowrap px-4 py-3 text-sm text-slate-700">{formatDateTime(event.timestamp)}</td>
-                    <td className="whitespace-nowrap px-4 py-3 text-sm text-slate-600">
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-page">{formatDateTime(event.timestamp)}</td>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm text-muted">
                       {event.gymId ? `Gym ${event.gymId}` : '–'}
                       {event.deviceId ? ` · Gerät ${event.deviceId}` : ''}
                     </td>
-                    <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-slate-900">
+                    <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-page">
                       {event.type ?? 'log'}
                     </td>
-                    <td className="px-4 py-3 text-sm text-slate-700">{event.description ?? 'Keine Beschreibung'}</td>
+                    <td className="px-4 py-3 text-sm text-page">{event.description ?? 'Keine Beschreibung'}</td>
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
         )}
-        <p className="text-xs text-slate-400">
+        <p className="text-xs text-muted">
           Quelle: Firestore collectionGroup('logs') · Zugriff nur mit Admin-Session
         </p>
       </section>

--- a/website/src/app/(portal)/gym/challenges/page.tsx
+++ b/website/src/app/(portal)/gym/challenges/page.tsx
@@ -7,8 +7,8 @@ export default async function GymChallengesPage() {
   return (
     <section className="space-y-6">
       <header className="space-y-2">
-        <h1 className="text-2xl font-semibold text-slate-900">Challenges & Kampagnen</h1>
-        <p className="text-sm text-slate-600">
+        <h1 className="text-2xl font-semibold text-page">Challenges & Kampagnen</h1>
+        <p className="text-sm text-muted">
           Aktuelle Engagement-Programme. Die Fortschrittsbalken werden später aus Echtzeitmetriken
           gespeist.
         </p>
@@ -17,27 +17,27 @@ export default async function GymChallengesPage() {
         {gymChallengesMock.map((challenge) => (
           <article key={challenge.id} className="space-y-4 rounded-lg border border-subtle bg-card p-6 shadow-sm">
             <header className="space-y-1">
-              <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted">
                 Challenge #{challenge.id}
               </p>
-              <h2 className="text-lg font-semibold text-slate-900">{challenge.title}</h2>
+              <h2 className="text-lg font-semibold text-page">{challenge.title}</h2>
             </header>
-            <p className="text-sm text-slate-600">{challenge.description}</p>
+            <p className="text-sm text-muted">{challenge.description}</p>
             <div>
-              <div className="flex items-center justify-between text-xs font-medium text-slate-600">
+              <div className="flex items-center justify-between text-xs font-medium text-muted">
                 <span>{challenge.participants} Teilnehmende</span>
                 <span>Endet am {challenge.endsOn}</span>
               </div>
               <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-card-muted">
                 <div
-                  className="h-full rounded-full bg-slate-900"
+                  className="h-full rounded-full bg-primary"
                   style={{ width: `${challenge.progress}%` }}
                   role="presentation"
                 />
               </div>
-              <p className="mt-1 text-xs text-slate-500">Fortschritt: {challenge.progress}%</p>
+              <p className="mt-1 text-xs text-muted">Fortschritt: {challenge.progress}%</p>
             </div>
-            <footer className="text-xs text-slate-500">
+            <footer className="text-xs text-muted">
               Die Anbindung an Tap&apos;em Challenges API folgt. Bis dahin dienen Mock-Daten zur UX-
               Abstimmung.
             </footer>

--- a/website/src/app/(portal)/gym/leaderboard/page.tsx
+++ b/website/src/app/(portal)/gym/leaderboard/page.tsx
@@ -7,54 +7,54 @@ export default async function GymLeaderboardPage() {
   return (
     <section className="space-y-6">
       <header className="space-y-2">
-        <h1 className="text-2xl font-semibold text-slate-900">Leaderboard</h1>
-        <p className="text-sm text-slate-600">
+        <h1 className="text-2xl font-semibold text-page">Leaderboard</h1>
+        <p className="text-sm text-muted">
           Motiviert Mitglieder durch transparente Gamification. Die Tabelle wird zukünftig mit
           Firestore-Scores gespeist.
         </p>
       </header>
       <div className="overflow-x-auto rounded-lg border border-subtle bg-card shadow-sm">
-        <table className="min-w-full divide-y divide-slate-200">
+        <table className="min-w-full divide-y divide-[color:var(--page-border)]">
           <thead className="bg-card-muted">
             <tr>
-              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
                 Rang
               </th>
-              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
                 Mitglied
               </th>
-              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
                 Punkte
               </th>
-              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
                 Aktuelle Streak
               </th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-slate-200">
+          <tbody className="divide-y divide-[color:var(--page-border)]">
             {gymLeaderboardMock.map((entry) => (
               <tr key={entry.id} className="hover:bg-card-muted">
-                <td className="whitespace-nowrap px-4 py-3 text-sm font-semibold text-slate-700">
+                <td className="whitespace-nowrap px-4 py-3 text-sm font-semibold text-page">
                   #{entry.rank}
                 </td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm text-slate-700">
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-page">
                   <div className="flex items-center gap-3">
-                    <span className="flex h-9 w-9 items-center justify-center rounded-full bg-slate-900 text-xs font-semibold text-white">
+                    <span className="flex h-9 w-9 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
                       {entry.avatarInitials}
                     </span>
-                    <span className="font-medium text-slate-900">{entry.member}</span>
+                    <span className="font-medium text-page">{entry.member}</span>
                   </div>
                 </td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm font-semibold text-slate-900">
+                <td className="whitespace-nowrap px-4 py-3 text-sm font-semibold text-page">
                   {entry.points} XP
                 </td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm text-slate-700">{entry.streak} Tage</td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-muted">{entry.streak} Tage</td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
-      <p className="text-xs text-slate-500">
+      <p className="text-xs text-muted">
         Ranking basiert auf Mock-Werten. Für das finale Produkt werden Echtzeit-Punkte und Badges
         aus dem Analytics-Backend übernommen.
       </p>

--- a/website/src/app/(portal)/gym/members/page.tsx
+++ b/website/src/app/(portal)/gym/members/page.tsx
@@ -7,8 +7,8 @@ export default async function GymMembersPage() {
   return (
     <section className="space-y-6">
       <header className="space-y-2">
-        <h1 className="text-2xl font-semibold text-slate-900">Mitgliederverwaltung</h1>
-        <p className="text-sm text-slate-600">
+        <h1 className="text-2xl font-semibold text-page">Mitgliederverwaltung</h1>
+        <p className="text-sm text-muted">
           Überblick über aktive Nutzerinnen und Nutzer. Filter und Sortierung folgen mit der
           Firestore-Anbindung.
         </p>
@@ -16,68 +16,68 @@ export default async function GymMembersPage() {
       <div className="flex flex-wrap gap-2 text-xs font-medium">
         <button
           type="button"
-          className="rounded border border-dashed border-slate-300 px-3 py-1 text-slate-500"
+          className="rounded border border-dashed border-subtle px-3 py-1 text-muted"
           disabled
         >
           Filter hinzufügen (bald)
         </button>
         <button
           type="button"
-          className="rounded border border-dashed border-slate-300 px-3 py-1 text-slate-500"
+          className="rounded border border-dashed border-subtle px-3 py-1 text-muted"
           disabled
         >
           Sortierung speichern (bald)
         </button>
       </div>
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-slate-200">
+        <table className="min-w-full divide-y divide-[color:var(--page-border)]">
           <thead className="bg-card-muted">
             <tr>
-              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
                 Mitglied
               </th>
-              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
                 Mitgliedschaft
               </th>
-              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
                 Status
               </th>
-              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
                 Letzter Check-in
               </th>
-              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
                 Check-ins (Woche)
               </th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-slate-200 bg-card">
+          <tbody className="divide-y divide-[color:var(--page-border)] bg-card">
             {gymMembersMock.map((member) => (
               <tr key={member.id} className="hover:bg-card-muted">
-                <td className="whitespace-nowrap px-4 py-3 text-sm text-slate-700">
-                  <div className="font-medium text-slate-900">{member.name}</div>
-                  <div className="text-xs text-slate-500">{member.email}</div>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-page">
+                  <div className="font-medium text-page">{member.name}</div>
+                  <div className="text-xs text-muted">{member.email}</div>
                 </td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm text-slate-700">{member.membership}</td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-page">{member.membership}</td>
                 <td className="whitespace-nowrap px-4 py-3 text-sm">
                   <span
                     className={
                       'inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ' +
                       (member.status === 'aktiv'
-                        ? 'bg-emerald-50 text-emerald-700'
-                        : 'bg-amber-50 text-amber-700')
+                        ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-200'
+                        : 'bg-amber-50 text-amber-700 dark:bg-amber-500/10 dark:text-amber-200')
                     }
                   >
                     {member.status === 'aktiv' ? 'Aktiv' : 'Pausiert'}
                   </span>
                 </td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm text-slate-700">{member.lastCheckIn}</td>
-                <td className="whitespace-nowrap px-4 py-3 text-sm text-slate-700">{member.weeklyCheckIns}</td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-page">{member.lastCheckIn}</td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-page">{member.weeklyCheckIns}</td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
-      <p className="text-xs text-slate-500">
+      <p className="text-xs text-muted">
         Die Tabelle basiert auf Mock-Daten aus <code>src/server/mocks/gym.ts</code>. Mit der Firebase
         Integration werden echte Filter, Pagination und Exportfunktionen ergänzt.
       </p>

--- a/website/src/app/(portal)/gym/page.tsx
+++ b/website/src/app/(portal)/gym/page.tsx
@@ -10,9 +10,9 @@ export default async function GymOverviewPage() {
     <div className="space-y-12">
       <section className="space-y-4">
         <header>
-          <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">Gym Dashboard</p>
-          <h1 className="mt-1 text-3xl font-semibold text-slate-900">Willkommen zurück, {user.email}</h1>
-          <p className="mt-2 max-w-2xl text-sm text-slate-600">
+          <p className="text-sm font-semibold uppercase tracking-wide text-muted">Gym Dashboard</p>
+          <h1 className="mt-1 text-3xl font-semibold text-page">Willkommen zurück, {user.email}</h1>
+          <p className="mt-2 max-w-2xl text-sm text-muted">
             Dieses Operator-Dashboard zeigt Live-Metriken aus dem Tap&apos;em-Netzwerk. Die Daten sind
             aktuell noch Mock-Werte und werden später über Firestore und Realtime-Analytics gespeist.
           </p>
@@ -23,9 +23,9 @@ export default async function GymOverviewPage() {
               key={kpi.label}
               className="rounded-lg border border-subtle bg-card p-4 shadow-sm"
             >
-              <p className="text-sm font-medium text-slate-600">{kpi.label}</p>
-              <p className="mt-2 text-2xl font-semibold text-slate-900">{kpi.value}</p>
-              <p className="mt-1 text-xs text-emerald-600">{kpi.change}</p>
+              <p className="text-sm font-medium text-muted">{kpi.label}</p>
+              <p className="mt-2 text-2xl font-semibold text-page">{kpi.value}</p>
+              <p className="mt-1 text-xs text-emerald-600 dark:text-emerald-300">{kpi.change}</p>
             </article>
           ))}
         </div>
@@ -33,17 +33,17 @@ export default async function GymOverviewPage() {
       <section className="grid gap-6 lg:grid-cols-2">
         <div className="space-y-4 rounded-lg border border-subtle bg-card p-6 shadow-sm">
           <header>
-            <h2 className="text-xl font-semibold text-slate-900">Aktive Challenges</h2>
-            <p className="mt-1 text-sm text-slate-600">
+            <h2 className="text-xl font-semibold text-page">Aktive Challenges</h2>
+            <p className="mt-1 text-sm text-muted">
               Top-Kampagnen, die deine Mitglieder aktuell motivieren.
             </p>
           </header>
           <ul className="space-y-4">
             {highlightedChallenges.map((challenge) => (
-              <li key={challenge.id} className="rounded-md border border-slate-100 p-4">
-                <h3 className="text-base font-semibold text-slate-900">{challenge.title}</h3>
-                <p className="mt-1 text-sm text-slate-600">{challenge.description}</p>
-                <div className="mt-3 flex items-center justify-between text-sm text-slate-500">
+              <li key={challenge.id} className="rounded-md border border-subtle p-4">
+                <h3 className="text-base font-semibold text-page">{challenge.title}</h3>
+                <p className="mt-1 text-sm text-muted">{challenge.description}</p>
+                <div className="mt-3 flex items-center justify-between text-sm text-muted">
                   <span>{challenge.participants} Teilnehmende</span>
                   <span>Fortschritt: {challenge.progress}%</span>
                   <span>Endet am {challenge.endsOn}</span>
@@ -51,15 +51,15 @@ export default async function GymOverviewPage() {
               </li>
             ))}
           </ul>
-          <p className="text-xs text-slate-500">
+          <p className="text-xs text-muted">
             Die Challenge-Daten stammen aus statischen Mocks. In Produktion werden sie dynamisch aus
             Firestore geladen.
           </p>
         </div>
         <div className="space-y-4 rounded-lg border border-subtle bg-card p-6 shadow-sm">
           <header>
-            <h2 className="text-xl font-semibold text-slate-900">Leaderboard (Top 3)</h2>
-            <p className="mt-1 text-sm text-slate-600">
+            <h2 className="text-xl font-semibold text-page">Leaderboard (Top 3)</h2>
+            <p className="mt-1 text-sm text-muted">
               Eine schnelle Vorschau auf die engagiertesten Mitglieder.
             </p>
           </header>
@@ -67,24 +67,24 @@ export default async function GymOverviewPage() {
             {topLeaderboard.map((entry) => (
               <li
                 key={entry.id}
-                className="flex items-center justify-between gap-4 rounded-md border border-slate-100 p-4"
+                className="flex items-center justify-between gap-4 rounded-md border border-subtle p-4"
               >
                 <div className="flex items-center gap-3">
-                  <span className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-900 text-sm font-semibold text-white">
+                  <span className="flex h-10 w-10 items-center justify-center rounded-full bg-primary text-sm font-semibold text-primary-foreground">
                     {entry.avatarInitials}
                   </span>
                   <div>
-                    <p className="text-sm font-semibold text-slate-900">
+                    <p className="text-sm font-semibold text-page">
                       #{entry.rank} {entry.member}
                     </p>
-                    <p className="text-xs text-slate-500">Streak: {entry.streak} Tage</p>
+                    <p className="text-xs text-muted">Streak: {entry.streak} Tage</p>
                   </div>
                 </div>
-                <span className="text-lg font-semibold text-slate-900">{entry.points} XP</span>
+                <span className="text-lg font-semibold text-page">{entry.points} XP</span>
               </li>
             ))}
           </ol>
-          <p className="text-xs text-slate-500">
+          <p className="text-xs text-muted">
             Vollständige Ranglisten stehen im Leaderboard-Tab bereit. Die Live-Version wird später
             mit Realtime-Daten gespeist.
           </p>

--- a/website/src/app/(portal)/login/login-form.tsx
+++ b/website/src/app/(portal)/login/login-form.tsx
@@ -40,30 +40,42 @@ export default function LoginForm() {
 
   return (
     <form action={onSubmit} className="max-w-md space-y-4">
-      <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+      <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-500/60 dark:bg-amber-500/10 dark:text-amber-200">
         <strong>Dev-Login (Stub):</strong> Nur für Preview/Entwicklung. In Production deaktiviert.
       </div>
 
       <div className="space-y-1">
-        <label htmlFor="email" className="block text-sm font-medium text-slate-700">E-Mail (optional)</label>
-        <input id="email" name="email" type="email" placeholder="you@example.com"
-          className="w-full rounded border border-slate-300 px-3 py-2 text-sm outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900" />
+        <label htmlFor="email" className="block text-sm font-medium text-page">E-Mail (optional)</label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          placeholder="you@example.com"
+          className="w-full rounded border border-subtle bg-card px-3 py-2 text-sm text-page focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+        />
       </div>
 
       <div className="space-y-1">
-        <label htmlFor="role" className="block text-sm font-medium text-slate-700">Rolle</label>
-        <select id="role" name="role" defaultValue="owner"
-          className="w-full rounded border border-slate-300 bg-white px-3 py-2 text-sm outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900">
+        <label htmlFor="role" className="block text-sm font-medium text-page">Rolle</label>
+        <select
+          id="role"
+          name="role"
+          defaultValue="owner"
+          className="w-full rounded border border-subtle bg-card px-3 py-2 text-sm text-page focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+        >
           <option value="owner">owner</option>
           <option value="operator">operator</option>
           <option value="admin">admin</option>
         </select>
       </div>
 
-      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+      {error ? <p className="text-sm text-red-600 dark:text-red-300">{error}</p> : null}
 
-      <button type="submit" disabled={submitting}
-        className="inline-flex items-center justify-center rounded bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800 disabled:opacity-50">
+      <button
+        type="submit"
+        disabled={submitting}
+        className="inline-flex items-center justify-center rounded bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
+      >
         {submitting ? 'Anmelden…' : 'Anmelden'}
       </button>
     </form>

--- a/website/src/app/(portal)/login/page.tsx
+++ b/website/src/app/(portal)/login/page.tsx
@@ -12,13 +12,13 @@ export default function Page() {
   return (
     <div className="mx-auto w-full max-w-xl space-y-6 px-6 py-16">
       <h1 className="text-2xl font-semibold">Anmelden (Dev-Stub)</h1>
-      <p className="text-sm text-slate-600">
+      <p className="text-sm text-muted">
         Diese Anmeldung setzt Vorschau-Cookies und dient dem Testen der geschützten Bereiche. In Production ist der Dev-Login
         deaktiviert.
       </p>
       <Suspense
         fallback={
-          <div className="rounded border border-subtle bg-card p-4 text-sm text-slate-500" aria-live="polite">
+          <div className="rounded border border-subtle bg-card p-4 text-sm text-muted" aria-live="polite">
             Lade Login-Parameter…
           </div>
         }

--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -1,8 +1,10 @@
 import type { Metadata, Viewport } from 'next';
-import { headers } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 import { ReactNode } from 'react';
 
 import { buildSiteMetadata, getSiteConfig } from '@/config/sites';
+import { ThemeScript } from '@/components/theme-script';
+import { THEME_COLORS, THEME_COOKIE_NAME, getServerThemeHint } from '@/lib/theme';
 
 import '../styles/globals.css';
 
@@ -13,12 +15,23 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export const viewport: Viewport = {
-  themeColor: '#0B0F1A',
+  themeColor: [
+    { media: '(prefers-color-scheme: dark)', color: THEME_COLORS.dark },
+    { media: '(prefers-color-scheme: light)', color: THEME_COLORS.light },
+  ],
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
+  const cookieStore = cookies();
+  const themeCookie = cookieStore.get(THEME_COOKIE_NAME)?.value;
+  const initialTheme = getServerThemeHint(themeCookie);
+  const htmlClassName = initialTheme === 'dark' ? 'h-full dark' : 'h-full';
+
   return (
-    <html lang="de" suppressHydrationWarning className="h-full">
+    <html lang="de" suppressHydrationWarning className={htmlClassName} data-theme={initialTheme}>
+      <head>
+        <ThemeScript />
+      </head>
       <body className="bg-page text-page">{children}</body>
     </html>
   );

--- a/website/src/components/admin/admin-login-form.tsx
+++ b/website/src/components/admin/admin-login-form.tsx
@@ -87,36 +87,39 @@ export default function AdminLoginForm() {
   return (
     <form onSubmit={onSubmit} className="grid gap-4">
       {!clientOk && (
-        <div className="rounded-md border border-red-400 bg-red-100/10 p-3 text-red-200">
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-red-900 dark:border-red-500/60 dark:bg-red-500/10 dark:text-red-200">
           Firebase ist noch nicht konfiguriert. Bitte die Umgebungsvariablen prüfen.
         </div>
       )}
 
       <label className="grid gap-2">
-        <span className="text-sm opacity-80">E-Mail-Adresse</span>
+        <span className="text-sm text-muted">E-Mail-Adresse</span>
         <input
           type="email"
           required
           value={email}
           onChange={(event) => setEmail(event.target.value)}
-          className="rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2"
+          className="rounded-md border border-subtle bg-card px-3 py-2 text-sm text-page focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
         />
       </label>
 
       <label className="grid gap-2">
-        <span className="text-sm opacity-80">Passwort</span>
+        <span className="text-sm text-muted">Passwort</span>
         <input
           type="password"
           required
           value={pw}
           onChange={(event) => setPw(event.target.value)}
-          className="rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2"
+          className="rounded-md border border-subtle bg-card px-3 py-2 text-sm text-page focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
         />
       </label>
 
-      {err && <div className="text-sm text-red-300">{err}</div>}
+      {err && <div className="text-sm text-red-600 dark:text-red-300">{err}</div>}
 
-      <button disabled={busy || !clientOk} className="rounded-md bg-blue-600 px-4 py-2 disabled:opacity-50">
+      <button
+        disabled={busy || !clientOk}
+        className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
+      >
         {busy ? 'Anmelden…' : 'Anmelden'}
       </button>
     </form>

--- a/website/src/components/dev-toolbar.tsx
+++ b/website/src/components/dev-toolbar.tsx
@@ -95,10 +95,10 @@ export default function DevToolbar({ currentRole }: DevToolbarProps) {
         </button>
       </div>
       {pending ? (
-        <p className="text-[11px] text-slate-500">{pending === 'logout' ? 'Abmelden…' : `Wechsel zu ${pending}…`}</p>
+        <p className="text-[11px] text-muted">{pending === 'logout' ? 'Abmelden…' : `Wechsel zu ${pending}…`}</p>
       ) : null}
       {error ? (
-        <p className="text-[11px] text-red-600" role="alert">
+        <p className="text-[11px] text-red-600 dark:text-red-300" role="alert">
           {error}
         </p>
       ) : null}

--- a/website/src/components/layout/admin-shell.tsx
+++ b/website/src/components/layout/admin-shell.tsx
@@ -8,6 +8,7 @@ import type { AuthenticatedUser, Role } from '@/lib/auth/types';
 import { ADMIN_ROUTES, type AdminRouteDefinition } from '@/lib/routes';
 import { isDevPreviewRoleSwitchesEnabled } from '@/lib/env';
 import { getAdminUserFromSession } from '@/server/auth/session';
+import { ThemeToggle } from '@/components/theme-toggle';
 
 type NavigationItem = {
   label: string;
@@ -31,7 +32,7 @@ function NavigationMenu({ items }: { items: NavigationItem[] }) {
           return (
             <span
               key={item.label}
-              className="block rounded-md px-3 py-2 text-sm text-slate-400"
+              className="block rounded-md px-3 py-2 text-sm text-muted"
               aria-disabled="true"
             >
               {item.label}
@@ -43,7 +44,7 @@ function NavigationMenu({ items }: { items: NavigationItem[] }) {
           <Link
             key={item.label}
             href={item.route.href}
-            className="block rounded-md px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            className="block rounded-md px-3 py-2 text-sm font-medium text-page transition hover:bg-card-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
           >
             {item.label}
           </Link>
@@ -78,23 +79,24 @@ function AdminHeader({
         <div className="flex items-center gap-4">
           {user ? (
             <div className="text-right">
-              <p className="text-sm font-semibold text-slate-900">{user.email}</p>
-              <p className="text-xs text-slate-500">Rolle: {user.role}</p>
+              <p className="text-sm font-semibold text-page">{user.email}</p>
+              <p className="text-xs text-muted">Rolle: {user.role}</p>
             </div>
           ) : devRole ? (
             <div className="text-right">
-              <p className="text-sm font-semibold text-slate-900">Dev-Rolle: {devRole}</p>
-              <p className="text-xs text-slate-500">Nur Vorschau</p>
+              <p className="text-sm font-semibold text-page">Dev-Rolle: {devRole}</p>
+              <p className="text-xs text-muted">Nur Vorschau</p>
             </div>
           ) : null}
           {user ? (
             <Link
               href={ADMIN_ROUTES.logout.href}
-              className="rounded-md border border-subtle px-3 py-1 text-sm font-semibold text-slate-700 transition hover:border-primary hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              className="rounded-md border border-subtle bg-card px-3 py-1 text-sm font-semibold text-page transition hover:border-primary hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
             >
               Abmelden
             </Link>
           ) : null}
+          <ThemeToggle />
           {showDevToolbar ? <DevToolbar currentRole={devRole} /> : null}
         </div>
       </div>
@@ -122,7 +124,7 @@ export default async function AdminShell({ children }: { children: ReactNode }) 
 
   if (!hasAdminAccess) {
     return (
-      <div className="flex min-h-screen flex-col bg-page">
+      <div className="flex min-h-screen flex-col bg-page text-page">
         {header}
         <main className="flex-1 bg-page">{children}</main>
         <footer className="border-t border-subtle bg-surface-muted">
@@ -135,7 +137,7 @@ export default async function AdminShell({ children }: { children: ReactNode }) 
   }
 
   return (
-    <div className="flex min-h-screen bg-page">
+    <div className="flex min-h-screen bg-page text-page">
       <aside className="hidden w-64 border-r border-subtle bg-surface px-4 py-6 lg:block">
         <NavigationMenu items={NAVIGATION} />
       </aside>

--- a/website/src/components/layout/marketing-shell.tsx
+++ b/website/src/components/layout/marketing-shell.tsx
@@ -17,7 +17,7 @@ export default function MarketingShell({ children }: { children: ReactNode }) {
   const showPreviewLabel = stage !== 'production';
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-screen flex-col bg-page text-page">
       <header className="border-b border-subtle surface-blur">
         <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-6 px-6 py-4">
           <Link

--- a/website/src/components/layout/portal-shell.tsx
+++ b/website/src/components/layout/portal-shell.tsx
@@ -6,6 +6,7 @@ import DevToolbar from '@/components/dev-toolbar';
 import { getDevUserFromCookies } from '@/lib/auth/server';
 import type { Role } from '@/lib/auth/types';
 import { PORTAL_ROUTES, type PortalRouteDefinition } from '@/lib/routes';
+import { ThemeToggle } from '@/components/theme-toggle';
 
 const portalNav = [
   { route: PORTAL_ROUTES.gym, label: 'Dashboard' },
@@ -21,7 +22,7 @@ export default function PortalShell({ children }: { children: ReactNode }) {
   const currentRole: Role | null = devUser?.role ?? null;
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-screen flex-col bg-page text-page">
       <header className="border-b border-subtle bg-surface">
         <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-4">
           <Link
@@ -36,14 +37,17 @@ export default function PortalShell({ children }: { children: ReactNode }) {
               <Link
                 key={item.route.href}
                 href={item.route.href}
-                className="rounded px-2 py-1 transition hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                className="rounded px-2 py-1 transition hover:bg-card-muted hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
               >
                 {item.label}
               </Link>
             ))}
           </nav>
 
-          {isProduction ? <div className="hidden" aria-hidden /> : <DevToolbar currentRole={currentRole} />}
+          <div className="flex items-center gap-3">
+            <ThemeToggle />
+            {isProduction ? <div className="hidden" aria-hidden /> : <DevToolbar currentRole={currentRole} />}
+          </div>
         </div>
       </header>
 

--- a/website/src/components/theme-script.tsx
+++ b/website/src/components/theme-script.tsx
@@ -1,0 +1,65 @@
+import { THEME_COLORS, THEME_COOKIE_NAME, THEME_STORAGE_KEY } from '@/lib/theme';
+
+const themeInitializer = `(() => {
+  try {
+    const storageKey = '${THEME_STORAGE_KEY}';
+    const cookieName = '${THEME_COOKIE_NAME}';
+    const metaSelector = 'meta[name="theme-color"]';
+    const darkColor = '${THEME_COLORS.dark}';
+    const lightColor = '${THEME_COLORS.light}';
+
+    const root = document.documentElement;
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const stored = window.localStorage.getItem(storageKey);
+    const isValidPreference = stored === 'light' || stored === 'dark' || stored === 'system';
+    const preference = isValidPreference ? stored : 'system';
+    if (!isValidPreference) {
+      try {
+        window.localStorage.setItem(storageKey, 'system');
+      } catch (error) {
+        // Storage ggf. deaktiviert – ignorieren.
+      }
+    }
+
+    const resolved = preference === 'system' ? (media.matches ? 'dark' : 'light') : preference;
+
+    root.classList.toggle('dark', resolved === 'dark');
+    root.setAttribute('data-theme', resolved);
+
+    const meta = document.querySelector(metaSelector);
+    if (meta) {
+      meta.setAttribute('content', resolved === 'dark' ? darkColor : lightColor);
+    }
+
+    document.cookie = cookieName + '=' + resolved + '; path=/; max-age=31536000; SameSite=Lax';
+
+    if (preference === 'system') {
+      const update = (event) => {
+        const currentPreference = window.localStorage.getItem(storageKey);
+        if (currentPreference && currentPreference !== 'system') {
+          return;
+        }
+        const next = event.matches ? 'dark' : 'light';
+        root.classList.toggle('dark', next === 'dark');
+        root.setAttribute('data-theme', next);
+        const metaEl = document.querySelector(metaSelector);
+        if (metaEl) {
+          metaEl.setAttribute('content', next === 'dark' ? darkColor : lightColor);
+        }
+        document.cookie = cookieName + '=' + next + '; path=/; max-age=31536000; SameSite=Lax';
+      };
+
+      if (typeof media.addEventListener === 'function') {
+        media.addEventListener('change', update);
+      } else if (typeof media.addListener === 'function') {
+        media.addListener(update);
+      }
+    }
+  } catch (error) {
+    // Kein Theme-Flash, wenn Storage/Cookies blockiert sind.
+  }
+})();`;
+
+export function ThemeScript() {
+  return <script dangerouslySetInnerHTML={{ __html: themeInitializer }} suppressHydrationWarning />;
+}

--- a/website/src/components/theme-toggle.tsx
+++ b/website/src/components/theme-toggle.tsx
@@ -1,42 +1,89 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
-const THEME_COLORS: Record<'light' | 'dark', string> = {
-  light: '#f1f5f9',
-  dark: '#020617',
+import {
+  THEME_STORAGE_KEY,
+  applyResolvedTheme,
+  isThemePreference,
+  persistTheme,
+  resolveTheme,
+  type ThemeMode,
+  type ThemePreference,
+} from '@/lib/theme';
+
+const TOGGLE_SEQUENCE: ThemePreference[] = ['light', 'dark', 'system'];
+
+const ICONS: Record<ThemePreference, string> = {
+  light: '☀️',
+  dark: '🌙',
+  system: '🖥️',
 };
 
-function applyTheme(nextTheme: 'light' | 'dark') {
-  document.documentElement.classList.toggle('dark', nextTheme === 'dark');
-  document.documentElement.setAttribute('data-theme', nextTheme);
-
-  const meta = document.querySelector('meta[name="theme-color"]');
-  if (meta) {
-    meta.setAttribute('content', THEME_COLORS[nextTheme]);
-  }
-}
+const LABELS: Record<ThemePreference, string> = {
+  light: 'Hellmodus',
+  dark: 'Dunkelmodus',
+  system: 'Systemmodus',
+};
 
 export function ThemeToggle() {
   const [isMounted, setIsMounted] = useState(false);
-  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  const [preference, setPreference] = useState<ThemePreference>('system');
+  const [resolvedTheme, setResolvedTheme] = useState<ThemeMode>('light');
+  const mediaQueryRef = useRef<MediaQueryList | null>(null);
+  const preferenceRef = useRef<ThemePreference>('system');
 
-  useEffect(() => {
-    const stored = window.localStorage.getItem('tapem-theme') as 'light' | 'dark' | null;
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const initialTheme = stored ?? (prefersDark ? 'dark' : 'light');
+  const applyPreference = useCallback((nextPreference: ThemePreference) => {
+    const media = mediaQueryRef.current;
+    if (!media) {
+      return;
+    }
 
-    setTheme(initialTheme);
-    applyTheme(initialTheme);
-    setIsMounted(true);
+    const nextResolved = resolveTheme(nextPreference, media.matches);
+    preferenceRef.current = nextPreference;
+    setPreference(nextPreference);
+    setResolvedTheme(nextResolved);
+    applyResolvedTheme(nextResolved);
+    persistTheme(nextPreference, nextResolved);
   }, []);
 
-  const toggleTheme = () => {
-    const nextTheme = theme === 'dark' ? 'light' : 'dark';
-    setTheme(nextTheme);
-    applyTheme(nextTheme);
-    window.localStorage.setItem('tapem-theme', nextTheme);
+  useEffect(() => {
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    mediaQueryRef.current = media;
+
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    const initialPreference = isThemePreference(stored) ? stored : 'system';
+    applyPreference(initialPreference);
+    setIsMounted(true);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      if (preferenceRef.current === 'system') {
+        const nextResolved = event.matches ? 'dark' : 'light';
+        setResolvedTheme(nextResolved);
+        applyResolvedTheme(nextResolved);
+        persistTheme('system', nextResolved);
+      }
+    };
+
+    if (typeof media.addEventListener === 'function') {
+      media.addEventListener('change', handleChange);
+      return () => media.removeEventListener('change', handleChange);
+    }
+
+    media.addListener(handleChange);
+    return () => media.removeListener(handleChange);
+  }, [applyPreference]);
+
+  const togglePreference = () => {
+    const currentIndex = TOGGLE_SEQUENCE.indexOf(preferenceRef.current);
+    const next = TOGGLE_SEQUENCE[(currentIndex + 1) % TOGGLE_SEQUENCE.length];
+    applyPreference(next);
   };
+
+  const nextPreference = TOGGLE_SEQUENCE[(TOGGLE_SEQUENCE.indexOf(preference) + 1) % TOGGLE_SEQUENCE.length];
+  const currentLabel = LABELS[preference];
+  const nextLabel = LABELS[nextPreference];
+  const resolvedModeLabel = resolvedTheme === 'dark' ? 'Dunkelmodus aktiv' : 'Hellmodus aktiv';
 
   if (!isMounted) {
     return (
@@ -52,11 +99,13 @@ export function ThemeToggle() {
   return (
     <button
       type="button"
-      onClick={toggleTheme}
-      aria-label={theme === 'dark' ? 'Hellmodus aktivieren' : 'Dunkelmodus aktivieren'}
+      onClick={togglePreference}
+      aria-label={`Theme wechseln (aktuell ${currentLabel}, nächster Modus ${nextLabel})`}
+      title={`Theme wechseln (nächster Modus: ${nextLabel})`}
       className="flex h-10 w-10 items-center justify-center rounded-full border border-subtle bg-card text-lg transition hover:border-primary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
     >
-      <span aria-hidden="true">{theme === 'dark' ? '🌙' : '☀️'}</span>
+      <span aria-hidden="true">{ICONS[preference]}</span>
+      <span className="sr-only">Aktiv: {currentLabel} · {resolvedModeLabel}</span>
     </button>
   );
 }

--- a/website/src/lib/theme.ts
+++ b/website/src/lib/theme.ts
@@ -1,0 +1,55 @@
+export const THEME_STORAGE_KEY = 'tapem-theme';
+export const THEME_COOKIE_NAME = 'tapem-theme';
+
+export type ThemePreference = 'light' | 'dark' | 'system';
+export type ThemeMode = 'light' | 'dark';
+
+export const THEME_COLORS: Record<ThemeMode, string> = {
+  light: '#f1f5f9',
+  dark: '#020617',
+};
+
+export function isThemePreference(value: string | null): value is ThemePreference {
+  return value === 'light' || value === 'dark' || value === 'system';
+}
+
+export function resolveTheme(preference: ThemePreference, systemPrefersDark: boolean): ThemeMode {
+  if (preference === 'system') {
+    return systemPrefersDark ? 'dark' : 'light';
+  }
+
+  return preference;
+}
+
+export function applyResolvedTheme(theme: ThemeMode) {
+  const root = document.documentElement;
+  root.classList.toggle('dark', theme === 'dark');
+  root.setAttribute('data-theme', theme);
+
+  const meta = document.querySelector('meta[name="theme-color"]');
+  if (meta) {
+    meta.setAttribute('content', THEME_COLORS[theme]);
+  }
+}
+
+export function persistTheme(preference: ThemePreference, resolved: ThemeMode) {
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, preference);
+  } catch {
+    // Ignorieren – Storage eventuell deaktiviert.
+  }
+
+  try {
+    document.cookie = `${THEME_COOKIE_NAME}=${resolved}; path=/; max-age=31536000; SameSite=Lax`;
+  } catch {
+    // Ignorieren – Cookies eventuell blockiert.
+  }
+}
+
+export function getServerThemeHint(cookieValue: string | undefined): ThemeMode {
+  if (cookieValue === 'dark') {
+    return 'dark';
+  }
+
+  return 'light';
+}


### PR DESCRIPTION
## Summary
- add shared theme utilities plus an inline boot script to set the correct HTML class on first paint and keep SSR hints in sync
- update the theme toggle to persist light/dark/system preferences via the central helpers and expose it across marketing, portal, and admin shells
- restyle admin and portal surfaces to reuse the landing page tokens and document the global theming flow in the README

## Testing
- `npm run lint` *(fails: local next binary missing because registry access returns HTTP 403 during npm install)*

------
https://chatgpt.com/codex/tasks/task_e_68d05557285083208271d93f0836b0fc