### PR TITLE
Add configurable previous set summary to device cards

### DIFF
--- a/lib/core/providers/settings_provider.dart
+++ b/lib/core/providers/settings_provider.dart
@@ -8,6 +8,7 @@ class SettingsProvider extends ChangeNotifier {
   final FirebaseFirestore _firestore;
 
   bool? _creatineEnabled;
+  bool _showPreviousSets = false;
   bool _isLoading = false;
   String? _error;
   String? _uid;
@@ -15,6 +16,7 @@ class SettingsProvider extends ChangeNotifier {
   bool get isLoading => _isLoading;
   String? get error => _error;
   bool get creatineEnabled => _creatineEnabled ?? false;
+  bool get showPreviousSets => _showPreviousSets;
 
   DocumentReference<Map<String, dynamic>> _doc(String uid) {
     return _firestore
@@ -34,11 +36,30 @@ class SettingsProvider extends ChangeNotifier {
       final ref = _doc(uid);
       final snap = await ref.get();
       final data = snap.data();
-      if (data != null && data['creatineEnabled'] != null) {
-        _creatineEnabled = data['creatineEnabled'] as bool;
+      if (data != null) {
+        final merged = <String, dynamic>{};
+        if (data['creatineEnabled'] != null) {
+          _creatineEnabled = data['creatineEnabled'] as bool;
+        } else {
+          _creatineEnabled = false;
+          merged['creatineEnabled'] = false;
+        }
+        if (data['showPreviousSets'] != null) {
+          _showPreviousSets = data['showPreviousSets'] as bool;
+        } else {
+          _showPreviousSets = false;
+          merged['showPreviousSets'] = false;
+        }
+        if (merged.isNotEmpty) {
+          await ref.set(merged, SetOptions(merge: true));
+        }
       } else {
         _creatineEnabled = false;
-        await ref.set({'creatineEnabled': false}, SetOptions(merge: true));
+        _showPreviousSets = false;
+        await ref.set({
+          'creatineEnabled': false,
+          'showPreviousSets': false,
+        }, SetOptions(merge: true));
       }
     } catch (e) {
       _error = e.toString();
@@ -58,6 +79,22 @@ class SettingsProvider extends ChangeNotifier {
       await _doc(uid).set({'creatineEnabled': value}, SetOptions(merge: true));
     } catch (e) {
       _creatineEnabled = old;
+      _error = e.toString();
+      notifyListeners();
+      rethrow;
+    }
+  }
+
+  Future<void> setShowPreviousSets(bool value) async {
+    final uid = _uid;
+    if (uid == null) return;
+    final old = _showPreviousSets;
+    _showPreviousSets = value;
+    notifyListeners();
+    try {
+      await _doc(uid).set({'showPreviousSets': value}, SetOptions(merge: true));
+    } catch (e) {
+      _showPreviousSets = old;
       _error = e.toString();
       notifyListeners();
       rethrow;

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -31,6 +31,7 @@ import 'package:tapem/features/feedback/presentation/widgets/feedback_button.dar
 import 'package:tapem/ui/timer/session_timer_bar.dart';
 import 'package:tapem/core/logging/elog.dart';
 import 'package:tapem/core/time/logic_day.dart';
+import 'package:tapem/core/providers/settings_provider.dart';
 
 void _dlog(String m) {}
 
@@ -149,10 +150,15 @@ class _DeviceScreenState extends State<DeviceScreen> {
                 if (_setKeys.length > prov.sets.length) {
                   _setKeys.removeRange(prov.sets.length, _setKeys.length);
                 }
-                final lastSnap = prov.sessionSnapshots.isNotEmpty ? prov.sessionSnapshots.first : null;
-                final lastSets = lastSnap != null ? mapSnapshotToVM(lastSnap) : mapLegacySetsToVM(prov.lastSessionSets);
+                final lastSnap =
+                    prov.sessionSnapshots.isNotEmpty ? prov.sessionSnapshots.first : null;
+                final lastSets = lastSnap != null
+                    ? mapSnapshotToVM(lastSnap)
+                    : mapLegacySetsToVM(prov.lastSessionSets);
                 final lastDate = lastSnap?.createdAt ?? prov.lastSessionDate;
                 final lastNote = lastSnap?.note ?? prov.lastSessionNote;
+                final showPreviousSets =
+                    context.watch<SettingsProvider>().showPreviousSets;
                 return ListView(
                   controller: _scrollController,
                   physics: const AlwaysScrollableScrollPhysics(),
@@ -172,7 +178,9 @@ class _DeviceScreenState extends State<DeviceScreen> {
                       if (prov.sets.isNotEmpty)
                         _GroupedSetList(
                           sets: prov.sets,
-                          previousSessionSets: prov.lastSessionSets,
+                          previousSessionSets:
+                              showPreviousSets ? prov.lastSessionSets : const [],
+                          showPrevious: showPreviousSets,
                           setKeys: _setKeys,
                           onRemove: (index, removed) {
                             context.read<DeviceProvider>().removeSet(index);
@@ -513,12 +521,14 @@ class _GroupedSetList extends StatelessWidget {
   final List<Map<String, dynamic>> previousSessionSets;
   final List<GlobalKey<SetCardState>> setKeys;
   final void Function(int index, Map<String, dynamic> removed) onRemove;
+  final bool showPrevious;
 
   const _GroupedSetList({
     required this.sets,
     required this.previousSessionSets,
     required this.setKeys,
     required this.onRemove,
+    this.showPrevious = false,
   });
 
   @override
@@ -561,8 +571,10 @@ class _GroupedSetList extends StatelessWidget {
                 key: setKeys[index],
                 index: index,
                 set: sets[index],
-                previous:
-                    index < previousSessionSets.length ? previousSessionSets[index] : null,
+                previous: index < previousSessionSets.length
+                    ? previousSessionSets[index]
+                    : null,
+                showPrevious: showPrevious,
                 size: SetCardSize.dense,
                 displayMode: SetCardDisplayMode.grouped,
                 groupedRadius: BorderRadius.only(

--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -93,6 +93,7 @@ class SetCard extends StatefulWidget {
   final int index;
   final Map<String, dynamic> set;
   final Map<String, dynamic>? previous;
+  final bool showPrevious;
   final SetCardSize size;
   final bool readOnly;
   final SetCardDisplayMode displayMode;
@@ -102,6 +103,7 @@ class SetCard extends StatefulWidget {
     required this.index,
     required this.set,
     this.previous,
+    this.showPrevious = false,
     this.size = SetCardSize.regular,
     this.readOnly = false,
     this.displayMode = SetCardDisplayMode.standalone,
@@ -369,6 +371,8 @@ class SetCardState extends State<SetCard> {
       readOnly: widget.readOnly,
       filled: filled,
       isBodyweightMode: prov.isBodyweightMode,
+      showPrevious: widget.showPrevious,
+      previous: widget.previous,
       loc: loc,
       weightController: _weightCtrl,
       weightFocus: _weightFocus,
@@ -417,7 +421,9 @@ class SetRowContent extends StatelessWidget {
   final bool readOnly;
   final bool filled;
   final bool isBodyweightMode;
+  final bool showPrevious;
   final AppLocalizations loc;
+  final Map<String, dynamic>? previous;
   final TextEditingController weightController;
   final FocusNode weightFocus;
   final TextEditingController repsController;
@@ -447,7 +453,9 @@ class SetRowContent extends StatelessWidget {
     required this.readOnly,
     required this.filled,
     required this.isBodyweightMode,
+    required this.showPrevious,
     required this.loc,
+    required this.previous,
     required this.weightController,
     required this.weightFocus,
     required this.repsController,
@@ -469,6 +477,7 @@ class SetRowContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final previousValue = _formatPreviousValue(loc);
     Widget body = Padding(
       padding: padding,
       child: Column(
@@ -487,7 +496,20 @@ class SetRowContent extends StatelessWidget {
                 _DropBadge(tokens: tokens, dense: dense),
               ],
               SizedBox(width: dense ? 8 : 12),
+              if (showPrevious) ...[
+                Expanded(
+                  flex: 3,
+                  child: _DisplayPill(
+                    label: loc.devicePreviousFieldLabel,
+                    value: previousValue,
+                    tokens: tokens,
+                    dense: dense,
+                  ),
+                ),
+                SizedBox(width: dense ? 8 : 12),
+              ],
               Expanded(
+                flex: showPrevious ? 3 : 4,
                 child: _InputPill(
                   controller: weightController,
                   focusNode: weightFocus,
@@ -507,6 +529,7 @@ class SetRowContent extends StatelessWidget {
               ),
               SizedBox(width: dense ? 8 : 12),
               Expanded(
+                flex: showPrevious ? 2 : 3,
                 child: _InputPill(
                   controller: repsController,
                   focusNode: repsFocus,
@@ -599,6 +622,41 @@ class SetRowContent extends StatelessWidget {
     }
 
     return SizedBox(width: double.infinity, child: body);
+  }
+
+  String _formatPreviousValue(AppLocalizations loc) {
+    if (!showPrevious) return '';
+    final prev = previous;
+    if (prev == null) {
+      return '-';
+    }
+    final rawWeight = (prev['weight'] ?? '').toString().trim();
+    final rawReps = (prev['reps'] ?? '').toString().trim();
+    final isBodyweight = prev['isBodyweight'] == true;
+
+    final hasWeight = rawWeight.isNotEmpty && rawWeight.toLowerCase() != 'null';
+    final hasReps = rawReps.isNotEmpty && rawReps.toLowerCase() != 'null';
+
+    String? weightLabel;
+    if (isBodyweight) {
+      if (hasWeight) {
+        weightLabel = loc.bodyweightPlus(rawWeight);
+      } else {
+        weightLabel = loc.bodyweight;
+      }
+    } else if (hasWeight) {
+      weightLabel = '$rawWeight kg';
+    }
+
+    final parts = <String>[
+      if (weightLabel != null && weightLabel.isNotEmpty) weightLabel,
+      if (hasReps) '× $rawReps',
+    ];
+
+    if (parts.isEmpty) {
+      return '-';
+    }
+    return parts.join(' ');
   }
 }
 
@@ -737,6 +795,58 @@ class _InputPill extends StatelessWidget {
           ),
           style: dense ? const TextStyle(fontSize: 14) : null,
           validator: validator,
+        ),
+      ),
+    );
+  }
+}
+
+class _DisplayPill extends StatelessWidget {
+  final String label;
+  final String value;
+  final SetCardTheme tokens;
+  final bool dense;
+
+  const _DisplayPill({
+    required this.label,
+    required this.value,
+    required this.tokens,
+    this.dense = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final labelStyle = TextStyle(
+      fontSize: dense ? 12 : 13,
+      color: tokens.chipFg.withOpacity(0.7),
+      fontWeight: FontWeight.w500,
+    );
+    final valueStyle = TextStyle(
+      fontSize: dense ? 14 : 16,
+      fontWeight: FontWeight.w600,
+      color: tokens.chipFg,
+    );
+
+    return Semantics(
+      label: '$label $value',
+      child: Container(
+        decoration: BoxDecoration(
+          color: tokens.chipBg,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: tokens.chipBorder.withOpacity(0.6),
+            width: 1.3,
+          ),
+        ),
+        padding: EdgeInsets.symmetric(horizontal: 12, vertical: dense ? 6 : 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(label, style: labelStyle),
+            SizedBox(height: dense ? 2 : 4),
+            Text(value, style: valueStyle),
+          ],
         ),
       ),
     );

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -224,6 +224,20 @@ class _ProfileScreenState extends State<ProfileScreen> {
           (_) => SimpleDialog(
             title: Text(loc.settingsDialogTitle),
             children: [
+              Consumer<SettingsProvider>(
+                builder: (context, settings, _) {
+                  return SwitchListTile.adaptive(
+                    contentPadding:
+                        const EdgeInsets.symmetric(horizontal: 24),
+                    title: Text(loc.settingsPreviousSetsTitle),
+                    subtitle: Text(loc.settingsPreviousSetsDescription),
+                    value: settings.showPreviousSets,
+                    onChanged: (value) {
+                      settings.setShowPreviousSets(value);
+                    },
+                  );
+                },
+              ),
               SimpleDialogOption(
                 onPressed: () {
                   Navigator.pop(context);

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -27,6 +27,9 @@
     "description": "Tooltip für den Verlauf-Button auf der Geräte-Seite"
   },
 
+  "devicePreviousFieldLabel": "Vorher",
+  "@devicePreviousFieldLabel": {"description": "Beschriftung für das Vorher-Feld in der Set-Karte"},
+
   "deviceNotFound": "Gerät nicht gefunden",
   "@deviceNotFound": {
     "description": "Fehlermeldung, wenn das Gerät nicht geladen werden kann"
@@ -549,6 +552,10 @@
   "@settingsCreatineSavedEnabled": {"description": "Snackbar wenn Kreatin-Tracker aktiviert wurde"},
   "settingsCreatineSavedDisabled": "Kreatin-Tracker deaktiviert.",
   "@settingsCreatineSavedDisabled": {"description": "Snackbar wenn Kreatin-Tracker deaktiviert wurde"},
+  "settingsPreviousSetsTitle": "Vorherige Sätze anzeigen",
+  "@settingsPreviousSetsTitle": {"description": "Schalter-Titel zum Anzeigen vorheriger Satzdaten"},
+  "settingsPreviousSetsDescription": "Zeigt Gewicht und Wiederholungen der letzten Einheit in den Set-Karten an.",
+  "@settingsPreviousSetsDescription": {"description": "Schalter-Beschreibung zum Anzeigen vorheriger Satzdaten"},
   "publicProfileDialogTitle": "Profil-Sichtbarkeit",
   "@publicProfileDialogTitle": {"description": "Titel des Dialogs für öffentliche Profil-Option"},
   "publicProfilePublic": "Öffentlich",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -27,6 +27,9 @@
     "description": "Tooltip for the history button on device screen"
   },
 
+  "devicePreviousFieldLabel": "Previous",
+  "@devicePreviousFieldLabel": {"description": "Label for the previous set summary field"},
+
   "deviceNotFound": "Device not found",
   "@deviceNotFound": {
     "description": "Error when the device cannot be loaded"
@@ -547,6 +550,10 @@
   "@settingsCreatineSavedEnabled": {"description": "Snackbar when creatine tracker enabled"},
   "settingsCreatineSavedDisabled": "Creatine tracker disabled.",
   "@settingsCreatineSavedDisabled": {"description": "Snackbar when creatine tracker disabled"},
+  "settingsPreviousSetsTitle": "Show previous sets",
+  "@settingsPreviousSetsTitle": {"description": "Toggle title for displaying previous set information"},
+  "settingsPreviousSetsDescription": "Display the weight and reps from your last session in set cards.",
+  "@settingsPreviousSetsDescription": {"description": "Toggle description for displaying previous set information"},
   "publicProfileDialogTitle": "Profile visibility",
   "@publicProfileDialogTitle": {"description": "Title for public profile dialog"},
   "publicProfilePublic": "Public",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -125,6 +125,12 @@ abstract class AppLocalizations {
   /// **'Show history'**
   String get deviceHistoryTooltip;
 
+  /// Label for the previous set summary field
+  ///
+  /// In en, this message translates to:
+  /// **'Previous'**
+  String get devicePreviousFieldLabel;
+
   /// Error when the device cannot be loaded
   ///
   /// In en, this message translates to:
@@ -916,6 +922,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Creatine tracker disabled.'**
   String get settingsCreatineSavedDisabled;
+
+  /// Toggle title for displaying previous set information
+  ///
+  /// In en, this message translates to:
+  /// **'Show previous sets'**
+  String get settingsPreviousSetsTitle;
+
+  /// Toggle description for displaying previous set information
+  ///
+  /// In en, this message translates to:
+  /// **'Display the weight and reps from your last session in set cards.'**
+  String get settingsPreviousSetsDescription;
 
   /// Title for public profile dialog
   ///

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -26,6 +26,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get deviceHistoryTooltip => 'Verlauf anzeigen';
 
   @override
+  String get devicePreviousFieldLabel => 'Vorher';
+
+  @override
   String get deviceNotFound => 'Gerät nicht gefunden';
 
   @override
@@ -438,6 +441,13 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get settingsCreatineSavedDisabled => 'Kreatin-Tracker deaktiviert.';
+
+  @override
+  String get settingsPreviousSetsTitle => 'Vorherige Sätze anzeigen';
+
+  @override
+  String get settingsPreviousSetsDescription =>
+      'Zeigt Gewicht und Wiederholungen der letzten Einheit in den Set-Karten an.';
 
   @override
   String get publicProfileDialogTitle => 'Profil-Sichtbarkeit';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -26,6 +26,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deviceHistoryTooltip => 'Show history';
 
   @override
+  String get devicePreviousFieldLabel => 'Previous';
+
+  @override
   String get deviceNotFound => 'Device not found';
 
   @override
@@ -438,6 +441,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settingsCreatineSavedDisabled => 'Creatine tracker disabled.';
+
+  @override
+  String get settingsPreviousSetsTitle => 'Show previous sets';
+
+  @override
+  String get settingsPreviousSetsDescription =>
+      'Display the weight and reps from your last session in set cards.';
 
   @override
   String get publicProfileDialogTitle => 'Profile visibility';


### PR DESCRIPTION
## Summary
- show an optional "Previous" pill in grouped set cards that surfaces last session weight and reps
- persist and expose a profile setting that toggles the previous-set summary on the device page
- extend localization strings to cover the new field and settings copy

## Testing
- `flutter test` *(fails: command not found)*
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d4791837908320ade62307107eeebc