### PR TITLE
feat: apply brand theme colors to device screen header

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -416,13 +416,31 @@ class _DeviceScreenState extends State<DeviceScreen> {
         body: Center(child: Text('Fehler: ${prov.error ?? "Unbekannt"}')),
       );
     } else {
+      final theme = Theme.of(context);
+      final accentColor = theme.colorScheme.secondary;
+      final titleBase = theme.textTheme.titleLarge ??
+          const TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.w600,
+          );
+      final titleStyle = titleBase.copyWith(color: accentColor);
+
       scaffold = Scaffold(
         appBar: AppBar(
+          foregroundColor: accentColor,
+          iconTheme: IconThemeData(color: accentColor),
+          actionsIconTheme: IconThemeData(color: accentColor),
+          titleTextStyle: titleStyle,
+          toolbarTextStyle:
+              theme.textTheme.titleMedium?.copyWith(color: accentColor),
           title: Hero(
             tag: 'device-${prov.device!.uid}',
             child: Material(
               type: MaterialType.transparency,
-              child: Text(prov.device!.name),
+              child: Text(
+                prov.device!.name,
+                style: titleStyle,
+              ),
             ),
           ),
           centerTitle: true,
@@ -436,8 +454,8 @@ class _DeviceScreenState extends State<DeviceScreen> {
               icon: Icon(
                 Icons.accessibility_new,
                 color: prov.isBodyweightMode
-                    ? Theme.of(context).colorScheme.primary
-                    : null,
+                    ? theme.colorScheme.primary
+                    : accentColor,
               ),
               tooltip: loc.bodyweightToggleTooltip,
               onPressed: () {


### PR DESCRIPTION
## Summary
- align the device screen app bar title and icons with the active brand accent color
- keep the bodyweight toggle highlighted via the primary color while defaulting to the brand accent when inactive

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68db0b44c84c8320a59d6f1f7d45eb8b