### PR TITLE
Add Firestore index for monitoring event logs

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -137,6 +137,21 @@
       "queryScope": "COLLECTION_GROUP",
       "fields": [
         {
+          "fieldPath": "gymId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "timestamp",
+          "order": "DESCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "logs",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        {
           "fieldPath": "deviceId",
           "order": "ASCENDING"
         },


### PR DESCRIPTION
## Summary
- add a composite Firestore index so monitoring can query logs by gym and timestamp

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68d3077e36088320962d709a739a668f