### PR TITLE
Center new session heading and remove set separators

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -166,11 +166,14 @@ class _DeviceScreenState extends State<DeviceScreen> {
                     if (plannedEntry != null)
                       _PlannedTable(entry: plannedEntry)
                     else ...[
-                      Text(
-                        loc.newSessionTitle,
-                        style: const TextStyle(
-                          fontSize: 18,
-                          fontWeight: FontWeight.bold,
+                      Center(
+                        child: BrandGradientText(
+                          loc.newSessionTitle,
+                          textAlign: TextAlign.center,
+                          style: const TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
                       ),
                       const SizedBox(height: 8),
@@ -629,11 +632,6 @@ class _GroupedSetList extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           for (var index = 0; index < sets.length; index++) ...[
-            if (index > 0)
-              const Divider(
-                height: 1,
-                thickness: 1,
-              ),
             Dismissible(
               key: ValueKey('set-${sets[index]['number']}'),
               direction: DismissDirection.endToStart,


### PR DESCRIPTION
## Summary
- center the "Neue Session" heading on the device screen and render it with the brand gradient text style
- remove divider widgets between grouped set cards to eliminate the visible white separator lines

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbb45547348320b0561e5abd068431