### PR TITLE
feat: add unified gym activity stream

### DIFF
--- a/docs/admin-activity-stream.md
+++ b/docs/admin-activity-stream.md
@@ -1,0 +1,62 @@
+# Admin Activity Stream
+
+Dieses Dokument beschreibt das einheitliche Ereignismodell für den Admin-Monitoring-Bereich.
+
+## Datenmodell
+
+* Sammlung: `gyms/{gymId}/activity/{eventId}` (Collection Group `activity`)
+* Pflichtfelder:
+  * `gymId` (string)
+  * `timestamp` (Firestore Timestamp)
+  * `eventType` (string, z. B. `training.set_logged`)
+  * `severity` (`info` | `warning` | `error`)
+  * `source` (`device` | `app` | `backend` | `admin` | `system`)
+* Optionale Felder:
+  * `summary` (string)
+  * `userId`, `deviceId`, `sessionId`
+  * `actor` ({ `type`: `user` | `system` | `admin`, `id`?, `label`? })
+  * `targets` (Array von Referenzen)
+  * `data` (schlanker Payload ohne PII)
+  * `updatedAt` (Timestamp)
+  * `idempotencyKey` (string)
+
+## Schreibpfade
+
+* Gerätesätze (`gyms/{gymId}/devices/{deviceId}/logs/{logId}`) werden via Cloud Function `mirrorDeviceLogToActivity` gespiegelt.
+* Trusted Backends schreiben direkt in `activity`. Clientseitige Schreibrechte sind in den Firestore-Regeln deaktiviert.
+
+## Abfragen & Indizes
+
+* Standard-Query: `collectionGroup('activity')` + Filter `gymId == :gymId`, optional Zeitraum (`timestamp`), Typen (`eventType`), Severity, `userId`, `deviceId`.
+* Sortierung: `orderBy('timestamp', 'desc').orderBy(FieldPath.documentId(), 'desc')`.
+* Paginierung: Cursor (Base64) über `timestamp` + Dokumentpfad.
+* Firestore-Indizes:
+  * `(gymId asc, timestamp desc)`
+  * `(gymId asc, eventType asc, timestamp desc)`
+  * `(gymId asc, severity asc, timestamp desc)`
+
+## Admin API
+
+* Endpoint: `GET /api/admin/gyms/:gymId/events`
+* Query-Parameter: `from`, `to`, `types`, `severity`, `userId`, `deviceId`, `limit`, `cursor`
+* Antwort: `items[]`, `nextCursor`, `stats { total, last24h, last7d, last30d }`, `warnings[]`, `requestId`
+* Auth: nur Admin/Owner Sessions.
+* Response-Caching: `Cache-Control: private, max-age=30`, ETag Support.
+
+## UI
+
+* Client-Komponente `GymActivityFeed` mit Filterformular, KPI-Badges, Tabelle (`AdminEventLogTable`) und Cursor-Ladefunktion.
+* Debounced Fetch via `AbortController`, Zusammenführung von Warnungen (z. B. fehlende Indizes).
+* Keine PII-Anzeige, IDs werden roh dargestellt (Monospace Chips).
+
+## Migration / Backfill
+
+1. Cloud Function deployen (`mirrorDeviceLogToActivity`).
+2. Historische Logs iterativ lesen und mit `idempotencyKey` in `activity` schreiben.
+3. Fehlende Firestore-Indizes erstellen (siehe oben).
+4. Monitoring-UI nutzt nur noch den neuen Endpoint.
+
+## Tests
+
+* `functions/__tests__/activity.test.js` prüft Mapping `Log -> Activity`.
+* API-Route wird über Next.js Routen-Handler getestet (manuell über `npm run dev` bzw. Integrationstest).

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,6 +1,59 @@
 {
   "indexes": [
     {
+      "collectionGroup": "activity",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "gymId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "timestamp",
+          "order": "DESCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "activity",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "gymId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "eventType",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "timestamp",
+          "order": "DESCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
+      "collectionGroup": "activity",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "gymId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "severity",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "timestamp",
+          "order": "DESCENDING"
+        }
+      ],
+      "density": "SPARSE_ALL"
+    },
+    {
       "collectionGroup": "completedChallenges",
       "queryScope": "COLLECTION",
       "fields": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -99,6 +99,14 @@ service cloud.firestore {
     }
 
     // ─────────────────────────
+    // Activity stream (server only)
+    // ─────────────────────────
+    match /gyms/{gymId}/activity/{eventId} {
+      allow read: if false;
+      allow write: if false;
+    }
+
+    // ─────────────────────────
     // Global logs read (owner-only)
     // ─────────────────────────
     match /{path=**}/logs/{logId} {

--- a/functions/__tests__/activity.test.js
+++ b/functions/__tests__/activity.test.js
@@ -1,0 +1,87 @@
+const admin = require('firebase-admin');
+
+const { buildDeviceLogActivityEvent } = require('../activity');
+
+describe('buildDeviceLogActivityEvent', () => {
+  const baseContext = {
+    params: { gymId: 'gym123', deviceId: 'deviceA', logId: 'log1' },
+  };
+
+  it('maps device log fields to activity event', () => {
+    const logTimestamp = admin.firestore.Timestamp.fromDate(new Date('2024-01-01T12:00:00Z'));
+    const now = admin.firestore.Timestamp.fromDate(new Date('2024-01-02T08:00:00Z'));
+    const event = buildDeviceLogActivityEvent(
+      {
+        timestamp: logTimestamp,
+        userId: 'user42',
+        sessionId: 'session88',
+        exerciseId: 'bench',
+        exerciseName: 'Bench Press',
+        setType: 'drop',
+        reps: 10,
+        weight: 80,
+        durationSeconds: 45,
+      },
+      baseContext,
+      { now, serverTimestamp: 'SERVER_TS' }
+    );
+
+    expect(event).toEqual({
+      gymId: 'gym123',
+      timestamp: logTimestamp,
+      eventType: 'training.set_logged',
+      severity: 'info',
+      source: 'device',
+      summary: 'Trainingseintrag gespeichert (Bench Press)',
+      userId: 'user42',
+      deviceId: 'deviceA',
+      sessionId: 'session88',
+      actor: { type: 'user', id: 'user42' },
+      targets: [
+        { type: 'session', id: 'session88' },
+        { type: 'exercise', id: 'bench' },
+      ],
+      data: {
+        exerciseId: 'bench',
+        exerciseName: 'Bench Press',
+        setType: 'drop',
+        reps: 10,
+        weight: 80,
+        duration: 45,
+      },
+      updatedAt: 'SERVER_TS',
+      idempotencyKey: 'gym123:deviceA:log1',
+    });
+  });
+
+  it('falls back to now timestamp and omits optional fields', () => {
+    const now = admin.firestore.Timestamp.fromDate(new Date('2024-02-01T10:00:00Z'));
+    const event = buildDeviceLogActivityEvent(
+      {},
+      baseContext,
+      { now, serverTimestamp: 'SERVER_TS' }
+    );
+
+    expect(event).toEqual({
+      gymId: 'gym123',
+      timestamp: now,
+      eventType: 'training.set_logged',
+      severity: 'info',
+      source: 'device',
+      summary: 'Trainingseintrag gespeichert',
+      userId: undefined,
+      deviceId: 'deviceA',
+      sessionId: undefined,
+      actor: { type: 'system' },
+      targets: undefined,
+      data: undefined,
+      updatedAt: 'SERVER_TS',
+      idempotencyKey: 'gym123:deviceA:log1',
+    });
+  });
+
+  it('returns null for missing context params', () => {
+    const event = buildDeviceLogActivityEvent({}, { params: {} }, {});
+    expect(event).toBeNull();
+  });
+});

--- a/functions/activity.js
+++ b/functions/activity.js
@@ -1,0 +1,137 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+
+function sanitizeString(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function sanitizeNumber(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+function buildDeviceLogActivityEvent(data, context, options = {}) {
+  const { gymId, deviceId, logId } = context.params;
+  if (!gymId || !deviceId || !logId) {
+    return null;
+  }
+
+  const nowTimestamp = options.now instanceof admin.firestore.Timestamp ? options.now : admin.firestore.Timestamp.now();
+  const serverTimestamp = options.serverTimestamp || admin.firestore.FieldValue.serverTimestamp();
+
+  const rawTimestamp = data.timestamp;
+  const timestamp = rawTimestamp instanceof admin.firestore.Timestamp ? rawTimestamp : nowTimestamp;
+  const userId = sanitizeString(data.userId ?? data.userID);
+  const sessionId = sanitizeString(data.sessionId);
+  const exerciseName = sanitizeString(data.exerciseName);
+  const exerciseId = sanitizeString(data.exerciseId);
+  const setType = sanitizeString(data.setType);
+
+  const summaryParts = ['Trainingseintrag gespeichert'];
+  if (exerciseName) {
+    summaryParts.push(`(${exerciseName})`);
+  } else if (exerciseId) {
+    summaryParts.push(`(${exerciseId})`);
+  }
+  const summary = summaryParts.join(' ');
+
+  const payload = {};
+  if (exerciseId) {
+    payload.exerciseId = exerciseId;
+  }
+  if (exerciseName) {
+    payload.exerciseName = exerciseName;
+  }
+  if (setType) {
+    payload.setType = setType;
+  }
+  const reps = sanitizeNumber(data.reps ?? data.repeatCount);
+  if (reps !== undefined) {
+    payload.reps = reps;
+  }
+  const weight = sanitizeNumber(data.weight ?? data.weightKg);
+  if (weight !== undefined) {
+    payload.weight = weight;
+  }
+  const duration = sanitizeNumber(data.durationSeconds ?? data.duration ?? data.timeUnderTension);
+  if (duration !== undefined) {
+    payload.duration = duration;
+  }
+  const distance = sanitizeNumber(data.distance ?? data.distanceMeters);
+  if (distance !== undefined) {
+    payload.distance = distance;
+  }
+  const calories = sanitizeNumber(data.calories);
+  if (calories !== undefined) {
+    payload.calories = calories;
+  }
+
+  const actor = userId ? { type: 'user', id: userId } : { type: 'system' };
+  const targets = [];
+  if (sessionId) {
+    targets.push({ type: 'session', id: sessionId });
+  }
+  if (exerciseId) {
+    targets.push({ type: 'exercise', id: exerciseId });
+  }
+
+  const event = {
+    gymId,
+    timestamp,
+    eventType: 'training.set_logged',
+    severity: 'info',
+    source: 'device',
+    summary,
+    userId: userId || undefined,
+    deviceId,
+    sessionId: sessionId || undefined,
+    actor,
+    targets: targets.length > 0 ? targets : undefined,
+    data: Object.keys(payload).length > 0 ? payload : undefined,
+    updatedAt: serverTimestamp,
+    idempotencyKey: `${gymId}:${deviceId}:${logId}`,
+  };
+
+  return event;
+}
+
+const mirrorDeviceLogToActivity = functions.firestore
+  .document('gyms/{gymId}/devices/{deviceId}/logs/{logId}')
+  .onCreate(async (snap, context) => {
+    const data = snap.data() || {};
+    const event = buildDeviceLogActivityEvent(data, context);
+    if (!event) {
+      console.warn('activity-mirror: invalid payload, skipping', context.params);
+      return null;
+    }
+
+    const db = admin.firestore();
+    const activityId = `device:${context.params.logId}`;
+    const activityRef = db.collection('gyms').doc(context.params.gymId).collection('activity').doc(activityId);
+
+    await activityRef.set(event, { merge: false });
+    console.info('activity-mirror: mirrored log to activity', {
+      gymId: context.params.gymId,
+      deviceId: context.params.deviceId,
+      logId: context.params.logId,
+      activityId,
+    });
+    return null;
+  });
+
+module.exports = {
+  buildDeviceLogActivityEvent,
+  mirrorDeviceLogToActivity,
+};

--- a/functions/index.js
+++ b/functions/index.js
@@ -4,6 +4,7 @@ admin.initializeApp();
 
 const avatars = require('./avatars');
 const xp = require('./xp');
+const activity = require('./activity');
 exports.adminGrantAvatar = avatars.adminGrantAvatar;
 exports.adminRevokeAvatar = avatars.adminRevokeAvatar;
 exports.onUserCreateDefaults = avatars.onUserCreateDefaults;
@@ -11,6 +12,7 @@ exports.onXpUpdate = avatars.onXpUpdate;
 exports.onChallengeState = avatars.onChallengeState;
 exports.onEventParticipation = avatars.onEventParticipation;
 exports.grantXpForSession = xp.grantXpForSession;
+exports.mirrorDeviceLogToActivity = activity.mirrorDeviceLogToActivity;
 
 exports.evaluateChallenges = functions.pubsub
   .schedule('every 24 hours')

--- a/website/src/app/(admin)/admin/monitoring/[gymId]/page.tsx
+++ b/website/src/app/(admin)/admin/monitoring/[gymId]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from 'next/navigation';
 
 import { requireRole } from '@/src/lib/auth/server';
 import { ADMIN_ROUTES } from '@/src/lib/routes';
-import { AdminEventLogTable } from '@/src/components/admin/admin-event-log-table';
+import { GymActivityFeed } from '@/src/components/admin/gym-activity-feed';
 import { fetchGymEventLogs, fetchGymMonitoringSummary } from '@/src/server/monitoring';
 
 export const runtime = 'nodejs';
@@ -78,12 +78,25 @@ export default async function MonitoringDetailPage({ params, searchParams }: Pag
     cursor: searchParams?.cursor ?? null,
   });
 
+  const initialEvents = events.entries.map((entry) => ({
+    id: entry.id,
+    gymId: entry.gymId,
+    timestamp: entry.timestamp.toISOString(),
+    eventType: entry.eventType,
+    severity: entry.severity ?? 'info',
+    source: entry.source ?? 'system',
+    summary: entry.summary ?? null,
+    userId: entry.userId ?? null,
+    deviceId: entry.deviceId ?? null,
+    sessionId: entry.sessionId ?? null,
+    actor: entry.actor ?? null,
+    targets: entry.targets ?? [],
+    data: entry.data ?? null,
+  }));
+
   const status = summary.status?.status ?? null;
   const statusLabel = resolveStatusLabel(status);
   const statusUpdatedAtLabel = formatTimestamp(summary.statusUpdatedAt);
-  const nextCursorHref = events.nextCursor
-    ? `${ADMIN_ROUTES.monitoringDetail.href.replace('[gymId]', encodeURIComponent(params.gymId))}?cursor=${encodeURIComponent(events.nextCursor)}`
-    : null;
 
   const locationParts = [summary.city, summary.state].filter((part): part is string => Boolean(part));
   const locationLabel = locationParts.length > 0 ? locationParts.join(' · ') : 'Keine Ortsangabe';
@@ -149,37 +162,13 @@ export default async function MonitoringDetailPage({ params, searchParams }: Pag
         </article>
       </section>
 
-      <section className="space-y-4 rounded-lg border border-subtle bg-card p-6 shadow-sm">
-        <header className="space-y-1">
-          <h2 className="text-xl font-semibold text-page">Letzte Ereignisse</h2>
-          <p className="text-sm text-muted">
-            Ereignisprotokoll für dieses Gym. Datenbasis: Firestore collectionGroup('logs') mit Filter auf gymId.
-          </p>
-        </header>
-        {events.error ? (
-          <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-500/60 dark:bg-amber-500/10 dark:text-amber-200">
-            {events.error === 'Index erforderlich'
-              ? 'Keine Daten verfügbar. Firestore Index wird benötigt oder befindet sich im Aufbau.'
-              : 'Aktueller Ereignisstream konnte nicht geladen werden.'}
-          </div>
-        ) : null}
-        <AdminEventLogTable
-          entries={events.entries}
-          formatTimestamp={(date) => dateTimeFormatter.format(date)}
-          emptyLabel="Keine Ereignisse vorhanden."
-          showGymColumn={false}
-        />
-        {nextCursorHref ? (
-          <div className="text-right">
-            <Link
-              href={nextCursorHref}
-              className="text-sm font-semibold text-primary underline-offset-4 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-            >
-              Weitere Ereignisse laden
-            </Link>
-          </div>
-        ) : null}
-      </section>
+      <GymActivityFeed
+        gymId={params.gymId}
+        initialEvents={initialEvents}
+        initialCursor={events.nextCursor}
+        initialStats={events.stats}
+        initialWarnings={events.warnings}
+      />
     </div>
   );
 }

--- a/website/src/app/(admin)/admin/page.tsx
+++ b/website/src/app/(admin)/admin/page.tsx
@@ -185,7 +185,7 @@ export default async function AdminPage() {
         <header className="space-y-1">
           <h2 className="text-xl font-semibold text-page">Letzte Ereignisse</h2>
           <p className="text-sm text-muted">
-            Aktuelle Logs aus den Gym-Geräten. Zeigt Typ, Quelle und Beschreibung der Aktivität.
+            Vereinheitlichter Aktivitäten-Stream pro Gym. Zeigt Quelle, Typ, Betroffene sowie Metadaten.
           </p>
         </header>
         {dashboard.events.error ? (
@@ -200,7 +200,7 @@ export default async function AdminPage() {
           showGymColumn
         />
         <p className="text-xs text-muted">
-          Quelle: Firestore collectionGroup('logs') · Zugriff nur mit Admin-Session
+          Quelle: Firestore collectionGroup('activity') · Zugriff nur mit Admin-Session
         </p>
       </section>
 

--- a/website/src/app/api/admin/gyms/[gymId]/events/route.ts
+++ b/website/src/app/api/admin/gyms/[gymId]/events/route.ts
@@ -1,0 +1,167 @@
+import { NextResponse } from 'next/server';
+import { createHash } from 'crypto';
+
+import { getAdminUserFromSession } from '@/src/server/auth/session';
+import { fetchActivityEventsForGym } from '@/src/server/activity/events';
+import type { GymActivityResponse } from '@/src/types/admin-activity';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+const CACHE_HEADER_VALUE = 'private, max-age=30';
+const ERROR_HEADERS = new Headers({ 'Cache-Control': 'no-store' });
+
+function createRequestId(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+function buildEtag(payload: string): string {
+  const hash = createHash('sha1').update(payload).digest('base64url');
+  return `"${hash}"`;
+}
+
+function normalizeEtag(value: string): string {
+  return value.trim().replace(/^W\//i, '');
+}
+
+function etagMatches(candidateHeader: string | null, etag: string): boolean {
+  if (!candidateHeader) {
+    return false;
+  }
+  const normalized = normalizeEtag(etag);
+  return candidateHeader
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .some((value) => {
+      if (value === '*') {
+        return true;
+      }
+      return normalizeEtag(value) === normalized;
+    });
+}
+
+function parseList(single: string | null, multi: string[]): string[] {
+  const values: string[] = [];
+  const sources = multi.length > 0 ? multi : single ? [single] : [];
+  sources.forEach((entry) => {
+    entry
+      .split(',')
+      .map((token) => token.trim())
+      .filter(Boolean)
+      .forEach((token) => {
+        if (!values.includes(token)) {
+          values.push(token);
+        }
+      });
+  });
+  return values.slice(0, 10);
+}
+
+function parseDate(value: string | null): Date | null {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function sanitizeId(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export async function GET(request: Request, { params }: { params: { gymId: string } }) {
+  const requestId = createRequestId();
+  const logPrefix = `[admin-monitoring] events ${requestId}`;
+  try {
+    const user = await getAdminUserFromSession();
+    if (!user) {
+      return NextResponse.json({ error: 'unauthorized', requestId }, { status: 401, headers: ERROR_HEADERS });
+    }
+    if (user.role !== 'admin' && user.role !== 'owner') {
+      return NextResponse.json({ error: 'forbidden', requestId }, { status: 403, headers: ERROR_HEADERS });
+    }
+
+    const url = new URL(request.url);
+    const searchParams = url.searchParams;
+    const limitRaw = searchParams.get('limit');
+    const limit = limitRaw ? Number.parseInt(limitRaw, 10) : 50;
+    if (Number.isNaN(limit) || limit < 1 || limit > 200) {
+      return NextResponse.json({ error: 'invalid_limit', requestId }, { status: 400, headers: ERROR_HEADERS });
+    }
+
+    const from = parseDate(searchParams.get('from'));
+    const to = parseDate(searchParams.get('to'));
+    if ((from && to && from > to) || (from && Number.isNaN(from.getTime())) || (to && Number.isNaN(to.getTime()))) {
+      return NextResponse.json({ error: 'invalid_range', requestId }, { status: 400, headers: ERROR_HEADERS });
+    }
+
+    const types = parseList(searchParams.get('types'), searchParams.getAll('types'));
+    const severity = parseList(searchParams.get('severity'), searchParams.getAll('severity')).filter((value) =>
+      value === 'info' || value === 'warning' || value === 'error'
+    );
+    const userId = sanitizeId(searchParams.get('userId'));
+    const deviceId = sanitizeId(searchParams.get('deviceId'));
+    const cursor = searchParams.get('cursor');
+
+    const result = await fetchActivityEventsForGym(params.gymId, {
+      limit,
+      from,
+      to,
+      eventTypes: types,
+      severity: severity.length > 0 ? (severity as ('info' | 'warning' | 'error')[]) : undefined,
+      userId: userId ?? undefined,
+      deviceId: deviceId ?? undefined,
+      cursor: cursor ?? undefined,
+    });
+
+    const payload: GymActivityResponse = {
+      items: result.items.map((item) => ({
+        id: item.id,
+        gymId: item.gymId,
+        timestamp: item.timestamp.toISOString(),
+        eventType: item.eventType,
+        severity: item.severity,
+        source: item.source,
+        summary: item.summary ?? null,
+        userId: item.userId ?? null,
+        deviceId: item.deviceId ?? null,
+        sessionId: item.sessionId ?? null,
+        actor: item.actor ?? null,
+        targets: item.targets ?? [],
+        data: item.data ?? null,
+      })),
+      nextCursor: result.nextCursor,
+      stats: result.stats,
+      requestId,
+      warnings: result.warnings,
+    };
+
+    const body = JSON.stringify(payload);
+    const etag = buildEtag(body);
+    const headers = new Headers({
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': CACHE_HEADER_VALUE,
+      ETag: etag,
+    });
+
+    const ifNoneMatch = request.headers.get('if-none-match');
+    if (etagMatches(ifNoneMatch, etag)) {
+      headers.delete('Content-Type');
+      return new Response(null, { status: 304, headers });
+    }
+
+    console.info(
+      `${logPrefix} gym=${params.gymId} items=${payload.items.length} limit=${limit} cursor=${cursor ? 'yes' : 'no'}`
+    );
+    return new Response(body, { status: 200, headers });
+  } catch (error) {
+    console.error(`${logPrefix} failed`, error);
+    return NextResponse.json({ error: 'internal_error', requestId }, { status: 500, headers: ERROR_HEADERS });
+  }
+}

--- a/website/src/components/admin/admin-event-log-table.tsx
+++ b/website/src/components/admin/admin-event-log-table.tsx
@@ -1,6 +1,43 @@
-import type { AdminEventLogEntry } from '@/src/server/admin/dashboard-data';
+import type { AdminActivityEventRecord } from '@/src/types/admin-activity';
 
 const defaultEmptyLabel = 'Keine Ereignisse vorhanden.';
+
+const SEVERITY_STYLES: Record<string, string> = {
+  info: 'bg-sky-100 text-sky-900 border-sky-200 dark:bg-sky-500/10 dark:text-sky-200 dark:border-sky-500/40',
+  warning: 'bg-amber-100 text-amber-900 border-amber-200 dark:bg-amber-500/10 dark:text-amber-200 dark:border-amber-500/40',
+  error: 'bg-rose-100 text-rose-900 border-rose-200 dark:bg-rose-500/10 dark:text-rose-200 dark:border-rose-500/40',
+};
+
+const SOURCE_LABELS: Record<string, string> = {
+  device: 'Gerät',
+  app: 'App',
+  backend: 'Backend',
+  admin: 'Admin',
+  system: 'System',
+};
+
+function formatEventType(value: string): string {
+  if (!value) {
+    return 'unbekannt';
+  }
+  return value.replace(/\./g, ' › ');
+}
+
+function resolveSeverityStyle(value: string | undefined) {
+  if (!value) {
+    return SEVERITY_STYLES.info;
+  }
+  return SEVERITY_STYLES[value] ?? SEVERITY_STYLES.info;
+}
+
+function resolveSourceLabel(value: string | undefined) {
+  if (!value) {
+    return SOURCE_LABELS.system;
+  }
+  return SOURCE_LABELS[value] ?? value;
+}
+
+type AdminEventLogTableEntry = AdminActivityEventRecord;
 
 export function AdminEventLogTable({
   entries,
@@ -8,7 +45,7 @@ export function AdminEventLogTable({
   emptyLabel = defaultEmptyLabel,
   showGymColumn = true,
 }: {
-  entries: AdminEventLogEntry[];
+  entries: AdminEventLogTableEntry[];
   formatTimestamp: (value: Date) => string;
   emptyLabel?: string;
   showGymColumn?: boolean;
@@ -39,26 +76,96 @@ export function AdminEventLogTable({
               </th>
             )}
             <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
-              Typ
+              Ereignis
             </th>
             <th scope="col" className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted">
-              Details
+              Kontext
             </th>
           </tr>
         </thead>
         <tbody className="divide-y divide-[color:var(--page-border)]">
-          {entries.map((event) => (
-            <tr key={`${event.id}-${event.timestamp.toISOString()}`} className="hover:bg-card-muted">
-              <td className="whitespace-nowrap px-4 py-3 text-sm text-page">{formatTimestamp(event.timestamp)}</td>
-              <td className="whitespace-nowrap px-4 py-3 text-sm text-muted">
-                {showGymColumn ? (event.gymId ? `Gym ${event.gymId}` : '–') : null}
-                {showGymColumn && event.deviceId ? ` · Gerät ${event.deviceId}` : null}
-                {!showGymColumn ? (event.deviceId ? `Gerät ${event.deviceId}` : '–') : null}
-              </td>
-              <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-page">{event.type ?? 'log'}</td>
-              <td className="px-4 py-3 text-sm text-page">{event.description ?? 'Keine Beschreibung'}</td>
-            </tr>
-          ))}
+          {entries.map((event) => {
+            const severity = event.severity ?? 'info';
+            const severityLabel = severity === 'info' ? 'Info' : severity === 'warning' ? 'Warnung' : 'Fehler';
+            const sourceLabel = resolveSourceLabel(event.source);
+            const contextItems: { label: string; value: string }[] = [];
+            if (showGymColumn && event.gymId) {
+              contextItems.push({ label: 'Gym', value: event.gymId });
+            }
+            if (event.deviceId) {
+              contextItems.push({ label: 'Gerät', value: event.deviceId });
+            }
+            if (event.userId) {
+              contextItems.push({ label: 'User', value: event.userId });
+            }
+            if (event.sessionId) {
+              contextItems.push({ label: 'Session', value: event.sessionId });
+            }
+            if (event.actor?.id) {
+              contextItems.push({ label: `Actor:${event.actor.type}`, value: event.actor.id });
+            }
+            (event.targets ?? []).forEach((target) => {
+              if (target.id) {
+                contextItems.push({ label: target.type, value: target.id });
+              }
+            });
+
+            const payloadEntries = Object.entries(event.data ?? {}).slice(0, 6);
+
+            return (
+              <tr key={`${event.id}-${event.timestamp.toISOString()}`} className="align-top hover:bg-card-muted">
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-page">{formatTimestamp(event.timestamp)}</td>
+                <td className="whitespace-nowrap px-4 py-3 text-sm text-muted">
+                  {showGymColumn ? (event.gymId ? `Gym ${event.gymId}` : '–') : null}
+                  {showGymColumn && event.deviceId ? ` · Gerät ${event.deviceId}` : null}
+                  {!showGymColumn ? (event.deviceId ? `Gerät ${event.deviceId}` : '–') : null}
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span
+                      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${resolveSeverityStyle(
+                        severity
+                      )}`}
+                    >
+                      {severityLabel}
+                    </span>
+                    <span className="text-sm font-semibold text-page">{formatEventType(event.eventType)}</span>
+                    <span className="text-xs text-muted">{sourceLabel}</span>
+                  </div>
+                  {event.summary ? <p className="mt-2 text-sm text-page">{event.summary}</p> : null}
+                </td>
+                <td className="px-4 py-3">
+                  {contextItems.length > 0 ? (
+                    <dl className="flex flex-wrap gap-2 text-xs text-muted">
+                      {contextItems.map((item) => (
+                        <div key={`${event.id}-${item.label}-${item.value}`} className="flex items-center gap-1 rounded border border-subtle px-2 py-1">
+                          <dt className="font-semibold uppercase tracking-wide">{item.label}</dt>
+                          <dd className="font-mono text-[11px] text-page">{item.value}</dd>
+                        </div>
+                      ))}
+                    </dl>
+                  ) : (
+                    <p className="text-xs text-muted">Keine Referenzen</p>
+                  )}
+                  {payloadEntries.length > 0 ? (
+                    <div className="mt-3 space-y-1">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-muted">Details</p>
+                      <dl className="grid gap-1 text-xs">
+                        {payloadEntries.map(([key, value]) => (
+                          <div key={key} className="grid grid-cols-[auto,1fr] items-start gap-2">
+                            <dt className="font-semibold text-muted">{key}</dt>
+                            <dd className="font-mono text-[11px] text-page">
+                              {typeof value === 'boolean' ? (value ? 'true' : 'false') : String(value)}
+                            </dd>
+                          </div>
+                        ))}
+                      </dl>
+                    </div>
+                  ) : null}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/website/src/components/admin/gym-activity-feed.tsx
+++ b/website/src/components/admin/gym-activity-feed.tsx
@@ -1,0 +1,422 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
+
+import { AdminEventLogTable } from '@/src/components/admin/admin-event-log-table';
+import type { ActivityEventStats, AdminActivityEvent, GymActivityResponse } from '@/src/types/admin-activity';
+
+const numberFormatter = new Intl.NumberFormat('de-DE');
+const dateTimeFormatter = new Intl.DateTimeFormat('de-DE', {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+const KNOWN_EVENT_TYPES = [
+  'training.set_logged',
+  'auth.login',
+  'auth.register',
+  'friend.request_sent',
+  'friend.request_accepted',
+  'challenge.joined',
+  'challenge.completed',
+  'device.status_changed',
+  'device.offline_detected',
+  'device.online_detected',
+  'admin.adjustment',
+  'backend.error_reported',
+];
+
+type AppliedFilters = {
+  range: '24h' | '7d' | '30d' | 'custom';
+  from?: string | null;
+  to?: string | null;
+  types: string[];
+  severity: string[];
+  userId?: string;
+  deviceId?: string;
+};
+
+type Props = {
+  gymId: string;
+  initialEvents: AdminActivityEvent[];
+  initialCursor: string | null;
+  initialStats: ActivityEventStats;
+  initialWarnings: string[];
+};
+
+function createDateInputValue(iso: string | undefined | null): string {
+  if (!iso) {
+    return '';
+  }
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return date.toISOString().slice(0, 16);
+}
+
+function computeRangeDates(range: AppliedFilters['range'], customFrom?: string | null, customTo?: string | null) {
+  const now = new Date();
+  if (range === '24h') {
+    return { from: new Date(now.getTime() - 24 * 60 * 60 * 1000), to: now };
+  }
+  if (range === '7d') {
+    return { from: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000), to: now };
+  }
+  if (range === '30d') {
+    return { from: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000), to: now };
+  }
+  if (customFrom) {
+    const from = new Date(customFrom);
+    const to = customTo ? new Date(customTo) : now;
+    if (!Number.isNaN(from.getTime()) && !Number.isNaN(to.getTime())) {
+      return { from, to };
+    }
+  }
+  return { from: null, to: null };
+}
+
+function formatNumber(value: number) {
+  return numberFormatter.format(value);
+}
+
+function parseEvents(items: AdminActivityEvent[]) {
+  return items.map((item) => ({
+    ...item,
+    timestamp: new Date(item.timestamp),
+  }));
+}
+
+export function GymActivityFeed({ gymId, initialEvents, initialCursor, initialStats, initialWarnings }: Props) {
+  const [events, setEvents] = useState<AdminActivityEvent[]>(initialEvents);
+  const [cursor, setCursor] = useState<string | null>(initialCursor);
+  const [stats, setStats] = useState<ActivityEventStats>(initialStats);
+  const [warnings, setWarnings] = useState<string[]>(initialWarnings);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [filters, setFilters] = useState<AppliedFilters>({
+    range: '7d',
+    types: [],
+    severity: [],
+  });
+  const [customFrom, setCustomFrom] = useState<string>('');
+  const [customTo, setCustomTo] = useState<string>('');
+  const abortRef = useRef<AbortController | null>(null);
+  const filtersRef = useRef<AppliedFilters>({
+    range: '7d',
+    types: [],
+    severity: [],
+  });
+
+  useEffect(() => {
+    if (filters.range === 'custom') {
+      setCustomFrom(createDateInputValue(filters.from ?? null));
+      setCustomTo(createDateInputValue(filters.to ?? null));
+    }
+  }, []);
+
+  useEffect(() => {
+    filtersRef.current = filters;
+  }, [filters]);
+
+  const fetchEvents = useCallback(
+    async ({
+      append,
+      cursorOverride,
+      overrideFilters,
+    }: {
+      append: boolean;
+      cursorOverride?: string | null;
+      overrideFilters?: AppliedFilters;
+    }) => {
+      const controller = new AbortController();
+      if (abortRef.current) {
+        abortRef.current.abort();
+      }
+      abortRef.current = controller;
+      setLoading(true);
+      setError(null);
+
+      const activeFilters = overrideFilters ?? filtersRef.current;
+      const { from, to } = computeRangeDates(activeFilters.range, activeFilters.from, activeFilters.to);
+      const params = new URLSearchParams();
+      params.set('limit', append ? '50' : '100');
+      if (from instanceof Date && !Number.isNaN(from.getTime())) {
+        params.set('from', from.toISOString());
+      }
+      if (to instanceof Date && !Number.isNaN(to.getTime())) {
+        params.set('to', to.toISOString());
+      }
+      if (activeFilters.types.length > 0) {
+        params.set('types', activeFilters.types.join(','));
+      }
+      if (activeFilters.severity.length > 0) {
+        params.set('severity', activeFilters.severity.join(','));
+      }
+      if (activeFilters.userId?.trim()) {
+        params.set('userId', activeFilters.userId.trim());
+      }
+      if (activeFilters.deviceId?.trim()) {
+        params.set('deviceId', activeFilters.deviceId.trim());
+      }
+      if (cursorOverride) {
+        params.set('cursor', cursorOverride);
+      }
+
+      try {
+        const response = await fetch(`/api/admin/gyms/${encodeURIComponent(gymId)}/events?${params.toString()}`, {
+          method: 'GET',
+          headers: { Accept: 'application/json' },
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({ error: 'unknown' }));
+          setError('Aktivitäten konnten nicht geladen werden.');
+          setWarnings((prev) => [...prev, body.error ?? 'http-error']);
+          return;
+        }
+        const payload = (await response.json()) as GymActivityResponse;
+        setCursor(payload.nextCursor ?? null);
+        setStats(payload.stats);
+        setWarnings(payload.warnings ?? []);
+        setEvents((prev) => (append ? [...prev, ...payload.items] : payload.items));
+      } catch (fetchError) {
+        if ((fetchError as { name?: string }).name === 'AbortError') {
+          return;
+        }
+        setError('Netzwerkfehler beim Laden des Aktivitätsstreams.');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [gymId]
+  );
+
+  const handleApplyFilters = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const formData = new FormData(event.currentTarget);
+      const range = (formData.get('range') as AppliedFilters['range']) ?? '7d';
+      const selectedTypes = formData.getAll('eventTypes') as string[];
+      const selectedSeverity = formData.getAll('severity') as string[];
+      const nextFilters: AppliedFilters = {
+        range,
+        types: selectedTypes,
+        severity: selectedSeverity,
+        userId: (formData.get('userId') as string | null) ?? undefined,
+        deviceId: (formData.get('deviceId') as string | null) ?? undefined,
+      };
+      if (range === 'custom') {
+        const nextFrom = formData.get('customFrom') as string | null;
+        const nextTo = formData.get('customTo') as string | null;
+        nextFilters.from = nextFrom && nextFrom.trim().length > 0 ? new Date(nextFrom).toISOString() : null;
+        nextFilters.to = nextTo && nextTo.trim().length > 0 ? new Date(nextTo).toISOString() : null;
+        setCustomFrom(nextFrom ?? '');
+        setCustomTo(nextTo ?? '');
+      } else {
+        setCustomFrom('');
+        setCustomTo('');
+        nextFilters.from = undefined;
+        nextFilters.to = undefined;
+      }
+      setFilters(nextFilters);
+      fetchEvents({ append: false, cursorOverride: null, overrideFilters: nextFilters });
+    },
+    [fetchEvents]
+  );
+
+  const handleLoadMore = useCallback(() => {
+    if (!cursor) {
+      return;
+    }
+    fetchEvents({ append: true, cursorOverride: cursor });
+  }, [cursor, fetchEvents]);
+
+  const handleReset = useCallback(() => {
+    const defaults: AppliedFilters = { range: '7d', types: [], severity: [] };
+    setFilters(defaults);
+    setCustomFrom('');
+    setCustomTo('');
+    fetchEvents({ append: false, cursorOverride: null, overrideFilters: defaults });
+  }, [fetchEvents]);
+
+  const statsItems = [
+    { label: 'Gesamt', value: stats.total },
+    { label: 'Letzte 24 h', value: stats.last24h },
+    { label: 'Letzte 7 Tage', value: stats.last7d },
+    { label: 'Letzte 30 Tage', value: stats.last30d },
+  ];
+
+  const tableEntries = useMemo(() => parseEvents(events), [events]);
+
+  return (
+    <div className="space-y-6">
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {statsItems.map((item) => (
+          <article key={item.label} className="rounded-lg border border-subtle bg-card p-5 shadow-sm">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted">{item.label}</p>
+            <p className="mt-2 text-2xl font-semibold text-page">{formatNumber(item.value)}</p>
+          </article>
+        ))}
+      </section>
+
+      <form
+        key={JSON.stringify(filters)}
+        onSubmit={handleApplyFilters}
+        className="space-y-4 rounded-lg border border-subtle bg-card p-4 shadow-sm"
+      >
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <label className="space-y-2 text-sm text-muted">
+            <span className="block text-xs font-semibold uppercase tracking-wide">Zeitraum</span>
+            <select name="range" defaultValue={filters.range} className="w-full rounded border border-subtle bg-card px-3 py-2 text-sm text-page">
+              <option value="24h">Letzte 24 Stunden</option>
+              <option value="7d">Letzte 7 Tage</option>
+              <option value="30d">Letzte 30 Tage</option>
+              <option value="custom">Benutzerdefiniert</option>
+            </select>
+          </label>
+
+          {filters.range === 'custom' ? (
+            <div className="space-y-4 md:col-span-2 lg:col-span-2">
+              <label className="space-y-2 text-sm text-muted">
+                <span className="block text-xs font-semibold uppercase tracking-wide">Von</span>
+                <input
+                  type="datetime-local"
+                  name="customFrom"
+                  defaultValue={customFrom}
+                  className="w-full rounded border border-subtle bg-card px-3 py-2 text-sm text-page"
+                  max={customTo || undefined}
+                />
+              </label>
+              <label className="space-y-2 text-sm text-muted">
+                <span className="block text-xs font-semibold uppercase tracking-wide">Bis</span>
+                <input
+                  type="datetime-local"
+                  name="customTo"
+                  defaultValue={customTo}
+                  className="w-full rounded border border-subtle bg-card px-3 py-2 text-sm text-page"
+                />
+              </label>
+            </div>
+          ) : null}
+
+          <label className="space-y-2 text-sm text-muted">
+            <span className="block text-xs font-semibold uppercase tracking-wide">Event-Typen</span>
+            <select
+              name="eventTypes"
+              multiple
+              defaultValue={filters.types}
+              className="h-32 w-full rounded border border-subtle bg-card px-3 py-2 text-sm text-page"
+            >
+              {KNOWN_EVENT_TYPES.map((type) => (
+                <option key={type} value={type}>
+                  {type}
+                </option>
+              ))}
+            </select>
+            <span className="block text-xs text-muted">Strg/Cmd gedrückt halten für Mehrfachauswahl.</span>
+          </label>
+
+          <fieldset className="space-y-2 text-sm text-muted">
+            <legend className="text-xs font-semibold uppercase tracking-wide">Severity</legend>
+            {['info', 'warning', 'error'].map((severity) => (
+              <label key={severity} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  name="severity"
+                  value={severity}
+                  defaultChecked={filters.severity.includes(severity)}
+                  className="h-4 w-4 rounded border-subtle text-primary focus:ring-primary"
+                />
+                <span className="text-sm text-page">{severity}</span>
+              </label>
+            ))}
+          </fieldset>
+
+          <label className="space-y-2 text-sm text-muted">
+            <span className="block text-xs font-semibold uppercase tracking-wide">User ID</span>
+            <input
+              type="text"
+              name="userId"
+              defaultValue={filters.userId ?? ''}
+              className="w-full rounded border border-subtle bg-card px-3 py-2 text-sm text-page"
+              placeholder="optional"
+            />
+          </label>
+
+          <label className="space-y-2 text-sm text-muted">
+            <span className="block text-xs font-semibold uppercase tracking-wide">Device ID</span>
+            <input
+              type="text"
+              name="deviceId"
+              defaultValue={filters.deviceId ?? ''}
+              className="w-full rounded border border-subtle bg-card px-3 py-2 text-sm text-page"
+              placeholder="optional"
+            />
+          </label>
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={handleReset}
+            className="rounded border border-subtle px-4 py-2 text-sm font-semibold text-muted hover:bg-card-muted"
+          >
+            Zurücksetzen
+          </button>
+          <button
+            type="submit"
+            className="rounded bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow hover:bg-primary/90 disabled:opacity-70"
+            disabled={loading}
+          >
+            {loading ? 'Lädt…' : 'Filter anwenden'}
+          </button>
+        </div>
+      </form>
+
+      {warnings.length > 0 ? (
+        <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-500/60 dark:bg-amber-500/10 dark:text-amber-200">
+          {warnings.includes('index-required')
+            ? 'Firestore Index wird erstellt oder fehlt. Ergebnisse können unvollständig sein.'
+            : 'Für einige Kennzahlen konnten keine Zähler berechnet werden.'}
+        </div>
+      ) : null}
+
+      {error ? (
+        <div className="rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-800 dark:border-rose-500/60 dark:bg-rose-500/10 dark:text-rose-200">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="space-y-4 rounded-lg border border-subtle bg-card p-4 shadow-sm">
+        <header className="space-y-1">
+          <h3 className="text-lg font-semibold text-page">Aktivitätsstream</h3>
+          <p className="text-sm text-muted">
+            Gefilterte Ereignisse für dieses Gym. Zeitzone basiert auf Browser-Einstellungen.
+          </p>
+        </header>
+        <AdminEventLogTable
+          entries={tableEntries.map((entry) => ({
+            ...entry,
+            timestamp: entry.timestamp instanceof Date ? entry.timestamp : new Date(entry.timestamp),
+          }))}
+          formatTimestamp={(date) => dateTimeFormatter.format(date)}
+          emptyLabel="Keine Ereignisse gefunden."
+          showGymColumn={false}
+        />
+        {cursor ? (
+          <div className="text-right">
+            <button
+              type="button"
+              onClick={handleLoadMore}
+              disabled={loading}
+              className="text-sm font-semibold text-primary underline-offset-4 hover:underline disabled:opacity-60"
+            >
+              {loading ? 'Lädt…' : 'Weitere Ereignisse laden'}
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/website/src/server/activity/events.ts
+++ b/website/src/server/activity/events.ts
@@ -1,0 +1,390 @@
+import 'server-only';
+
+import {
+  FieldPath,
+  Timestamp,
+  type Firestore,
+  type Query,
+  type QueryDocumentSnapshot,
+} from 'firebase-admin/firestore';
+
+import { adminDb } from '@/src/server/firebase/admin';
+import type {
+  ActivityEventSeverity,
+  AdminActivityActor,
+  AdminActivityEventRecord,
+  AdminActivityTarget,
+  ActivityEventStats,
+} from '@/src/types/admin-activity';
+
+export type ActivityEventFilters = {
+  from?: Date | null;
+  to?: Date | null;
+  eventTypes?: string[];
+  severity?: ActivityEventSeverity[];
+  userId?: string | null;
+  deviceId?: string | null;
+  limit?: number;
+  cursor?: string | null;
+};
+
+export type ActivityEventQueryResult = {
+  items: AdminActivityEventRecord[];
+  nextCursor: string | null;
+  stats: ActivityEventStats;
+  warnings: string[];
+};
+
+type CursorPayload = {
+  ts: string;
+  path: string;
+};
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+const MIN_LIMIT = 1;
+
+function toDate(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return value;
+  }
+  if (value instanceof Timestamp) {
+    return value.toDate();
+  }
+  if (value && typeof (value as { toDate?: () => Date }).toDate === 'function') {
+    try {
+      return (value as { toDate: () => Date }).toDate();
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function sanitizeString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function sanitizeActor(value: unknown): AdminActivityActor | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const typeValue = record.type;
+  const type = typeValue === 'user' || typeValue === 'system' || typeValue === 'admin' ? typeValue : undefined;
+  if (!type) {
+    return null;
+  }
+  const id = sanitizeString(record.id);
+  const label = sanitizeString(record.label);
+  return {
+    type,
+    id: id ?? undefined,
+    label: label ?? undefined,
+  };
+}
+
+function sanitizeTarget(value: unknown): AdminActivityTarget | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const type = sanitizeString(record.type);
+  if (!type) {
+    return null;
+  }
+  const id = sanitizeString(record.id);
+  const label = sanitizeString(record.label);
+  return {
+    type,
+    id: id ?? undefined,
+    label: label ?? undefined,
+  };
+}
+
+function sanitizeData(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  Object.entries(record).forEach(([key, entryValue]) => {
+    if (!key || typeof key !== 'string') {
+      return;
+    }
+    const normalizedKey = key.trim();
+    if (!normalizedKey) {
+      return;
+    }
+    if (normalizedKey.toLowerCase().includes('email')) {
+      return;
+    }
+    if (
+      entryValue === null ||
+      typeof entryValue === 'string' ||
+      typeof entryValue === 'number' ||
+      typeof entryValue === 'boolean'
+    ) {
+      result[normalizedKey] = entryValue;
+      return;
+    }
+    if (entryValue instanceof Timestamp) {
+      result[normalizedKey] = entryValue.toDate().toISOString();
+      return;
+    }
+    if (entryValue instanceof Date) {
+      result[normalizedKey] = entryValue.toISOString();
+      return;
+    }
+    if (Array.isArray(entryValue)) {
+      const sanitizedArray = entryValue.filter((item) => {
+        return (
+          item === null ||
+          typeof item === 'string' ||
+          typeof item === 'number' ||
+          typeof item === 'boolean'
+        );
+      });
+      if (sanitizedArray.length > 0) {
+        result[normalizedKey] = sanitizedArray.slice(0, 20);
+      }
+      return;
+    }
+    if (typeof entryValue === 'object') {
+      const nested = sanitizeData(entryValue);
+      if (nested && Object.keys(nested).length > 0) {
+        result[normalizedKey] = nested;
+      }
+    }
+  });
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+export function mapActivityEventDoc(doc: QueryDocumentSnapshot): AdminActivityEventRecord | null {
+  const data = doc.data() as Record<string, unknown>;
+  const timestamp = toDate(data.timestamp);
+  if (!timestamp) {
+    return null;
+  }
+  const segments = doc.ref.path.split('/');
+  const gymId = segments.length >= 2 ? segments[1] : null;
+  if (!gymId) {
+    return null;
+  }
+
+  const eventTypeValue = data.eventType ?? (data as { type?: unknown }).type;
+  const eventType = typeof eventTypeValue === 'string' ? eventTypeValue : 'unknown';
+  const severityValue = data.severity;
+  const severity:
+    | ActivityEventSeverity
+    | undefined = severityValue === 'warning' || severityValue === 'error' ? severityValue : 'info';
+  const sourceValue = data.source;
+  const source =
+    sourceValue === 'device' ||
+    sourceValue === 'app' ||
+    sourceValue === 'backend' ||
+    sourceValue === 'admin' ||
+    sourceValue === 'system'
+      ? sourceValue
+      : 'system';
+  const summary = sanitizeString(data.summary ?? (data as { description?: unknown }).description ?? (data as { message?: unknown }).message);
+  const userId = sanitizeString(data.userId);
+  const deviceId = sanitizeString(data.deviceId);
+  const sessionId = sanitizeString(data.sessionId);
+  const actor = sanitizeActor(data.actor);
+  const targets = Array.isArray(data.targets)
+    ? (data.targets
+        .map((target) => sanitizeTarget(target))
+        .filter((target): target is AdminActivityTarget => Boolean(target)) as AdminActivityTarget[])
+    : undefined;
+  const payload = sanitizeData(data.data);
+
+  return {
+    id: doc.id,
+    gymId,
+    timestamp,
+    eventType,
+    severity: severity ?? 'info',
+    source,
+    summary: summary ?? null,
+    userId: userId ?? undefined,
+    deviceId: deviceId ?? undefined,
+    sessionId: sessionId ?? undefined,
+    actor: actor ?? undefined,
+    targets,
+    data: payload ?? undefined,
+  };
+}
+
+function buildBaseQuery(
+  firestore: Firestore,
+  gymId: string,
+  filters: ActivityEventFilters
+): Query {
+  let query: Query = firestore.collectionGroup('activity').where('gymId', '==', gymId);
+
+  const normalizedEventTypes = (filters.eventTypes ?? []).filter((type) => typeof type === 'string' && type.trim());
+  if (normalizedEventTypes.length === 1) {
+    query = query.where('eventType', '==', normalizedEventTypes[0]!);
+  } else if (normalizedEventTypes.length > 1) {
+    query = query.where('eventType', 'in', normalizedEventTypes.slice(0, 10));
+  }
+
+  const normalizedSeverity = (filters.severity ?? []).filter((value) => value === 'info' || value === 'warning' || value === 'error');
+  if (normalizedSeverity.length === 1) {
+    query = query.where('severity', '==', normalizedSeverity[0]!);
+  } else if (normalizedSeverity.length > 1) {
+    query = query.where('severity', 'in', normalizedSeverity.slice(0, 10));
+  }
+
+  const userId = sanitizeString(filters.userId);
+  if (userId) {
+    query = query.where('userId', '==', userId);
+  }
+
+  const deviceId = sanitizeString(filters.deviceId);
+  if (deviceId) {
+    query = query.where('deviceId', '==', deviceId);
+  }
+
+  if (filters.from instanceof Date) {
+    query = query.where('timestamp', '>=', Timestamp.fromDate(filters.from));
+  }
+  if (filters.to instanceof Date) {
+    query = query.where('timestamp', '<=', Timestamp.fromDate(filters.to));
+  }
+
+  return query;
+}
+
+function parseCursor(value: string | null | undefined): CursorPayload | null {
+  if (!value) {
+    return null;
+  }
+  try {
+    const decoded = Buffer.from(value, 'base64url').toString('utf8');
+    const payload = JSON.parse(decoded) as Partial<CursorPayload>;
+    if (!payload || typeof payload.ts !== 'string' || typeof payload.path !== 'string') {
+      return null;
+    }
+    return { ts: payload.ts, path: payload.path };
+  } catch {
+    return null;
+  }
+}
+
+function encodeCursor(doc: QueryDocumentSnapshot): string {
+  const data = doc.data() as { timestamp?: unknown };
+  const timestamp = toDate(data.timestamp);
+  const payload: CursorPayload = {
+    ts: timestamp ? timestamp.toISOString() : new Date().toISOString(),
+    path: doc.ref.path,
+  };
+  return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+}
+
+function clampLimit(value: number | null | undefined): number {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return DEFAULT_LIMIT;
+  }
+  return Math.min(Math.max(Math.floor(value), MIN_LIMIT), MAX_LIMIT);
+}
+
+function createStats(): ActivityEventStats {
+  return {
+    total: 0,
+    last24h: 0,
+    last7d: 0,
+    last30d: 0,
+  };
+}
+
+export async function fetchActivityEventsForGym(
+  gymId: string,
+  filters: ActivityEventFilters
+): Promise<ActivityEventQueryResult> {
+  const firestore = adminDb();
+  const limit = clampLimit(filters.limit);
+  const cursorPayload = parseCursor(filters.cursor);
+  const warnings: string[] = [];
+
+  try {
+    const baseQuery = buildBaseQuery(firestore, gymId, filters);
+    let itemsQuery = baseQuery
+      .orderBy('timestamp', 'desc')
+      .orderBy(FieldPath.documentId(), 'desc');
+
+    if (cursorPayload) {
+      const cursorDate = new Date(cursorPayload.ts);
+      const cursorDocId = cursorPayload.path.split('/').pop();
+      if (!Number.isNaN(cursorDate.getTime()) && cursorDocId) {
+        itemsQuery = itemsQuery.startAfter(Timestamp.fromDate(cursorDate), cursorDocId);
+      }
+    }
+
+    const snapshot = await itemsQuery.limit(limit + 1).get();
+    const docs = snapshot.docs;
+    const hasMore = docs.length > limit;
+    const relevantDocs = hasMore ? docs.slice(0, limit) : docs;
+    const items = relevantDocs
+      .map((doc) => mapActivityEventDoc(doc))
+      .filter((entry): entry is AdminActivityEventRecord => Boolean(entry));
+
+    const stats = createStats();
+
+    const now = new Date();
+    const dayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const monthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+    const [totalSnapshot, daySnapshot, weekSnapshot, monthSnapshot] = await Promise.allSettled([
+      baseQuery.count().get(),
+      buildBaseQuery(firestore, gymId, { ...filters, from: dayAgo }).count().get(),
+      buildBaseQuery(firestore, gymId, { ...filters, from: weekAgo }).count().get(),
+      buildBaseQuery(firestore, gymId, { ...filters, from: monthAgo }).count().get(),
+    ]);
+
+    if (totalSnapshot.status === 'fulfilled') {
+      stats.total = totalSnapshot.value.data().count ?? 0;
+    } else {
+      warnings.push('total-count-unavailable');
+    }
+    if (daySnapshot.status === 'fulfilled') {
+      stats.last24h = daySnapshot.value.data().count ?? 0;
+    } else {
+      warnings.push('24h-count-unavailable');
+    }
+    if (weekSnapshot.status === 'fulfilled') {
+      stats.last7d = weekSnapshot.value.data().count ?? 0;
+    } else {
+      warnings.push('7d-count-unavailable');
+    }
+    if (monthSnapshot.status === 'fulfilled') {
+      stats.last30d = monthSnapshot.value.data().count ?? 0;
+    } else {
+      warnings.push('30d-count-unavailable');
+    }
+
+    return {
+      items,
+      nextCursor: hasMore ? encodeCursor(docs[docs.length - 1]!) : null,
+      stats,
+      warnings,
+    };
+  } catch (error) {
+    if ((error as { code?: unknown }).code === 'failed-precondition' || (error as { code?: unknown }).code === 9) {
+      warnings.push('index-required');
+      return {
+        items: [],
+        nextCursor: null,
+        stats: createStats(),
+        warnings,
+      };
+    }
+    throw error;
+  }
+}

--- a/website/src/server/admin/dashboard-data.ts
+++ b/website/src/server/admin/dashboard-data.ts
@@ -1,23 +1,16 @@
 import 'server-only';
 
-import { Timestamp } from 'firebase-admin/firestore';
+import { FieldPath, Timestamp } from 'firebase-admin/firestore';
 
 import { adminDb } from '@/src/server/firebase/admin';
+import { mapActivityEventDoc } from '@/src/server/activity/events';
+import type { AdminActivityEventRecord } from '@/src/types/admin-activity';
 
 export type AdminKpiMetric = {
   id: string;
   label: string;
   value: number;
   helper?: string;
-};
-
-export type AdminEventLogEntry = {
-  id: string;
-  timestamp: Date;
-  gymId?: string;
-  deviceId?: string;
-  type?: string;
-  description?: string;
 };
 
 export type AdminActivityPoint = {
@@ -39,7 +32,7 @@ export type AdminDashboardData = {
     warnings: AdminDashboardWarning[];
   };
   events: {
-    items: AdminEventLogEntry[];
+    items: AdminActivityEventRecord[];
     error?: string;
   };
   activity: {
@@ -286,100 +279,59 @@ export async function fetchAdminDashboardData(): Promise<AdminDashboardData> {
       : undefined;
 
   let eventsError: string | undefined;
-  const eventEntries: AdminEventLogEntry[] = [];
+  const eventEntries: AdminActivityEventRecord[] = [];
 
   try {
     const eventSnapshot = await firestore
-      .collectionGroup('logs')
+      .collectionGroup('activity')
       .orderBy('timestamp', 'desc')
+      .orderBy(FieldPath.documentId(), 'desc')
       .limit(20)
       .get();
 
     eventSnapshot.docs.forEach((doc) => {
-      const data = doc.data();
-      const timestampValue = data.timestamp;
-      const timestamp =
-        timestampValue instanceof Timestamp
-          ? timestampValue.toDate()
-          : typeof timestampValue?.toDate === 'function'
-          ? timestampValue.toDate()
-          : null;
-
-      const segments = doc.ref.path.split('/');
-      const gymId = segments.length >= 2 ? segments[1] : undefined;
-      const deviceId = segments.length >= 4 ? segments[3] : undefined;
-      const type = typeof data.type === 'string' ? data.type : typeof data.eventType === 'string' ? data.eventType : undefined;
-      const description =
-        typeof data.description === 'string'
-          ? data.description
-          : typeof data.message === 'string'
-          ? data.message
-          : undefined;
-
-      if (timestamp) {
-        eventEntries.push({
-          id: doc.id,
-          timestamp,
-          gymId,
-          deviceId,
-          type,
-          description,
-        });
+      const entry = mapActivityEventDoc(doc);
+      if (entry) {
+        eventEntries.push(entry);
       }
     });
   } catch (error) {
     if (isFailedPrecondition(error)) {
-      console.warn('[admin-dashboard] Event-Log Index erforderlich – Fallback aktiv.', error);
+      console.warn('[admin-dashboard] Activity Index erforderlich – Fallback aktiv.', error);
       try {
         const fallbackSnapshot = await firestore
-          .collectionGroup('logs')
+          .collectionGroup('activity')
           .where('timestamp', '>=', Timestamp.fromDate(twoWeeksAgo))
-          .select('timestamp', 'type', 'eventType', 'description', 'message')
+          .select(
+            'timestamp',
+            'eventType',
+            'summary',
+            'severity',
+            'source',
+            'userId',
+            'deviceId',
+            'sessionId',
+            'actor',
+            'targets',
+            'data'
+          )
           .limit(1000)
           .get();
 
         const fallbackEntries = fallbackSnapshot.docs
-          .map((doc) => {
-            const data = doc.data();
-            const timestampValue = data.timestamp;
-            const timestamp =
-              timestampValue instanceof Timestamp
-                ? timestampValue.toDate()
-                : typeof timestampValue?.toDate === 'function'
-                ? timestampValue.toDate()
-                : null;
-            if (!timestamp) return null;
-            const segments = doc.ref.path.split('/');
-            const gymId = segments.length >= 2 ? segments[1] : undefined;
-            const deviceId = segments.length >= 4 ? segments[3] : undefined;
-            const type = typeof data.type === 'string' ? data.type : typeof data.eventType === 'string' ? data.eventType : undefined;
-            const description =
-              typeof data.description === 'string'
-                ? data.description
-                : typeof data.message === 'string'
-                ? data.message
-                : undefined;
-            return {
-              id: doc.id,
-              timestamp,
-              gymId,
-              deviceId,
-              type,
-              description,
-            } as AdminEventLogEntry;
-          })
-          .filter((entry): entry is AdminEventLogEntry => Boolean(entry))
+          .map((doc) => mapActivityEventDoc(doc))
+          .filter((entry): entry is AdminActivityEventRecord => Boolean(entry))
           .sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())
           .slice(0, 20);
 
         eventEntries.push(...fallbackEntries);
         eventsError = 'Index für Aktivitätsprotokoll wird erstellt – Fallback aktiv.';
       } catch (fallbackError) {
-        console.error('[admin-dashboard] event log fallback failed', fallbackError);
+        console.error('[admin-dashboard] activity fallback failed', fallbackError);
         eventsError = 'Aktivitätsprotokoll konnte nicht geladen werden.';
       }
     } else {
-      console.error('[admin-dashboard] event log query failed', error);
+      console.error('[admin-dashboard] activity query failed', error);
       eventsError = 'Aktivitätsprotokoll konnte nicht geladen werden.';
     }
   }

--- a/website/src/server/monitoring.ts
+++ b/website/src/server/monitoring.ts
@@ -1,9 +1,10 @@
 import 'server-only';
 
-import { GeoPoint, Timestamp, type DocumentSnapshot, type QueryDocumentSnapshot } from 'firebase-admin/firestore';
+import { GeoPoint, Timestamp, type DocumentSnapshot } from 'firebase-admin/firestore';
 
 import { adminDb } from '@/src/server/firebase/admin';
-import type { AdminEventLogEntry } from '@/src/server/admin/dashboard-data';
+import { fetchActivityEventsForGym } from '@/src/server/activity/events';
+import type { ActivityEventStats, AdminActivityEventRecord } from '@/src/types/admin-activity';
 import type {
   MonitoringGymFeature,
   MonitoringGymListItem,
@@ -48,9 +49,10 @@ export type FetchGymEventLogsOptions = {
 };
 
 export type FetchGymEventLogsResult = {
-  entries: AdminEventLogEntry[];
+  entries: AdminActivityEventRecord[];
   nextCursor: string | null;
-  error?: string;
+  stats: ActivityEventStats;
+  warnings: string[];
 };
 
 function toDate(value: unknown): Date | null {
@@ -162,28 +164,6 @@ function parseStatusSnapshot(
     return null;
   }
   return parseStatus(record);
-}
-
-function encodeCursor(path: string): string {
-  return Buffer.from(path, 'utf8').toString('base64url');
-}
-
-function decodeCursor(value: string | null | undefined): string | null {
-  if (!value) {
-    return null;
-  }
-  try {
-    const decoded = Buffer.from(value, 'base64url').toString('utf8');
-    if (!decoded.startsWith('gyms/')) {
-      return null;
-    }
-    if (!decoded.includes('/logs/')) {
-      return null;
-    }
-    return decoded;
-  } catch {
-    return null;
-  }
 }
 
 function isFailedPrecondition(error: unknown): boolean {
@@ -406,72 +386,38 @@ export async function fetchGymMonitoringSummary(gymId: string): Promise<FetchGym
   };
 }
 
-function mapEventDoc(doc: QueryDocumentSnapshot): AdminEventLogEntry | null {
-  const data = doc.data() as Record<string, unknown>;
-  const timestampValue = data.timestamp ?? (data as { timestamp?: unknown }).timestamp;
-  const timestamp = toDate(timestampValue);
-  if (!timestamp) {
-    return null;
-  }
-  const segments = doc.ref.path.split('/');
-  const gymId = segments.length >= 2 ? segments[1] : undefined;
-  const deviceId = segments.length >= 4 ? segments[3] : undefined;
-  const typeValue = data.type ?? (data as { eventType?: unknown }).eventType;
-  const type = typeof typeValue === 'string' ? typeValue : undefined;
-  const descriptionValue =
-    typeof data.description === 'string'
-      ? data.description
-      : typeof (data as { message?: unknown }).message === 'string'
-      ? ((data as { message: string }).message as string)
-      : undefined;
-
-  return {
-    id: doc.id,
-    timestamp,
-    gymId,
-    deviceId,
-    type,
-    description: descriptionValue,
-  };
-}
-
 export async function fetchGymEventLogs(
   gymId: string,
   options?: FetchGymEventLogsOptions
 ): Promise<FetchGymEventLogsResult> {
-  const firestore = adminDb();
-  const pageSize = Math.min(Math.max(options?.limit ?? 20, 1), 100);
-  const cursorPath = decodeCursor(options?.cursor);
-
   try {
-    let query = firestore
-      .collectionGroup('logs')
-      .where('gymId', '==', gymId)
-      .orderBy('timestamp', 'desc');
+    const result = await fetchActivityEventsForGym(gymId, {
+      limit: options?.limit ?? 50,
+      cursor: options?.cursor ?? null,
+    });
 
-    if (cursorPath && cursorPath.includes(`/gyms/${gymId}/`)) {
-      const cursorSnapshot = await firestore.doc(cursorPath).get();
-      if (cursorSnapshot.exists) {
-        query = query.startAfter(cursorSnapshot);
-      }
-    }
-
-    const snapshot = await query.limit(pageSize + 1).get();
-    const docs = snapshot.docs;
-    const hasMore = docs.length > pageSize;
-    const relevantDocs = hasMore ? docs.slice(0, pageSize) : docs;
-    const entries = relevantDocs
-      .map((doc) => mapEventDoc(doc))
-      .filter((entry): entry is AdminEventLogEntry => Boolean(entry));
-    const nextCursor = hasMore ? encodeCursor(docs[docs.length - 1].ref.path) : null;
-
-    return { entries, nextCursor };
+    return {
+      entries: result.items,
+      nextCursor: result.nextCursor,
+      stats: result.stats,
+      warnings: result.warnings,
+    };
   } catch (error) {
     if (isFailedPrecondition(error)) {
-      console.warn(`[admin-monitoring] event-log index fehlt für ${gymId}`, error);
-      return { entries: [], nextCursor: null, error: 'Index erforderlich' };
+      console.warn(`[admin-monitoring] activity index fehlt für ${gymId}`, error);
+      return {
+        entries: [],
+        nextCursor: null,
+        stats: { total: 0, last24h: 0, last7d: 0, last30d: 0 },
+        warnings: ['index-required'],
+      };
     }
-    console.error(`[admin-monitoring] event-log abruf fehlgeschlagen für ${gymId}`, error);
-    return { entries: [], nextCursor: null, error: 'Abruf fehlgeschlagen' };
+    console.error(`[admin-monitoring] activity abruf fehlgeschlagen für ${gymId}`, error);
+    return {
+      entries: [],
+      nextCursor: null,
+      stats: { total: 0, last24h: 0, last7d: 0, last30d: 0 },
+      warnings: ['fetch-failed'],
+    };
   }
 }

--- a/website/src/types/admin-activity.ts
+++ b/website/src/types/admin-activity.ts
@@ -1,0 +1,56 @@
+import type { Timestamp } from 'firebase-admin/firestore';
+
+export type ActivityEventSeverity = 'info' | 'warning' | 'error';
+export type ActivityEventSource = 'device' | 'app' | 'backend' | 'admin' | 'system';
+export type ActivityActorType = 'user' | 'system' | 'admin';
+
+export type AdminActivityActor = {
+  type: ActivityActorType;
+  id?: string | null;
+  label?: string | null;
+};
+
+export type AdminActivityTarget = {
+  type: string;
+  id?: string | null;
+  label?: string | null;
+};
+
+export type AdminActivityEvent = {
+  id: string;
+  gymId: string;
+  timestamp: string;
+  eventType: string;
+  severity: ActivityEventSeverity;
+  source: ActivityEventSource;
+  summary: string | null;
+  userId?: string | null;
+  deviceId?: string | null;
+  sessionId?: string | null;
+  actor?: AdminActivityActor | null;
+  targets?: AdminActivityTarget[];
+  data?: Record<string, unknown> | null;
+};
+
+export type AdminActivityEventRecord = Omit<AdminActivityEvent, 'timestamp'> & {
+  timestamp: Date;
+};
+
+export type FirestoreActivityEvent = Omit<AdminActivityEvent, 'timestamp'> & {
+  timestamp: Timestamp;
+};
+
+export type ActivityEventStats = {
+  total: number;
+  last24h: number;
+  last7d: number;
+  last30d: number;
+};
+
+export type GymActivityResponse = {
+  items: AdminActivityEvent[];
+  nextCursor: string | null;
+  stats: ActivityEventStats;
+  requestId: string;
+  warnings?: string[];
+};


### PR DESCRIPTION
## Summary
- introduce a shared activity event model with Firestore queries, pagination helpers, and a secured admin API endpoint
- replace the monitoring detail table with a filterable GymActivityFeed and richer event rendering across the admin UI
- mirror device logs into the new activity stream via Cloud Function, add documentation, rules, indexes, and Jest coverage

## Testing
- npm run test:functions *(fails: Firestore emulator download blocked by 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d31591fe908320a16414abbe947c89