### PR TITLE
Apply brand gradient styling across key screens

### DIFF
--- a/lib/core/widgets/brand_action_tile.dart
+++ b/lib/core/widgets/brand_action_tile.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
 import 'brand_gradient_card.dart';
+import 'brand_gradient_icon.dart';
+import 'brand_gradient_text.dart';
 import 'brand_outline.dart';
 import '../theme/brand_on_colors.dart';
 import '../theme/design_tokens.dart';
@@ -61,33 +63,58 @@ class BrandActionTile extends StatelessWidget {
     if (uiLogEvent != null) {
       elogUi(uiLogEvent!, {'title': title});
     }
+    final theme = Theme.of(context);
     final onGradient =
-        Theme.of(context).extension<BrandOnColors>()?.onGradient ?? Colors.black;
-    final titleStyle =
-        variant == BrandActionTileVariant.gradient ? TextStyle(color: onGradient) : null;
-    final subtitleStyle =
-        variant == BrandActionTileVariant.gradient ? TextStyle(color: onGradient) : null;
+        theme.extension<BrandOnColors>()?.onGradient ?? Colors.black;
+    final defaultTitleStyle = theme.textTheme.titleMedium;
+    final defaultSubtitleStyle = theme.textTheme.bodyMedium;
+
+    final Widget titleWidget = variant == BrandActionTileVariant.gradient
+        ? Text(
+            title,
+            textAlign: centerTitle ? TextAlign.center : TextAlign.start,
+            style: TextStyle(color: onGradient),
+          )
+        : BrandGradientText(
+            title,
+            textAlign: centerTitle ? TextAlign.center : TextAlign.start,
+            style: defaultTitleStyle,
+          );
+
+    final Widget? subtitleWidget = subtitle != null
+        ? (variant == BrandActionTileVariant.gradient
+            ? Text(
+                subtitle!,
+                style: TextStyle(color: onGradient),
+              )
+            : BrandGradientText(
+                subtitle!,
+                style: defaultSubtitleStyle,
+              ))
+        : null;
+
+    final Widget? leadingWidget = leading ??
+        (leadingIcon != null
+            ? (variant == BrandActionTileVariant.gradient
+                ? Icon(leadingIcon, color: onGradient)
+                : BrandGradientIcon(leadingIcon!))
+            : null);
+
+    final Widget? trailingWidget = showChevron
+        ? (trailing ??
+            (variant == BrandActionTileVariant.gradient
+                ? Icon(Icons.chevron_right, color: onGradient)
+                : const BrandGradientIcon(Icons.chevron_right)))
+        : trailing;
 
     final tile = ListTile(
       contentPadding: EdgeInsets.zero,
       dense: dense,
       minVerticalPadding: minVerticalPadding,
-      leading: leading ??
-          (leadingIcon != null ? Icon(leadingIcon, color: onGradient) : null),
-      title: Text(
-        title,
-        textAlign: centerTitle ? TextAlign.center : TextAlign.start,
-        style: titleStyle,
-      ),
-      subtitle: subtitle != null
-          ? Text(
-              subtitle!,
-              style: subtitleStyle,
-            )
-          : null,
-      trailing: showChevron
-          ? (trailing ?? Icon(Icons.chevron_right, color: onGradient))
-          : null,
+      leading: leadingWidget,
+      title: titleWidget,
+      subtitle: subtitleWidget,
+      trailing: trailingWidget,
     );
 
     final Widget card = variant == BrandActionTileVariant.gradient

--- a/lib/core/widgets/brand_gradient_icon.dart
+++ b/lib/core/widgets/brand_gradient_icon.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+import '../theme/design_tokens.dart';
+
+/// Icon widget that paints its glyph using the global brand gradient.
+class BrandGradientIcon extends StatelessWidget {
+  const BrandGradientIcon(
+    this.icon, {
+    super.key,
+    this.size,
+    this.gradient,
+    this.alignment = Alignment.center,
+    this.semanticLabel,
+    this.textDirection,
+  });
+
+  /// Icon to render using the brand gradient.
+  final IconData icon;
+
+  /// Optional size override, matches [Icon.size].
+  final double? size;
+
+  /// Optional gradient override. Falls back to [AppGradients.brandGradient].
+  final Gradient? gradient;
+
+  /// Alignment for the gradient shader.
+  final AlignmentGeometry alignment;
+
+  /// Optional semantic label for accessibility.
+  final String? semanticLabel;
+
+  /// Optional explicit text direction override.
+  final TextDirection? textDirection;
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveGradient = gradient ?? AppGradients.brandGradient;
+    return ShaderMask(
+      shaderCallback: (bounds) {
+        final rect = bounds.isEmpty
+            ? const Rect.fromLTWH(0, 0, 1, 1)
+            : Rect.fromLTWH(0, 0, bounds.width, bounds.height);
+        return effectiveGradient.createShader(rect);
+      },
+      blendMode: BlendMode.srcIn,
+      child: Icon(
+        icon,
+        size: size,
+        semanticLabel: semanticLabel,
+        textDirection: textDirection,
+        color: Colors.white,
+      ),
+    );
+  }
+}

--- a/lib/features/gym/presentation/screens/gym_screen.dart
+++ b/lib/features/gym/presentation/screens/gym_screen.dart
@@ -7,6 +7,7 @@ import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/core/recent_devices_store.dart';
 import 'package:tapem/app_router.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
+import 'package:tapem/core/widgets/brand_gradient_text.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/ui/common/search_and_filters.dart';
 import 'package:tapem/ui/devices/device_card.dart';
@@ -92,7 +93,12 @@ class _GymScreenState extends State<GymScreen>
     }
     if (gymProv.error != null) {
       return Scaffold(
-        appBar: AppBar(title: Text(loc.gymTitle)),
+        appBar: AppBar(
+          title: BrandGradientText(
+            loc.gymTitle,
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+        ),
         body: Center(child: Text('${loc.errorPrefix}: ${gymProv.error}')),
       );
     }
@@ -101,8 +107,15 @@ class _GymScreenState extends State<GymScreen>
     }
     final devices = _filtered(gymProv.devices);
 
+    final theme = Theme.of(context);
+
     return Scaffold(
-      appBar: AppBar(title: Text(loc.gymTitle)),
+      appBar: AppBar(
+        title: BrandGradientText(
+          loc.gymTitle,
+          style: theme.textTheme.titleLarge,
+        ),
+      ),
       body: SafeArea(
         child: Column(
           children: [

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -12,6 +12,8 @@ import 'package:tapem/features/friends/providers/friends_provider.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/widgets/brand_action_tile.dart';
+import 'package:tapem/core/widgets/brand_gradient_icon.dart';
+import 'package:tapem/core/widgets/brand_gradient_text.dart';
 import 'package:tapem/core/logging/elog.dart';
 import 'package:tapem/core/utils/avatar_assets.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
@@ -288,6 +290,9 @@ class _ProfileScreenState extends State<ProfileScreen> {
     final userId = auth.userId ?? '';
     const avatarSize = 44.0;
 
+    final theme = Theme.of(context);
+    final profileTitle = auth.userName ?? auth.userEmail ?? loc.profileTitle;
+
     return Scaffold(
       appBar: AppBar(
         automaticallyImplyLeading: false,
@@ -328,6 +333,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
             ),
           ),
         ),
+        title: BrandGradientText(
+          profileTitle,
+          style: theme.textTheme.titleLarge,
+        ),
         actions: [
           if (enableFriends)
             Consumer<FriendsProvider>(
@@ -336,7 +345,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                 return IconButton(
                   icon: Stack(
                     children: [
-                      const Icon(Icons.group),
+                      const BrandGradientIcon(Icons.group),
                       if (showBadge)
                         const Positioned(
                           right: 0,
@@ -355,19 +364,19 @@ class _ProfileScreenState extends State<ProfileScreen> {
             ),
           if (context.watch<SettingsProvider>().creatineEnabled)
             IconButton(
-              icon: const Icon(Icons.medication),
+              icon: const BrandGradientIcon(Icons.medication),
               tooltip: loc.creatineTitle,
               onPressed: () {
                 Navigator.pushNamed(context, AppRouter.creatine);
               },
             ),
           IconButton(
-            icon: const Icon(Icons.settings),
+            icon: const BrandGradientIcon(Icons.settings),
             tooltip: loc.settingsIconTooltip,
             onPressed: _showSettingsDialog,
           ),
           IconButton(
-            icon: const Icon(Icons.logout),
+            icon: const BrandGradientIcon(Icons.logout),
             tooltip: loc.logoutTooltip,
             onPressed: () {
               context.read<AuthProvider>().logout();
@@ -386,12 +395,11 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                      const Text(
+                      BrandGradientText(
                         'Trainingstage',
                         textAlign: TextAlign.center,
-                        style: TextStyle(
+                        style: theme.textTheme.titleMedium?.copyWith(
                           fontWeight: FontWeight.bold,
-                          fontSize: 16,
                         ),
                       ),
                       const SizedBox(height: AppSpacing.sm),

--- a/lib/features/rank/presentation/screens/rank_screen.dart
+++ b/lib/features/rank/presentation/screens/rank_screen.dart
@@ -5,6 +5,7 @@ import 'package:tapem/app_router.dart';
 import 'package:tapem/features/challenges/presentation/screens/challenge_tab.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/widgets/brand_action_tile.dart';
+import 'package:tapem/core/widgets/brand_gradient_text.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/logging/elog.dart';
 
@@ -40,12 +41,30 @@ class _RankScreenState extends State<RankScreen>
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Leaderboard'),
+        title: BrandGradientText(
+          'Leaderboard',
+          style: theme.textTheme.titleLarge,
+        ),
         bottom: TabBar(
           controller: _tabController,
-          tabs: const [Tab(text: 'Rank'), Tab(text: 'Challenges')],
+          tabs: [
+            Tab(
+              child: BrandGradientText(
+                'Rank',
+                style: theme.textTheme.titleMedium,
+              ),
+            ),
+            Tab(
+              child: BrandGradientText(
+                'Challenges',
+                style: theme.textTheme.titleMedium,
+              ),
+            ),
+          ],
         ),
       ),
       body: Consumer<RankProvider>(

--- a/lib/ui/common/search_and_filters.dart
+++ b/lib/ui/common/search_and_filters.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/core/ui_mutation_guard.dart';
+import 'package:tapem/core/widgets/brand_gradient_icon.dart';
+import 'package:tapem/core/widgets/brand_gradient_text.dart';
 import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 
@@ -146,7 +148,7 @@ class _SearchAndFiltersState extends State<SearchAndFilters> {
           onChanged: widget.onQuery,
           decoration: InputDecoration(
             hintText: loc.multiDeviceSearchHint,
-            prefixIcon: const Icon(Icons.search),
+            prefixIcon: const BrandGradientIcon(Icons.search),
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
               borderSide: BorderSide.none,
@@ -159,7 +161,10 @@ class _SearchAndFiltersState extends State<SearchAndFilters> {
         Row(
           children: [
             FilterChip(
-              label: const Text('Name'),
+              label: BrandGradientText(
+                'Name',
+                style: theme.textTheme.labelLarge,
+              ),
               selected: widget.sort == SortOrder.za,
               onSelected: (_) => _showSortSheet(),
               shape: const StadiumBorder(),
@@ -168,7 +173,10 @@ class _SearchAndFiltersState extends State<SearchAndFilters> {
             ),
             const SizedBox(width: 8),
             FilterChip(
-              label: const Text('Muskel'),
+              label: BrandGradientText(
+                'Muskel',
+                style: theme.textTheme.labelLarge,
+              ),
               selected: widget.muscleFilterIds.isNotEmpty,
               onSelected: (_) => _showMuscleSheet(),
               shape: const StadiumBorder(),
@@ -177,7 +185,10 @@ class _SearchAndFiltersState extends State<SearchAndFilters> {
             ),
             const SizedBox(width: 8),
             FilterChip(
-              label: const Text('Zuletzt'),
+              label: BrandGradientText(
+                'Zuletzt',
+                style: theme.textTheme.labelLarge,
+              ),
               selected: widget.sort == SortOrder.recent,
               onSelected: (v) =>
                   widget.onSort(v ? SortOrder.recent : SortOrder.az),

--- a/lib/ui/devices/device_card.dart
+++ b/lib/ui/devices/device_card.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:tapem/core/widgets/brand_gradient_icon.dart';
+import 'package:tapem/core/widgets/brand_gradient_text.dart';
 import 'package:tapem/core/widgets/brand_outline.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/features/device/presentation/widgets/muscle_chips.dart';
@@ -37,7 +39,7 @@ class DeviceCard extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
+                  BrandGradientText(
                     device.name,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
@@ -46,7 +48,7 @@ class DeviceCard extends StatelessWidget {
                   if (brand.isNotEmpty)
                     Padding(
                       padding: const EdgeInsets.only(top: 4),
-                      child: Text(
+                      child: BrandGradientText(
                         brand,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
@@ -67,10 +69,14 @@ class DeviceCard extends StatelessWidget {
                   Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      Text('ID: $idText', style: theme.textTheme.labelSmall),
+                      BrandGradientText(
+                        'ID: $idText',
+                        style: theme.textTheme.labelSmall,
+                      ),
                       if (onAssignMuscles != null || onResetMuscles != null)
                         PopupMenuButton<_Menu>(
                           tooltip: loc.assignMuscleGroups,
+                          icon: const BrandGradientIcon(Icons.more_vert),
                           onSelected: (v) {
                             switch (v) {
                               case _Menu.assign:


### PR DESCRIPTION
## Summary
- add a reusable brand gradient icon widget
- apply gradient typography to gym, profile, and leaderboard headers and controls
- refresh device and action tiles to share the gradient styling for outlined variants

## Testing
- Not run (flutter tooling unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68db18b359ec8320957f9cb0f95370fc