### PR TITLE
Load last session data for set card placeholders

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -268,6 +268,7 @@ class DeviceProvider extends ChangeNotifier {
     required String deviceId,
     required String exerciseId,
     required String userId,
+    bool loadLastSession = FF.isLastSessionVisible,
   }) async {
     _setLoading(true);
     _error = null;
@@ -341,8 +342,7 @@ class DeviceProvider extends ChangeNotifier {
 
       await loadMoreSnapshots(gymId: gymId, deviceId: deviceId, userId: userId);
 
-      if (FF.showLastSessionOnDevicePage ||
-          FF.runtimeShowLastSessionOnDevicePage) {
+      if (loadLastSession) {
         await _loadLastSession(gymId, deviceId, exerciseId, userId);
       }
       await _loadUserNote(gymId, deviceId, userId);

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -66,11 +66,15 @@ class _DeviceScreenState extends State<DeviceScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       final auth = context.read<AuthProvider>();
       _dlog('loadDevice() → start');
+      final settings = context.read<SettingsProvider>();
+      final shouldLoadLastSession =
+          settings.showLastSessionInSetCard || FF.isLastSessionVisible;
       await context.read<DeviceProvider>().loadDevice(
         gymId: widget.gymId,
         deviceId: widget.deviceId,
         exerciseId: widget.exerciseId,
         userId: auth.userId!,
+        loadLastSession: shouldLoadLastSession,
       );
       final planProv = context.read<TrainingPlanProvider>();
       if (planProv.plans.isEmpty && !planProv.isLoading) {


### PR DESCRIPTION
## Summary
- add an opt-in flag to DeviceProvider.loadDevice so callers can request last session data
- request the last session data when set card history placeholders are enabled or the feature flag is active

## Testing
- not run (environment missing flutter)

------
https://chatgpt.com/codex/tasks/task_e_68db020231048320af5c587979ad3fd4