### PR TITLE
Fix keypad next navigation by syncing focused input

### DIFF
--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -414,6 +414,25 @@ class OverlayNumericKeypad extends StatelessWidget {
       return;
     }
 
+    final targetController = controller.target;
+    if (targetController != null) {
+      final text = targetController.text;
+      switch (focusedField) {
+        case DeviceSetFieldFocus.weight:
+          prov.updateSet(focusedIndex, weight: text);
+          break;
+        case DeviceSetFieldFocus.reps:
+          prov.updateSet(focusedIndex, reps: text);
+          break;
+        case DeviceSetFieldFocus.dropWeight:
+          prov.updateSet(focusedIndex, dropWeight: text);
+          break;
+        case DeviceSetFieldFocus.dropReps:
+          prov.updateSet(focusedIndex, dropReps: text);
+          break;
+      }
+    }
+
     int targetIndex = focusedIndex;
     DeviceSetFieldFocus? targetField;
 


### PR DESCRIPTION
## Summary
- update the overlay keypad navigation to push the focused field's text into the device provider before switching
- keep the provider state in sync so moving forward with the "Weiter" button can correctly advance to the next pending set

## Testing
- not run (Flutter SDK not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dbb0db39988320b09fcf4e015db1ac