### PR TITLE
Start workout timer when sets complete via keypad

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -464,11 +464,15 @@ class DeviceProvider extends ChangeNotifier {
     _error = null;
     final before = Map<String, dynamic>.from(s);
     final current = (s['done'] == true || s['done'] == 'true');
-    s['done'] = !current;
+    final toggledToDone = !current;
+    s['done'] = toggledToDone;
     _sets[index] = Map<String, dynamic>.from(s);
     _log('☑️ [Provider] toggleSetDone($index) $before → ${_sets[index]}');
     notifyListeners();
     _onSessionMutated();
+    if (toggledToDone) {
+      _maybeStartSessionTimer();
+    }
     return true;
   }
 
@@ -490,6 +494,7 @@ class DeviceProvider extends ChangeNotifier {
     _log('☑️ [Provider] completeNextFilledSet($idx)');
     notifyListeners();
     _onSessionMutated();
+    _maybeStartSessionTimer();
     return idx;
   }
 
@@ -508,6 +513,7 @@ class DeviceProvider extends ChangeNotifier {
       _log('☑️ [Provider] completeAllFilledNotDone count=$count');
       notifyListeners();
       _onSessionMutated();
+      _maybeStartSessionTimer();
     }
     return count;
   }
@@ -565,6 +571,16 @@ class DeviceProvider extends ChangeNotifier {
 
   bool _hasCompletedSets() {
     return _sets.any((s) => s['done'] == true || s['done'] == 'true');
+  }
+
+  void _maybeStartSessionTimer() {
+    final durationService = _sessionDurationService;
+    if (durationService == null || durationService.isRunning) return;
+    final uid = _currentUserId;
+    final gymId = _currentGymId;
+    if (uid == null || gymId == null) return;
+    if (!_hasCompletedSets()) return;
+    unawaited(durationService.start(uid: uid, gymId: gymId));
   }
 
   void _onSessionMutated() {

--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -8,15 +8,12 @@ import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/device_provider.dart';
-import 'package:tapem/core/providers/auth_provider.dart';
-import 'package:tapem/core/providers/branding_provider.dart';
 import 'package:tapem/core/ui_mutation_guard.dart';
 import 'package:tapem/core/theme/brand_on_colors.dart';
 import 'package:tapem/core/widgets/brand_outline.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/ui/numeric_keypad/overlay_numeric_keypad.dart';
 import 'package:tapem/core/logging/elog.dart';
-import 'package:tapem/core/services/workout_session_duration_service.dart';
 
 void _slog(int idx, String m) => debugPrint('🧾 [SetCard#$idx] $m');
 
@@ -344,21 +341,6 @@ class SetCardState extends State<SetCard> {
         });
         HapticFeedback.lightImpact();
         if (ok) {
-          final sets = prov.sets;
-          final isDone = sets[widget.index]['done'] == true ||
-              sets[widget.index]['done'] == 'true';
-          if (isDone) {
-            final service = context.read<WorkoutSessionDurationService>();
-            if (!service.isRunning) {
-              final auth = context.read<AuthProvider>();
-              final branding = context.read<BrandingProvider>();
-              final uid = auth.userId;
-              final gymId = branding.gymId;
-              if (uid != null && gymId != null) {
-                unawaited(service.start(uid: uid, gymId: gymId));
-              }
-            }
-          }
           context.read<OverlayNumericKeypadController>().close();
         }
       };


### PR DESCRIPTION
## Summary
- ensure the workout session timer starts whenever a set is marked done through the device provider
- remove duplicate timer start logic from the set card widget so overlay actions behave the same

## Testing
- not run (Flutter CLI unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68db2cd862bc8320951e7ed24eb8b13e