### PR TITLE
Improve device screen branding and layout

### DIFF
--- a/lib/core/widgets/brand_primary_button.dart
+++ b/lib/core/widgets/brand_primary_button.dart
@@ -32,34 +32,40 @@ class BrandPrimaryButton extends StatelessWidget {
         Theme.of(context).extension<BrandOnColors>()?.onCta ?? Colors.black;
     final textStyle = surface?.textStyle;
     final height = surface?.height ?? 48;
-    final padding = surface?.padding ?? const EdgeInsets.symmetric(horizontal: AppSpacing.sm);
+    final padding = surface?.padding ??
+        const EdgeInsets.symmetric(horizontal: AppSpacing.sm);
+    final isEnabled = onPressed != null;
 
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        gradient: gradient,
-        borderRadius: borderRadius,
-        boxShadow: shadow,
-      ),
-      child: Semantics(
-        button: true,
-        label: semanticsLabel,
-        child: Material(
-          type: MaterialType.transparency,
-          child: InkWell(
-            borderRadius: borderRadius,
-            splashColor: overlay,
-            highlightColor: overlay,
-            onTap: onPressed,
-            child: Container(
-              height: height,
-              padding: padding,
-              alignment: Alignment.center,
-              child: DefaultTextStyle.merge(
-                style: (textStyle ?? const TextStyle(fontWeight: FontWeight.bold))
-                    .copyWith(color: onBrand),
-                child: IconTheme(
-                  data: IconThemeData(color: onBrand),
-                  child: child,
+    return Opacity(
+      opacity: isEnabled ? 1 : 0.5,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: gradient,
+          borderRadius: borderRadius,
+          boxShadow: shadow,
+        ),
+        child: Semantics(
+          button: true,
+          enabled: isEnabled,
+          label: semanticsLabel,
+          child: Material(
+            type: MaterialType.transparency,
+            child: InkWell(
+              borderRadius: borderRadius,
+              splashColor: isEnabled ? overlay : Colors.transparent,
+              highlightColor: isEnabled ? overlay : Colors.transparent,
+              onTap: isEnabled ? onPressed : null,
+              child: Container(
+                height: height,
+                padding: padding,
+                alignment: Alignment.center,
+                child: DefaultTextStyle.merge(
+                  style: (textStyle ?? const TextStyle(fontWeight: FontWeight.bold))
+                      .copyWith(color: onBrand),
+                  child: IconTheme(
+                    data: IconThemeData(color: onBrand),
+                    child: child,
+                  ),
                 ),
               ),
             ),

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -10,6 +10,8 @@ import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
 import 'package:tapem/core/widgets/brand_gradient_text.dart';
 import 'package:tapem/core/widgets/brand_outline.dart';
+import 'package:tapem/core/widgets/brand_primary_button.dart';
+import 'package:tapem/core/theme/brand_on_colors.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/config/feature_flags.dart';
 
@@ -191,17 +193,16 @@ class _DeviceScreenState extends State<DeviceScreen> {
                         ),
                       if (prov.sets.isNotEmpty) const SizedBox(height: 12),
                       Center(
-                        child: TextButton.icon(
+                        child: BrandPrimaryButton(
                           onPressed: _addSet,
-                          style: TextButton.styleFrom(
-                            foregroundColor:
-                                Theme.of(context).colorScheme.primary,
-                            textStyle: const TextStyle(
-                              fontWeight: FontWeight.bold,
-                            ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              const Icon(Icons.add),
+                              const SizedBox(width: AppSpacing.xs),
+                              Text(loc.addSetButton),
+                            ],
                           ),
-                          icon: const Icon(Icons.add),
-                          label: Text(loc.addSetButton),
                         ),
                       ),
                     ],
@@ -246,7 +247,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
           child: Row(
             children: [
               Expanded(
-                child: OutlinedButton(
+                child: BrandPrimaryButton(
                   onPressed: () {
                     _closeKeyboard();
                     Navigator.pop(context);
@@ -256,7 +257,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
               ),
               const SizedBox(width: 12),
               Expanded(
-                child: OutlinedButton(
+                child: BrandPrimaryButton(
                   onPressed: prov.hasSessionToday || prov.isSaving
                       ? null
                       : () async {
@@ -367,10 +368,15 @@ class _DeviceScreenState extends State<DeviceScreen> {
                           });
                         },
                   child: prov.isSaving
-                      ? const SizedBox(
+                      ? SizedBox(
                           width: 24,
                           height: 24,
-                          child: CircularProgressIndicator(strokeWidth: 2),
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                              onBrandColor,
+                            ),
+                          ),
                         )
                       : Text(loc.saveButton),
                 ),
@@ -419,6 +425,8 @@ class _DeviceScreenState extends State<DeviceScreen> {
     } else {
       final theme = Theme.of(context);
       final accentColor = theme.colorScheme.secondary;
+      final onBrandColor =
+          theme.extension<BrandOnColors>()?.onCta ?? Colors.black;
       final titleBase = theme.textTheme.titleLarge ??
           const TextStyle(
             fontSize: 20,
@@ -438,13 +446,23 @@ class _DeviceScreenState extends State<DeviceScreen> {
             tag: 'device-${prov.device!.uid}',
             child: Material(
               type: MaterialType.transparency,
-              child: BrandGradientText(
-                prov.device!.name,
-                style: titleStyle,
-                textAlign: TextAlign.center,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                softWrap: false,
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  return ConstrainedBox(
+                    constraints:
+                        BoxConstraints(maxWidth: constraints.maxWidth),
+                    child: FittedBox(
+                      fit: BoxFit.scaleDown,
+                      alignment: Alignment.center,
+                      child: BrandGradientText(
+                        prov.device!.name,
+                        style: titleStyle,
+                        textAlign: TextAlign.center,
+                        softWrap: false,
+                      ),
+                    ),
+                  );
+                },
               ),
             ),
           ),

--- a/lib/features/device/presentation/widgets/device_pager.dart
+++ b/lib/features/device/presentation/widgets/device_pager.dart
@@ -113,17 +113,6 @@ class DevicePagerState extends State<DevicePager> {
     return Stack(
       children: [
         pageView,
-        if (prov.sessionSnapshots.isEmpty && !prov.isLoadingSnapshots)
-          Positioned.fill(
-            child: IgnorePointer(
-              child: Center(
-                child: Text(
-                  'Keine Historie',
-                  style: Theme.of(context).textTheme.bodyMedium,
-                ),
-              ),
-            ),
-          ),
         EdgeGestureOverlay(
           enabled: isEditor,
           onLeftEdgeSwipe: _goToPreviousSession,


### PR DESCRIPTION
## Summary
- auto-scale the device name in the header so long names remain fully visible
- remove the obsolete "Keine Historie" placeholder from the device pager
- restyle key device actions with the brand gradient, including disabled handling for gradient buttons

## Testing
- not run (flutter not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68db0fd6075883208cde672668a41033