### PR TITLE
style: align overlay keypad with brand theming

### DIFF
--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -789,6 +789,7 @@ class _InputPillState extends State<_InputPill> {
     final hasFocus = _hasFocus;
     final disabled = widget.readOnly;
     final isDark = Theme.of(context).brightness == Brightness.dark;
+    final brandColor = Theme.of(context).colorScheme.primary;
 
     final radius = BorderRadius.circular(widget.dense ? 18 : 22);
     final baseOverlay = showLabel
@@ -811,8 +812,8 @@ class _InputPillState extends State<_InputPill> {
       color: widget.tokens.chipFg.withOpacity(hasFocus ? 0.8 : 0.6),
     );
 
-    final valueColor = widget.tokens.chipFg
-        .withOpacity(disabled ? 0.4 : (hasValue ? 0.95 : 0.55));
+    final valueColor = brandColor
+        .withOpacity(disabled ? 0.4 : (hasValue ? 0.95 : 0.65));
     final valueStyle = GoogleFonts.spaceGrotesk(
       fontSize: showLabel ? (widget.dense ? 18 : 20) : (widget.dense ? 22 : 26),
       fontWeight: FontWeight.w700,
@@ -821,7 +822,7 @@ class _InputPillState extends State<_InputPill> {
     );
 
     final placeholderStyle = valueStyle.copyWith(
-      color: widget.tokens.chipFg.withOpacity(0.35),
+      color: brandColor.withOpacity(0.35),
     );
 
     final supportingStyle = TextStyle(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -495,6 +495,7 @@ class MyApp extends StatelessWidget {
         return OverlayNumericKeypadHost(
           controller: keypad,
           outsideTapMode: OutsideTapMode.closeAfterTap,
+          theme: NumericKeypadTheme.fromContext(context),
           child: app,
         );
       },

--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/device_provider.dart';
 import 'package:tapem/core/logging/elog.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
 
 void _klog(String m) => debugPrint('🔢 [Keypad] $m');
 
@@ -40,6 +41,30 @@ class NumericKeypadTheme {
     this.railIcon = Colors.white70,
     this.press = const Color(0xFF2A2E33),
   });
+
+  factory NumericKeypadTheme.fromContext(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final brand = theme.extension<AppBrandTheme>();
+
+    Color blend(Color base, Color overlay, double opacity) {
+      return Color.alphaBlend(overlay.withOpacity(opacity), base);
+    }
+
+    final surface = theme.canvasColor;
+    final sheetBg = blend(surface, Colors.black, 0.75);
+    final keyFg = brand?.gradient.colors.last ?? scheme.primary;
+    final press = brand?.pressedOverlay ?? keyFg.withOpacity(0.18);
+
+    return NumericKeypadTheme(
+      sheetBg: sheetBg,
+      keyBg: Colors.black,
+      keyFg: keyFg,
+      railBg: Colors.black,
+      railIcon: keyFg,
+      press: press,
+    );
+  }
 }
 
 class OverlayNumericKeypadController extends ChangeNotifier {
@@ -111,7 +136,7 @@ enum OutsideTapMode { none, closeAfterTap }
 class OverlayNumericKeypadHost extends StatefulWidget {
   final OverlayNumericKeypadController controller;
   final Widget child;
-  final NumericKeypadTheme theme;
+  final NumericKeypadTheme? theme;
   final bool interceptAndroidBack;
   final OutsideTapMode outsideTapMode;
 
@@ -119,7 +144,7 @@ class OverlayNumericKeypadHost extends StatefulWidget {
     super.key,
     required this.controller,
     required this.child,
-    this.theme = const NumericKeypadTheme(),
+    this.theme,
     this.interceptAndroidBack = true,
     this.outsideTapMode = OutsideTapMode.none,
   });
@@ -177,7 +202,7 @@ class _OverlayNumericKeypadHostState extends State<OverlayNumericKeypadHost>
         ? OverlayNumericKeypad(
             key: _keypadKey,
             controller: widget.controller,
-            theme: widget.theme,
+            theme: widget.theme ?? NumericKeypadTheme.fromContext(context),
           )
         : const SizedBox.shrink();
 
@@ -708,7 +733,7 @@ class _ActionRailCompact extends StatelessWidget {
     }
 
     return Container(
-      color: theme.sheetBg,
+      color: theme.railBg,
       child: ClipRRect(
         borderRadius: BorderRadius.only(
           topRight: Radius.circular(theme.corner),
@@ -802,11 +827,16 @@ class _RailBtnSquareState extends State<_RailBtnSquare> {
           width: double.infinity,
           height: double.infinity,
           decoration: BoxDecoration(
-            color: th.keyBg,
+            color: th.railBg,
             borderRadius: BorderRadius.circular(12),
           ),
           alignment: Alignment.center,
-          child: FittedBox(child: Icon(widget.icon, color: th.railIcon)),
+          child: FittedBox(
+            child: Icon(
+              widget.icon,
+              color: th.railIcon,
+            ),
+          ),
         ),
       ),
     );
@@ -839,12 +869,17 @@ class _RailBtnWide extends StatelessWidget {
         child: Container(
           height: height,
           decoration: BoxDecoration(
-            color: th.keyBg,
+            color: th.railBg,
             borderRadius: BorderRadius.circular(12),
           ),
           alignment: Alignment.center,
           // Icon only (consistent with compact rail); gets more visual weight
-          child: FittedBox(child: Icon(icon, color: th.railIcon)),
+          child: FittedBox(
+            child: Icon(
+              icon,
+              color: th.railIcon,
+            ),
+          ),
         ),
       ),
     );
@@ -903,14 +938,20 @@ class _KeyButtonState extends State<_KeyButton> {
   @override
   Widget build(BuildContext context) {
     final th = widget.theme;
+    final disabled = widget.disabled || widget.onTap == null;
+    final fg = disabled ? th.keyFg.withOpacity(0.35) : th.keyFg;
 
     final child = FittedBox(
       fit: BoxFit.scaleDown,
       child: widget.icon != null
-          ? Icon(widget.icon, color: th.keyFg)
+          ? Icon(widget.icon, color: fg)
           : Text(
               widget.label ?? '',
-              style: const TextStyle(fontSize: 28, fontWeight: FontWeight.w600),
+              style: TextStyle(
+                fontSize: 28,
+                fontWeight: FontWeight.w600,
+                color: fg,
+              ),
             ),
     );
 
@@ -927,7 +968,7 @@ class _KeyButtonState extends State<_KeyButton> {
         onTapCancel: _stop,
         child: Container(
           decoration: BoxDecoration(
-            color: widget.disabled ? th.keyBg.withOpacity(0.5) : th.keyBg,
+            color: disabled ? th.keyBg.withOpacity(0.5) : th.keyBg,
             borderRadius: BorderRadius.circular(14),
           ),
           alignment: Alignment.center,


### PR DESCRIPTION
## Summary
- derive the numeric keypad theme from the active app branding when building the overlay host
- recolor keypad keys and action buttons with brand accents while keeping their backgrounds deep black
- tint set card input values with the brand accent instead of neutral white

## Testing
- not run (flutter unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68db3165bbdc8320990b24b51942f96a