### PR TITLE
Fix TabBar theme type for neutral theme

### DIFF
--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -180,7 +180,7 @@ class AppTheme {
       foregroundColor: Colors.white,
       centerTitle: true,
     ),
-    tabBarTheme: const TabBarTheme(
+    tabBarTheme: const TabBarThemeData(
       labelColor: Colors.white,
       unselectedLabelColor: Colors.white70,
       indicatorColor: Colors.white,


### PR DESCRIPTION
## Summary
- update the neutral theme to use TabBarThemeData to match the latest Flutter API changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc2152d9ec8320830d6c97ffeebe31