### PR TITLE
Refine set grouping layout on device screen

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -6,7 +6,9 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
+import 'package:tapem/core/widgets/brand_outline.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/config/feature_flags.dart';
 
@@ -167,61 +169,27 @@ class _DeviceScreenState extends State<DeviceScreen> {
                         ),
                       ),
                       const SizedBox(height: 8),
-                      ListView.separated(
-                        shrinkWrap: true,
-                        physics: const NeverScrollableScrollPhysics(),
-                        itemCount: prov.sets.length,
-                        itemBuilder: (context, index) {
-                          final set = prov.sets[index];
-                          final prev = index < prov.lastSessionSets.length
-                              ? prov.lastSessionSets[index]
-                              : null;
-                          return Dismissible(
-                            key: ValueKey('set-${set['number']}'),
-                            direction: DismissDirection.endToStart,
-                            background: const SizedBox.shrink(),
-                            secondaryBackground: Container(
-                              alignment: Alignment.centerRight,
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 16,
-                              ),
-                              color: Colors.red.withOpacity(0.15),
-                              child: const Icon(
-                                Icons.delete,
-                                semanticLabel: 'Löschen',
-                              ),
-                            ),
-                            onDismissed: (_) {
-                              final removed = Map<String, dynamic>.from(set);
-                              context
-                                  .read<DeviceProvider>()
-                                  .removeSet(index);
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(
-                                  content: Text(loc.setRemoved),
-                                  action: SnackBarAction(
-                                    label: loc.undo,
-                                    onPressed: () => context
-                                        .read<DeviceProvider>()
-                                        .insertSetAt(index, removed),
-                                  ),
+                      if (prov.sets.isNotEmpty)
+                        _GroupedSetList(
+                          sets: prov.sets,
+                          previousSessionSets: prov.lastSessionSets,
+                          setKeys: _setKeys,
+                          onRemove: (index, removed) {
+                            context.read<DeviceProvider>().removeSet(index);
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                content: Text(loc.setRemoved),
+                                action: SnackBarAction(
+                                  label: loc.undo,
+                                  onPressed: () => context
+                                      .read<DeviceProvider>()
+                                      .insertSetAt(index, removed),
                                 ),
-                              );
-                            },
-                            child: SetCard(
-                              key: _setKeys[index],
-                              index: index,
-                              set: set,
-                              previous: prev,
-                              size: SetCardSize.dense,
-                            ),
-                          );
-                        },
-                        separatorBuilder: (_, __) => const Padding(
-                          padding: EdgeInsets.symmetric(vertical: 8),
-                          child: Divider(thickness: 1, height: 1),
+                              ),
+                            );
+                          },
                         ),
-                      ),
+                      if (prov.sets.isNotEmpty) const SizedBox(height: 12),
                       Center(
                         child: TextButton.icon(
                           onPressed: _addSet,
@@ -536,6 +504,80 @@ class _DeviceScreenState extends State<DeviceScreen> {
         return true;
       },
       child: scaffold,
+    );
+  }
+}
+
+class _GroupedSetList extends StatelessWidget {
+  final List<Map<String, dynamic>> sets;
+  final List<Map<String, dynamic>> previousSessionSets;
+  final List<GlobalKey<SetCardState>> setKeys;
+  final void Function(int index, Map<String, dynamic> removed) onRemove;
+
+  const _GroupedSetList({
+    required this.sets,
+    required this.previousSessionSets,
+    required this.setKeys,
+    required this.onRemove,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = Theme.of(context).extension<AppBrandTheme>();
+    final outlineRadius = (brand?.outlineRadius as BorderRadius?) ??
+        BorderRadius.circular(AppRadius.card);
+    final outlineWidth = brand?.outlineWidth ?? 2;
+    final innerRadius = outlineRadius - BorderRadius.circular(outlineWidth);
+
+    return BrandOutline(
+      padding: EdgeInsets.zero,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          for (var index = 0; index < sets.length; index++) ...[
+            if (index > 0)
+              const Divider(
+                height: 1,
+                thickness: 1,
+              ),
+            Dismissible(
+              key: ValueKey('set-${sets[index]['number']}'),
+              direction: DismissDirection.endToStart,
+              background: const SizedBox.shrink(),
+              secondaryBackground: Container(
+                alignment: Alignment.centerRight,
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                color: Colors.red.withOpacity(0.15),
+                child: const Icon(
+                  Icons.delete,
+                  semanticLabel: 'Löschen',
+                ),
+              ),
+              onDismissed: (_) {
+                final removed = Map<String, dynamic>.from(sets[index]);
+                onRemove(index, removed);
+              },
+              child: SetCard(
+                key: setKeys[index],
+                index: index,
+                set: sets[index],
+                previous:
+                    index < previousSessionSets.length ? previousSessionSets[index] : null,
+                size: SetCardSize.dense,
+                displayMode: SetCardDisplayMode.grouped,
+                groupedRadius: BorderRadius.only(
+                  topLeft: index == 0 ? innerRadius.topLeft : Radius.zero,
+                  topRight: index == 0 ? innerRadius.topRight : Radius.zero,
+                  bottomLeft:
+                      index == sets.length - 1 ? innerRadius.bottomLeft : Radius.zero,
+                  bottomRight:
+                      index == sets.length - 1 ? innerRadius.bottomRight : Radius.zero,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
     );
   }
 }

--- a/lib/features/device/presentation/widgets/read_only_snapshot_page.dart
+++ b/lib/features/device/presentation/widgets/read_only_snapshot_page.dart
@@ -57,6 +57,7 @@ class ReadOnlySnapshotPage extends StatelessWidget {
                     },
                     readOnly: true,
                     size: SetCardSize.dense,
+                    displayMode: SetCardDisplayMode.standalone,
                   ),
                   if (drops.isNotEmpty)
                     Padding(

--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -87,12 +87,16 @@ class SetCardTheme {
 
 enum SetCardSize { regular, dense }
 
+enum SetCardDisplayMode { standalone, grouped }
+
 class SetCard extends StatefulWidget {
   final int index;
   final Map<String, dynamic> set;
   final Map<String, dynamic>? previous;
   final SetCardSize size;
   final bool readOnly;
+  final SetCardDisplayMode displayMode;
+  final BorderRadiusGeometry? groupedRadius;
   const SetCard({
     super.key,
     required this.index,
@@ -100,6 +104,8 @@ class SetCard extends StatefulWidget {
     this.previous,
     this.size = SetCardSize.regular,
     this.readOnly = false,
+    this.displayMode = SetCardDisplayMode.standalone,
+    this.groupedRadius,
   });
 
   @override
@@ -298,187 +304,301 @@ class SetCardState extends State<SetCard> {
                 double.tryParse(weight.replaceAll(',', '.')) != null)) &&
         reps.isNotEmpty &&
         int.tryParse(reps) != null;
+    VoidCallback? toggleExtras;
+    if (!widget.readOnly) {
+      toggleExtras = () {
+        _slog(
+          widget.index,
+          'tap: more options → ${!_showExtras}',
+        );
+        HapticFeedback.lightImpact();
+        setState(() => _showExtras = !_showExtras);
+      };
+    }
+
+    VoidCallback? toggleDone;
+    if (!widget.readOnly && filled) {
+      toggleDone = () {
+        _slog(
+          widget.index,
+          'tap: toggle done via provider',
+        );
+        final prov = context.read<DeviceProvider>();
+        final ok = prov.toggleSetDone(widget.index);
+        elogUi('SET_DONE_TAP', {
+          'index': widget.index,
+          'wasValid': ok,
+          if (!ok) 'reasonIfBlocked': 'invalid',
+        });
+        HapticFeedback.lightImpact();
+        if (ok) {
+          final sets = prov.sets;
+          final isDone = sets[widget.index]['done'] == true ||
+              sets[widget.index]['done'] == 'true';
+          if (isDone) {
+            final service = context.read<WorkoutSessionDurationService>();
+            if (!service.isRunning) {
+              final auth = context.read<AuthProvider>();
+              final branding = context.read<BrandingProvider>();
+              final uid = auth.userId;
+              final gymId = branding.gymId;
+              if (uid != null && gymId != null) {
+                unawaited(service.start(uid: uid, gymId: gymId));
+              }
+            }
+          }
+          context.read<OverlayNumericKeypadController>().close();
+        }
+      };
+    }
+
+    final displayMode = widget.displayMode;
+    final contentPadding =
+        displayMode == SetCardDisplayMode.grouped ? tokens.padding : EdgeInsets.zero;
+    final BorderRadius? rowRadius = displayMode == SetCardDisplayMode.grouped
+        ? (widget.groupedRadius as BorderRadius?)
+        : null;
+
+    final content = SetRowContent(
+      tokens: tokens,
+      dense: dense,
+      index: widget.index + 1,
+      dropActive: dropActive,
+      showExtras: _showExtras,
+      done: done,
+      readOnly: widget.readOnly,
+      filled: filled,
+      isBodyweightMode: prov.isBodyweightMode,
+      loc: loc,
+      weightController: _weightCtrl,
+      weightFocus: _weightFocus,
+      repsController: _repsCtrl,
+      repsFocus: _repsFocus,
+      dropWeightController: _dropWeightCtrl,
+      dropWeightFocus: _dropWeightFocus,
+      dropRepsController: _dropRepsCtrl,
+      dropRepsFocus: _dropRepsFocus,
+      onToggleExtras: toggleExtras,
+      onToggleDone: toggleDone,
+      onTapWeight:
+          widget.readOnly ? null : () => _openKeypad(_weightCtrl, allowDecimal: true),
+      onTapReps:
+          widget.readOnly ? null : () => _openKeypad(_repsCtrl, allowDecimal: false),
+      onTapDropWeight: done || widget.readOnly
+          ? null
+          : () => _openKeypad(_dropWeightCtrl, allowDecimal: true),
+      onTapDropReps: done || widget.readOnly
+          ? null
+          : () => _openKeypad(_dropRepsCtrl, allowDecimal: false),
+      dropValidator: _validateDrop,
+      padding: contentPadding,
+      radius: rowRadius,
+    );
 
     return Semantics(
       label: 'Set ${widget.index + 1}',
-      child: BrandOutline(
-        padding: tokens.padding,
-        child: Column(
-          children: [
+      child: displayMode == SetCardDisplayMode.standalone
+          ? BrandOutline(
+              padding: tokens.padding,
+              child: content,
+            )
+          : content,
+    );
+  }
+}
+
+class SetRowContent extends StatelessWidget {
+  final SetCardTheme tokens;
+  final bool dense;
+  final int index;
+  final bool dropActive;
+  final bool showExtras;
+  final bool done;
+  final bool readOnly;
+  final bool filled;
+  final bool isBodyweightMode;
+  final AppLocalizations loc;
+  final TextEditingController weightController;
+  final FocusNode weightFocus;
+  final TextEditingController repsController;
+  final FocusNode repsFocus;
+  final TextEditingController dropWeightController;
+  final FocusNode dropWeightFocus;
+  final TextEditingController dropRepsController;
+  final FocusNode dropRepsFocus;
+  final VoidCallback? onToggleExtras;
+  final VoidCallback? onToggleDone;
+  final VoidCallback? onTapWeight;
+  final VoidCallback? onTapReps;
+  final VoidCallback? onTapDropWeight;
+  final VoidCallback? onTapDropReps;
+  final FormFieldValidator<String>? dropValidator;
+  final EdgeInsetsGeometry padding;
+  final BorderRadius? radius;
+
+  const SetRowContent({
+    super.key,
+    required this.tokens,
+    required this.dense,
+    required this.index,
+    required this.dropActive,
+    required this.showExtras,
+    required this.done,
+    required this.readOnly,
+    required this.filled,
+    required this.isBodyweightMode,
+    required this.loc,
+    required this.weightController,
+    required this.weightFocus,
+    required this.repsController,
+    required this.repsFocus,
+    required this.dropWeightController,
+    required this.dropWeightFocus,
+    required this.dropRepsController,
+    required this.dropRepsFocus,
+    required this.onToggleExtras,
+    required this.onToggleDone,
+    required this.onTapWeight,
+    required this.onTapReps,
+    required this.onTapDropWeight,
+    required this.onTapDropReps,
+    required this.dropValidator,
+    this.padding = EdgeInsets.zero,
+    this.radius,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    Widget body = Padding(
+      padding: padding,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              _IndexBadge(
+                tokens: tokens,
+                index: index,
+                dense: dense,
+              ),
+              if (dropActive) ...[
+                SizedBox(width: dense ? 4 : 6),
+                _DropBadge(tokens: tokens, dense: dense),
+              ],
+              SizedBox(width: dense ? 8 : 12),
+              Expanded(
+                child: _InputPill(
+                  controller: weightController,
+                  focusNode: weightFocus,
+                  label: isBodyweightMode ? loc.bodyweight : 'kg',
+                  readOnly: done || readOnly,
+                  tokens: tokens,
+                  dense: dense,
+                  onTap: onTapWeight,
+                  validator: (v) {
+                    if (v == null || v.isEmpty) return null;
+                    if (double.tryParse(v.replaceAll(',', '.')) == null) {
+                      return loc.numberInvalid;
+                    }
+                    return null;
+                  },
+                ),
+              ),
+              SizedBox(width: dense ? 8 : 12),
+              Expanded(
+                child: _InputPill(
+                  controller: repsController,
+                  focusNode: repsFocus,
+                  label: 'x',
+                  readOnly: done || readOnly,
+                  tokens: tokens,
+                  dense: dense,
+                  onTap: onTapReps,
+                  validator: (v) {
+                    if (v == null || v.isEmpty) return null;
+                    if (int.tryParse(v) == null) return loc.intRequired;
+                    return null;
+                  },
+                ),
+              ),
+              SizedBox(width: dense ? 8 : 12),
+              _RoundButton(
+                tokens: tokens,
+                icon: showExtras ? Icons.expand_less : Icons.expand_more,
+                filled: false,
+                semantics: 'Mehr Optionen',
+                dense: dense,
+                iconColor: Colors.black,
+                disabledIconColor: Colors.black,
+                filledIconColor: Colors.black,
+                onTap: onToggleExtras,
+              ),
+              SizedBox(width: dense ? 6 : 8),
+              _RoundButton(
+                tokens: tokens,
+                icon: Icons.check,
+                filled: done,
+                semantics:
+                    done ? loc.setReopenTooltip : loc.setCompleteTooltip,
+                dense: dense,
+                iconColor: Colors.black,
+                disabledIconColor: Colors.black,
+                filledIconColor: Colors.black,
+                onTap: onToggleDone,
+              ),
+            ],
+          ),
+          if (showExtras) ...[
+            SizedBox(height: dense ? 8 : 12),
             Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
               children: [
-                _IndexBadge(
-                  tokens: tokens,
-                  index: widget.index + 1,
-                  dense: dense,
-                ),
-                if (dropActive) ...[
-                  SizedBox(width: dense ? 4 : 6),
-                  _DropBadge(tokens: tokens, dense: dense),
-                ],
-                SizedBox(width: dense ? 8 : 12),
                 Expanded(
-                  child: _InputPill(
-                    controller: _weightCtrl,
-                    focusNode: _weightFocus,
-                    label: prov.isBodyweightMode ? loc.bodyweight : 'kg',
-                    readOnly: done || widget.readOnly,
-                    tokens: tokens,
-                    dense: dense,
-                    onTap: widget.readOnly
-                        ? null
-                        : () => _openKeypad(_weightCtrl, allowDecimal: true),
-                    validator: (v) {
-                      if (v == null || v.isEmpty) return null;
-                      if (double.tryParse(v.replaceAll(',', '.')) == null) {
-                        return loc.numberInvalid;
-                      }
-                      return null;
-                    },
+                  child: TextFormField(
+                    controller: dropWeightController,
+                    focusNode: dropWeightFocus,
+                    decoration: InputDecoration(
+                      labelText: loc.dropKgFieldLabel,
+                      isDense: true,
+                    ),
+                    enabled: !readOnly,
+                    readOnly: true,
+                    keyboardType: TextInputType.none,
+                    validator: dropValidator,
+                    onTap: onTapDropWeight,
                   ),
                 ),
                 SizedBox(width: dense ? 8 : 12),
                 Expanded(
-                  child: _InputPill(
-                    controller: _repsCtrl,
-                    focusNode: _repsFocus,
-                    label: 'x',
-                    readOnly: done || widget.readOnly,
-                    tokens: tokens,
-                    dense: dense,
-                    onTap: widget.readOnly
-                        ? null
-                        : () => _openKeypad(_repsCtrl, allowDecimal: false),
-                    validator: (v) {
-                      if (v == null || v.isEmpty) return null;
-                      if (int.tryParse(v) == null) return loc.intRequired;
-                      return null;
-                    },
+                  child: TextFormField(
+                    controller: dropRepsController,
+                    focusNode: dropRepsFocus,
+                    decoration: InputDecoration(
+                      labelText: loc.dropRepsFieldLabel,
+                      isDense: true,
+                    ),
+                    enabled: !readOnly,
+                    readOnly: true,
+                    keyboardType: TextInputType.none,
+                    validator: dropValidator,
+                    onTap: onTapDropReps,
                   ),
-                ),
-                SizedBox(width: dense ? 8 : 12),
-                _RoundButton(
-                  tokens: tokens,
-                  icon: _showExtras ? Icons.expand_less : Icons.expand_more,
-                  filled: false,
-                  semantics: 'Mehr Optionen',
-                  dense: dense,
-                  iconColor: Colors.black,
-                  disabledIconColor: Colors.black,
-                  filledIconColor: Colors.black,
-                  onTap: widget.readOnly
-                      ? null
-                      : () {
-                          _slog(
-                            widget.index,
-                            'tap: more options → ${!_showExtras}',
-                          );
-                          HapticFeedback.lightImpact();
-                          setState(() => _showExtras = !_showExtras);
-                        },
-                ),
-                SizedBox(width: dense ? 6 : 8),
-                _RoundButton(
-                  tokens: tokens,
-                  icon: Icons.check,
-                  filled: done,
-                  semantics:
-                      done ? loc.setReopenTooltip : loc.setCompleteTooltip,
-                  dense: dense,
-                  iconColor: Colors.black,
-                  disabledIconColor: Colors.black,
-                  filledIconColor: Colors.black,
-                  onTap: widget.readOnly || !filled
-                      ? null
-                      : () {
-                          _slog(
-                            widget.index,
-                            'tap: toggle done via provider',
-                          );
-                          final prov = context.read<DeviceProvider>();
-                          final ok = prov.toggleSetDone(widget.index);
-                          elogUi('SET_DONE_TAP', {
-                            'index': widget.index,
-                            'wasValid': ok,
-                            if (!ok) 'reasonIfBlocked': 'invalid',
-                          });
-                          HapticFeedback.lightImpact();
-                          if (ok) {
-                            final sets = prov.sets;
-                            final isDone = sets[widget.index]['done'] == true ||
-                                sets[widget.index]['done'] == 'true';
-                            if (isDone) {
-                              final service =
-                                  context.read<WorkoutSessionDurationService>();
-                              if (!service.isRunning) {
-                                final auth = context.read<AuthProvider>();
-                                final branding = context.read<BrandingProvider>();
-                                final uid = auth.userId;
-                                final gymId = branding.gymId;
-                                if (uid != null && gymId != null) {
-                                  unawaited(service.start(uid: uid, gymId: gymId));
-                                }
-                              }
-                            }
-                            context
-                                .read<OverlayNumericKeypadController>()
-                                .close();
-                          }
-                        },
                 ),
               ],
             ),
-            if (_showExtras) ...[
-              SizedBox(height: dense ? 8 : 12),
-              Row(
-                children: [
-                  Expanded(
-                    child: TextFormField(
-                      controller: _dropWeightCtrl,
-                      focusNode: _dropWeightFocus,
-                      decoration: InputDecoration(
-                        labelText: loc.dropKgFieldLabel,
-                        isDense: true,
-                      ),
-                      enabled: !widget.readOnly,
-                      readOnly: true,
-                      keyboardType: TextInputType.none,
-                      validator: _validateDrop,
-                      onTap: done || widget.readOnly
-                          ? null
-                          : () =>
-                              _openKeypad(_dropWeightCtrl, allowDecimal: true),
-                    ),
-                  ),
-                  SizedBox(width: dense ? 8 : 12),
-                  Expanded(
-                    child: TextFormField(
-                      controller: _dropRepsCtrl,
-                      focusNode: _dropRepsFocus,
-                      decoration: InputDecoration(
-                        labelText: loc.dropRepsFieldLabel,
-                        isDense: true,
-                      ),
-                      enabled: !widget.readOnly,
-                      readOnly: true,
-                      keyboardType: TextInputType.none,
-                      validator: _validateDrop,
-                      onTap: done || widget.readOnly
-                          ? null
-                          : () => _openKeypad(
-                                _dropRepsCtrl,
-                                allowDecimal: false,
-                              ),
-                    ),
-                  ),
-                ],
-              ),
-            ],
           ],
-        ),
+        ],
       ),
     );
+
+    if (radius != null) {
+      body = ClipRRect(
+        borderRadius: radius!,
+        child: body,
+      );
+    }
+
+    return SizedBox(width: double.infinity, child: body);
   }
 }
 

--- a/test/widgets/dismissible_session_list_test.dart
+++ b/test/widgets/dismissible_session_list_test.dart
@@ -94,6 +94,7 @@ class _TestList extends StatelessWidget {
             child: SetCard(
               index: entry.key,
               set: entry.value,
+              displayMode: SetCardDisplayMode.standalone,
             ),
           ),
       ],

--- a/test/widgets/set_card_test.dart
+++ b/test/widgets/set_card_test.dart
@@ -89,6 +89,7 @@ void main() {
               child: SetCard(
                 index: 0,
                 set: provider.sets[0],
+                displayMode: SetCardDisplayMode.standalone,
               ),
             ),
           ),


### PR DESCRIPTION
## Summary
- wrap the editable session list in a grouped BrandOutline card that renders all dismissible sets with shared dividers and rounded edges
- extend SetCard with a grouped display mode and extract the shared row layout into the new SetRowContent widget
- update read-only set cards and widget tests to opt into the standalone display mode

## Testing
- Not run (flutter CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d44f87ff648320902e41c3e113ab7d