### PR TITLE
Switch device session actions to outlined branding

### DIFF
--- a/lib/core/widgets/brand_outline_button.dart
+++ b/lib/core/widgets/brand_outline_button.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_brand_theme.dart';
+import '../theme/design_tokens.dart';
+import 'brand_outline.dart';
+
+/// Button styled with the branded outline surface.
+///
+/// Uses the outline tokens from [AppBrandTheme] to ensure consistent spacing,
+/// typography and interaction behaviour across the app.
+class BrandOutlineButton extends StatelessWidget {
+  final VoidCallback? onPressed;
+  final Widget child;
+  final String? semanticsLabel;
+  final EdgeInsetsGeometry? padding;
+  final double? height;
+
+  const BrandOutlineButton({
+    super.key,
+    required this.onPressed,
+    required this.child,
+    this.semanticsLabel,
+    this.padding,
+    this.height,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final brand = Theme.of(context).extension<AppBrandTheme>();
+    final effectivePadding =
+        padding ?? brand?.padding ?? const EdgeInsets.symmetric(horizontal: AppSpacing.sm);
+    final effectiveHeight = height ?? brand?.height ?? 48.0;
+    final outlineColor = brand?.outline ?? Theme.of(context).colorScheme.primary;
+    final textStyle = brand?.textStyle ?? const TextStyle(fontWeight: FontWeight.bold);
+
+    final buttonContent = BrandOutline(
+      onTap: onPressed,
+      isDisabled: onPressed == null,
+      padding: EdgeInsets.zero,
+      child: SizedBox(
+        height: effectiveHeight,
+        child: Padding(
+          padding: effectivePadding,
+          child: Center(
+            child: DefaultTextStyle.merge(
+              style: textStyle.copyWith(color: outlineColor),
+              child: IconTheme(
+                data: IconThemeData(color: outlineColor),
+                child: child,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    return Semantics(
+      button: true,
+      enabled: onPressed != null,
+      label: semanticsLabel,
+      child: buttonContent,
+    );
+  }
+}

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -10,8 +10,7 @@ import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
 import 'package:tapem/core/widgets/brand_gradient_text.dart';
 import 'package:tapem/core/widgets/brand_outline.dart';
-import 'package:tapem/core/widgets/brand_primary_button.dart';
-import 'package:tapem/core/theme/brand_on_colors.dart';
+import 'package:tapem/core/widgets/brand_outline_button.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/config/feature_flags.dart';
 
@@ -126,8 +125,10 @@ class _DeviceScreenState extends State<DeviceScreen> {
     AppLocalizations loc,
     String locale,
     ExerciseEntry? plannedEntry,
-    Color onBrandColor,
   ) {
+    final theme = Theme.of(context);
+    final outlineColor =
+        theme.extension<AppBrandTheme>()?.outline ?? theme.colorScheme.secondary;
     return Column(
       children: [
         const Padding(
@@ -241,7 +242,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
           child: Row(
             children: [
               Expanded(
-                child: BrandPrimaryButton(
+                child: BrandOutlineButton(
                   onPressed: () {
                     _closeKeyboard();
                     Navigator.pop(context);
@@ -251,7 +252,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
               ),
               const SizedBox(width: 12),
               Expanded(
-                child: BrandPrimaryButton(
+                child: BrandOutlineButton(
                   onPressed: prov.hasSessionToday || prov.isSaving
                       ? null
                       : () async {
@@ -367,9 +368,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                           height: 24,
                           child: CircularProgressIndicator(
                             strokeWidth: 2,
-                            valueColor: AlwaysStoppedAnimation<Color>(
-                              onBrandColor,
-                            ),
+                            valueColor: AlwaysStoppedAnimation<Color>(outlineColor),
                           ),
                         )
                       : Text(loc.saveButton),
@@ -419,8 +418,6 @@ class _DeviceScreenState extends State<DeviceScreen> {
     } else {
       final theme = Theme.of(context);
       final accentColor = theme.colorScheme.secondary;
-      final onBrandColor =
-          theme.extension<BrandOnColors>()?.onCta ?? Colors.black;
       final titleBase = theme.textTheme.titleLarge ??
           const TextStyle(
             fontSize: 20,
@@ -532,7 +529,6 @@ class _DeviceScreenState extends State<DeviceScreen> {
                 loc,
                 locale,
                 plannedEntry,
-                onBrandColor,
               ),
         ),
       );


### PR DESCRIPTION
## Summary
- add a reusable `BrandOutlineButton` that renders actions with the branded outline style
- replace the device session cancel/save buttons with the outlined variant and align the loading indicator colour with the outline tokens

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db15795de083209adc2d66c2600de6