### PR TITLE
Implement sequential navigation in overlay keypad

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -17,7 +17,6 @@ import 'package:tapem/features/device/domain/usecases/get_devices_for_gym.dart';
 import 'package:uuid/uuid.dart';
 import 'package:tapem/features/rank/domain/models/level_info.dart';
 import 'package:tapem/features/rank/domain/services/level_service.dart';
-import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/xp_provider.dart';
 import 'package:tapem/core/providers/challenge_provider.dart';
 import 'package:tapem/features/xp/domain/device_xp_result.dart';
@@ -32,6 +31,13 @@ import 'package:tapem/core/logging/xp_trace.dart';
 import 'package:tapem/core/time/logic_day.dart';
 import 'package:tapem/core/recent_devices_store.dart';
 import 'package:tapem/core/services/workout_session_duration_service.dart';
+
+enum DeviceSetFieldFocus {
+  weight,
+  reps,
+  dropWeight,
+  dropReps,
+}
 
 typedef LogFn = void Function(String message, [StackTrace? stack]);
 
@@ -448,9 +454,32 @@ class DeviceProvider extends ChangeNotifier {
     return weightValid && r.isNotEmpty && int.tryParse(r) != null;
   }
 
+  DeviceSetFieldFocus? _focusedField;
   int? _focusedIndex;
+  int _focusRequestId = 0;
+
   int? get focusedIndex => _focusedIndex;
-  void setFocusedIndex(int? i) => _focusedIndex = i;
+  DeviceSetFieldFocus? get focusedField => _focusedField;
+  int get focusRequestId => _focusRequestId;
+
+  int requestFocus({
+    required int index,
+    required DeviceSetFieldFocus field,
+  }) {
+    _focusedIndex = index;
+    _focusedField = field;
+    _focusRequestId++;
+    notifyListeners();
+    return _focusRequestId;
+  }
+
+  int clearFocus() {
+    _focusedIndex = null;
+    _focusedField = null;
+    _focusRequestId++;
+    notifyListeners();
+    return _focusRequestId;
+  }
 
   bool toggleSetDone(int index) {
     final s = _sets[index];
@@ -474,6 +503,45 @@ class DeviceProvider extends ChangeNotifier {
       _maybeStartSessionTimer();
     }
     return true;
+  }
+
+  bool markSetDone(int index) {
+    if (index < 0 || index >= _sets.length) return false;
+    final s = _sets[index];
+    if (!_isFilled(s)) {
+      _log(
+        '⚠️ [Provider] markSetDone($index) blocked: invalid',
+      );
+      return false;
+    }
+
+    final current = (s['done'] == true || s['done'] == 'true');
+    if (current) return true;
+
+    final after = Map<String, dynamic>.from(s);
+    after['done'] = true;
+    _sets[index] = after;
+    _log('☑️ [Provider] markSetDone($index)');
+    notifyListeners();
+    _onSessionMutated();
+    _maybeStartSessionTimer();
+    return true;
+  }
+
+  int? nextPendingSetIndex(int afterIndex) {
+    for (var i = afterIndex + 1; i < _sets.length; i++) {
+      final s = _sets[i];
+      if (s['done'] == true || s['done'] == 'true') continue;
+      return i;
+    }
+    return null;
+  }
+
+  bool get allSetsCompleted {
+    for (final s in _sets) {
+      if (!(s['done'] == true || s['done'] == 'true')) return false;
+    }
+    return _sets.isNotEmpty;
   }
 
   int? nextFilledNotDoneIndex() {

--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -132,6 +132,7 @@ class SetCardState extends State<SetCard> {
   late final FocusNode _dropRepsFocus;
 
   bool _showExtras = false;
+  int _lastFocusRequestId = -1;
 
   // 🔒 Silent-update Mechanik
   bool _muteCtrls = false;
@@ -254,13 +255,23 @@ class SetCardState extends State<SetCard> {
   void _openKeypad(
     TextEditingController controller, {
     required bool allowDecimal,
+    required DeviceSetFieldFocus field,
+    bool notifyFocus = true,
   }) {
     _slog(
       widget.index,
-      'open keypad allowDecimal=$allowDecimal text="${controller.text}"',
+      'open keypad field=$field allowDecimal=$allowDecimal text="${controller.text}"',
     );
     FocusScope.of(context).unfocus();
-    context.read<DeviceProvider>().setFocusedIndex(widget.index);
+    final prov = context.read<DeviceProvider>();
+    if (notifyFocus) {
+      _lastFocusRequestId = prov.requestFocus(
+        index: widget.index,
+        field: field,
+      );
+    } else {
+      _lastFocusRequestId = prov.focusRequestId;
+    }
     context.read<OverlayNumericKeypadController>().openFor(
       controller,
       allowDecimal: allowDecimal,
@@ -269,7 +280,11 @@ class SetCardState extends State<SetCard> {
   }
 
   void focusWeight() {
-    _openKeypad(_weightCtrl, allowDecimal: true);
+    _openKeypad(
+      _weightCtrl,
+      allowDecimal: true,
+      field: DeviceSetFieldFocus.weight,
+    );
   }
 
   String? _validateDrop(String? _) {
@@ -313,6 +328,52 @@ class SetCardState extends State<SetCard> {
                 double.tryParse(weight.replaceAll(',', '.')) != null)) &&
         reps.isNotEmpty &&
         int.tryParse(reps) != null;
+
+    final focusField = prov.focusedField;
+    final focusRequestId = prov.focusRequestId;
+    if (!widget.readOnly &&
+        focusField != null &&
+        prov.focusedIndex == widget.index &&
+        focusRequestId != _lastFocusRequestId) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _lastFocusRequestId = focusRequestId;
+        switch (focusField) {
+          case DeviceSetFieldFocus.weight:
+            _openKeypad(
+              _weightCtrl,
+              allowDecimal: true,
+              field: focusField,
+              notifyFocus: false,
+            );
+            break;
+          case DeviceSetFieldFocus.reps:
+            _openKeypad(
+              _repsCtrl,
+              allowDecimal: false,
+              field: focusField,
+              notifyFocus: false,
+            );
+            break;
+          case DeviceSetFieldFocus.dropWeight:
+            _openKeypad(
+              _dropWeightCtrl,
+              allowDecimal: true,
+              field: focusField,
+              notifyFocus: false,
+            );
+            break;
+          case DeviceSetFieldFocus.dropReps:
+            _openKeypad(
+              _dropRepsCtrl,
+              allowDecimal: false,
+              field: focusField,
+              notifyFocus: false,
+            );
+            break;
+        }
+      });
+    }
     VoidCallback? toggleExtras;
     if (!widget.readOnly) {
       toggleExtras = () {
@@ -341,6 +402,7 @@ class SetCardState extends State<SetCard> {
         });
         HapticFeedback.lightImpact();
         if (ok) {
+          prov.clearFocus();
           context.read<OverlayNumericKeypadController>().close();
         }
       };
@@ -381,15 +443,35 @@ class SetCardState extends State<SetCard> {
       onToggleExtras: toggleExtras,
       onToggleDone: toggleDone,
       onTapWeight:
-          widget.readOnly ? null : () => _openKeypad(_weightCtrl, allowDecimal: true),
+          widget.readOnly
+              ? null
+              : () => _openKeypad(
+                    _weightCtrl,
+                    allowDecimal: true,
+                    field: DeviceSetFieldFocus.weight,
+                  ),
       onTapReps:
-          widget.readOnly ? null : () => _openKeypad(_repsCtrl, allowDecimal: false),
+          widget.readOnly
+              ? null
+              : () => _openKeypad(
+                    _repsCtrl,
+                    allowDecimal: false,
+                    field: DeviceSetFieldFocus.reps,
+                  ),
       onTapDropWeight: done || widget.readOnly
           ? null
-          : () => _openKeypad(_dropWeightCtrl, allowDecimal: true),
+          : () => _openKeypad(
+                _dropWeightCtrl,
+                allowDecimal: true,
+                field: DeviceSetFieldFocus.dropWeight,
+              ),
       onTapDropReps: done || widget.readOnly
           ? null
-          : () => _openKeypad(_dropRepsCtrl, allowDecimal: false),
+          : () => _openKeypad(
+                _dropRepsCtrl,
+                allowDecimal: false,
+                field: DeviceSetFieldFocus.dropReps,
+              ),
       dropValidator: _validateDrop,
       padding: contentPadding,
       weightPlaceholder: weightPlaceholder,

--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -367,16 +367,12 @@ class OverlayNumericKeypad extends StatelessWidget {
                     totalGridRows: 4,
                     gap: gap,
                     theme: theme,
-                    onHide: controller.close,
-                    onPaste: () async {
-                      final data = await Clipboard.getData('text/plain');
-                      if (data?.text != null) {
-                        _klog('paste "${data!.text}"');
-                        _pasteInto(context, controller, data.text!);
-                        _haptic(context);
-                      }
+                    onHide: () {
+                      Provider.of<DeviceProvider?>(context, listen: false)
+                          ?.clearFocus();
+                      controller.close();
                     },
-                    onCheckNext: () => _checkNext(context, controller),
+                    onNavigate: () => _navigateNext(context, controller),
                     onPlus: () => _increment(context, controller, 1),
                     onMinus: () => _increment(context, controller, -1),
                   ),
@@ -399,27 +395,85 @@ class OverlayNumericKeypad extends StatelessWidget {
     }
   }
 
-  static void _checkNext(
+  static void _navigateNext(
     BuildContext context,
     OverlayNumericKeypadController controller,
   ) {
     final prov = context.read<DeviceProvider>();
-    final next = prov.nextFilledNotDoneIndex();
-    elogUi('OVERLAY_CHECK_TAP', {
+    final focusedIndex = prov.focusedIndex;
+    final focusedField = prov.focusedField;
+
+    elogUi('OVERLAY_NAVIGATE_NEXT', {
       'deviceId': prov.device?.uid,
-      'setIndexFocused': prov.focusedIndex,
-      'nextToComplete': next,
+      'focusedIndex': focusedIndex,
+      'focusedField': focusedField?.name,
     });
-    final idx = prov.completeNextFilledSet();
-    if (idx != null) {
-      elogUi('AUTO_CHECK_NEXT_OK', {'completedIndex': idx});
-      if (prov.nextFilledNotDoneIndex() == null) {
-        controller.close();
-      }
-    } else {
-      elogUi('AUTO_CHECK_NEXT_SKIP', {'reason': 'none'});
-      controller.close();
+
+    if (focusedIndex == null || focusedField == null) {
+      _haptic(context);
+      return;
     }
+
+    int targetIndex = focusedIndex;
+    DeviceSetFieldFocus? targetField;
+
+    switch (focusedField) {
+      case DeviceSetFieldFocus.weight:
+        targetField = DeviceSetFieldFocus.reps;
+        break;
+      case DeviceSetFieldFocus.reps:
+        final done = prov.markSetDone(focusedIndex);
+        if (!done) {
+          elogUi('OVERLAY_NAVIGATE_BLOCKED', {
+            'reason': 'invalid_set',
+            'index': focusedIndex,
+          });
+          _haptic(context);
+          return;
+        }
+        final nextIndex = prov.nextPendingSetIndex(focusedIndex);
+        if (nextIndex != null) {
+          targetIndex = nextIndex;
+          targetField = DeviceSetFieldFocus.weight;
+        } else {
+          prov.clearFocus();
+          controller.close();
+          elogUi('OVERLAY_NAVIGATE_CLOSE', {'reason': 'all_sets_completed'});
+          _haptic(context);
+          return;
+        }
+        break;
+      case DeviceSetFieldFocus.dropWeight:
+        targetField = DeviceSetFieldFocus.dropReps;
+        break;
+      case DeviceSetFieldFocus.dropReps:
+        final done = prov.markSetDone(focusedIndex);
+        if (!done) {
+          elogUi('OVERLAY_NAVIGATE_BLOCKED', {
+            'reason': 'invalid_set',
+            'index': focusedIndex,
+          });
+          _haptic(context);
+          return;
+        }
+        final nextIndex = prov.nextPendingSetIndex(focusedIndex);
+        if (nextIndex != null) {
+          targetIndex = nextIndex;
+          targetField = DeviceSetFieldFocus.weight;
+        } else {
+          prov.clearFocus();
+          controller.close();
+          elogUi('OVERLAY_NAVIGATE_CLOSE', {'reason': 'all_sets_completed'});
+          _haptic(context);
+          return;
+        }
+        break;
+    }
+
+    if (targetField != null) {
+      prov.requestFocus(index: targetIndex, field: targetField);
+    }
+
     _haptic(context);
   }
 
@@ -444,29 +498,6 @@ class OverlayNumericKeypad extends StatelessWidget {
       'hu',
     };
     return commaLangs.contains(lang) ? ',' : '.';
-  }
-
-  static void _pasteInto(
-    BuildContext ctx,
-    OverlayNumericKeypadController ctl,
-    String text,
-  ) {
-    final t = ctl.target;
-    if (t == null) return;
-    final cleaned = ctl.allowDecimal
-        ? text.trim().replaceAll(',', '.').replaceAll(RegExp(r'[^0-9\.]'), '')
-        : text.replaceAll(RegExp(r'[^0-9]'), '');
-    final parts = cleaned.split('.');
-    final normalized = ctl.allowDecimal && parts.length > 1
-        ? '${parts[0]}.${parts.sublist(1).join()}'
-        : cleaned;
-    final display = ctl.allowDecimal
-        ? normalized.replaceAll('.', _decimalChar(ctx))
-        : normalized;
-    t.value = TextEditingValue(
-      text: display,
-      selection: TextSelection.collapsed(offset: display.length),
-    );
   }
 
   static void _applyToken(
@@ -615,7 +646,7 @@ class _ActionRailCompact extends StatelessWidget {
   final int totalGridRows;
   final double gap;
   final NumericKeypadTheme theme;
-  final VoidCallback onHide, onPaste, onCheckNext, onPlus, onMinus;
+  final VoidCallback onHide, onNavigate, onPlus, onMinus;
 
   const _ActionRailCompact({
     required this.gridCellWidth,
@@ -624,8 +655,7 @@ class _ActionRailCompact extends StatelessWidget {
     required this.gap,
     required this.theme,
     required this.onHide,
-    required this.onPaste,
-    required this.onCheckNext,
+    required this.onNavigate,
     required this.onPlus,
     required this.onMinus,
   });
@@ -637,8 +667,12 @@ class _ActionRailCompact extends StatelessWidget {
 
     // Actions without "done". Last action is WIDE hide-keyboard.
     final actions = <_RailAction>[
-      _RailAction(Icons.check_rounded, 'Bestätigen', onCheckNext),
-      _RailAction(Icons.paste_rounded, 'Einfügen', onPaste),
+      _RailAction(
+        Icons.arrow_forward_rounded,
+        'Weiter',
+        onNavigate,
+        wide: true,
+      ),
       _RailAction(Icons.remove_rounded, 'Verringern', onMinus, repeat: true),
       _RailAction(Icons.add_rounded, 'Erhöhen', onPlus, repeat: true),
       _RailAction(


### PR DESCRIPTION
## Summary
- replace the overlay keypad check and paste actions with a single wide "Weiter" navigation button
- add provider focus tracking so the keypad can advance through weight, reps, and subsequent sets while marking sets as done
- clear focus when the keypad closes to prevent stale highlights

## Testing
- Not run (Flutter SDK is not available in the container)

------
https://chatgpt.com/codex/tasks/task_e_68dbabd1e1f083209b4c034556a70720