### PR TITLE
Add optional previous set view and toggle

### DIFF
--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -8,6 +8,7 @@ class SettingsProvider extends ChangeNotifier {
   final FirebaseFirestore _firestore;
 
   bool? _creatineEnabled;
+  bool? _showPreviousSets;
   bool _isLoading = false;
   String? _error;
   String? _uid;
@@ -15,6 +16,7 @@ class SettingsProvider extends ChangeNotifier {
   bool get isLoading => _isLoading;
   String? get error => _error;
   bool get creatineEnabled => _creatineEnabled ?? false;
+  bool get showPreviousSets => _showPreviousSets ?? false;
 
   DocumentReference<Map<String, dynamic>> _doc(String uid) {
     return _firestore
@@ -25,20 +27,38 @@ class SettingsProvider extends ChangeNotifier {
   }
 
   Future<void> load(String uid) async {
-    if (_uid == uid && _creatineEnabled != null) return;
+    if (_uid == uid && _creatineEnabled != null && _showPreviousSets != null) {
+      return;
+    }
     _uid = uid;
     _isLoading = true;
     _error = null;
+    _showPreviousSets = null;
     notifyListeners();
     try {
       final ref = _doc(uid);
       final snap = await ref.get();
       final data = snap.data();
-      if (data != null && data['creatineEnabled'] != null) {
-        _creatineEnabled = data['creatineEnabled'] as bool;
+      final updates = <String, dynamic>{};
+
+      final creatine = data?['creatineEnabled'];
+      if (creatine is bool) {
+        _creatineEnabled = creatine;
       } else {
         _creatineEnabled = false;
-        await ref.set({'creatineEnabled': false}, SetOptions(merge: true));
+        updates['creatineEnabled'] = false;
+      }
+
+      final showPrev = data?['showPreviousSets'];
+      if (showPrev is bool) {
+        _showPreviousSets = showPrev;
+      } else {
+        _showPreviousSets = false;
+        updates['showPreviousSets'] = false;
+      }
+
+      if (updates.isNotEmpty) {
+        await ref.set(updates, SetOptions(merge: true));
       }
     } catch (e) {
       _error = e.toString();
@@ -58,6 +78,22 @@ class SettingsProvider extends ChangeNotifier {
       await _doc(uid).set({'creatineEnabled': value}, SetOptions(merge: true));
     } catch (e) {
       _creatineEnabled = old;
+      _error = e.toString();
+      notifyListeners();
+      rethrow;
+    }
+  }
+
+  Future<void> setShowPreviousSets(bool value) async {
+    final uid = _uid;
+    if (uid == null) return;
+    final old = _showPreviousSets;
+    _showPreviousSets = value;
+    notifyListeners();
+    try {
+      await _doc(uid).set({'showPreviousSets': value}, SetOptions(merge: true));
+    } catch (e) {
+      _showPreviousSets = old;
       _error = e.toString();
       notifyListeners();
       rethrow;

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -15,6 +15,7 @@ import 'package:tapem/core/config/feature_flags.dart';
 import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/core/providers/device_provider.dart';
+import 'package:tapem/core/providers/settings_provider.dart';
 import 'package:tapem/core/providers/training_plan_provider.dart';
 import 'package:tapem/core/providers/exercise_provider.dart';
 import 'package:tapem/features/device/domain/models/exercise.dart';
@@ -124,6 +125,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
     String locale,
     ExerciseEntry? plannedEntry,
   ) {
+    final showPreviousSets = context.watch<SettingsProvider>().showPreviousSets;
     return Column(
       children: [
         const Padding(
@@ -173,6 +175,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                         _GroupedSetList(
                           sets: prov.sets,
                           previousSessionSets: prov.lastSessionSets,
+                          showPreviousSets: showPreviousSets,
                           setKeys: _setKeys,
                           onRemove: (index, removed) {
                             context.read<DeviceProvider>().removeSet(index);
@@ -513,12 +516,14 @@ class _GroupedSetList extends StatelessWidget {
   final List<Map<String, dynamic>> previousSessionSets;
   final List<GlobalKey<SetCardState>> setKeys;
   final void Function(int index, Map<String, dynamic> removed) onRemove;
+  final bool showPreviousSets;
 
   const _GroupedSetList({
     required this.sets,
     required this.previousSessionSets,
     required this.setKeys,
     required this.onRemove,
+    required this.showPreviousSets,
   });
 
   @override
@@ -561,8 +566,10 @@ class _GroupedSetList extends StatelessWidget {
                 key: setKeys[index],
                 index: index,
                 set: sets[index],
-                previous:
-                    index < previousSessionSets.length ? previousSessionSets[index] : null,
+                previous: showPreviousSets && index < previousSessionSets.length
+                    ? previousSessionSets[index]
+                    : null,
+                showPrevious: showPreviousSets,
                 size: SetCardSize.dense,
                 displayMode: SetCardDisplayMode.grouped,
                 groupedRadius: BorderRadius.only(

--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/device_provider.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
@@ -97,6 +98,7 @@ class SetCard extends StatefulWidget {
   final bool readOnly;
   final SetCardDisplayMode displayMode;
   final BorderRadiusGeometry? groupedRadius;
+  final bool showPrevious;
   const SetCard({
     super.key,
     required this.index,
@@ -106,6 +108,7 @@ class SetCard extends StatefulWidget {
     this.readOnly = false,
     this.displayMode = SetCardDisplayMode.standalone,
     this.groupedRadius,
+    this.showPrevious = false,
   });
 
   @override
@@ -282,6 +285,7 @@ class SetCardState extends State<SetCard> {
   Widget build(BuildContext context) {
     final prov = context.watch<DeviceProvider>();
     final loc = AppLocalizations.of(context)!;
+    final locale = Localizations.localeOf(context);
     var tokens = SetCardTheme.of(context);
     final dense = widget.size == SetCardSize.dense;
     if (dense) {
@@ -370,6 +374,9 @@ class SetCardState extends State<SetCard> {
       filled: filled,
       isBodyweightMode: prov.isBodyweightMode,
       loc: loc,
+      showPrevious: widget.showPrevious,
+      previousLabel: loc.setCardPreviousLabel,
+      previousValue: _buildPreviousValue(loc, locale),
       weightController: _weightCtrl,
       weightFocus: _weightFocus,
       repsController: _repsCtrl,
@@ -405,6 +412,50 @@ class SetCardState extends State<SetCard> {
           : content,
     );
   }
+
+  String _buildPreviousValue(AppLocalizations loc, Locale locale) {
+    if (!widget.showPrevious) return '-';
+    final prev = widget.previous;
+    if (prev == null) return '-';
+
+    final rawWeight = (prev['weight'] ?? '').toString().trim();
+    final rawReps = (prev['reps'] ?? '').toString().trim();
+    final isBodyweight = prev['isBodyweight'] == true || prev['isBodyweight'] == 'true';
+
+    if (rawWeight.isEmpty && rawReps.isEmpty) {
+      return '-';
+    }
+
+    final formatter = NumberFormat.decimalPattern(locale.toString());
+    final sanitizedWeight = rawWeight.replaceAll(',', '.');
+    final parsedWeight = double.tryParse(sanitizedWeight);
+    final repsText = rawReps.isEmpty ? '-' : rawReps;
+
+    String weightText;
+    if (isBodyweight) {
+      if (parsedWeight == null || parsedWeight == 0) {
+        weightText = loc.bodyweight;
+      } else {
+        final formatted = formatter.format(parsedWeight);
+        weightText = loc.bodyweightPlus(formatted);
+      }
+    } else {
+      if (parsedWeight != null) {
+        final formatted = formatter.format(parsedWeight);
+        weightText = '$formatted ${loc.tableHeaderKg}';
+      } else if (rawWeight.isNotEmpty) {
+        weightText = rawWeight;
+      } else {
+        weightText = '-';
+      }
+    }
+
+    if (weightText == '-' && repsText == '-') {
+      return '-';
+    }
+
+    return '$weightText × $repsText';
+  }
 }
 
 class SetRowContent extends StatelessWidget {
@@ -418,6 +469,9 @@ class SetRowContent extends StatelessWidget {
   final bool filled;
   final bool isBodyweightMode;
   final AppLocalizations loc;
+  final bool showPrevious;
+  final String previousLabel;
+  final String previousValue;
   final TextEditingController weightController;
   final FocusNode weightFocus;
   final TextEditingController repsController;
@@ -448,6 +502,9 @@ class SetRowContent extends StatelessWidget {
     required this.filled,
     required this.isBodyweightMode,
     required this.loc,
+    required this.showPrevious,
+    required this.previousLabel,
+    required this.previousValue,
     required this.weightController,
     required this.weightFocus,
     required this.repsController,
@@ -469,6 +526,8 @@ class SetRowContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final weightFlex = showPrevious ? 3 : 4;
+    final repsFlex = showPrevious ? 2 : 3;
     Widget body = Padding(
       padding: padding,
       child: Column(
@@ -488,6 +547,7 @@ class SetRowContent extends StatelessWidget {
               ],
               SizedBox(width: dense ? 8 : 12),
               Expanded(
+                flex: weightFlex,
                 child: _InputPill(
                   controller: weightController,
                   focusNode: weightFocus,
@@ -506,7 +566,20 @@ class SetRowContent extends StatelessWidget {
                 ),
               ),
               SizedBox(width: dense ? 8 : 12),
+              if (showPrevious) ...[
+                Expanded(
+                  flex: 3,
+                  child: _StaticPill(
+                    label: previousLabel,
+                    value: previousValue,
+                    tokens: tokens,
+                    dense: dense,
+                  ),
+                ),
+                SizedBox(width: dense ? 8 : 12),
+              ],
               Expanded(
+                flex: repsFlex,
                 child: _InputPill(
                   controller: repsController,
                   focusNode: repsFocus,
@@ -737,6 +810,53 @@ class _InputPill extends StatelessWidget {
           ),
           style: dense ? const TextStyle(fontSize: 14) : null,
           validator: validator,
+        ),
+      ),
+    );
+  }
+}
+
+class _StaticPill extends StatelessWidget {
+  final String label;
+  final String value;
+  final SetCardTheme tokens;
+  final bool dense;
+
+  const _StaticPill({
+    required this.label,
+    required this.value,
+    required this.tokens,
+    this.dense = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final hasValue = value != '-';
+    final baseStyle = dense ? const TextStyle(fontSize: 14) : const TextStyle();
+    return Container(
+      decoration: BoxDecoration(
+        color: tokens.chipBg,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: tokens.chipBorder.withOpacity(0.6),
+          width: 1.3,
+        ),
+      ),
+      padding: EdgeInsets.symmetric(horizontal: 12, vertical: dense ? 2 : 4),
+      alignment: Alignment.centerLeft,
+      child: InputDecorator(
+        decoration: InputDecoration(
+          isDense: dense,
+          border: InputBorder.none,
+          labelText: label,
+          labelStyle: dense ? const TextStyle(fontSize: 14) : null,
+        ),
+        child: Text(
+          value,
+          style: baseStyle.copyWith(
+            fontWeight: hasValue ? FontWeight.w600 : FontWeight.w400,
+            color: hasValue ? tokens.chipFg : tokens.chipFg.withOpacity(0.6),
+          ),
         ),
       ),
     );

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -249,6 +249,20 @@ class _ProfileScreenState extends State<ProfileScreen> {
               SimpleDialogOption(
                 onPressed: () {
                   Navigator.pop(context);
+                  _showSetCardSettingsDialog();
+                },
+                child: Row(
+                  children: [
+                    Expanded(child: Text(loc.settingsOptionSetCards)),
+                    Text(context.read<SettingsProvider>().showPreviousSets
+                        ? loc.settingsToggleOn
+                        : loc.settingsToggleOff),
+                  ],
+                ),
+              ),
+              SimpleDialogOption(
+                onPressed: () {
+                  Navigator.pop(context);
                   _showPrivacyDialog();
                 },
                 child: Text(loc.settingsOptionPublicProfile),
@@ -262,6 +276,36 @@ class _ProfileScreenState extends State<ProfileScreen> {
               ),
             ],
           ),
+    );
+  }
+
+  void _showSetCardSettingsDialog() {
+    final loc = AppLocalizations.of(context)!;
+    showDialog(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: Text(loc.settingsSetCardDialogTitle),
+          content: Consumer<SettingsProvider>(
+            builder: (_, settings, __) {
+              return SwitchListTile(
+                contentPadding: EdgeInsets.zero,
+                title: Text(loc.settingsPreviousSetsLabel),
+                value: settings.showPreviousSets,
+                onChanged: (value) {
+                  settings.setShowPreviousSets(value);
+                },
+              );
+            },
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(dialogContext),
+              child: Text(loc.cancelButton),
+            ),
+          ],
+        );
+      },
     );
   }
 

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -375,6 +375,11 @@
     "description": "Tooltip wenn Satz abgeschlossen ist"
   },
 
+  "setCardPreviousLabel": "Vorher",
+  "@setCardPreviousLabel": {
+    "description": "Beschriftung für das Feld mit den vorherigen Satzzahlen"
+  },
+
   "registerButton": "Registrieren",
   "@registerButton": {
     "description": "Beschriftung für den Registrieren-Knopf"
@@ -549,6 +554,16 @@
   "@settingsCreatineSavedEnabled": {"description": "Snackbar wenn Kreatin-Tracker aktiviert wurde"},
   "settingsCreatineSavedDisabled": "Kreatin-Tracker deaktiviert.",
   "@settingsCreatineSavedDisabled": {"description": "Snackbar wenn Kreatin-Tracker deaktiviert wurde"},
+  "settingsOptionSetCards": "Satzkarten",
+  "@settingsOptionSetCards": {"description": "Einstellung für die Satzkarten"},
+  "settingsToggleOn": "Ein",
+  "@settingsToggleOn": {"description": "Allgemeine Bezeichnung für aktivierte Schalter"},
+  "settingsToggleOff": "Aus",
+  "@settingsToggleOff": {"description": "Allgemeine Bezeichnung für deaktivierte Schalter"},
+  "settingsSetCardDialogTitle": "Satzkarten",
+  "@settingsSetCardDialogTitle": {"description": "Titel des Satzkarten-Dialogs"},
+  "settingsPreviousSetsLabel": "Vorherige Satzwerte anzeigen",
+  "@settingsPreviousSetsLabel": {"description": "Schalter zum Anzeigen der vorherigen Satzwerte"},
   "publicProfileDialogTitle": "Profil-Sichtbarkeit",
   "@publicProfileDialogTitle": {"description": "Titel des Dialogs für öffentliche Profil-Option"},
   "publicProfilePublic": "Öffentlich",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -373,6 +373,11 @@
     "description": "Tooltip when set is completed"
   },
 
+  "setCardPreviousLabel": "Previous",
+  "@setCardPreviousLabel": {
+    "description": "Label for the previous set value pill"
+  },
+
   "registerButton": "Register",
   "@registerButton": {
     "description": "Label for the Register button"
@@ -547,6 +552,16 @@
   "@settingsCreatineSavedEnabled": {"description": "Snackbar when creatine tracker enabled"},
   "settingsCreatineSavedDisabled": "Creatine tracker disabled.",
   "@settingsCreatineSavedDisabled": {"description": "Snackbar when creatine tracker disabled"},
+  "settingsOptionSetCards": "Set cards",
+  "@settingsOptionSetCards": {"description": "Settings option for set card preferences"},
+  "settingsToggleOn": "On",
+  "@settingsToggleOn": {"description": "Generic label for enabled toggles"},
+  "settingsToggleOff": "Off",
+  "@settingsToggleOff": {"description": "Generic label for disabled toggles"},
+  "settingsSetCardDialogTitle": "Set cards",
+  "@settingsSetCardDialogTitle": {"description": "Title for the set card settings dialog"},
+  "settingsPreviousSetsLabel": "Show previous set history",
+  "@settingsPreviousSetsLabel": {"description": "Toggle label for showing previous set values"},
   "publicProfileDialogTitle": "Profile visibility",
   "@publicProfileDialogTitle": {"description": "Title for public profile dialog"},
   "publicProfilePublic": "Public",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -617,6 +617,12 @@ abstract class AppLocalizations {
   /// **'Reopen set'**
   String get setReopenTooltip;
 
+  /// No description provided for @setCardPreviousLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Previous'**
+  String get setCardPreviousLabel;
+
   /// Label for the Register button
   ///
   /// In en, this message translates to:
@@ -916,6 +922,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Creatine tracker disabled.'**
   String get settingsCreatineSavedDisabled;
+
+  /// No description provided for @settingsOptionSetCards.
+  ///
+  /// In en, this message translates to:
+  /// **'Set cards'**
+  String get settingsOptionSetCards;
+
+  /// No description provided for @settingsToggleOn.
+  ///
+  /// In en, this message translates to:
+  /// **'On'**
+  String get settingsToggleOn;
+
+  /// No description provided for @settingsToggleOff.
+  ///
+  /// In en, this message translates to:
+  /// **'Off'**
+  String get settingsToggleOff;
+
+  /// No description provided for @settingsSetCardDialogTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Set cards'**
+  String get settingsSetCardDialogTitle;
+
+  /// No description provided for @settingsPreviousSetsLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Show previous set history'**
+  String get settingsPreviousSetsLabel;
 
   /// Title for public profile dialog
   ///

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -288,6 +288,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get setReopenTooltip => 'Satz wieder öffnen';
 
   @override
+  String get setCardPreviousLabel => 'Vorher';
+
+  @override
   String get registerButton => 'Registrieren';
 
   @override
@@ -438,6 +441,21 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get settingsCreatineSavedDisabled => 'Kreatin-Tracker deaktiviert.';
+
+  @override
+  String get settingsOptionSetCards => 'Satzkarten';
+
+  @override
+  String get settingsToggleOn => 'Ein';
+
+  @override
+  String get settingsToggleOff => 'Aus';
+
+  @override
+  String get settingsSetCardDialogTitle => 'Satzkarten';
+
+  @override
+  String get settingsPreviousSetsLabel => 'Vorherige Satzwerte anzeigen';
 
   @override
   String get publicProfileDialogTitle => 'Profil-Sichtbarkeit';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -288,6 +288,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get setReopenTooltip => 'Reopen set';
 
   @override
+  String get setCardPreviousLabel => 'Previous';
+
+  @override
   String get registerButton => 'Register';
 
   @override
@@ -438,6 +441,21 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settingsCreatineSavedDisabled => 'Creatine tracker disabled.';
+
+  @override
+  String get settingsOptionSetCards => 'Set cards';
+
+  @override
+  String get settingsToggleOn => 'On';
+
+  @override
+  String get settingsToggleOff => 'Off';
+
+  @override
+  String get settingsSetCardDialogTitle => 'Set cards';
+
+  @override
+  String get settingsPreviousSetsLabel => 'Show previous set history';
 
   @override
   String get publicProfileDialogTitle => 'Profile visibility';


### PR DESCRIPTION
## Summary
- add an optional "previous" column to device set cards with locale-aware formatting
- persist the preference in settings and expose a toggle in the profile settings dialog
- localize the new UI text for both English and German

## Testing
- not run (Flutter SDK not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d4791837908320ade62307107eeebc