### PR TITLE
Adjust black and white preset background

### DIFF
--- a/lib/core/theme/brand_theme_preset.dart
+++ b/lib/core/theme/brand_theme_preset.dart
@@ -53,6 +53,7 @@ class BrandThemePreset {
     this.useMagentaTokens = false,
     this.useClubAktivTokens = false,
     this.onColors,
+    this.background,
   });
 
   final BrandThemeId id;
@@ -65,6 +66,7 @@ class BrandThemePreset {
   final bool useMagentaTokens;
   final bool useClubAktivTokens;
   final BrandOnColors? onColors;
+  final Color? background;
 }
 
 /// Built-in presets that users can manually select.
@@ -115,6 +117,7 @@ class BrandThemePresets {
       onGradient: Colors.white,
       onCta: Colors.white,
     ),
+    background: Color(0xFF1E1E1E),
   );
 
   static const List<BrandThemePreset> all = [

--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -117,7 +117,26 @@ class AppTheme {
   static ThemeData customTheme({
     required Color primary,
     required Color secondary,
-  }) => _buildTheme(primary: primary, secondary: secondary);
+    Color? background,
+    Color? surface,
+    Color? surface2,
+    Color? textPrimary,
+    Color? textSecondary,
+    Color? focus,
+    Color? buttonColor,
+  }) {
+    return _buildTheme(
+      primary: primary,
+      secondary: secondary,
+      background: background ?? AppColors.background,
+      surface: surface ?? AppColors.surface,
+      surface2: surface2,
+      textPrimary: textPrimary ?? AppColors.textPrimary,
+      textSecondary: textSecondary ?? AppColors.textSecondary,
+      focus: focus ?? AppColors.accentTurquoise,
+      buttonColor: buttonColor,
+    );
+  }
 
   /// The default dark theme using mint as primary and turquoise as secondary.
   static final ThemeData mintDarkTheme = _buildTheme(

--- a/lib/core/theme/theme_loader.dart
+++ b/lib/core/theme/theme_loader.dart
@@ -146,6 +146,7 @@ class ThemeLoader extends ChangeNotifier {
       useMagenta: preset.useMagentaTokens,
       useClubAktiv: preset.useClubAktivTokens,
       onColors: preset.onColors,
+      background: preset.background,
     );
     if (preset.useMagentaTokens) {
       MagentaTones.normalizeFromGradient(AppGradients.brandGradient);
@@ -169,10 +170,12 @@ class ThemeLoader extends ChangeNotifier {
     bool useMagenta = false,
     bool useClubAktiv = false,
     BrandOnColors? onColors,
+    Color? background,
   }) {
     _currentTheme = AppTheme.customTheme(
       primary: primary,
       secondary: secondary,
+      background: background,
     );
     AppGradients.setBrandGradient(gradStart, gradEnd);
     AppGradients.setCtaGlow(focus);


### PR DESCRIPTION
## Summary
- allow theme presets to supply optional background colors when building brand themes
- update the custom theme builder to accept background overrides
- set the black and white preset to use a grey scaffold background for improved contrast

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbcd52fdf483209f8425a2ac548597