### PR TITLE
Use brand gradient for session timer bar

### DIFF
--- a/lib/ui/timer/session_timer_bar.dart
+++ b/lib/ui/timer/session_timer_bar.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'session_timer_controller.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/l10n/app_localizations.dart';
+
+import 'session_timer_controller.dart';
 
 class SessionTimerBar extends StatefulWidget {
   final Duration initialDuration;
@@ -69,6 +71,9 @@ class _SessionTimerBarState extends State<SessionTimerBar>
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final loc = AppLocalizations.of(context)!;
+    final brand = theme.extension<AppBrandTheme>();
+    final highContrast = MediaQuery.of(context).highContrast;
+
     return ValueListenableBuilder<Duration>(
       valueListenable: _controller.remaining,
       builder: (context, remaining, _) {
@@ -99,12 +104,18 @@ class _SessionTimerBarState extends State<SessionTimerBar>
                     widthFactor: progress,
                     child: Container(
                       decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          colors: [
-                            theme.colorScheme.primaryContainer,
-                            theme.colorScheme.primary,
-                          ],
-                        ),
+                        gradient: highContrast
+                            ? null
+                            : brand?.gradient ??
+                                LinearGradient(
+                                  colors: [
+                                    theme.colorScheme.primaryContainer,
+                                    theme.colorScheme.primary,
+                                  ],
+                                ),
+                        color: highContrast
+                            ? brand?.outlineColorFallback ?? theme.colorScheme.primary
+                            : null,
                       ),
                     ),
                   ),


### PR DESCRIPTION
## Summary
- apply the app brand gradient to the session timer progress fill so it matches branded outlines
- provide a solid color fallback when high contrast mode is enabled

## Testing
- dart format lib/ui/timer/session_timer_bar.dart *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f40c1c848320bc200e9f984a6987