### PR TITLE
Fix profile header icons using current theme gradient

### DIFF
--- a/lib/core/widgets/brand_gradient_icon.dart
+++ b/lib/core/widgets/brand_gradient_icon.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../theme/app_brand_theme.dart';
 import '../theme/design_tokens.dart';
 
 /// Icon widget that paints its glyph using the global brand gradient.
@@ -34,7 +35,10 @@ class BrandGradientIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final effectiveGradient = gradient ?? AppGradients.brandGradient;
+    final theme = Theme.of(context);
+    final brandTheme = theme.extension<AppBrandTheme>();
+    final effectiveGradient =
+        gradient ?? brandTheme?.gradient ?? AppGradients.brandGradient;
     return ShaderMask(
       shaderCallback: (bounds) {
         final rect = bounds.isEmpty


### PR DESCRIPTION
## Summary
- make BrandGradientIcon read the active brand gradient from the current theme
- keep a graceful fallback to the default gradient when no theme extension is present

## Testing
- flutter test *(fails: Flutter is not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc6d7c88c83209750fc1fe0fdfbe2