### PR TITLE
Align set card input typography with keypad

### DIFF
--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -910,9 +910,13 @@ class _InputPillState extends State<_InputPill> {
 
     final valueColor = brandColor
         .withOpacity(disabled ? 0.4 : (hasValue ? 0.95 : 0.65));
-    final valueStyle = GoogleFonts.spaceGrotesk(
-      fontSize: showLabel ? (widget.dense ? 18 : 20) : (widget.dense ? 22 : 26),
-      fontWeight: FontWeight.w700,
+    final keypadTypeface = Theme.of(context).textTheme.titleLarge ??
+        Theme.of(context).textTheme.bodyMedium ??
+        const TextStyle();
+    final valueStyle = keypadTypeface.copyWith(
+      fontSize:
+          showLabel ? (widget.dense ? 18 : 20) : (widget.dense ? 22 : 26),
+      fontWeight: FontWeight.w600,
       color: valueColor,
       height: 1.15,
     );


### PR DESCRIPTION
## Summary
- update the set card input value text style to reuse the keypad font family
- ensure placeholder text inherits the updated style for consistent appearance

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc0c177d6883209bfddafb564c7103