### PR TITLE
Style device action buttons with outline theme

### DIFF
--- a/lib/core/widgets/brand_outline_button.dart
+++ b/lib/core/widgets/brand_outline_button.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_brand_theme.dart';
+import '../theme/brand_on_colors.dart';
+import '../theme/design_tokens.dart';
+
+/// Outlined button that uses the branded gradient stroke while keeping the
+/// surface neutral.
+class BrandOutlineButton extends StatelessWidget {
+  final VoidCallback? onPressed;
+  final Widget child;
+  final String? semanticsLabel;
+
+  const BrandOutlineButton({
+    super.key,
+    required this.onPressed,
+    required this.child,
+    this.semanticsLabel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = Theme.of(context).extension<AppBrandTheme>();
+    if (brand == null) {
+      return OutlinedButton(
+        onPressed: onPressed,
+        child: child,
+      );
+    }
+
+    final highContrast = MediaQuery.of(context).highContrast;
+    final borderRadius =
+        (brand.radius ?? BorderRadius.circular(AppRadius.button)) as BorderRadius;
+    final outlineWidth = brand.outlineWidth;
+    final innerRadius = borderRadius - BorderRadius.circular(outlineWidth);
+    final isEnabled = onPressed != null;
+    final onColors = Theme.of(context).extension<BrandOnColors>();
+    final foregroundColor =
+        onColors?.onSecondary ?? Theme.of(context).colorScheme.secondary;
+
+    Widget button = DecoratedBox(
+      decoration: BoxDecoration(
+        gradient: highContrast ? null : brand.outlineGradient,
+        color: highContrast ? brand.outlineColorFallback : null,
+        borderRadius: borderRadius,
+        boxShadow: isEnabled ? brand.outlineShadow : null,
+      ),
+      child: Padding(
+        padding: EdgeInsets.all(outlineWidth),
+        child: Material(
+          type: MaterialType.transparency,
+          borderRadius: innerRadius,
+          child: InkWell(
+            borderRadius: innerRadius,
+            overlayColor: MaterialStateProperty.resolveWith((states) {
+              if (!isEnabled) return Colors.transparent;
+              if (states.contains(MaterialState.pressed)) {
+                return brand.pressedOverlay;
+              }
+              if (states.contains(MaterialState.focused)) {
+                return brand.focusRing.withOpacity(0.3);
+              }
+              return null;
+            }),
+            onTap: isEnabled ? onPressed : null,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.surface,
+                borderRadius: innerRadius,
+              ),
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minHeight: brand.height),
+                child: Padding(
+                  padding: brand.padding,
+                  child: Center(
+                    child: DefaultTextStyle.merge(
+                      style: brand.textStyle.copyWith(color: foregroundColor),
+                      child: IconTheme(
+                        data: IconThemeData(color: foregroundColor),
+                        child: child,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    if (!isEnabled) {
+      button = Opacity(
+        opacity: brand.outlineDisabledOpacity,
+        child: button,
+      );
+    }
+
+    if (semanticsLabel != null) {
+      button = Semantics(
+        button: true,
+        enabled: isEnabled,
+        label: semanticsLabel,
+        child: button,
+      );
+    }
+
+    return button;
+  }
+}

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -10,7 +10,7 @@ import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
 import 'package:tapem/core/widgets/brand_gradient_text.dart';
 import 'package:tapem/core/widgets/brand_outline.dart';
-import 'package:tapem/core/widgets/brand_primary_button.dart';
+import 'package:tapem/core/widgets/brand_outline_button.dart';
 import 'package:tapem/core/theme/brand_on_colors.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/config/feature_flags.dart';
@@ -241,7 +241,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
           child: Row(
             children: [
               Expanded(
-                child: BrandPrimaryButton(
+                child: BrandOutlineButton(
                   onPressed: () {
                     _closeKeyboard();
                     Navigator.pop(context);
@@ -251,7 +251,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
               ),
               const SizedBox(width: 12),
               Expanded(
-                child: BrandPrimaryButton(
+                child: BrandOutlineButton(
                   onPressed: prov.hasSessionToday || prov.isSaving
                       ? null
                       : () async {


### PR DESCRIPTION
## Summary
- add a reusable BrandOutlineButton component that renders the branded gradient stroke without a filled background
- update the device screen cancel/save actions to use the outline button for consistent styling with the rest of the app

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db15795de083209adc2d66c2600de6