### PR TITLE
feat(admin-monitoring): wire geojson endpoint and refresh monitoring UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,36 @@ Next.js erzwingt mit `experimental.typedRoutes` streng typisierte Navigation. Da
 - Manuell prüfen: Navbar-Links (`/`, `/gym`, `/admin`), Dev-Login ohne `next`, mit `next=/admin` und mit ungültigem `next` leitet nach `/gym`.
 
 
+## Admin Monitoring
+
+Die Admin-Oberfläche bündelt unter `/admin/monitoring` eine MapLibre-Karte aller aktiven deutschen Studios. Die API arbeitet vollständig serverseitig mit dem Firebase Admin SDK, nutzt strukturierte Fehlerantworten und vermeidet personenbezogene Daten in der GeoJSON-Ausgabe.
+
+### Firestore-Daten
+
+- `gyms/{gymId}` (ID entspricht dem Slug) mit mindestens `active: true`, `countryCode: "DE"` und einem echten `location`-GeoPoint. Optionale Felder wie `name`, `slug` oder `code` werden übernommen, leere Werte fallen zurück auf Defaults.
+- `gyms/{gymId}/status/current` enthält den aktuellen Status (`key: "current"`, `updatedAt` als `Timestamp` sowie optionale Kennzahlen wie `checkins24h`, `devicesOnline`, `lastEventAt`).
+- Falls zusätzlich `gymStatus/{gymId}` existiert, werden die Daten mit dem Sub-Dokument zusammengeführt.
+
+Nur Gyms mit gültigen Koordinaten erscheinen als Feature. Ungültige oder fehlende Koordinaten zählen für die Aggregation `withoutCoords`, tauchen aber nicht in der Karte auf.
+
+### Relevante Umgebungsvariablen
+
+- `FIREBASE_SERVICE_ACCOUNT`: Base64-kodiertes Service-Account-JSON für das Admin-SDK.
+- `NEXT_PUBLIC_MAP_STYLE_URL`: MapLibre-Style-URL für das Standard-Theme (optional `NEXT_PUBLIC_MAP_STYLE_URL_DARK` für Dark Mode).
+- `TAPEM_DEBUG=1`: Aktiviert zusätzliche Server-Logs mit `requestId`, um Monitoring-Abfragen zu debuggen.
+
+### API & Caching
+
+- `GET /api/admin/gyms.geojson` ist ausschließlich für eingeloggte Admin- oder Owner-Rollen verfügbar und liefert `application/geo+json; charset=utf-8` zurück.
+- Die Antwort ist eine `FeatureCollection` mit `features` (Properties: `id`, `name`, `slug`, `code`, `countryCode`, `active`, `statusUpdatedAt`) und `aggregates` (`total`, `withCoords`, `withoutCoords`) für die Badges im UI.
+- Serverseitig wird `Cache-Control: public, max-age=60` gesetzt und ein deterministischer `ETag` vergeben. Requests mit passendem `If-None-Match` erhalten `304 Not Modified`.
+- Fehlerfälle antworten konsistent mit `{ error: "internal_error", requestId }` und loggen intern mit dem Präfix `[admin-monitoring]`.
+
+### Frontend
+
+- Die Karte lädt MapLibre ausschließlich clientseitig, berücksichtigt das aktuelle Theme und nutzt `credentials: 'include'` sowie `AbortController` mit Timeout für alle Fetches.
+- Marker-Klicks führen zur Detailansicht `/admin/monitoring/{gymId}`, welche Stammdaten, Status-Badges und ein Ereignisprotokoll anzeigt.
+
 ## Recht & SEO
 
 - Unter `/imprint` und `/privacy` findest du rechtliche Pflichtseiten mit deutschsprachigen Platzhaltertexten. Bitte vor dem Livegang

--- a/website/src/app/(admin)/admin/monitoring/[gymId]/page.tsx
+++ b/website/src/app/(admin)/admin/monitoring/[gymId]/page.tsx
@@ -80,6 +80,7 @@ export default async function MonitoringDetailPage({ params, searchParams }: Pag
 
   const status = summary.status?.status ?? null;
   const statusLabel = resolveStatusLabel(status);
+  const statusUpdatedAtLabel = formatTimestamp(summary.statusUpdatedAt);
   const nextCursorHref = events.nextCursor
     ? `${ADMIN_ROUTES.monitoringDetail.href.replace('[gymId]', encodeURIComponent(params.gymId))}?cursor=${encodeURIComponent(events.nextCursor)}`
     : null;
@@ -89,6 +90,13 @@ export default async function MonitoringDetailPage({ params, searchParams }: Pag
   const coordinateLabel = summary.location
     ? `${summary.location.lat.toFixed(5)}, ${summary.location.lng.toFixed(5)}`
     : '—';
+  const infoItems: { label: string; value: string }[] = [
+    { label: 'Slug', value: summary.slug },
+    { label: 'Code', value: summary.code ?? '—' },
+    { label: 'Land', value: summary.countryCode ?? '—' },
+    { label: 'Koordinaten', value: coordinateLabel },
+    { label: 'Aktiv', value: summary.active ? 'Ja' : 'Nein' },
+  ];
 
   return (
     <div className="mx-auto w-full max-w-5xl space-y-10 px-6 py-12">
@@ -97,7 +105,14 @@ export default async function MonitoringDetailPage({ params, searchParams }: Pag
           <p className="text-sm font-semibold uppercase tracking-wide text-muted">Monitoring</p>
           <h1 className="mt-1 text-3xl font-semibold text-page">{summary.name}</h1>
           <p className="mt-2 text-sm text-muted">{locationLabel}</p>
-          <p className="text-xs text-muted">Slug: {summary.slug} · Koordinaten: {coordinateLabel}</p>
+          <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-3">
+            {infoItems.map((item) => (
+              <div key={item.label} className="space-y-1">
+                <dt className="text-xs font-semibold uppercase tracking-wide text-muted">{item.label}</dt>
+                <dd className="text-sm text-page">{item.value}</dd>
+              </div>
+            ))}
+          </dl>
         </div>
         <div className="flex flex-col items-end gap-3 text-right">
           <span
@@ -115,7 +130,7 @@ export default async function MonitoringDetailPage({ params, searchParams }: Pag
         </div>
       </div>
 
-      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <article className="rounded-lg border border-subtle bg-card p-5 shadow-sm">
           <p className="text-xs font-semibold uppercase tracking-wide text-muted">Check-ins (24h)</p>
           <p className="mt-2 text-2xl font-semibold text-page">{formatNumber(summary.status?.checkins24h)}</p>
@@ -127,6 +142,10 @@ export default async function MonitoringDetailPage({ params, searchParams }: Pag
         <article className="rounded-lg border border-subtle bg-card p-5 shadow-sm">
           <p className="text-xs font-semibold uppercase tracking-wide text-muted">Letztes Ereignis</p>
           <p className="mt-2 text-base font-semibold text-page">{formatTimestamp(summary.status?.lastEventAt ?? null)}</p>
+        </article>
+        <article className="rounded-lg border border-subtle bg-card p-5 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted">Letzte Status-Aktualisierung</p>
+          <p className="mt-2 text-base font-semibold text-page">{statusUpdatedAtLabel}</p>
         </article>
       </section>
 

--- a/website/src/app/api/admin/gyms.geojson/route.ts
+++ b/website/src/app/api/admin/gyms.geojson/route.ts
@@ -3,56 +3,58 @@ import { createHash } from 'crypto';
 
 import { getAdminUserFromSession } from '@/src/server/auth/session';
 import { fetchGymsForMap } from '@/src/server/monitoring';
+import type { MonitoringGymsFeatureCollection } from '@/src/types/monitoring';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-const CACHE_HEADER_VALUE = 'private, max-age=60';
-const EMPTY_HEADERS = new Headers({ 'Cache-Control': CACHE_HEADER_VALUE });
+const CACHE_HEADER_VALUE = 'public, max-age=60';
+const ERROR_HEADERS = new Headers({ 'Cache-Control': 'no-store' });
 
 function buildEtag(payload: string): string {
   const hash = createHash('sha1').update(payload).digest('base64url');
   return `"${hash}"`;
 }
 
+function createRequestId(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+function normalizeEtag(value: string): string {
+  return value.trim().replace(/^W\//i, '');
+}
+
+function etagMatches(candidateHeader: string | null, etag: string): boolean {
+  if (!candidateHeader) {
+    return false;
+  }
+  const normalized = normalizeEtag(etag);
+  return candidateHeader
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .some((value) => {
+      if (value === '*') {
+        return true;
+      }
+      return normalizeEtag(value) === normalized;
+    });
+}
+
 export async function GET(request: Request) {
-  const debugId = Math.random().toString(36).slice(2, 8);
+  const requestId = createRequestId();
+  const logPrefix = `[admin-monitoring] ${requestId}`;
   try {
     const user = await getAdminUserFromSession();
     if (!user) {
-      return NextResponse.json({ error: 'unauthorized', requestId: debugId }, { status: 401, headers: EMPTY_HEADERS });
+      return NextResponse.json({ error: 'unauthorized', requestId }, { status: 401, headers: ERROR_HEADERS });
     }
     if (user.role !== 'admin' && user.role !== 'owner') {
-      return NextResponse.json({ error: 'forbidden', requestId: debugId }, { status: 403, headers: EMPTY_HEADERS });
+      return NextResponse.json({ error: 'forbidden', requestId }, { status: 403, headers: ERROR_HEADERS });
     }
 
-    const { gyms, total, missingLocation } = await fetchGymsForMap();
-    const featureCollection = {
-      type: 'FeatureCollection' as const,
-      features: gyms.map((gym) => ({
-        type: 'Feature' as const,
-        geometry: {
-          type: 'Point' as const,
-          coordinates: [gym.location.lng, gym.location.lat],
-        },
-        properties: {
-          id: gym.id,
-          name: gym.name,
-          slug: gym.slug,
-          city: gym.city ?? null,
-          state: gym.state ?? null,
-          status: gym.status?.status ?? null,
-          checkins24h: gym.status?.checkins24h ?? null,
-          devicesOnline: gym.status?.devicesOnline ?? null,
-        },
-      })),
-      meta: {
-        total,
-        missingLocation,
-      },
-    };
-
+    const featureCollection: MonitoringGymsFeatureCollection = await fetchGymsForMap({ requestId });
     const body = JSON.stringify(featureCollection);
     const etag = buildEtag(body);
     const headers = new Headers({
@@ -62,14 +64,19 @@ export async function GET(request: Request) {
     });
 
     const ifNoneMatch = request.headers.get('if-none-match');
-    if (ifNoneMatch && ifNoneMatch.replace(/^W\//, '') === etag.replace(/^W\//, '')) {
+    if (etagMatches(ifNoneMatch, etag)) {
+      headers.delete('Content-Type');
+      console.info(`${logPrefix} 304 cache-hit`);
       return new Response(null, { status: 304, headers });
     }
 
-    console.info(`[admin-monitoring] ${debugId} gyms=${gyms.length} missing=${missingLocation}`);
+    console.info(
+      `${logPrefix} features=${featureCollection.features.length} withCoords=${featureCollection.aggregates.withCoords} ` +
+        `withoutCoords=${featureCollection.aggregates.withoutCoords}`
+    );
     return new Response(body, { status: 200, headers });
   } catch (error) {
-    console.error(`[admin-monitoring] ${debugId} failed`, error);
-    return NextResponse.json({ error: 'internal_error', requestId: debugId }, { status: 500, headers: EMPTY_HEADERS });
+    console.error(`${logPrefix} failed`, error);
+    return NextResponse.json({ error: 'internal_error', requestId }, { status: 500, headers: ERROR_HEADERS });
   }
 }

--- a/website/src/components/monitoring/monitoring-map.tsx
+++ b/website/src/components/monitoring/monitoring-map.tsx
@@ -4,6 +4,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { buildAdminMonitoringDetailRoute } from '@/src/lib/routes';
+import type {
+  MonitoringGymFeatureProperties,
+  MonitoringGymsAggregates,
+  MonitoringGymsFeatureCollection,
+} from '@/src/types/monitoring';
 
 type MapLibreModule = any;
 type MapLibreMap = any;
@@ -64,48 +69,38 @@ async function loadMapLibre(): Promise<MapLibreModule> {
   return mapLibreLoader;
 }
 
-type GymFeatureProperties = {
-  id: string;
-  name: string;
-  slug: string;
-  city: string | null;
-  state: string | null;
-  status: 'online' | 'offline' | 'degraded' | null;
-  checkins24h: number | null;
-  devicesOnline: number | null;
-};
-
-type MapFeature = {
-  type: 'Feature';
-  geometry: { type: 'Point'; coordinates: [number, number] };
-  properties: GymFeatureProperties;
-};
-
-type MapResponse = {
-  type: 'FeatureCollection';
-  features: MapFeature[];
-  meta?: {
-    total?: number;
-    missingLocation?: number;
-  };
-};
+type MapResponse = MonitoringGymsFeatureCollection;
+type GymFeatureProperties = MonitoringGymFeatureProperties;
 
 type ThemeMode = 'light' | 'dark';
 
+const DEFAULT_STYLE_LIGHT = 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json';
+const DEFAULT_STYLE_DARK = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
+const ENV_STYLE_LIGHT = (process.env.NEXT_PUBLIC_MAP_STYLE_URL ?? '').trim();
+const ENV_STYLE_DARK = (process.env.NEXT_PUBLIC_MAP_STYLE_URL_DARK ?? '').trim();
+
 const STYLE_URLS: Record<ThemeMode, string> = {
-  light: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
-  dark: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
+  light: ENV_STYLE_LIGHT || DEFAULT_STYLE_LIGHT,
+  dark: ENV_STYLE_DARK || ENV_STYLE_LIGHT || DEFAULT_STYLE_DARK,
 };
 
-const STATUS_COLORS: Record<'online' | 'offline' | 'degraded' | 'unknown', string> = {
-  online: '#16a34a',
-  degraded: '#f97316',
-  offline: '#dc2626',
-  unknown: '#64748b',
+const POINT_COLORS: Record<ThemeMode, string> = {
+  light: '#2563eb',
+  dark: '#38bdf8',
+};
+
+const POINT_STROKE_COLORS: Record<ThemeMode, string> = {
+  light: '#ffffff',
+  dark: '#0f172a',
 };
 
 const DEFAULT_CENTER: [number, number] = [10.451526, 51.165691];
 const DEFAULT_ZOOM = 4.8;
+
+const POPUP_DATE_FORMATTER = new Intl.DateTimeFormat('de-DE', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
 
 function useResolvedTheme(): ThemeMode {
   const [theme, setTheme] = useState<ThemeMode>('light');
@@ -128,13 +123,6 @@ function useResolvedTheme(): ThemeMode {
   return theme;
 }
 
-function formatStatusLabel(status: GymFeatureProperties['status']): string {
-  if (status === 'online') return 'Online';
-  if (status === 'degraded') return 'Eingeschränkt';
-  if (status === 'offline') return 'Offline';
-  return 'Unbekannt';
-}
-
 function buildPopupContent(feature: GymFeatureProperties): HTMLDivElement {
   const container = document.createElement('div');
   container.className = 'space-y-2 text-sm text-page';
@@ -144,32 +132,41 @@ function buildPopupContent(feature: GymFeatureProperties): HTMLDivElement {
   title.textContent = feature.name;
   container.appendChild(title);
 
-  if (feature.city || feature.state) {
-    const location = document.createElement('p');
-    location.className = 'text-xs text-muted';
-    location.textContent = [feature.city, feature.state].filter(Boolean).join(' · ');
-    container.appendChild(location);
+  const metaLine = document.createElement('p');
+  metaLine.className = 'text-xs text-muted';
+  const metaParts: string[] = [`Slug: ${feature.slug}`];
+  if (feature.code) {
+    metaParts.push(`Code: ${feature.code}`);
   }
+  metaLine.textContent = metaParts.join(' · ');
+  container.appendChild(metaLine);
 
-  const status = document.createElement('p');
-  status.className = 'text-xs text-muted';
-  const statusLabel = formatStatusLabel(feature.status);
-  const statusDetails: string[] = [statusLabel];
-  if (typeof feature.devicesOnline === 'number') {
-    statusDetails.push(`${feature.devicesOnline} Geräte aktiv`);
+  const countryLine = document.createElement('p');
+  countryLine.className = 'text-xs text-muted';
+  countryLine.textContent = `Land: ${feature.countryCode}`;
+  container.appendChild(countryLine);
+
+  const activeLine = document.createElement('p');
+  activeLine.className = 'text-xs text-muted';
+  activeLine.textContent = feature.active ? 'Status: aktiv' : 'Status: inaktiv';
+  container.appendChild(activeLine);
+
+  if (feature.statusUpdatedAt) {
+    const parsed = new Date(feature.statusUpdatedAt);
+    if (!Number.isNaN(parsed.valueOf())) {
+      const updatedLine = document.createElement('p');
+      updatedLine.className = 'text-xs text-muted';
+      updatedLine.textContent = `Letzte Aktualisierung: ${POPUP_DATE_FORMATTER.format(parsed)}`;
+      container.appendChild(updatedLine);
+    }
   }
-  if (typeof feature.checkins24h === 'number') {
-    statusDetails.push(`${feature.checkins24h} Check-ins (24h)`);
-  }
-  status.textContent = statusDetails.join(' · ');
-  container.appendChild(status);
 
   const button = document.createElement('button');
   button.type = 'button';
   button.className =
     'w-full rounded-md border border-primary bg-primary px-3 py-2 text-sm font-semibold text-white transition hover:bg-primary/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary';
   button.textContent = 'Details ansehen';
-  button.setAttribute('data-gym-id', feature.id);
+  button.setAttribute('data-gym-id', String(feature.id));
   container.appendChild(button);
 
   return container;
@@ -189,43 +186,78 @@ export function MonitoringMap() {
     pointLeave?: (event: any) => void;
   }>({});
   const hasFitBoundsRef = useRef(false);
+  const fetchControllerRef = useRef<AbortController | null>(null);
 
   const [data, setData] = useState<MapResponse | null>(null);
-  const [meta, setMeta] = useState<{ total: number; missing: number }>({ total: 0, missing: 0 });
+  const [aggregates, setAggregates] = useState<MonitoringGymsAggregates>({
+    total: 0,
+    withCoords: 0,
+    withoutCoords: 0,
+  });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const withLocation = data?.features.length ?? 0;
-  const withoutLocation = meta.missing;
-  const totalGyms = meta.total;
+  const withLocation = aggregates.withCoords;
+  const withoutLocation = aggregates.withoutCoords;
+  const totalGyms = aggregates.total;
+  const isInitialLoad = loading && !data;
 
   const loadData = useCallback(async () => {
+    fetchControllerRef.current?.abort();
+    const controller = new AbortController();
+    fetchControllerRef.current = controller;
+    const timeoutId = window.setTimeout(() => controller.abort(), 10000);
+    let aborted = false;
+
     setLoading(true);
     setError(null);
+
     try {
       const response = await fetch('/api/admin/gyms.geojson', {
         headers: { Accept: 'application/geo+json' },
+        credentials: 'include',
+        signal: controller.signal,
       });
+
+      if (response.status === 304) {
+        return;
+      }
+
       if (response.status === 401 || response.status === 403) {
         throw new Error('Zugriff verweigert. Bitte melde dich erneut als Admin an.');
       }
+
       if (!response.ok) {
         throw new Error('Standortdaten konnten nicht geladen werden.');
       }
+
       const json = (await response.json()) as MapResponse;
       setData(json);
       hasFitBoundsRef.current = false;
-      setMeta({
-        total: typeof json.meta?.total === 'number' ? json.meta.total : json.features.length,
-        missing: typeof json.meta?.missingLocation === 'number' ? json.meta.missingLocation : 0,
-      });
+      setAggregates(
+        json.aggregates ?? {
+          total: json.features.length,
+          withCoords: json.features.length,
+          withoutCoords: 0,
+        }
+      );
     } catch (err) {
+      if ((err as { name?: string }).name === 'AbortError') {
+        aborted = true;
+        return;
+      }
       console.error('[admin-monitoring] map data load failed', err);
       setError(err instanceof Error ? err.message : 'Unbekannter Fehler beim Laden der Karte.');
       setData(null);
-      setMeta({ total: 0, missing: 0 });
+      setAggregates({ total: 0, withCoords: 0, withoutCoords: 0 });
     } finally {
-      setLoading(false);
+      window.clearTimeout(timeoutId);
+      if (fetchControllerRef.current === controller) {
+        fetchControllerRef.current = null;
+      }
+      if (!aborted) {
+        setLoading(false);
+      }
     }
   }, []);
 
@@ -251,6 +283,7 @@ export function MonitoringMap() {
   useEffect(() => {
     return () => {
       resetPopup();
+      fetchControllerRef.current?.abort();
       if (mapRef.current) {
         mapRef.current.remove();
         mapRef.current = null;
@@ -259,7 +292,7 @@ export function MonitoringMap() {
   }, [resetPopup]);
 
   const attachInteractions = useCallback(
-    (map: MapLibreMap, module: MapLibreModule) => {
+    (map: MapLibreMap, maplibre: MapLibreModule) => {
       const mapCanvas = map.getCanvas();
       mapCanvas.setAttribute('role', 'application');
       mapCanvas.setAttribute('tabindex', '0');
@@ -305,13 +338,14 @@ export function MonitoringMap() {
         const popupContent = buildPopupContent(properties);
         const button = popupContent.querySelector('button[data-gym-id]');
         if (button) {
+          const gymId = String(properties.id);
           button.addEventListener('click', () => {
             resetPopup();
-            router.push(buildAdminMonitoringDetailRoute(properties.id));
+            router.push(buildAdminMonitoringDetailRoute(gymId));
           });
         }
         resetPopup();
-        const popup = new module.Popup({ closeButton: true, closeOnMove: false, offset: 12, focusAfterOpen: false })
+        const popup = new maplibre.Popup({ closeButton: true, closeOnMove: false, offset: 12, focusAfterOpen: false })
           .setDOMContent(popupContent)
           .setLngLat(coordinates)
           .addTo(map);
@@ -323,10 +357,11 @@ export function MonitoringMap() {
         const [feature] = event.features ?? [];
         if (feature) {
           const props = feature.properties as GymFeatureProperties;
-          map.getCanvas().setAttribute(
-            'aria-label',
-            `Marker: ${props.name}${props.city ? `, ${props.city}` : ''} (${formatStatusLabel(props.status)})`
-          );
+          const parts = [props.name];
+          if (props.code) {
+            parts.push(`Code ${props.code}`);
+          }
+          map.getCanvas().setAttribute('aria-label', `Marker: ${parts.join(' · ')}`);
         }
       };
 
@@ -346,7 +381,7 @@ export function MonitoringMap() {
   );
 
   const applyDataToMap = useCallback(
-    (map: MapLibreMap, module: MapLibreModule, collection: MapResponse) => {
+    (map: MapLibreMap, maplibre: MapLibreModule, collection: MapResponse) => {
       if (map.getLayer('gym-clusters')) {
         map.removeLayer('gym-clusters');
       }
@@ -401,24 +436,15 @@ export function MonitoringMap() {
         source: 'gyms',
         filter: ['!', ['has', 'point_count']],
         paint: {
-          'circle-color': [
-            'match',
-            ['get', 'status'],
-            'online',
-            STATUS_COLORS.online,
-            'degraded',
-            STATUS_COLORS.degraded,
-            'offline',
-            STATUS_COLORS.offline,
-            STATUS_COLORS.unknown,
-          ],
+          'circle-color': POINT_COLORS[theme],
           'circle-radius': 9,
           'circle-stroke-width': 2,
-          'circle-stroke-color': theme === 'dark' ? '#0f172a' : '#ffffff',
+          'circle-stroke-color': POINT_STROKE_COLORS[theme],
+          'circle-opacity': 0.85,
         },
       });
 
-      attachInteractions(map, module);
+      attachInteractions(map, maplibre);
 
       if (!hasFitBoundsRef.current) {
         if (collection.features.length > 0) {
@@ -455,12 +481,12 @@ export function MonitoringMap() {
       if (!moduleRef.current) {
         moduleRef.current = await loadMapLibre();
       }
-      const module = moduleRef.current;
-      if (!module) {
+      const maplibre = moduleRef.current;
+      if (!maplibre) {
         return;
       }
       if (!mapRef.current) {
-        const map = new module.Map({
+        const map = new maplibre.Map({
           container: mapContainerRef.current,
           style: STYLE_URLS[theme],
           center: DEFAULT_CENTER,
@@ -468,12 +494,12 @@ export function MonitoringMap() {
           attributionControl: true,
         });
         mapRef.current = map;
-        map.addControl(new module.NavigationControl({ visualizePitch: false, showCompass: false }), 'top-right');
+        map.addControl(new maplibre.NavigationControl({ visualizePitch: false, showCompass: false }), 'top-right');
         map.on('load', () => {
-          applyDataToMap(map, module, collection);
+          applyDataToMap(map, maplibre, collection);
         });
       } else {
-        applyDataToMap(mapRef.current, module, collection);
+        applyDataToMap(mapRef.current, maplibre, collection);
       }
     },
     [applyDataToMap, theme]
@@ -491,10 +517,10 @@ export function MonitoringMap() {
       return;
     }
     const map = mapRef.current;
-    const module = moduleRef.current;
+    const maplibre = moduleRef.current;
     const onStyleData = () => {
       if (map.isStyleLoaded()) {
-        applyDataToMap(map, module, data);
+        applyDataToMap(map, maplibre, data);
       }
     };
     map.once('styledata', onStyleData);
@@ -505,22 +531,23 @@ export function MonitoringMap() {
   }, [theme, data, applyDataToMap]);
 
   const infoBoxes = useMemo(() => {
-    const boxes = [
+    const showPlaceholder = isInitialLoad || Boolean(error);
+    const formatValue = (value: number) => (showPlaceholder ? '–' : value.toString());
+    return [
       {
         label: 'Mit Koordinate',
-        value: loading ? '–' : withLocation.toString(),
+        value: formatValue(withLocation),
       },
       {
         label: 'Ohne Koordinate',
-        value: loading ? '–' : withoutLocation.toString(),
+        value: formatValue(withoutLocation),
       },
       {
         label: 'Gesamt',
-        value: loading ? '–' : totalGyms.toString(),
+        value: formatValue(totalGyms),
       },
     ];
-    return boxes;
-  }, [loading, totalGyms, withLocation, withoutLocation]);
+  }, [error, isInitialLoad, totalGyms, withLocation, withoutLocation]);
 
   return (
     <section className="space-y-5">

--- a/website/src/server/monitoring.ts
+++ b/website/src/server/monitoring.ts
@@ -1,38 +1,42 @@
 import 'server-only';
 
-import { FieldPath, GeoPoint, Timestamp, type QueryDocumentSnapshot } from 'firebase-admin/firestore';
+import { GeoPoint, Timestamp, type DocumentSnapshot, type QueryDocumentSnapshot } from 'firebase-admin/firestore';
 
 import { adminDb } from '@/src/server/firebase/admin';
 import type { AdminEventLogEntry } from '@/src/server/admin/dashboard-data';
+import type {
+  MonitoringGymFeature,
+  MonitoringGymsAggregates,
+  MonitoringGymsFeatureCollection,
+} from '@/src/types/monitoring';
 
 export type MonitoringGymStatus = {
   status?: 'online' | 'offline' | 'degraded';
   checkins24h?: number;
   devicesOnline?: number;
   lastEventAt?: Date | null;
+  updatedAt?: Date | null;
 };
 
 export type MonitoringGymSummary = {
   id: string;
   name: string;
   slug: string;
+  code: string | null;
+  countryCode: string | null;
   city?: string;
   state?: string;
   location: { lat: number; lng: number } | null;
   active: boolean;
+  statusUpdatedAt: Date | null;
   status: MonitoringGymStatus | null;
 };
 
-export type MapGymFeature = Omit<MonitoringGymSummary, 'location' | 'status'> & {
-  location: { lat: number; lng: number };
-  status: MonitoringGymStatus | null;
+export type FetchGymsForMapOptions = {
+  requestId?: string;
 };
 
-export type FetchGymsForMapResult = {
-  gyms: MapGymFeature[];
-  total: number;
-  missingLocation: number;
-};
+export type FetchGymsForMapResult = MonitoringGymsFeatureCollection;
 
 export type FetchGymMonitoringSummaryResult = MonitoringGymSummary | null;
 
@@ -65,8 +69,14 @@ function toDate(value: unknown): Date | null {
 }
 
 function parseGeoPoint(value: unknown): { lat: number; lng: number } | null {
+  const toPair = (lat: number, lng: number): { lat: number; lng: number } | null => {
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+      return null;
+    }
+    return { lat, lng };
+  };
   if (value instanceof GeoPoint) {
-    return { lat: value.latitude, lng: value.longitude };
+    return toPair(value.latitude, value.longitude);
   }
   if (
     value &&
@@ -74,10 +84,7 @@ function parseGeoPoint(value: unknown): { lat: number; lng: number } | null {
     typeof (value as { latitude?: unknown }).latitude === 'number' &&
     typeof (value as { longitude?: unknown }).longitude === 'number'
   ) {
-    return {
-      lat: (value as { latitude: number }).latitude,
-      lng: (value as { longitude: number }).longitude,
-    };
+    return toPair((value as { latitude: number }).latitude, (value as { longitude: number }).longitude);
   }
   if (
     value &&
@@ -85,10 +92,7 @@ function parseGeoPoint(value: unknown): { lat: number; lng: number } | null {
     typeof (value as { lat?: unknown }).lat === 'number' &&
     typeof (value as { lng?: unknown }).lng === 'number'
   ) {
-    return {
-      lat: (value as { lat: number }).lat,
-      lng: (value as { lng: number }).lng,
-    };
+    return toPair((value as { lat: number }).lat, (value as { lng: number }).lng);
   }
   return null;
 }
@@ -106,7 +110,8 @@ function parseStatus(data: unknown): MonitoringGymStatus | null {
   const checkins24h = typeof record.checkins24h === 'number' ? record.checkins24h : undefined;
   const devicesOnline = typeof record.devicesOnline === 'number' ? record.devicesOnline : undefined;
   const lastEventAt = toDate(record.lastEventAt) ?? null;
-  if (!status && checkins24h === undefined && devicesOnline === undefined && !lastEventAt) {
+  const updatedAt = toDate(record.updatedAt ?? (record as { lastUpdatedAt?: unknown }).lastUpdatedAt) ?? null;
+  if (!status && checkins24h === undefined && devicesOnline === undefined && !lastEventAt && !updatedAt) {
     return null;
   }
   return {
@@ -114,6 +119,7 @@ function parseStatus(data: unknown): MonitoringGymStatus | null {
     checkins24h,
     devicesOnline,
     lastEventAt,
+    updatedAt,
   };
 }
 
@@ -121,12 +127,39 @@ function mergeStatus(primary: MonitoringGymStatus | null, secondary: MonitoringG
   if (!primary && !secondary) {
     return null;
   }
+  let updatedAt: Date | null = null;
+  const primaryUpdated = primary?.updatedAt ?? null;
+  const secondaryUpdated = secondary?.updatedAt ?? null;
+  if (primaryUpdated && secondaryUpdated) {
+    updatedAt = primaryUpdated >= secondaryUpdated ? primaryUpdated : secondaryUpdated;
+  } else {
+    updatedAt = primaryUpdated ?? secondaryUpdated ?? null;
+  }
   return {
     status: primary?.status ?? secondary?.status,
     checkins24h: primary?.checkins24h ?? secondary?.checkins24h,
     devicesOnline: primary?.devicesOnline ?? secondary?.devicesOnline,
     lastEventAt: primary?.lastEventAt ?? secondary?.lastEventAt ?? null,
+    updatedAt,
   };
+}
+
+function parseStatusSnapshot(
+  snapshot: DocumentSnapshot | QueryDocumentSnapshot | null | undefined
+): MonitoringGymStatus | null {
+  if (!snapshot || !snapshot.exists) {
+    return null;
+  }
+  const data = snapshot.data();
+  if (!data) {
+    return null;
+  }
+  const record = data as Record<string, unknown>;
+  const key = record.key;
+  if (typeof key === 'string' && key !== 'current') {
+    return null;
+  }
+  return parseStatus(record);
 }
 
 function encodeCursor(path: string): string {
@@ -170,74 +203,111 @@ function isFailedPrecondition(error: unknown): boolean {
   return false;
 }
 
-export async function fetchGymsForMap(): Promise<FetchGymsForMapResult> {
+export async function fetchGymsForMap(options?: FetchGymsForMapOptions): Promise<FetchGymsForMapResult> {
   const firestore = adminDb();
-  const [gymsSnapshot, rootStatusSnapshot, nestedStatusSnapshot] = await Promise.all([
-    firestore.collection('gyms').get(),
-    firestore.collection('gymStatus').get().catch(() => null),
-    firestore
-      .collectionGroup('status')
-      .where(FieldPath.documentId(), '==', 'current')
-      .get()
-      .catch(() => null),
-  ]);
+  const requestId = options?.requestId;
+  const debug = process.env.TAPEM_DEBUG === '1';
+  const logPrefix = `[admin-monitoring]${requestId ? ` ${requestId}` : ''}`;
 
-  const total = gymsSnapshot.size;
-  let missingLocation = 0;
+  const gymsSnapshot = await firestore
+    .collection('gyms')
+    .where('active', '==', true)
+    .where('countryCode', '==', 'DE')
+    .get();
+
+  if (debug) {
+    console.debug(`${logPrefix} gyms-query size=${gymsSnapshot.size}`);
+  }
+
+  const statusEntries = await Promise.all(
+    gymsSnapshot.docs.map(async (doc) => {
+      const [rootStatusSnapshot, nestedStatusSnapshot] = await Promise.all([
+        firestore
+          .collection('gymStatus')
+          .doc(doc.id)
+          .get()
+          .catch((error) => {
+            if (debug) {
+              console.warn(`${logPrefix} gymStatus read failed for ${doc.id}`, error);
+            }
+            return null;
+          }),
+        doc.ref
+          .collection('status')
+          .doc('current')
+          .get()
+          .catch((error) => {
+            if (debug) {
+              console.warn(`${logPrefix} nested status read failed for ${doc.id}`, error);
+            }
+            return null;
+          }),
+      ]);
+
+      const rootStatus = parseStatusSnapshot(rootStatusSnapshot);
+      const nestedStatus = parseStatusSnapshot(nestedStatusSnapshot);
+      const status = mergeStatus(rootStatus, nestedStatus);
+      return { id: doc.id, status } as const;
+    })
+  );
+
   const statusMap = new Map<string, MonitoringGymStatus | null>();
+  statusEntries.forEach((entry) => {
+    statusMap.set(entry.id, entry.status ?? null);
+  });
 
-  if (rootStatusSnapshot) {
-    rootStatusSnapshot.docs.forEach((doc) => {
-      statusMap.set(doc.id, parseStatus(doc.data()));
-    });
-  }
-
-  if (nestedStatusSnapshot) {
-    nestedStatusSnapshot.docs.forEach((doc) => {
-      const parent = doc.ref.parent?.parent;
-      const gymId = parent?.id;
-      if (!gymId) {
-        return;
-      }
-      const parsed = parseStatus(doc.data());
-      const existing = statusMap.get(gymId) ?? null;
-      statusMap.set(gymId, mergeStatus(parsed, existing));
-    });
-  }
-
-  const gyms: MapGymFeature[] = [];
+  const features: MonitoringGymFeature[] = [];
+  const aggregates: MonitoringGymsAggregates = {
+    total: gymsSnapshot.size,
+    withCoords: 0,
+    withoutCoords: 0,
+  };
 
   gymsSnapshot.docs.forEach((doc) => {
     const data = doc.data() as Record<string, unknown>;
     const location = parseGeoPoint(data.location);
     if (!location) {
-      missingLocation += 1;
+      aggregates.withoutCoords += 1;
+      if (debug) {
+        console.debug(`${logPrefix} missing-location gym=${doc.id}`);
+      }
       return;
     }
 
+    aggregates.withCoords += 1;
+
     const name = typeof data.name === 'string' && data.name.trim().length > 0 ? data.name : `Gym ${doc.id}`;
     const slug = typeof data.slug === 'string' && data.slug.trim().length > 0 ? data.slug : doc.id;
-    const city = typeof data.city === 'string' && data.city.trim().length > 0 ? data.city : undefined;
-    const state = typeof data.state === 'string' && data.state.trim().length > 0 ? data.state : undefined;
+    const code = typeof data.code === 'string' && data.code.trim().length > 0 ? data.code : null;
     const active = typeof data.active === 'boolean' ? data.active : true;
     const status = statusMap.get(doc.id) ?? null;
+    const statusUpdatedAt = status?.updatedAt ?? null;
+    const countryCode = typeof data.countryCode === 'string' && data.countryCode.trim().length > 0 ? data.countryCode : 'DE';
 
-    gyms.push({
-      id: doc.id,
-      name,
-      slug,
-      city,
-      state,
-      location,
-      active,
-      status,
-    });
+    const feature: MonitoringGymFeature = {
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [location.lng, location.lat],
+      },
+      properties: {
+        id: doc.id,
+        name,
+        slug,
+        code,
+        countryCode,
+        active,
+        statusUpdatedAt: statusUpdatedAt ? statusUpdatedAt.toISOString() : null,
+      },
+    };
+
+    features.push(feature);
   });
 
   return {
-    gyms,
-    total,
-    missingLocation,
+    type: 'FeatureCollection',
+    features,
+    aggregates,
   };
 }
 
@@ -246,8 +316,16 @@ export async function fetchGymMonitoringSummary(gymId: string): Promise<FetchGym
   const gymRef = firestore.collection('gyms').doc(gymId);
   const [gymSnapshot, rootStatusSnapshot, nestedStatusSnapshot] = await Promise.all([
     gymRef.get(),
-    firestore.collection('gymStatus').doc(gymId).get().catch(() => null),
-    gymRef.collection('status').doc('current').get().catch(() => null),
+    firestore
+      .collection('gymStatus')
+      .doc(gymId)
+      .get()
+      .catch(() => null),
+    gymRef
+      .collection('status')
+      .doc('current')
+      .get()
+      .catch(() => null),
   ]);
 
   if (!gymSnapshot.exists) {
@@ -257,23 +335,29 @@ export async function fetchGymMonitoringSummary(gymId: string): Promise<FetchGym
   const data = gymSnapshot.data() as Record<string, unknown>;
   const name = typeof data.name === 'string' && data.name.trim().length > 0 ? data.name : `Gym ${gymId}`;
   const slug = typeof data.slug === 'string' && data.slug.trim().length > 0 ? data.slug : gymId;
+  const code = typeof data.code === 'string' && data.code.trim().length > 0 ? data.code : null;
   const city = typeof data.city === 'string' && data.city.trim().length > 0 ? data.city : undefined;
   const state = typeof data.state === 'string' && data.state.trim().length > 0 ? data.state : undefined;
   const active = typeof data.active === 'boolean' ? data.active : true;
+  const countryCode = typeof data.countryCode === 'string' && data.countryCode.trim().length > 0 ? data.countryCode : null;
   const location = parseGeoPoint(data.location);
 
-  const rootStatus = rootStatusSnapshot?.exists ? parseStatus(rootStatusSnapshot.data()) : null;
-  const nestedStatus = nestedStatusSnapshot?.exists ? parseStatus(nestedStatusSnapshot.data()) : null;
+  const rootStatus = parseStatusSnapshot(rootStatusSnapshot);
+  const nestedStatus = parseStatusSnapshot(nestedStatusSnapshot);
   const status = mergeStatus(rootStatus, nestedStatus);
+  const statusUpdatedAt = status?.updatedAt ?? null;
 
   return {
     id: gymId,
     name,
     slug,
+    code,
+    countryCode,
     city,
     state,
     location,
     active,
+    statusUpdatedAt,
     status,
   };
 }

--- a/website/src/types/monitoring.ts
+++ b/website/src/types/monitoring.ts
@@ -1,0 +1,27 @@
+export type MonitoringGymFeatureProperties = {
+  id: string;
+  name: string;
+  slug: string;
+  code: string | null;
+  countryCode: string;
+  active: boolean;
+  statusUpdatedAt: string | null;
+};
+
+export type MonitoringGymFeature = {
+  type: 'Feature';
+  geometry: { type: 'Point'; coordinates: [number, number] };
+  properties: MonitoringGymFeatureProperties;
+};
+
+export type MonitoringGymsAggregates = {
+  total: number;
+  withCoords: number;
+  withoutCoords: number;
+};
+
+export type MonitoringGymsFeatureCollection = {
+  type: 'FeatureCollection';
+  features: MonitoringGymFeature[];
+  aggregates: MonitoringGymsAggregates;
+};


### PR DESCRIPTION
## Summary
- adjust the monitoring server helper to collect active German gyms, merge `status/current` docs and emit a GeoJSON feature collection with aggregates
- secure `/api/admin/gyms.geojson` with admin auth, caching/ETag handling and the new shared monitoring types
- refresh the monitoring map and detail pages to consume the new payload, add abortable fetches and document the monitoring setup in the README

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d184f283248320ad53ea228add454e