### PR TITLE
feat(admin): Monitoring-Karte + Gym-Detailansicht

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -155,6 +155,15 @@ Server-Variablen dürfen **nicht** mit `NEXT_PUBLIC_` beginnen, damit sie nicht 
 - Während `npm run dev` aktiv ist, liefert `curl http://localhost:3000/api/health/firebase-admin` ein `{ "ok": true, ... }`, sobald das Admin SDK korrekt konfiguriert ist.
 - Für detailliertere Logs `TAPEM_DEBUG=1` in `.env.local` setzen.
 
+## Monitoring (Admin)
+
+- `/admin/monitoring` zeigt eine dynamische MapLibre-Karte mit allen Gyms, die über ein Geopoint-Feld `gyms.location` verfügen.
+- Gym-Statuswerte werden optional aus `gymStatus/{gymId}` oder `gyms/{gymId}/status/current` gelesen. Felder: `status`, `checkins24h`, `devicesOnline`, `lastEventAt`.
+- Gyms ohne Koordinate erscheinen nicht auf der Karte; der Zähler in der Infozeile weist auf fehlende Geodaten hin. Koordinaten können direkt in Firestore als `GeoPoint(lat, lng)` ergänzt werden.
+- Die API `/api/admin/gyms.geojson` liefert eine `FeatureCollection` ohne personenbezogene Daten und setzt `Cache-Control: private, max-age=60` sowie ETag-Header.
+- Detailseiten unter `/admin/monitoring/[gymId]` zeigen KPI-Karten (Check-ins/24h, Geräte online, letztes Ereignis) und binden das gefilterte Ereignislog ein.
+- DSGVO-Hinweis: In der Map-Payload befinden sich ausschließlich Gym-Metadaten und aggregierte Betriebskennzahlen – keine Nutzer:innen-Daten oder Geräteseriennummern.
+
 ### Guards & Middleware
 
 - `middleware.ts` unterscheidet Marketing/Portal/Admin-Hosts und prüft Session-Cookies.

--- a/website/package.json
+++ b/website/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "node --test tests/**/*.test.js",
     "check:admin": "node scripts/diag/firebase-admin-health.mjs",
     "health:admin": "node scripts/diag/http-admin-health.mjs"
   },

--- a/website/src/app/(admin)/admin/monitoring/[gymId]/page.tsx
+++ b/website/src/app/(admin)/admin/monitoring/[gymId]/page.tsx
@@ -1,0 +1,166 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+import { requireRole } from '@/src/lib/auth/server';
+import { ADMIN_ROUTES } from '@/src/lib/routes';
+import { AdminEventLogTable } from '@/src/components/admin/admin-event-log-table';
+import { fetchGymEventLogs, fetchGymMonitoringSummary } from '@/src/server/monitoring';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+const numberFormatter = new Intl.NumberFormat('de-DE');
+const dateTimeFormatter = new Intl.DateTimeFormat('de-DE', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+const STATUS_BADGES: Record<'online' | 'offline' | 'degraded' | 'unknown', string> = {
+  online: 'bg-emerald-100 text-emerald-900 border-emerald-200 dark:bg-emerald-500/10 dark:text-emerald-200 dark:border-emerald-500/40',
+  offline: 'bg-rose-100 text-rose-900 border-rose-200 dark:bg-rose-500/10 dark:text-rose-200 dark:border-rose-500/40',
+  degraded: 'bg-amber-100 text-amber-900 border-amber-200 dark:bg-amber-500/10 dark:text-amber-200 dark:border-amber-500/40',
+  unknown: 'bg-slate-200 text-slate-900 border-slate-300 dark:bg-slate-500/10 dark:text-slate-200 dark:border-slate-500/40',
+};
+
+export const metadata: Metadata = {
+  title: 'Monitoring',
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+type PageProps = {
+  params: { gymId: string };
+  searchParams?: { cursor?: string };
+};
+
+function formatNumber(value: number | null | undefined): string {
+  if (typeof value !== 'number') {
+    return '—';
+  }
+  return numberFormatter.format(value);
+}
+
+function formatTimestamp(value: Date | null | undefined): string {
+  if (!value) {
+    return '—';
+  }
+  return dateTimeFormatter.format(value);
+}
+
+function resolveStatusBadge(status: 'online' | 'offline' | 'degraded' | null | undefined) {
+  if (status === 'online') return STATUS_BADGES.online;
+  if (status === 'offline') return STATUS_BADGES.offline;
+  if (status === 'degraded') return STATUS_BADGES.degraded;
+  return STATUS_BADGES.unknown;
+}
+
+function resolveStatusLabel(status: 'online' | 'offline' | 'degraded' | null | undefined) {
+  if (status === 'online') return 'Online';
+  if (status === 'offline') return 'Offline';
+  if (status === 'degraded') return 'Eingeschränkt';
+  return 'Unbekannt';
+}
+
+export default async function MonitoringDetailPage({ params, searchParams }: PageProps) {
+  await requireRole(['admin', 'owner'], { failure: 'not-found', loginSite: 'admin' });
+
+  const summary = await fetchGymMonitoringSummary(params.gymId);
+  if (!summary) {
+    notFound();
+  }
+
+  const events = await fetchGymEventLogs(params.gymId, {
+    limit: 20,
+    cursor: searchParams?.cursor ?? null,
+  });
+
+  const status = summary.status?.status ?? null;
+  const statusLabel = resolveStatusLabel(status);
+  const nextCursorHref = events.nextCursor
+    ? `${ADMIN_ROUTES.monitoringDetail.href.replace('[gymId]', encodeURIComponent(params.gymId))}?cursor=${encodeURIComponent(events.nextCursor)}`
+    : null;
+
+  const locationParts = [summary.city, summary.state].filter((part): part is string => Boolean(part));
+  const locationLabel = locationParts.length > 0 ? locationParts.join(' · ') : 'Keine Ortsangabe';
+  const coordinateLabel = summary.location
+    ? `${summary.location.lat.toFixed(5)}, ${summary.location.lng.toFixed(5)}`
+    : '—';
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-10 px-6 py-12">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-wide text-muted">Monitoring</p>
+          <h1 className="mt-1 text-3xl font-semibold text-page">{summary.name}</h1>
+          <p className="mt-2 text-sm text-muted">{locationLabel}</p>
+          <p className="text-xs text-muted">Slug: {summary.slug} · Koordinaten: {coordinateLabel}</p>
+        </div>
+        <div className="flex flex-col items-end gap-3 text-right">
+          <span
+            className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm font-semibold ${resolveStatusBadge(status)}`}
+          >
+            <span className="inline-flex h-2 w-2 rounded-full bg-current opacity-80" aria-hidden />
+            {statusLabel}
+          </span>
+          <Link
+            href={ADMIN_ROUTES.monitoring.href}
+            className="text-sm font-semibold text-primary underline-offset-4 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          >
+            Zur Karte
+          </Link>
+        </div>
+      </div>
+
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <article className="rounded-lg border border-subtle bg-card p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted">Check-ins (24h)</p>
+          <p className="mt-2 text-2xl font-semibold text-page">{formatNumber(summary.status?.checkins24h)}</p>
+        </article>
+        <article className="rounded-lg border border-subtle bg-card p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted">Geräte online</p>
+          <p className="mt-2 text-2xl font-semibold text-page">{formatNumber(summary.status?.devicesOnline)}</p>
+        </article>
+        <article className="rounded-lg border border-subtle bg-card p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted">Letztes Ereignis</p>
+          <p className="mt-2 text-base font-semibold text-page">{formatTimestamp(summary.status?.lastEventAt ?? null)}</p>
+        </article>
+      </section>
+
+      <section className="space-y-4 rounded-lg border border-subtle bg-card p-6 shadow-sm">
+        <header className="space-y-1">
+          <h2 className="text-xl font-semibold text-page">Letzte Ereignisse</h2>
+          <p className="text-sm text-muted">
+            Ereignisprotokoll für dieses Gym. Datenbasis: Firestore collectionGroup('logs') mit Filter auf gymId.
+          </p>
+        </header>
+        {events.error ? (
+          <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-500/60 dark:bg-amber-500/10 dark:text-amber-200">
+            {events.error === 'Index erforderlich'
+              ? 'Keine Daten verfügbar. Firestore Index wird benötigt oder befindet sich im Aufbau.'
+              : 'Aktueller Ereignisstream konnte nicht geladen werden.'}
+          </div>
+        ) : null}
+        <AdminEventLogTable
+          entries={events.entries}
+          formatTimestamp={(date) => dateTimeFormatter.format(date)}
+          emptyLabel="Keine Ereignisse vorhanden."
+          showGymColumn={false}
+        />
+        {nextCursorHref ? (
+          <div className="text-right">
+            <Link
+              href={nextCursorHref}
+              className="text-sm font-semibold text-primary underline-offset-4 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            >
+              Weitere Ereignisse laden
+            </Link>
+          </div>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/website/src/app/(admin)/admin/monitoring/page.tsx
+++ b/website/src/app/(admin)/admin/monitoring/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next';
+
+import { requireRole } from '@/src/lib/auth/server';
+import { MonitoringMap } from '@/src/components/monitoring/monitoring-map';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export const metadata: Metadata = {
+  title: 'Monitoring',
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default async function MonitoringPage() {
+  await requireRole(['admin', 'owner'], { failure: 'not-found', loginSite: 'admin' });
+
+  return (
+    <div className="mx-auto w-full max-w-6xl space-y-8 px-6 py-12">
+      <header className="space-y-2">
+        <p className="text-sm font-semibold uppercase tracking-wide text-muted">Monitoring</p>
+        <h1 className="text-3xl font-semibold text-page">Standorte</h1>
+        <p className="max-w-2xl text-sm text-muted">
+          Interaktive Übersicht aller Tap&apos;em Studios mit gültigen Koordinaten. Klicke auf einen Marker, um die Detailansicht mit Statusdaten und
+          Ereignissen zu öffnen.
+        </p>
+      </header>
+      <MonitoringMap />
+    </div>
+  );
+}

--- a/website/src/app/(admin)/admin/page.tsx
+++ b/website/src/app/(admin)/admin/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 import { requireRole } from '@/lib/auth/server';
 import { ADMIN_ROUTES } from '@/lib/routes';
 import { fetchAdminDashboardData } from '@/server/admin/dashboard-data';
+import { AdminEventLogTable } from '@/components/admin/admin-event-log-table';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -192,47 +193,12 @@ export default async function AdminPage() {
             {dashboard.events.error}
           </div>
         ) : null}
-        {dashboard.events.items.length === 0 ? (
-          <div className="rounded-md border border-dashed border-subtle bg-card-muted px-4 py-6 text-sm text-muted">
-            Keine aktuellen Ereignisse vorhanden.
-          </div>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-[color:var(--page-border)]">
-              <thead className="bg-card-muted">
-                <tr>
-                  <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
-                    Zeitstempel
-                  </th>
-                  <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
-                    Gym / Gerät
-                  </th>
-                  <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
-                    Typ
-                  </th>
-                  <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
-                    Details
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-[color:var(--page-border)]">
-                {dashboard.events.items.map((event) => (
-                  <tr key={`${event.id}-${event.timestamp.toISOString()}`} className="hover:bg-card-muted">
-                    <td className="whitespace-nowrap px-4 py-3 text-sm text-page">{formatDateTime(event.timestamp)}</td>
-                    <td className="whitespace-nowrap px-4 py-3 text-sm text-muted">
-                      {event.gymId ? `Gym ${event.gymId}` : '–'}
-                      {event.deviceId ? ` · Gerät ${event.deviceId}` : ''}
-                    </td>
-                    <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-page">
-                      {event.type ?? 'log'}
-                    </td>
-                    <td className="px-4 py-3 text-sm text-page">{event.description ?? 'Keine Beschreibung'}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
+        <AdminEventLogTable
+          entries={dashboard.events.items}
+          formatTimestamp={formatDateTime}
+          emptyLabel="Keine aktuellen Ereignisse vorhanden."
+          showGymColumn
+        />
         <p className="text-xs text-muted">
           Quelle: Firestore collectionGroup('logs') · Zugriff nur mit Admin-Session
         </p>

--- a/website/src/app/api/admin/gyms.geojson/route.ts
+++ b/website/src/app/api/admin/gyms.geojson/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from 'next/server';
+import { createHash } from 'crypto';
+
+import { getAdminUserFromSession } from '@/src/server/auth/session';
+import { fetchGymsForMap } from '@/src/server/monitoring';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+const CACHE_HEADER_VALUE = 'private, max-age=60';
+const EMPTY_HEADERS = new Headers({ 'Cache-Control': CACHE_HEADER_VALUE });
+
+function buildEtag(payload: string): string {
+  const hash = createHash('sha1').update(payload).digest('base64url');
+  return `"${hash}"`;
+}
+
+export async function GET(request: Request) {
+  const debugId = Math.random().toString(36).slice(2, 8);
+  try {
+    const user = await getAdminUserFromSession();
+    if (!user) {
+      return NextResponse.json({ error: 'unauthorized', requestId: debugId }, { status: 401, headers: EMPTY_HEADERS });
+    }
+    if (user.role !== 'admin' && user.role !== 'owner') {
+      return NextResponse.json({ error: 'forbidden', requestId: debugId }, { status: 403, headers: EMPTY_HEADERS });
+    }
+
+    const { gyms, total, missingLocation } = await fetchGymsForMap();
+    const featureCollection = {
+      type: 'FeatureCollection' as const,
+      features: gyms.map((gym) => ({
+        type: 'Feature' as const,
+        geometry: {
+          type: 'Point' as const,
+          coordinates: [gym.location.lng, gym.location.lat],
+        },
+        properties: {
+          id: gym.id,
+          name: gym.name,
+          slug: gym.slug,
+          city: gym.city ?? null,
+          state: gym.state ?? null,
+          status: gym.status?.status ?? null,
+          checkins24h: gym.status?.checkins24h ?? null,
+          devicesOnline: gym.status?.devicesOnline ?? null,
+        },
+      })),
+      meta: {
+        total,
+        missingLocation,
+      },
+    };
+
+    const body = JSON.stringify(featureCollection);
+    const etag = buildEtag(body);
+    const headers = new Headers({
+      'Content-Type': 'application/geo+json; charset=utf-8',
+      'Cache-Control': CACHE_HEADER_VALUE,
+      ETag: etag,
+    });
+
+    const ifNoneMatch = request.headers.get('if-none-match');
+    if (ifNoneMatch && ifNoneMatch.replace(/^W\//, '') === etag.replace(/^W\//, '')) {
+      return new Response(null, { status: 304, headers });
+    }
+
+    console.info(`[admin-monitoring] ${debugId} gyms=${gyms.length} missing=${missingLocation}`);
+    return new Response(body, { status: 200, headers });
+  } catch (error) {
+    console.error(`[admin-monitoring] ${debugId} failed`, error);
+    return NextResponse.json({ error: 'internal_error', requestId: debugId }, { status: 500, headers: EMPTY_HEADERS });
+  }
+}

--- a/website/src/components/admin/admin-event-log-table.tsx
+++ b/website/src/components/admin/admin-event-log-table.tsx
@@ -1,0 +1,66 @@
+import type { AdminEventLogEntry } from '@/src/server/admin/dashboard-data';
+
+const defaultEmptyLabel = 'Keine Ereignisse vorhanden.';
+
+export function AdminEventLogTable({
+  entries,
+  formatTimestamp,
+  emptyLabel = defaultEmptyLabel,
+  showGymColumn = true,
+}: {
+  entries: AdminEventLogEntry[];
+  formatTimestamp: (value: Date) => string;
+  emptyLabel?: string;
+  showGymColumn?: boolean;
+}) {
+  if (entries.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-subtle bg-card-muted px-4 py-6 text-sm text-muted">
+        {emptyLabel}
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-[color:var(--page-border)]">
+        <thead className="bg-card-muted">
+          <tr>
+            <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
+              Zeitstempel
+            </th>
+            {showGymColumn ? (
+              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
+                Gym / Gerät
+              </th>
+            ) : (
+              <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
+                Gerät
+              </th>
+            )}
+            <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
+              Typ
+            </th>
+            <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
+              Details
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-[color:var(--page-border)]">
+          {entries.map((event) => (
+            <tr key={`${event.id}-${event.timestamp.toISOString()}`} className="hover:bg-card-muted">
+              <td className="whitespace-nowrap px-4 py-3 text-sm text-page">{formatTimestamp(event.timestamp)}</td>
+              <td className="whitespace-nowrap px-4 py-3 text-sm text-muted">
+                {showGymColumn ? (event.gymId ? `Gym ${event.gymId}` : '–') : null}
+                {showGymColumn && event.deviceId ? ` · Gerät ${event.deviceId}` : null}
+                {!showGymColumn ? (event.deviceId ? `Gerät ${event.deviceId}` : '–') : null}
+              </td>
+              <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-page">{event.type ?? 'log'}</td>
+              <td className="px-4 py-3 text-sm text-page">{event.description ?? 'Keine Beschreibung'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/website/src/components/layout/admin-shell.tsx
+++ b/website/src/components/layout/admin-shell.tsx
@@ -14,6 +14,7 @@ type NavigationItem = {
   label: string;
   route?: AdminRouteDefinition;
   disabled?: boolean;
+  icon?: ReactNode;
 };
 
 const NAVIGATION: NavigationItem[] = [
@@ -22,6 +23,7 @@ const NAVIGATION: NavigationItem[] = [
   { label: 'Geräteverwaltung', disabled: true },
   { label: 'Challenges', disabled: true },
   { label: 'Event-Logs', disabled: true },
+  { label: 'Monitoring', route: ADMIN_ROUTES.monitoring, icon: '📡' },
 ];
 
 function NavigationMenu({ items }: { items: NavigationItem[] }) {
@@ -46,7 +48,14 @@ function NavigationMenu({ items }: { items: NavigationItem[] }) {
             href={item.route.href}
             className="block rounded-md px-3 py-2 text-sm font-medium text-page transition hover:bg-card-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
           >
-            {item.label}
+            <span className="flex items-center gap-2">
+              {item.icon ? (
+                <span aria-hidden className="text-base leading-none">
+                  {item.icon}
+                </span>
+              ) : null}
+              <span>{item.label}</span>
+            </span>
           </Link>
         );
       })}

--- a/website/src/components/monitoring/monitoring-map.tsx
+++ b/website/src/components/monitoring/monitoring-map.tsx
@@ -1,0 +1,568 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { buildAdminMonitoringDetailRoute } from '@/src/lib/routes';
+
+type MapLibreModule = any;
+type MapLibreMap = any;
+type GeoJSONSource = any;
+type Popup = any;
+
+declare global {
+  interface Window {
+    maplibregl?: MapLibreModule;
+  }
+}
+
+let mapLibreLoader: Promise<MapLibreModule> | null = null;
+
+function ensureMapLibreStyle() {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  if (document.querySelector('link[data-maplibre-style="true"]')) {
+    return;
+  }
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = 'https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css';
+  link.setAttribute('data-maplibre-style', 'true');
+  document.head.appendChild(link);
+}
+
+async function loadMapLibre(): Promise<MapLibreModule> {
+  if (typeof window === 'undefined') {
+    throw new Error('MapLibre benötigt eine Browser-Umgebung.');
+  }
+  ensureMapLibreStyle();
+  if (window.maplibregl) {
+    return window.maplibregl;
+  }
+  if (!mapLibreLoader) {
+    mapLibreLoader = new Promise<MapLibreModule>((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = 'https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js';
+      script.async = true;
+      script.onload = () => {
+        if (window.maplibregl) {
+          resolve(window.maplibregl);
+        } else {
+          mapLibreLoader = null;
+          reject(new Error('MapLibre konnte nicht initialisiert werden.'));
+        }
+      };
+      script.onerror = () => {
+        script.remove();
+        mapLibreLoader = null;
+        reject(new Error('MapLibre-Skript konnte nicht geladen werden.'));
+      };
+      document.head.appendChild(script);
+    });
+  }
+  return mapLibreLoader;
+}
+
+type GymFeatureProperties = {
+  id: string;
+  name: string;
+  slug: string;
+  city: string | null;
+  state: string | null;
+  status: 'online' | 'offline' | 'degraded' | null;
+  checkins24h: number | null;
+  devicesOnline: number | null;
+};
+
+type MapFeature = {
+  type: 'Feature';
+  geometry: { type: 'Point'; coordinates: [number, number] };
+  properties: GymFeatureProperties;
+};
+
+type MapResponse = {
+  type: 'FeatureCollection';
+  features: MapFeature[];
+  meta?: {
+    total?: number;
+    missingLocation?: number;
+  };
+};
+
+type ThemeMode = 'light' | 'dark';
+
+const STYLE_URLS: Record<ThemeMode, string> = {
+  light: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
+  dark: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
+};
+
+const STATUS_COLORS: Record<'online' | 'offline' | 'degraded' | 'unknown', string> = {
+  online: '#16a34a',
+  degraded: '#f97316',
+  offline: '#dc2626',
+  unknown: '#64748b',
+};
+
+const DEFAULT_CENTER: [number, number] = [10.451526, 51.165691];
+const DEFAULT_ZOOM = 4.8;
+
+function useResolvedTheme(): ThemeMode {
+  const [theme, setTheme] = useState<ThemeMode>('light');
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const root = document.documentElement;
+    const readTheme = () => {
+      const attr = root.getAttribute('data-theme');
+      setTheme(attr === 'dark' ? 'dark' : 'light');
+    };
+    readTheme();
+    const observer = new MutationObserver(readTheme);
+    observer.observe(root, { attributes: true, attributeFilter: ['data-theme'] });
+    return () => observer.disconnect();
+  }, []);
+
+  return theme;
+}
+
+function formatStatusLabel(status: GymFeatureProperties['status']): string {
+  if (status === 'online') return 'Online';
+  if (status === 'degraded') return 'Eingeschränkt';
+  if (status === 'offline') return 'Offline';
+  return 'Unbekannt';
+}
+
+function buildPopupContent(feature: GymFeatureProperties): HTMLDivElement {
+  const container = document.createElement('div');
+  container.className = 'space-y-2 text-sm text-page';
+
+  const title = document.createElement('h3');
+  title.className = 'text-base font-semibold text-page';
+  title.textContent = feature.name;
+  container.appendChild(title);
+
+  if (feature.city || feature.state) {
+    const location = document.createElement('p');
+    location.className = 'text-xs text-muted';
+    location.textContent = [feature.city, feature.state].filter(Boolean).join(' · ');
+    container.appendChild(location);
+  }
+
+  const status = document.createElement('p');
+  status.className = 'text-xs text-muted';
+  const statusLabel = formatStatusLabel(feature.status);
+  const statusDetails: string[] = [statusLabel];
+  if (typeof feature.devicesOnline === 'number') {
+    statusDetails.push(`${feature.devicesOnline} Geräte aktiv`);
+  }
+  if (typeof feature.checkins24h === 'number') {
+    statusDetails.push(`${feature.checkins24h} Check-ins (24h)`);
+  }
+  status.textContent = statusDetails.join(' · ');
+  container.appendChild(status);
+
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className =
+    'w-full rounded-md border border-primary bg-primary px-3 py-2 text-sm font-semibold text-white transition hover:bg-primary/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary';
+  button.textContent = 'Details ansehen';
+  button.setAttribute('data-gym-id', feature.id);
+  container.appendChild(button);
+
+  return container;
+}
+
+export function MonitoringMap() {
+  const router = useRouter();
+  const theme = useResolvedTheme();
+  const mapContainerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<MapLibreMap | null>(null);
+  const moduleRef = useRef<MapLibreModule | null>(null);
+  const popupRef = useRef<Popup | null>(null);
+  const handlersRef = useRef<{
+    clusterClick?: (event: any) => void;
+    pointClick?: (event: any) => void;
+    pointEnter?: (event: any) => void;
+    pointLeave?: (event: any) => void;
+  }>({});
+  const hasFitBoundsRef = useRef(false);
+
+  const [data, setData] = useState<MapResponse | null>(null);
+  const [meta, setMeta] = useState<{ total: number; missing: number }>({ total: 0, missing: 0 });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const withLocation = data?.features.length ?? 0;
+  const withoutLocation = meta.missing;
+  const totalGyms = meta.total;
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/admin/gyms.geojson', {
+        headers: { Accept: 'application/geo+json' },
+      });
+      if (response.status === 401 || response.status === 403) {
+        throw new Error('Zugriff verweigert. Bitte melde dich erneut als Admin an.');
+      }
+      if (!response.ok) {
+        throw new Error('Standortdaten konnten nicht geladen werden.');
+      }
+      const json = (await response.json()) as MapResponse;
+      setData(json);
+      hasFitBoundsRef.current = false;
+      setMeta({
+        total: typeof json.meta?.total === 'number' ? json.meta.total : json.features.length,
+        missing: typeof json.meta?.missingLocation === 'number' ? json.meta.missingLocation : 0,
+      });
+    } catch (err) {
+      console.error('[admin-monitoring] map data load failed', err);
+      setError(err instanceof Error ? err.message : 'Unbekannter Fehler beim Laden der Karte.');
+      setData(null);
+      setMeta({ total: 0, missing: 0 });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const resetPopup = useCallback(() => {
+    popupRef.current?.remove();
+    popupRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        resetPopup();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [resetPopup]);
+
+  useEffect(() => {
+    return () => {
+      resetPopup();
+      if (mapRef.current) {
+        mapRef.current.remove();
+        mapRef.current = null;
+      }
+    };
+  }, [resetPopup]);
+
+  const attachInteractions = useCallback(
+    (map: MapLibreMap, module: MapLibreModule) => {
+      const mapCanvas = map.getCanvas();
+      mapCanvas.setAttribute('role', 'application');
+      mapCanvas.setAttribute('tabindex', '0');
+      mapCanvas.setAttribute('aria-label', 'Monitoring-Karte der Studios');
+
+      if (handlersRef.current?.clusterClick) {
+        map.off('click', 'gym-clusters', handlersRef.current.clusterClick);
+      }
+      if (handlersRef.current?.pointClick) {
+        map.off('click', 'gym-points', handlersRef.current.pointClick);
+      }
+      if (handlersRef.current?.pointEnter) {
+        map.off('mouseenter', 'gym-points', handlersRef.current.pointEnter);
+      }
+      if (handlersRef.current?.pointLeave) {
+        map.off('mouseleave', 'gym-points', handlersRef.current.pointLeave);
+      }
+
+      const clusterClick = (event: any) => {
+        const features = map.queryRenderedFeatures(event.point, { layers: ['gym-clusters'] });
+        const cluster = features[0];
+        const source = map.getSource('gyms') as GeoJSONSource | undefined;
+        if (cluster && source) {
+          const clusterId = cluster.properties?.cluster_id as number | undefined;
+          if (clusterId !== undefined) {
+            source.getClusterExpansionZoom(clusterId, (err, zoom) => {
+              if (err) {
+                return;
+              }
+              map.easeTo({ center: (cluster.geometry as any).coordinates, zoom });
+            });
+          }
+        }
+      };
+
+      const pointClick = (event: any) => {
+        const [feature] = event.features ?? [];
+        if (!feature || feature.geometry.type !== 'Point') {
+          return;
+        }
+        const coordinates = feature.geometry.coordinates.slice() as [number, number];
+        const properties = feature.properties as GymFeatureProperties;
+        const popupContent = buildPopupContent(properties);
+        const button = popupContent.querySelector('button[data-gym-id]');
+        if (button) {
+          button.addEventListener('click', () => {
+            resetPopup();
+            router.push(buildAdminMonitoringDetailRoute(properties.id));
+          });
+        }
+        resetPopup();
+        const popup = new module.Popup({ closeButton: true, closeOnMove: false, offset: 12, focusAfterOpen: false })
+          .setDOMContent(popupContent)
+          .setLngLat(coordinates)
+          .addTo(map);
+        popupRef.current = popup;
+      };
+
+      const pointEnter = (event: any) => {
+        map.getCanvas().style.cursor = 'pointer';
+        const [feature] = event.features ?? [];
+        if (feature) {
+          const props = feature.properties as GymFeatureProperties;
+          map.getCanvas().setAttribute(
+            'aria-label',
+            `Marker: ${props.name}${props.city ? `, ${props.city}` : ''} (${formatStatusLabel(props.status)})`
+          );
+        }
+      };
+
+      const pointLeave = () => {
+        map.getCanvas().style.cursor = '';
+        map.getCanvas().setAttribute('aria-label', 'Monitoring-Karte der Studios');
+      };
+
+      map.on('click', 'gym-clusters', clusterClick);
+      map.on('click', 'gym-points', pointClick);
+      map.on('mouseenter', 'gym-points', pointEnter);
+      map.on('mouseleave', 'gym-points', pointLeave);
+
+      handlersRef.current = { clusterClick, pointClick, pointEnter, pointLeave };
+    },
+    [resetPopup, router]
+  );
+
+  const applyDataToMap = useCallback(
+    (map: MapLibreMap, module: MapLibreModule, collection: MapResponse) => {
+      if (map.getLayer('gym-clusters')) {
+        map.removeLayer('gym-clusters');
+      }
+      if (map.getLayer('gym-cluster-count')) {
+        map.removeLayer('gym-cluster-count');
+      }
+      if (map.getLayer('gym-points')) {
+        map.removeLayer('gym-points');
+      }
+      if (map.getSource('gyms')) {
+        map.removeSource('gyms');
+      }
+
+      map.addSource('gyms', {
+        type: 'geojson',
+        data: collection,
+        cluster: true,
+        clusterRadius: 60,
+        clusterMaxZoom: 12,
+      });
+
+      map.addLayer({
+        id: 'gym-clusters',
+        type: 'circle',
+        source: 'gyms',
+        filter: ['has', 'point_count'],
+        paint: {
+          'circle-color': '#2563eb',
+          'circle-radius': ['step', ['get', 'point_count'], 16, 10, 22, 25, 30],
+          'circle-opacity': 0.8,
+        },
+      });
+
+      map.addLayer({
+        id: 'gym-cluster-count',
+        type: 'symbol',
+        source: 'gyms',
+        filter: ['has', 'point_count'],
+        layout: {
+          'text-field': ['to-string', ['get', 'point_count']],
+          'text-font': ['Open Sans Semibold'],
+          'text-size': 12,
+        },
+        paint: {
+          'text-color': '#ffffff',
+        },
+      });
+
+      map.addLayer({
+        id: 'gym-points',
+        type: 'circle',
+        source: 'gyms',
+        filter: ['!', ['has', 'point_count']],
+        paint: {
+          'circle-color': [
+            'match',
+            ['get', 'status'],
+            'online',
+            STATUS_COLORS.online,
+            'degraded',
+            STATUS_COLORS.degraded,
+            'offline',
+            STATUS_COLORS.offline,
+            STATUS_COLORS.unknown,
+          ],
+          'circle-radius': 9,
+          'circle-stroke-width': 2,
+          'circle-stroke-color': theme === 'dark' ? '#0f172a' : '#ffffff',
+        },
+      });
+
+      attachInteractions(map, module);
+
+      if (!hasFitBoundsRef.current) {
+        if (collection.features.length > 0) {
+          const bounds = collection.features.reduce(
+            (acc, feature) => {
+              const [lng, lat] = feature.geometry.coordinates;
+              acc[0][0] = Math.min(acc[0][0], lng);
+              acc[0][1] = Math.min(acc[0][1], lat);
+              acc[1][0] = Math.max(acc[1][0], lng);
+              acc[1][1] = Math.max(acc[1][1], lat);
+              return acc;
+            },
+            [
+              [collection.features[0].geometry.coordinates[0], collection.features[0].geometry.coordinates[1]],
+              [collection.features[0].geometry.coordinates[0], collection.features[0].geometry.coordinates[1]],
+            ] as [[number, number], [number, number]]
+          );
+          map.fitBounds(bounds, { padding: 60, maxZoom: 12, duration: 700 });
+        } else {
+          map.setCenter(DEFAULT_CENTER);
+          map.setZoom(DEFAULT_ZOOM);
+        }
+        hasFitBoundsRef.current = true;
+      }
+    },
+    [attachInteractions, theme]
+  );
+
+  const initializeMap = useCallback(
+    async (collection: MapResponse) => {
+      if (!mapContainerRef.current) {
+        return;
+      }
+      if (!moduleRef.current) {
+        moduleRef.current = await loadMapLibre();
+      }
+      const module = moduleRef.current;
+      if (!module) {
+        return;
+      }
+      if (!mapRef.current) {
+        const map = new module.Map({
+          container: mapContainerRef.current,
+          style: STYLE_URLS[theme],
+          center: DEFAULT_CENTER,
+          zoom: DEFAULT_ZOOM,
+          attributionControl: true,
+        });
+        mapRef.current = map;
+        map.addControl(new module.NavigationControl({ visualizePitch: false, showCompass: false }), 'top-right');
+        map.on('load', () => {
+          applyDataToMap(map, module, collection);
+        });
+      } else {
+        applyDataToMap(mapRef.current, module, collection);
+      }
+    },
+    [applyDataToMap, theme]
+  );
+
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+    initializeMap(data);
+  }, [data, initializeMap]);
+
+  useEffect(() => {
+    if (!data || !mapRef.current || !moduleRef.current) {
+      return;
+    }
+    const map = mapRef.current;
+    const module = moduleRef.current;
+    const onStyleData = () => {
+      if (map.isStyleLoaded()) {
+        applyDataToMap(map, module, data);
+      }
+    };
+    map.once('styledata', onStyleData);
+    map.setStyle(STYLE_URLS[theme]);
+    return () => {
+      map.off('styledata', onStyleData);
+    };
+  }, [theme, data, applyDataToMap]);
+
+  const infoBoxes = useMemo(() => {
+    const boxes = [
+      {
+        label: 'Mit Koordinate',
+        value: loading ? '–' : withLocation.toString(),
+      },
+      {
+        label: 'Ohne Koordinate',
+        value: loading ? '–' : withoutLocation.toString(),
+      },
+      {
+        label: 'Gesamt',
+        value: loading ? '–' : totalGyms.toString(),
+      },
+    ];
+    return boxes;
+  }, [loading, totalGyms, withLocation, withoutLocation]);
+
+  return (
+    <section className="space-y-5">
+      <div className="flex flex-wrap gap-3">
+        {infoBoxes.map((box) => (
+          <div key={box.label} className="rounded-lg border border-subtle bg-card px-4 py-3 text-sm">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted">{box.label}</p>
+            <p className="mt-1 text-base font-semibold text-page">{box.value}</p>
+          </div>
+        ))}
+      </div>
+
+      {error ? (
+        <div className="space-y-3 rounded-lg border border-rose-200 bg-rose-50 p-6 text-sm text-rose-900 dark:border-rose-500/50 dark:bg-rose-500/10 dark:text-rose-100">
+          <p className="font-semibold">Karte konnte nicht geladen werden.</p>
+          <p>{error}</p>
+          <button
+            type="button"
+            onClick={() => loadData()}
+            className="rounded-md border border-primary bg-primary px-3 py-2 text-sm font-semibold text-white transition hover:bg-primary/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+          >
+            Erneut versuchen
+          </button>
+        </div>
+      ) : null}
+
+      {!error ? (
+        <div className="relative min-h-[480px] overflow-hidden rounded-xl border border-subtle bg-card">
+          {loading ? (
+            <div className="absolute inset-0 flex items-center justify-center">
+              <div className="h-12 w-12 animate-spin rounded-full border-4 border-subtle border-t-primary" aria-label="Lade Karte" />
+            </div>
+          ) : null}
+          {!loading && data && data.features.length === 0 ? (
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-sm text-muted">
+              <p className="font-semibold text-page">Keine Standorte mit Koordinaten</p>
+              <p>Bitte trage Geopunkte in Firestore ein, um die Karte zu befüllen.</p>
+            </div>
+          ) : null}
+          <div ref={mapContainerRef} className="h-[520px] w-full" aria-hidden={loading || Boolean(error)} />
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/website/src/lib/routes.ts
+++ b/website/src/lib/routes.ts
@@ -54,6 +54,8 @@ export const ADMIN_ROUTES = {
   dashboard: defineRoute('admin', '/admin' as Route),
   login: defineRoute('admin', '/admin/login' as Route),
   logout: defineRoute('admin', '/admin/logout' as Route),
+  monitoring: defineRoute('admin', '/admin/monitoring' as Route),
+  monitoringDetail: defineRoute('admin', '/admin/monitoring/[gymId]' as Route),
 } as const;
 
 export type AdminRouteDefinition =
@@ -133,7 +135,10 @@ const ADMIN_PUBLIC_PATHS = buildPathSet([
 
 const ADMIN_PROTECTED_PATHS = buildPathSet([
   ADMIN_ROUTES.dashboard.href,
+  ADMIN_ROUTES.monitoring.href,
 ]);
+
+const ADMIN_PROTECTED_PREFIXES = ['/admin/monitoring/'];
 
 export const AFTER_LOGIN_ROUTES = [
   PORTAL_ROUTES.gym,
@@ -239,6 +244,11 @@ export function buildAdminLoginRedirectRoute(target: AdminAfterLoginRoute): Rout
   return `${ADMIN_ROUTES.login.href}?next=${target}` as Route;
 }
 
+export function buildAdminMonitoringDetailRoute(gymId: string): Route {
+  const safe = encodeURIComponent(gymId);
+  return `/admin/monitoring/${safe}` as Route;
+}
+
 export function normalizePathname(pathname: string): string {
   if (!pathname) {
     return '/';
@@ -267,14 +277,21 @@ export function isPortalProtectedPath(pathname: string): boolean {
 
 export function isAdminPath(pathname: string): boolean {
   const normalized = normalizePathname(pathname);
-  return (
+  if (
     ADMIN_PUBLIC_PATHS.has(normalized) ||
     ADMIN_PROTECTED_PATHS.has(normalized)
-  );
+  ) {
+    return true;
+  }
+  return ADMIN_PROTECTED_PREFIXES.some((prefix) => normalized.startsWith(prefix));
 }
 
 export function isAdminProtectedPath(pathname: string): boolean {
-  return ADMIN_PROTECTED_PATHS.has(normalizePathname(pathname));
+  const normalized = normalizePathname(pathname);
+  if (ADMIN_PROTECTED_PATHS.has(normalized)) {
+    return true;
+  }
+  return ADMIN_PROTECTED_PREFIXES.some((prefix) => normalized.startsWith(prefix));
 }
 
 export function isRouteAllowedOnSite(pathname: string, site: SiteKey): boolean {

--- a/website/src/server/monitoring.ts
+++ b/website/src/server/monitoring.ts
@@ -1,0 +1,349 @@
+import 'server-only';
+
+import { FieldPath, GeoPoint, Timestamp, type QueryDocumentSnapshot } from 'firebase-admin/firestore';
+
+import { adminDb } from '@/src/server/firebase/admin';
+import type { AdminEventLogEntry } from '@/src/server/admin/dashboard-data';
+
+export type MonitoringGymStatus = {
+  status?: 'online' | 'offline' | 'degraded';
+  checkins24h?: number;
+  devicesOnline?: number;
+  lastEventAt?: Date | null;
+};
+
+export type MonitoringGymSummary = {
+  id: string;
+  name: string;
+  slug: string;
+  city?: string;
+  state?: string;
+  location: { lat: number; lng: number } | null;
+  active: boolean;
+  status: MonitoringGymStatus | null;
+};
+
+export type MapGymFeature = Omit<MonitoringGymSummary, 'location' | 'status'> & {
+  location: { lat: number; lng: number };
+  status: MonitoringGymStatus | null;
+};
+
+export type FetchGymsForMapResult = {
+  gyms: MapGymFeature[];
+  total: number;
+  missingLocation: number;
+};
+
+export type FetchGymMonitoringSummaryResult = MonitoringGymSummary | null;
+
+export type FetchGymEventLogsOptions = {
+  limit?: number;
+  cursor?: string | null;
+};
+
+export type FetchGymEventLogsResult = {
+  entries: AdminEventLogEntry[];
+  nextCursor: string | null;
+  error?: string;
+};
+
+function toDate(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return value;
+  }
+  if (value instanceof Timestamp) {
+    return value.toDate();
+  }
+  if (value && typeof (value as { toDate?: () => Date }).toDate === 'function') {
+    try {
+      return (value as { toDate: () => Date }).toDate();
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function parseGeoPoint(value: unknown): { lat: number; lng: number } | null {
+  if (value instanceof GeoPoint) {
+    return { lat: value.latitude, lng: value.longitude };
+  }
+  if (
+    value &&
+    typeof value === 'object' &&
+    typeof (value as { latitude?: unknown }).latitude === 'number' &&
+    typeof (value as { longitude?: unknown }).longitude === 'number'
+  ) {
+    return {
+      lat: (value as { latitude: number }).latitude,
+      lng: (value as { longitude: number }).longitude,
+    };
+  }
+  if (
+    value &&
+    typeof value === 'object' &&
+    typeof (value as { lat?: unknown }).lat === 'number' &&
+    typeof (value as { lng?: unknown }).lng === 'number'
+  ) {
+    return {
+      lat: (value as { lat: number }).lat,
+      lng: (value as { lng: number }).lng,
+    };
+  }
+  return null;
+}
+
+function parseStatus(data: unknown): MonitoringGymStatus | null {
+  if (!data || typeof data !== 'object') {
+    return null;
+  }
+  const record = data as Record<string, unknown>;
+  const statusRaw = record.status;
+  const status =
+    statusRaw === 'online' || statusRaw === 'offline' || statusRaw === 'degraded'
+      ? statusRaw
+      : undefined;
+  const checkins24h = typeof record.checkins24h === 'number' ? record.checkins24h : undefined;
+  const devicesOnline = typeof record.devicesOnline === 'number' ? record.devicesOnline : undefined;
+  const lastEventAt = toDate(record.lastEventAt) ?? null;
+  if (!status && checkins24h === undefined && devicesOnline === undefined && !lastEventAt) {
+    return null;
+  }
+  return {
+    status,
+    checkins24h,
+    devicesOnline,
+    lastEventAt,
+  };
+}
+
+function mergeStatus(primary: MonitoringGymStatus | null, secondary: MonitoringGymStatus | null): MonitoringGymStatus | null {
+  if (!primary && !secondary) {
+    return null;
+  }
+  return {
+    status: primary?.status ?? secondary?.status,
+    checkins24h: primary?.checkins24h ?? secondary?.checkins24h,
+    devicesOnline: primary?.devicesOnline ?? secondary?.devicesOnline,
+    lastEventAt: primary?.lastEventAt ?? secondary?.lastEventAt ?? null,
+  };
+}
+
+function encodeCursor(path: string): string {
+  return Buffer.from(path, 'utf8').toString('base64url');
+}
+
+function decodeCursor(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  try {
+    const decoded = Buffer.from(value, 'base64url').toString('utf8');
+    if (!decoded.startsWith('gyms/')) {
+      return null;
+    }
+    if (!decoded.includes('/logs/')) {
+      return null;
+    }
+    return decoded;
+  } catch {
+    return null;
+  }
+}
+
+function isFailedPrecondition(error: unknown): boolean {
+  const code = (error as { code?: unknown }).code;
+  if (typeof code === 'number') {
+    return code === 9;
+  }
+  if (typeof code === 'string') {
+    return code.toLowerCase() === 'failed-precondition';
+  }
+  const message = (error as { message?: unknown }).message;
+  if (typeof message === 'string') {
+    return message.toLowerCase().includes('failed_precondition');
+  }
+  const details = (error as { details?: unknown }).details;
+  if (typeof details === 'string') {
+    return details.toLowerCase().includes('failed_precondition');
+  }
+  return false;
+}
+
+export async function fetchGymsForMap(): Promise<FetchGymsForMapResult> {
+  const firestore = adminDb();
+  const [gymsSnapshot, rootStatusSnapshot, nestedStatusSnapshot] = await Promise.all([
+    firestore.collection('gyms').get(),
+    firestore.collection('gymStatus').get().catch(() => null),
+    firestore
+      .collectionGroup('status')
+      .where(FieldPath.documentId(), '==', 'current')
+      .get()
+      .catch(() => null),
+  ]);
+
+  const total = gymsSnapshot.size;
+  let missingLocation = 0;
+  const statusMap = new Map<string, MonitoringGymStatus | null>();
+
+  if (rootStatusSnapshot) {
+    rootStatusSnapshot.docs.forEach((doc) => {
+      statusMap.set(doc.id, parseStatus(doc.data()));
+    });
+  }
+
+  if (nestedStatusSnapshot) {
+    nestedStatusSnapshot.docs.forEach((doc) => {
+      const parent = doc.ref.parent?.parent;
+      const gymId = parent?.id;
+      if (!gymId) {
+        return;
+      }
+      const parsed = parseStatus(doc.data());
+      const existing = statusMap.get(gymId) ?? null;
+      statusMap.set(gymId, mergeStatus(parsed, existing));
+    });
+  }
+
+  const gyms: MapGymFeature[] = [];
+
+  gymsSnapshot.docs.forEach((doc) => {
+    const data = doc.data() as Record<string, unknown>;
+    const location = parseGeoPoint(data.location);
+    if (!location) {
+      missingLocation += 1;
+      return;
+    }
+
+    const name = typeof data.name === 'string' && data.name.trim().length > 0 ? data.name : `Gym ${doc.id}`;
+    const slug = typeof data.slug === 'string' && data.slug.trim().length > 0 ? data.slug : doc.id;
+    const city = typeof data.city === 'string' && data.city.trim().length > 0 ? data.city : undefined;
+    const state = typeof data.state === 'string' && data.state.trim().length > 0 ? data.state : undefined;
+    const active = typeof data.active === 'boolean' ? data.active : true;
+    const status = statusMap.get(doc.id) ?? null;
+
+    gyms.push({
+      id: doc.id,
+      name,
+      slug,
+      city,
+      state,
+      location,
+      active,
+      status,
+    });
+  });
+
+  return {
+    gyms,
+    total,
+    missingLocation,
+  };
+}
+
+export async function fetchGymMonitoringSummary(gymId: string): Promise<FetchGymMonitoringSummaryResult> {
+  const firestore = adminDb();
+  const gymRef = firestore.collection('gyms').doc(gymId);
+  const [gymSnapshot, rootStatusSnapshot, nestedStatusSnapshot] = await Promise.all([
+    gymRef.get(),
+    firestore.collection('gymStatus').doc(gymId).get().catch(() => null),
+    gymRef.collection('status').doc('current').get().catch(() => null),
+  ]);
+
+  if (!gymSnapshot.exists) {
+    return null;
+  }
+
+  const data = gymSnapshot.data() as Record<string, unknown>;
+  const name = typeof data.name === 'string' && data.name.trim().length > 0 ? data.name : `Gym ${gymId}`;
+  const slug = typeof data.slug === 'string' && data.slug.trim().length > 0 ? data.slug : gymId;
+  const city = typeof data.city === 'string' && data.city.trim().length > 0 ? data.city : undefined;
+  const state = typeof data.state === 'string' && data.state.trim().length > 0 ? data.state : undefined;
+  const active = typeof data.active === 'boolean' ? data.active : true;
+  const location = parseGeoPoint(data.location);
+
+  const rootStatus = rootStatusSnapshot?.exists ? parseStatus(rootStatusSnapshot.data()) : null;
+  const nestedStatus = nestedStatusSnapshot?.exists ? parseStatus(nestedStatusSnapshot.data()) : null;
+  const status = mergeStatus(rootStatus, nestedStatus);
+
+  return {
+    id: gymId,
+    name,
+    slug,
+    city,
+    state,
+    location,
+    active,
+    status,
+  };
+}
+
+function mapEventDoc(doc: QueryDocumentSnapshot): AdminEventLogEntry | null {
+  const data = doc.data() as Record<string, unknown>;
+  const timestampValue = data.timestamp ?? (data as { timestamp?: unknown }).timestamp;
+  const timestamp = toDate(timestampValue);
+  if (!timestamp) {
+    return null;
+  }
+  const segments = doc.ref.path.split('/');
+  const gymId = segments.length >= 2 ? segments[1] : undefined;
+  const deviceId = segments.length >= 4 ? segments[3] : undefined;
+  const typeValue = data.type ?? (data as { eventType?: unknown }).eventType;
+  const type = typeof typeValue === 'string' ? typeValue : undefined;
+  const descriptionValue =
+    typeof data.description === 'string'
+      ? data.description
+      : typeof (data as { message?: unknown }).message === 'string'
+      ? ((data as { message: string }).message as string)
+      : undefined;
+
+  return {
+    id: doc.id,
+    timestamp,
+    gymId,
+    deviceId,
+    type,
+    description: descriptionValue,
+  };
+}
+
+export async function fetchGymEventLogs(
+  gymId: string,
+  options?: FetchGymEventLogsOptions
+): Promise<FetchGymEventLogsResult> {
+  const firestore = adminDb();
+  const pageSize = Math.min(Math.max(options?.limit ?? 20, 1), 100);
+  const cursorPath = decodeCursor(options?.cursor);
+
+  try {
+    let query = firestore
+      .collectionGroup('logs')
+      .where('gymId', '==', gymId)
+      .orderBy('timestamp', 'desc');
+
+    if (cursorPath && cursorPath.includes(`/gyms/${gymId}/`)) {
+      const cursorSnapshot = await firestore.doc(cursorPath).get();
+      if (cursorSnapshot.exists) {
+        query = query.startAfter(cursorSnapshot);
+      }
+    }
+
+    const snapshot = await query.limit(pageSize + 1).get();
+    const docs = snapshot.docs;
+    const hasMore = docs.length > pageSize;
+    const relevantDocs = hasMore ? docs.slice(0, pageSize) : docs;
+    const entries = relevantDocs
+      .map((doc) => mapEventDoc(doc))
+      .filter((entry): entry is AdminEventLogEntry => Boolean(entry));
+    const nextCursor = hasMore ? encodeCursor(docs[docs.length - 1].ref.path) : null;
+
+    return { entries, nextCursor };
+  } catch (error) {
+    if (isFailedPrecondition(error)) {
+      console.warn(`[admin-monitoring] event-log index fehlt für ${gymId}`, error);
+      return { entries: [], nextCursor: null, error: 'Index erforderlich' };
+    }
+    console.error(`[admin-monitoring] event-log abruf fehlgeschlagen für ${gymId}`, error);
+    return { entries: [], nextCursor: null, error: 'Abruf fehlgeschlagen' };
+  }
+}

--- a/website/tests/api-geojson.test.js
+++ b/website/tests/api-geojson.test.js
@@ -1,0 +1,16 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+test('GeoJSON admin API exposes secure caching headers and properties', () => {
+  const filePath = resolve(process.cwd(), 'src/app/api/admin/gyms.geojson/route.ts');
+  const content = readFileSync(filePath, 'utf8');
+  assert.match(content, /FeatureCollection/, 'Response should include FeatureCollection type');
+  assert.match(content, /const CACHE_HEADER_VALUE = 'private, max-age=60';/, 'API must use private cache control');
+  assert.match(
+    content,
+    /properties: \{\s*id: gym.id,\s*name: gym.name,\s*slug: gym.slug/s,
+    'GeoJSON features should expose id, name and slug'
+  );
+});

--- a/website/tests/monitoring-page.test.js
+++ b/website/tests/monitoring-page.test.js
@@ -1,0 +1,11 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+test('Monitoring page renders map component and heading', () => {
+  const filePath = resolve(process.cwd(), 'src/app/(admin)/admin/monitoring/page.tsx');
+  const content = readFileSync(filePath, 'utf8');
+  assert.match(content, /<h1 className=\"[^\"]*\">Standorte<\/h1>/, 'Monitoring page should render Standorte heading');
+  assert.match(content, /<MonitoringMap \/>/, 'Monitoring page should include MonitoringMap component');
+});

--- a/website/tests/navigation.test.js
+++ b/website/tests/navigation.test.js
@@ -1,0 +1,14 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+test('Admin navigation includes Monitoring entry', () => {
+  const filePath = resolve(process.cwd(), 'src/components/layout/admin-shell.tsx');
+  const content = readFileSync(filePath, 'utf8');
+  assert.match(
+    content,
+    /\{ label: 'Monitoring', route: ADMIN_ROUTES\.monitoring/,
+    'Sidebar navigation should link to the Monitoring route'
+  );
+});


### PR DESCRIPTION
## Summary
- add Monitoring navigation entry and protected admin routes for the new map and detail views
- implement server utilities plus the `/api/admin/gyms.geojson` endpoint to expose GeoJSON with aggregated status data
- build the monitoring overview map, gym detail page and shared event log table, and document Monitoring requirements
- add lightweight smoke tests covering navigation, monitoring page wiring and API structure

## Testing
- npm test
- npm run lint *(fails: `next` binary unavailable because npm installs are blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d08a1c702483209c53705d394d3506