### PR TITLE
Restore workout timer indicator in the branded header

### DIFF
--- a/lib/core/utils/duration_format.dart
+++ b/lib/core/utils/duration_format.dart
@@ -28,3 +28,14 @@ String formatDurationHm(Duration duration) {
   final mStr = m.toString().padLeft(2, '0');
   return '$hStr:$mStr';
 }
+
+/// Formats [duration] as `HH:mm:ss`, including leading zeros for each unit.
+String formatDurationHms(Duration duration) {
+  final h = duration.inHours;
+  final m = duration.inMinutes % 60;
+  final s = duration.inSeconds % 60;
+  final hStr = h.toString().padLeft(2, '0');
+  final mStr = m.toString().padLeft(2, '0');
+  final sStr = s.toString().padLeft(2, '0');
+  return '$hStr:$mStr:$sStr';
+}

--- a/lib/core/widgets/base_screen.dart
+++ b/lib/core/widgets/base_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:tapem/features/nfc/widgets/nfc_scan_button.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 
 /// BaseScreen: Gemeinsamer Scaffold mit AppBar-Titel und NFC-Scan-Button.
 /// Alle Screens, die diese Basisklasse nutzen, erhalten automatisch den NFC-Button.
@@ -14,9 +14,7 @@ class BaseScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text(title),
-        actions: const [
-          NfcScanButton(), // Button-getriggertes NFC-Scanning
-        ],
+        actions: buildGlobalAppBarActions(),
       ),
       body: child,
     );

--- a/lib/core/widgets/global_app_bar_actions.dart
+++ b/lib/core/widgets/global_app_bar_actions.dart
@@ -1,0 +1,140 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:tapem/core/services/workout_session_duration_service.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/core/utils/duration_format.dart';
+import 'package:tapem/features/nfc/widgets/nfc_scan_button.dart';
+
+/// Builds a list of app bar actions that always appends the global
+/// workout timer and NFC scan controls to the provided [leadingActions].
+List<Widget> buildGlobalAppBarActions({
+  List<Widget>? leadingActions,
+  bool showNfcButton = true,
+}) {
+  return <Widget>[
+    ...?leadingActions,
+    GlobalAppBarActions(showNfcButton: showNfcButton),
+  ];
+}
+
+/// Shared trailing action row that exposes the running workout timer and the
+/// NFC scan shortcut.
+class GlobalAppBarActions extends StatelessWidget {
+  final bool showNfcButton;
+
+  const GlobalAppBarActions({super.key, this.showNfcButton = true});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const WorkoutTimerChip(),
+        if (showNfcButton) const SizedBox(width: 8),
+        if (showNfcButton) const NfcScanButton(),
+      ],
+    );
+  }
+}
+
+/// Compact chip that surfaces the currently running workout duration in the
+/// global header. When no workout is active, the chip collapses.
+class WorkoutTimerChip extends StatelessWidget {
+  const WorkoutTimerChip({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<WorkoutSessionDurationService>(
+      builder: (context, service, _) {
+        return AnimatedSwitcher(
+          duration: const Duration(milliseconds: 200),
+          switchInCurve: Curves.easeOut,
+          switchOutCurve: Curves.easeIn,
+          transitionBuilder: (child, animation) {
+            return FadeTransition(
+              opacity: animation,
+              child: SizeTransition(
+                axis: Axis.horizontal,
+                axisAlignment: -1,
+                sizeFactor: animation,
+                child: child,
+              ),
+            );
+          },
+          child: service.isRunning
+              ? _RunningTimerChip(
+                  key: const ValueKey('workout-timer-active'),
+                  service: service,
+                )
+              : const SizedBox.shrink(
+                  key: ValueKey('workout-timer-idle'),
+                ),
+        );
+      },
+    );
+  }
+}
+
+class _RunningTimerChip extends StatelessWidget {
+  final WorkoutSessionDurationService service;
+
+  const _RunningTimerChip({required this.service, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+    final brand = theme.extension<AppBrandTheme>();
+    final textStyle = (brand?.textStyle ?? theme.textTheme.labelLarge)?.copyWith(
+      color: brand?.onBrand ?? colors.onPrimary,
+      fontFeatures: const [FontFeature.tabularFigures()],
+      letterSpacing: 0.2,
+    );
+
+    final decoration = BoxDecoration(
+      gradient: brand?.gradient,
+      color: brand == null ? colors.secondaryContainer : null,
+      borderRadius: BorderRadius.circular(AppRadius.button),
+      boxShadow: brand?.shadow,
+    );
+
+    return StreamBuilder<Duration>(
+      stream: service.tickStream,
+      initialData: service.elapsed,
+      builder: (context, snapshot) {
+        final duration = snapshot.data ?? service.elapsed;
+        final formatted = formatDurationHms(duration);
+        final contentColor = textStyle?.color ?? colors.onSecondaryContainer;
+
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: DecoratedBox(
+            decoration: decoration,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.timer_outlined,
+                    size: 18,
+                    color: contentColor,
+                  ),
+                  const SizedBox(width: 6),
+                  Text(
+                    formatted,
+                    style: textStyle,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/admin/presentation/screens/admin_dashboard_screen.dart
+++ b/lib/features/admin/presentation/screens/admin_dashboard_screen.dart
@@ -16,6 +16,7 @@ import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/widgets/brand_primary_button.dart';
 import 'package:tapem/core/widgets/brand_action_tile.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/core/logging/elog.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 
@@ -191,13 +192,19 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen> {
     final loc = AppLocalizations.of(context)!;
     if (!auth.isAdmin) {
       return Scaffold(
-        appBar: AppBar(title: const Text('Adminbereich')),
+        appBar: AppBar(
+          title: const Text('Adminbereich'),
+          actions: buildGlobalAppBarActions(),
+        ),
         body: const Center(child: Text('Keine Admin-Rechte')),
       );
     }
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Admin-Dashboard')),
+      appBar: AppBar(
+        title: const Text('Admin-Dashboard'),
+        actions: buildGlobalAppBarActions(),
+      ),
       body:
           _loading
               ? const Center(child: CircularProgressIndicator())

--- a/lib/features/admin/presentation/screens/admin_symbols_screen.dart
+++ b/lib/features/admin/presentation/screens/admin_symbols_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/features/friends/domain/models/public_profile.dart';
@@ -35,7 +36,10 @@ class _AdminSymbolsScreenState extends State<AdminSymbolsScreen> {
     final auth = context.watch<AuthProvider>();
     if (!auth.isAdmin) {
       return Scaffold(
-        appBar: AppBar(title: Text(loc.admin_symbols_title)),
+        appBar: AppBar(
+          title: Text(loc.admin_symbols_title),
+          actions: buildGlobalAppBarActions(),
+        ),
         body: const Center(child: Text('Kein Zugriff')),
       );
     }
@@ -48,14 +52,16 @@ class _AdminSymbolsScreenState extends State<AdminSymbolsScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text(loc.admin_symbols_title),
-        actions: [
-          if (kDebugMode)
-            IconButton(
-              icon: const Icon(Icons.build),
-              tooltip: 'backfill usernameLower',
-              onPressed: () => _backfill(fs, gymId),
-            ),
-        ],
+        actions: buildGlobalAppBarActions(
+          leadingActions: [
+            if (kDebugMode)
+              IconButton(
+                icon: const Icon(Icons.build),
+                tooltip: 'backfill usernameLower',
+                onPressed: () => _backfill(fs, gymId),
+              ),
+          ],
+        ),
       ),
       body: Column(
         children: [

--- a/lib/features/admin/presentation/screens/branding_screen.dart
+++ b/lib/features/admin/presentation/screens/branding_screen.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/functions_provider.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:file_picker/file_picker.dart';
 
 import 'package:tapem/core/providers/auth_provider.dart';
@@ -78,7 +79,10 @@ class _BrandingScreenState extends State<BrandingScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Branding')),
+      appBar: AppBar(
+        title: const Text('Branding'),
+        actions: buildGlobalAppBarActions(),
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(

--- a/lib/features/admin/presentation/screens/challenge_admin_screen.dart
+++ b/lib/features/admin/presentation/screens/challenge_admin_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/ui/numeric_keypad/overlay_numeric_keypad.dart';
 
 import '../../../../core/providers/auth_provider.dart';
@@ -121,7 +122,10 @@ class _ChallengeAdminScreenState extends State<ChallengeAdminScreen> {
   Widget build(BuildContext context) {
     final devices = context.watch<GymProvider>().devices;
     return Scaffold(
-      appBar: AppBar(title: const Text('Challenges verwalten')),
+      appBar: AppBar(
+        title: const Text('Challenges verwalten'),
+        actions: buildGlobalAppBarActions(),
+      ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
         child: Column(

--- a/lib/features/admin/presentation/screens/user_symbols_screen.dart
+++ b/lib/features/admin/presentation/screens/user_symbols_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/config/remote_config.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 import 'package:tapem/features/avatars/presentation/providers/avatar_inventory_provider.dart';
 import 'package:tapem/l10n/app_localizations.dart';
@@ -313,13 +314,19 @@ class _UserSymbolsScreenState extends State<UserSymbolsScreen> {
     final loc = AppLocalizations.of(context)!;
     if (_loading) {
       return Scaffold(
-        appBar: AppBar(title: Text(loc.user_symbols_title(''))),
+        appBar: AppBar(
+          title: Text(loc.user_symbols_title('')),
+          actions: buildGlobalAppBarActions(),
+        ),
         body: const Center(child: CircularProgressIndicator()),
       );
     }
     if (!_permitted) {
       return Scaffold(
-        appBar: AppBar(title: Text(loc.user_symbols_title(''))),
+        appBar: AppBar(
+          title: Text(loc.user_symbols_title('')),
+          actions: buildGlobalAppBarActions(),
+        ),
         body: const Center(child: Text('Kein Zugriff')),
       );
     }
@@ -409,7 +416,10 @@ class _UserSymbolsScreenState extends State<UserSymbolsScreen> {
       builder: (context, snap) {
         final name = snap.data?.data()?['username'] as String? ?? widget.uid;
         return Scaffold(
-          appBar: AppBar(title: Text(loc.user_symbols_title(name))),
+          appBar: AppBar(
+            title: Text(loc.user_symbols_title(name)),
+            actions: buildGlobalAppBarActions(),
+          ),
           floatingActionButton: _permitted && _gymId.isNotEmpty
               ? FloatingActionButton(
                   onPressed: _openAddDialog,

--- a/lib/features/affiliate/presentation/screens/affiliate_screen.dart
+++ b/lib/features/affiliate/presentation/screens/affiliate_screen.dart
@@ -1,13 +1,18 @@
 // lib/features/affiliate/presentation/screens/affiliate_screen.dart
 import 'package:flutter/material.dart';
 
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
+
 class AffiliateScreen extends StatelessWidget {
   const AffiliateScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Affiliate')),
+      appBar: AppBar(
+        title: const Text('Affiliate'),
+        actions: buildGlobalAppBarActions(),
+      ),
       body: const Center(child: Text('Affiliate-Bereich hier')),
     );
   }

--- a/lib/features/auth/presentation/screens/auth_screen.dart
+++ b/lib/features/auth/presentation/screens/auth_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/theme/theme.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/features/auth/presentation/widgets/login_form.dart';
 import 'package:tapem/features/auth/presentation/widgets/registration_form.dart';
 
@@ -39,6 +40,7 @@ class _AuthScreenState extends State<AuthScreen>
       child: Scaffold(
         appBar: AppBar(
           title: Text(loc.authTitle),
+          actions: buildGlobalAppBarActions(showNfcButton: false),
           bottom: TabBar(
             controller: _tabController,
             tabs: [Tab(text: loc.loginButton), Tab(text: loc.registerButton)],

--- a/lib/features/auth/presentation/screens/reset_password_screen.dart
+++ b/lib/features/auth/presentation/screens/reset_password_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart' as fb_auth;
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import '../../../../app_router.dart';
 
@@ -50,7 +51,10 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> {
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
     return Scaffold(
-      appBar: AppBar(title: Text(loc.resetPasswordTitle)),
+      appBar: AppBar(
+        title: Text(loc.resetPasswordTitle),
+        actions: buildGlobalAppBarActions(showNfcButton: false),
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Form(

--- a/lib/features/challenges/presentation/screens/challenge_screen.dart
+++ b/lib/features/challenges/presentation/screens/challenge_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/features/challenges/presentation/screens/challenge_tab.dart';
 
 class ChallengeScreen extends StatelessWidget {
@@ -7,7 +8,10 @@ class ChallengeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Challenges')),
+      appBar: AppBar(
+        title: Text('Challenges'),
+        actions: buildGlobalAppBarActions(),
+      ),
       body: ChallengeTab(),
     );
   }

--- a/lib/features/creatine/presentation/screens/creatine_screen.dart
+++ b/lib/features/creatine/presentation/screens/creatine_screen.dart
@@ -3,6 +3,7 @@ import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/logging/elog.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/providers/settings_provider.dart';
 import 'package:tapem/features/profile/presentation/widgets/calendar.dart';
@@ -162,7 +163,10 @@ class _CreatineScreenState extends State<CreatineScreen> {
     }
 
     return Scaffold(
-      appBar: AppBar(title: Text(loc.creatineTitle)),
+      appBar: AppBar(
+        title: Text(loc.creatineTitle),
+        actions: buildGlobalAppBarActions(),
+      ),
       body: body,
     );
   }

--- a/lib/features/dashboard/presentation/screens/example_dashboard_screen.dart
+++ b/lib/features/dashboard/presentation/screens/example_dashboard_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:tapem/core/widgets/circular_xp_indicator.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/core/widgets/line_chart_widget.dart';
 import 'package:tapem/core/widgets/horizontal_bar_chart_widget.dart';
 import 'package:tapem/core/widgets/heatmap_widget.dart';
@@ -33,9 +34,11 @@ class ExampleDashboardScreen extends StatelessWidget {
           icon: const Icon(Icons.arrow_back),
           onPressed: () => Navigator.of(context).maybePop(),
         ),
-        actions: [
-          IconButton(icon: const Icon(Icons.settings), onPressed: () {}),
-        ],
+        actions: buildGlobalAppBarActions(
+          leadingActions: [
+            IconButton(icon: const Icon(Icons.settings), onPressed: () {}),
+          ],
+        ),
         title: const Text('Dashboard'),
       ),
       body: SingleChildScrollView(

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -11,6 +11,7 @@ import 'package:tapem/core/widgets/brand_gradient_card.dart';
 import 'package:tapem/core/widgets/brand_gradient_text.dart';
 import 'package:tapem/core/widgets/brand_outline.dart';
 import 'package:tapem/core/widgets/brand_outline_button.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/config/feature_flags.dart';
 
@@ -412,7 +413,10 @@ class _DeviceScreenState extends State<DeviceScreen> {
       );
     } else if (prov.error != null || prov.device == null) {
       scaffold = Scaffold(
-        appBar: AppBar(title: const Text('Gerät nicht gefunden')),
+        appBar: AppBar(
+          title: const Text('Gerät nicht gefunden'),
+          actions: buildGlobalAppBarActions(),
+        ),
         body: Center(child: Text('Fehler: ${prov.error ?? "Unbekannt"}')),
       );
     } else {
@@ -458,7 +462,8 @@ class _DeviceScreenState extends State<DeviceScreen> {
             ),
           ),
           centerTitle: true,
-          actions: [
+          actions: buildGlobalAppBarActions(
+            leadingActions: [
             Padding(
               padding: const EdgeInsets.only(right: 8.0),
               child: XpInfoButton(xp: prov.xp, level: prov.level),
@@ -513,7 +518,8 @@ class _DeviceScreenState extends State<DeviceScreen> {
                 );
               },
             ),
-          ],
+            ],
+          ),
         ),
         floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
         floatingActionButton: NoteButtonWidget(deviceId: widget.deviceId),

--- a/lib/features/device/presentation/screens/exercise_list_screen.dart
+++ b/lib/features/device/presentation/screens/exercise_list_screen.dart
@@ -4,6 +4,7 @@ import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/core/providers/exercise_provider.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/features/device/domain/models/exercise.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import '../widgets/multi_device_banner.dart';
@@ -157,7 +158,10 @@ class _ExerciseListScreenState extends State<ExerciseListScreen> {
     }
 
     return Scaffold(
-      appBar: AppBar(title: Text(loc.multiDeviceExerciseListTitle)),
+      appBar: AppBar(
+        title: Text(loc.multiDeviceExerciseListTitle),
+        actions: buildGlobalAppBarActions(),
+      ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => _openAdd(),
         tooltip: loc.multiDeviceNewExercise,

--- a/lib/features/feedback/presentation/screens/feedback_overview_screen.dart
+++ b/lib/features/feedback/presentation/screens/feedback_overview_screen.dart
@@ -5,6 +5,7 @@ import 'package:tapem/features/feedback/feedback_provider.dart';
 import 'package:tapem/features/feedback/models/feedback_entry.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/core/providers/gym_provider.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 
 class FeedbackOverviewScreen extends StatefulWidget {
   final String gymId;
@@ -44,6 +45,7 @@ class _FeedbackOverviewScreenState extends State<FeedbackOverviewScreen>
     return Scaffold(
       appBar: AppBar(
         title: const Text('Feedback'),
+        actions: buildGlobalAppBarActions(),
         bottom: TabBar(
           controller: _tabController,
           tabs: const [Tab(text: 'Offen'), Tab(text: 'Erledigt')],

--- a/lib/features/friends/presentation/screens/friend_detail_screen.dart
+++ b/lib/features/friends/presentation/screens/friend_detail_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import '../../data/user_search_source.dart';
 import '../../domain/models/public_profile.dart';
 
@@ -39,7 +40,10 @@ class _FriendDetailScreenState extends State<FriendDetailScreen> {
   Widget build(BuildContext context) {
     final name = _profile?.username ?? 'Profil';
     return Scaffold(
-      appBar: AppBar(title: Text(name)),
+      appBar: AppBar(
+        title: Text(name),
+        actions: buildGlobalAppBarActions(),
+      ),
       body: Center(
         child: _profile == null
             ? const Text('Keine Daten')

--- a/lib/features/friends/presentation/screens/friend_training_calendar_screen.dart
+++ b/lib/features/friends/presentation/screens/friend_training_calendar_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/features/friends/providers/friend_calendar_provider.dart';
 import 'package:tapem/features/profile/presentation/widgets/calendar.dart';
 import 'package:tapem/features/profile/presentation/widgets/calendar_popup.dart';
@@ -77,7 +78,10 @@ class _FriendTrainingCalendarScreenState extends State<FriendTrainingCalendarScr
     }
 
     return Scaffold(
-      appBar: AppBar(title: Text(widget.friendName)),
+      appBar: AppBar(
+        title: Text(widget.friendName),
+        actions: buildGlobalAppBarActions(),
+      ),
       body: body,
     );
   }

--- a/lib/features/friends/presentation/screens/friends_home_screen.dart
+++ b/lib/features/friends/presentation/screens/friends_home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/app_router.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import '../../providers/friends_provider.dart';
 import '../../providers/friend_search_provider.dart';
@@ -55,6 +56,7 @@ class _FriendsHomeScreenState extends State<FriendsHomeScreen>
     return Scaffold(
       appBar: AppBar(
         title: Text(loc.friends_title),
+        actions: buildGlobalAppBarActions(),
         bottom: TabBar(
           controller: _tabController,
           tabs: [

--- a/lib/features/gym/presentation/screens/gym_screen.dart
+++ b/lib/features/gym/presentation/screens/gym_screen.dart
@@ -8,6 +8,7 @@ import 'package:tapem/core/recent_devices_store.dart';
 import 'package:tapem/app_router.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/core/widgets/brand_gradient_text.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/ui/common/search_and_filters.dart';
 import 'package:tapem/ui/devices/device_card.dart';
@@ -98,6 +99,7 @@ class _GymScreenState extends State<GymScreen>
             loc.gymTitle,
             style: Theme.of(context).textTheme.titleLarge,
           ),
+          actions: buildGlobalAppBarActions(),
         ),
         body: Center(child: Text('${loc.errorPrefix}: ${gymProv.error}')),
       );
@@ -115,6 +117,7 @@ class _GymScreenState extends State<GymScreen>
           loc.gymTitle,
           style: theme.textTheme.titleLarge,
         ),
+        actions: buildGlobalAppBarActions(),
       ),
       body: SafeArea(
         child: Column(

--- a/lib/features/gym/presentation/screens/select_gym_screen.dart
+++ b/lib/features/gym/presentation/screens/select_gym_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 
 class SelectGymScreen extends StatelessWidget {
   const SelectGymScreen({super.key});
@@ -10,7 +11,10 @@ class SelectGymScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final gyms = context.watch<AuthProvider>().gymCodes ?? [];
     return Scaffold(
-      appBar: AppBar(title: const Text('Gym auswählen')),
+      appBar: AppBar(
+        title: const Text('Gym auswählen'),
+        actions: buildGlobalAppBarActions(showNfcButton: false),
+      ),
       body: ListView.separated(
         itemCount: gyms.length,
         separatorBuilder: (_, __) => const Divider(),

--- a/lib/features/history/presentation/screens/history_screen.dart
+++ b/lib/features/history/presentation/screens/history_screen.dart
@@ -11,6 +11,7 @@ import 'package:tapem/features/training_details/presentation/widgets/session_exe
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
 import 'package:tapem/core/widgets/brand_outline.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/logging/elog.dart';
@@ -69,7 +70,10 @@ class _HistoryScreenState extends State<HistoryScreen> {
         subtitle.isNotEmpty ? '$title — $subtitle' : title;
     if (prov.error != null) {
       return Scaffold(
-        appBar: AppBar(title: Text(fullTitle)),
+        appBar: AppBar(
+          title: Text(fullTitle),
+          actions: buildGlobalAppBarActions(),
+        ),
         body: Center(child: Text('${loc.errorPrefix}: ${prov.error}')),
       );
     }
@@ -265,7 +269,10 @@ class _HistoryScreenState extends State<HistoryScreen> {
     }
 
     return Scaffold(
-        appBar: AppBar(title: Text(fullTitle)),
+      appBar: AppBar(
+        title: Text(fullTitle),
+        actions: buildGlobalAppBarActions(),
+      ),
       body: CustomScrollView(
         slivers: [
           SliverPadding(

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -15,7 +15,7 @@ import 'package:tapem/features/rank/presentation/screens/rank_screen.dart';
 import 'package:tapem/features/training_plan/presentation/screens/plan_overview_screen.dart';
 import 'package:tapem/features/auth/presentation/widgets/username_dialog.dart';
 import 'package:tapem/core/config/feature_flags.dart';
-import 'package:tapem/features/nfc/widgets/nfc_scan_button.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 
 class HomeScreen extends StatefulWidget {
   final int initialIndex;
@@ -114,9 +114,7 @@ class _HomeScreenState extends State<HomeScreen> {
     }
     return Scaffold(
       appBar: AppBar(
-        actions: const [
-          NfcScanButton(),
-        ],
+        actions: buildGlobalAppBarActions(),
       ),
       body: tabs[_currentIndex].page,
       bottomNavigationBar: BottomNavigationBar(

--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import '../../../../core/providers/muscle_group_provider.dart';
 import '../widgets/svg_muscle_heatmap_widget.dart';
 import '../widgets/mesh_3d_heatmap_widget.dart';
@@ -54,13 +55,19 @@ class _MuscleGroupScreenState extends State<MuscleGroupScreen> {
     }
     if (prov.error != null) {
       return Scaffold(
-        appBar: AppBar(title: const Text('Muskelgruppen')),
+        appBar: AppBar(
+          title: const Text('Muskelgruppen'),
+          actions: buildGlobalAppBarActions(),
+        ),
         body: Center(child: Text(prov.error!)),
       );
     }
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Muskelgruppen')),
+      appBar: AppBar(
+        title: const Text('Muskelgruppen'),
+        actions: buildGlobalAppBarActions(),
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Builder(

--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:collection/collection.dart';
 
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import '../../../../core/providers/muscle_group_provider.dart';
 import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/xp_provider.dart';
@@ -50,7 +51,10 @@ class _MuscleGroupScreenNewState extends State<MuscleGroupScreenNew> {
     }
     if (prov.error != null) {
       return Scaffold(
-        appBar: AppBar(title: const Text('Muskelgruppen')),
+        appBar: AppBar(
+          title: const Text('Muskelgruppen'),
+          actions: buildGlobalAppBarActions(),
+        ),
         body: Center(child: Text(prov.error!)),
       );
     }
@@ -127,7 +131,10 @@ class _MuscleGroupScreenNewState extends State<MuscleGroupScreenNew> {
     }
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Muskelgruppen')),
+      appBar: AppBar(
+        title: const Text('Muskelgruppen'),
+        actions: buildGlobalAppBarActions(),
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: DefaultTabController(

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -14,6 +14,7 @@ import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/widgets/brand_action_tile.dart';
 import 'package:tapem/core/widgets/brand_gradient_icon.dart';
 import 'package:tapem/core/widgets/brand_gradient_text.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/core/logging/elog.dart';
 import 'package:tapem/core/utils/avatar_assets.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
@@ -337,12 +338,13 @@ class _ProfileScreenState extends State<ProfileScreen> {
           profileTitle,
           style: theme.textTheme.titleLarge,
         ),
-        actions: [
-          if (enableFriends)
-            Consumer<FriendsProvider>(
-              builder: (context, friends, _) {
-                final showBadge = friends.pendingCount > 0;
-                return IconButton(
+        actions: buildGlobalAppBarActions(
+          leadingActions: [
+            if (enableFriends)
+              Consumer<FriendsProvider>(
+                builder: (context, friends, _) {
+                  final showBadge = friends.pendingCount > 0;
+                  return IconButton(
                   icon: Stack(
                     children: [
                       const BrandGradientIcon(Icons.group),
@@ -375,15 +377,16 @@ class _ProfileScreenState extends State<ProfileScreen> {
             tooltip: loc.settingsIconTooltip,
             onPressed: _showSettingsDialog,
           ),
-          IconButton(
-            icon: const BrandGradientIcon(Icons.logout),
-            tooltip: loc.logoutTooltip,
-            onPressed: () {
-              context.read<AuthProvider>().logout();
-              Navigator.of(context).pushReplacementNamed(AppRouter.auth);
-            },
-          ),
-        ],
+            IconButton(
+              icon: const BrandGradientIcon(Icons.logout),
+              tooltip: loc.logoutTooltip,
+              onPressed: () {
+                context.read<AuthProvider>().logout();
+                Navigator.of(context).pushReplacementNamed(AppRouter.auth);
+              },
+            ),
+          ],
+        ),
       ),
       body:
           prov.isLoading

--- a/lib/features/rank/presentation/screens/device_leaderboard_list_screen.dart
+++ b/lib/features/rank/presentation/screens/device_leaderboard_list_screen.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/gym_provider.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/app_router.dart';
 
 class DeviceLeaderboardListScreen extends StatelessWidget {
@@ -16,7 +17,10 @@ class DeviceLeaderboardListScreen extends StatelessWidget {
     final devices = gymProv.devices.where((d) => d.isMulti == false).toList();
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Geräte-Auswahl')),
+      appBar: AppBar(
+        title: const Text('Geräte-Auswahl'),
+        actions: buildGlobalAppBarActions(),
+      ),
       body: ListView.builder(
         itemCount: devices.length,
         itemBuilder: (_, i) {

--- a/lib/features/rank/presentation/screens/rank_screen.dart
+++ b/lib/features/rank/presentation/screens/rank_screen.dart
@@ -6,6 +6,7 @@ import 'package:tapem/features/challenges/presentation/screens/challenge_tab.dar
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/widgets/brand_action_tile.dart';
 import 'package:tapem/core/widgets/brand_gradient_text.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/logging/elog.dart';
 
@@ -49,6 +50,7 @@ class _RankScreenState extends State<RankScreen>
           'Leaderboard',
           style: theme.textTheme.titleLarge,
         ),
+        actions: buildGlobalAppBarActions(),
         bottom: TabBar(
           controller: _tabController,
           tabs: [

--- a/lib/features/report/presentation/screens/report_screen_new.dart
+++ b/lib/features/report/presentation/screens/report_screen_new.dart
@@ -11,6 +11,7 @@ import '../../../survey/presentation/widgets/create_survey_sheet.dart';
 import '../../../../core/providers/report_provider.dart';
 import '../../../../core/theme/design_tokens.dart';
 import '../../../../core/widgets/brand_action_tile.dart';
+import '../../../../core/widgets/global_app_bar_actions.dart';
 import '../../../../core/logging/elog.dart';
 
 class ReportScreenNew extends StatelessWidget {
@@ -30,7 +31,10 @@ class ReportScreenNew extends StatelessWidget {
     final int openCount = feedbackProvider.openEntries.length;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Report')),
+      appBar: AppBar(
+        title: const Text('Report'),
+        actions: buildGlobalAppBarActions(),
+      ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(AppSpacing.sm),
         child: Column(

--- a/lib/features/survey/presentation/screens/survey_detail_screen.dart
+++ b/lib/features/survey/presentation/screens/survey_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import '../../survey.dart';
 import '../../survey_provider.dart';
 
@@ -33,7 +34,10 @@ class _SurveyDetailScreenState extends State<SurveyDetailScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(widget.survey.title)),
+      appBar: AppBar(
+        title: Text(widget.survey.title),
+        actions: buildGlobalAppBarActions(),
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Column(

--- a/lib/features/survey/presentation/screens/survey_vote_screen.dart
+++ b/lib/features/survey/presentation/screens/survey_vote_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import '../../survey_provider.dart';
 import '../../survey.dart';
 
@@ -34,7 +35,10 @@ class _SurveyVoteScreenState extends State<SurveyVoteScreen> {
     final prov = context.watch<SurveyProvider>();
     final surveys = prov.openSurveys;
     return Scaffold(
-      appBar: AppBar(title: const Text('Umfragen')),
+      appBar: AppBar(
+        title: const Text('Umfragen'),
+        actions: buildGlobalAppBarActions(),
+      ),
       body:
           surveys.isEmpty
               ? const Center(child: Text('Keine offenen Umfragen'))
@@ -87,7 +91,10 @@ class _SurveyVoteDetailScreenState extends State<_SurveyVoteDetailScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(widget.survey.title)),
+      appBar: AppBar(
+        title: Text(widget.survey.title),
+        actions: buildGlobalAppBarActions(),
+      ),
       body:
           _submitted
               ? const Center(child: Text('Danke für deine Teilnahme!'))

--- a/lib/features/training_plan/presentation/screens/import_plan_screen.dart
+++ b/lib/features/training_plan/presentation/screens/import_plan_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:file_picker/file_picker.dart';
 
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/training_plan_provider.dart';
 import '../../../../core/providers/device_provider.dart';
@@ -47,7 +48,10 @@ class _ImportPlanScreenState extends State<ImportPlanScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Plan importieren')),
+      appBar: AppBar(
+        title: const Text('Plan importieren'),
+        actions: buildGlobalAppBarActions(),
+      ),
       body: Consumer<TrainingPlanProvider>(
         builder:
             (context, prov, _) => Padding(

--- a/lib/features/training_plan/presentation/screens/plan_editor_screen.dart
+++ b/lib/features/training_plan/presentation/screens/plan_editor_screen.dart
@@ -13,6 +13,7 @@ import '../../domain/models/day_entry.dart';
 import '../../domain/models/week_block.dart';
 import '../widgets/device_selection_dialog.dart';
 import 'package:tapem/ui/numeric_keypad/overlay_numeric_keypad.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 
 class PlanEditorScreen extends StatefulWidget {
   const PlanEditorScreen({super.key});
@@ -48,51 +49,53 @@ class _PlanEditorScreenState extends State<PlanEditorScreen>
       child: Scaffold(
         appBar: AppBar(
           title: Text(plan.name),
-          actions: [
-            IconButton(
-              icon:
-                  prov.isSaving
-                      ? const SizedBox(
-                        height: 24,
-                        width: 24,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                      : const Icon(Icons.check),
-              tooltip: 'Speichern',
-              onPressed:
-                  prov.isSaving
-                      ? null
-                      : () async {
-                        final gymId = context.read<AuthProvider>().gymCode!;
-                        await prov.saveCurrentPlan(gymId);
-                        if (context.mounted) {
-                          final msg = prov.error ?? 'Plan gespeichert';
-                          ScaffoldMessenger.of(
-                            context,
-                          ).showSnackBar(SnackBar(content: Text(msg)));
-                        }
-                      },
-            ),
-            IconButton(
-              icon: const Icon(Icons.calendar_today),
-              onPressed: () async {
-                final picked = await showDatePicker(
-                  context: context,
-                  initialDate: plan.startDate,
-                  firstDate: DateTime.now().subtract(
-                    const Duration(days: 365 * 5),
-                  ),
-                  lastDate: DateTime.now().add(const Duration(days: 365 * 5)),
-                );
-                if (picked != null) {
-                  final monday = picked.subtract(
-                    Duration(days: picked.weekday - 1),
+          actions: buildGlobalAppBarActions(
+            leadingActions: [
+              IconButton(
+                icon:
+                    prov.isSaving
+                        ? const SizedBox(
+                          height: 24,
+                          width: 24,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                        : const Icon(Icons.check),
+                tooltip: 'Speichern',
+                onPressed:
+                    prov.isSaving
+                        ? null
+                        : () async {
+                          final gymId = context.read<AuthProvider>().gymCode!;
+                          await prov.saveCurrentPlan(gymId);
+                          if (context.mounted) {
+                            final msg = prov.error ?? 'Plan gespeichert';
+                            ScaffoldMessenger.of(
+                              context,
+                            ).showSnackBar(SnackBar(content: Text(msg)));
+                          }
+                        },
+              ),
+              IconButton(
+                icon: const Icon(Icons.calendar_today),
+                onPressed: () async {
+                  final picked = await showDatePicker(
+                    context: context,
+                    initialDate: plan.startDate,
+                    firstDate: DateTime.now().subtract(
+                      const Duration(days: 365 * 5),
+                    ),
+                    lastDate: DateTime.now().add(const Duration(days: 365 * 5)),
                   );
-                  prov.setStartDate(monday);
-                }
-              },
-            ),
-          ],
+                  if (picked != null) {
+                    final monday = picked.subtract(
+                      Duration(days: picked.weekday - 1),
+                    );
+                    prov.setStartDate(monday);
+                  }
+                },
+              ),
+            ],
+          ),
           bottom: TabBar(
             controller: _weekController,
             isScrollable: true,

--- a/lib/features/training_plan/presentation/screens/plan_overview_screen.dart
+++ b/lib/features/training_plan/presentation/screens/plan_overview_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/ui/numeric_keypad/overlay_numeric_keypad.dart';
 
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/training_plan_provider.dart';
 import '../../../../core/theme/design_tokens.dart';
@@ -40,7 +41,10 @@ class _PlanOverviewScreenState extends State<PlanOverviewScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Trainingspläne')),
+      appBar: AppBar(
+        title: const Text('Trainingspläne'),
+        actions: buildGlobalAppBarActions(),
+      ),
       body: Consumer<TrainingPlanProvider>(
         builder: (_, prov, __) {
           if (prov.isLoading) {

--- a/lib/features/xp/presentation/screens/day_xp_screen.dart
+++ b/lib/features/xp/presentation/screens/day_xp_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/xp_provider.dart';
 import 'package:tapem/features/friends/domain/models/public_profile.dart';
@@ -135,13 +136,15 @@ class _DayXpScreenState extends State<DayXpScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Erfahrung'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.leaderboard),
-            tooltip: 'Rangliste',
-            onPressed: _openLeaderboard,
-          ),
-        ],
+        actions: buildGlobalAppBarActions(
+          leadingActions: [
+            IconButton(
+              icon: const Icon(Icons.leaderboard),
+              tooltip: 'Rangliste',
+              onPressed: _openLeaderboard,
+            ),
+          ],
+        ),
       ),
       body: ListView(
         children: [

--- a/lib/features/xp/presentation/screens/device_xp_screen.dart
+++ b/lib/features/xp/presentation/screens/device_xp_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/gym_provider.dart';
 import '../../../../core/providers/xp_provider.dart';
@@ -57,7 +58,10 @@ class _DeviceXpScreenState extends State<DeviceXpScreen> {
       final xpProv = context.watch<XpProvider>();
       final devices = gymProv.devices.toList();
     return Scaffold(
-      appBar: AppBar(title: const Text('Geräte XP')),
+      appBar: AppBar(
+        title: const Text('Geräte XP'),
+        actions: buildGlobalAppBarActions(),
+      ),
       body: ListView.builder(
         itemCount: devices.length,
         itemBuilder: (_, i) {

--- a/lib/features/xp/presentation/screens/leaderboard_screen.dart
+++ b/lib/features/xp/presentation/screens/leaderboard_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import 'package:tapem/features/friends/domain/models/public_profile.dart';
 import 'package:tapem/features/friends/presentation/widgets/friend_list_tile.dart';
 import '../widgets/xp_time_series_chart.dart';
@@ -70,7 +71,10 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(widget.title)),
+      appBar: AppBar(
+        title: Text(widget.title),
+        actions: buildGlobalAppBarActions(),
+      ),
       body: Column(
         children: [
           Padding(

--- a/lib/features/xp/presentation/screens/xp_overview_screen.dart
+++ b/lib/features/xp/presentation/screens/xp_overview_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:collection/collection.dart';
 
+import 'package:tapem/core/widgets/global_app_bar_actions.dart';
 import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/xp_provider.dart';
 import '../../../../core/providers/muscle_group_provider.dart';
@@ -98,6 +99,7 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
       appBar: AppBar(
         title: const Text('XP Übersicht'),
         backgroundColor: const Color(0xFF121212),
+        actions: buildGlobalAppBarActions(),
       ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16.0),


### PR DESCRIPTION
## Summary
- add a reusable global app bar actions helper that surfaces the workout timer chip alongside the NFC entry point
- render the active workout duration in HH:mm:ss with branded styling via a new formatter and chip widget
- update screens to adopt the shared helper so the timer remains visible throughout the app

## Testing
- Not run (Flutter SDK is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68db206c70a88320945d407c2e1b8f58