### PR TITLE
Fix onBrandColor lookup in device screen

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -126,6 +126,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
     AppLocalizations loc,
     String locale,
     ExerciseEntry? plannedEntry,
+    Color onBrandColor,
   ) {
     return Column(
       children: [
@@ -533,7 +534,13 @@ class _DeviceScreenState extends State<DeviceScreen> {
           userId: auth.userId!,
           provider: prov,
           editablePage:
-              _buildEditablePage(prov, loc, locale, plannedEntry),
+              _buildEditablePage(
+                prov,
+                loc,
+                locale,
+                plannedEntry,
+                onBrandColor,
+              ),
         ),
       );
     }


### PR DESCRIPTION
## Summary
- pass the computed onBrandColor color into the editable page builder so the save button can access it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db12042e708320b925117b16f97106