### PR TITLE
Improve device page title styling

### DIFF
--- a/lib/core/widgets/brand_gradient_text.dart
+++ b/lib/core/widgets/brand_gradient_text.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
+
+/// Text widget that renders its foreground using the global brand gradient.
+class BrandGradientText extends StatelessWidget {
+  const BrandGradientText(
+    this.text, {
+    super.key,
+    this.style,
+    this.textAlign,
+    this.maxLines,
+    this.overflow,
+    this.softWrap,
+  });
+
+  final String text;
+  final TextStyle? style;
+  final TextAlign? textAlign;
+  final int? maxLines;
+  final TextOverflow? overflow;
+  final bool? softWrap;
+
+  @override
+  Widget build(BuildContext context) {
+    final defaultStyle = DefaultTextStyle.of(context).style;
+    final effectiveStyle = defaultStyle
+        .merge(style)
+        .copyWith(color: Colors.white, decoration: TextDecoration.none);
+
+    return ShaderMask(
+      shaderCallback: (bounds) {
+        final rect = bounds.isEmpty
+            ? const Rect.fromLTWH(0, 0, 1, 1)
+            : Rect.fromLTWH(0, 0, bounds.width, bounds.height);
+        return AppGradients.brandGradient.createShader(rect);
+      },
+      blendMode: BlendMode.srcIn,
+      child: Text(
+        text,
+        style: effectiveStyle,
+        textAlign: textAlign,
+        maxLines: maxLines,
+        overflow: overflow,
+        softWrap: softWrap,
+      ),
+    );
+  }
+}

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -8,6 +8,7 @@ import 'package:intl/intl.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
+import 'package:tapem/core/widgets/brand_gradient_text.dart';
 import 'package:tapem/core/widgets/brand_outline.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/config/feature_flags.dart';
@@ -423,7 +424,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
             fontSize: 20,
             fontWeight: FontWeight.w600,
           );
-      final titleStyle = titleBase.copyWith(color: accentColor);
+      final titleStyle = titleBase.copyWith(fontWeight: FontWeight.w600);
 
       scaffold = Scaffold(
         appBar: AppBar(
@@ -437,9 +438,13 @@ class _DeviceScreenState extends State<DeviceScreen> {
             tag: 'device-${prov.device!.uid}',
             child: Material(
               type: MaterialType.transparency,
-              child: Text(
+              child: BrandGradientText(
                 prov.device!.name,
                 style: titleStyle,
+                textAlign: TextAlign.center,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                softWrap: false,
               ),
             ),
           ),


### PR DESCRIPTION
## Summary
- ensure the device screen title stays on a single line with ellipsis handling
- render the device title with the app brand gradient via a reusable BrandGradientText widget

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db0d7f3e788320ab55766cd3b38094