### PR TITLE
Align black and white theme across the app

### DIFF
--- a/lib/core/theme/brand_theme_preset.dart
+++ b/lib/core/theme/brand_theme_preset.dart
@@ -107,9 +107,9 @@ class BrandThemePresets {
     id: BrandThemeId.blackWhite,
     nameKey: 'settingsThemeBlackWhite',
     primary: Colors.white,
-    secondary: Colors.black,
-    gradientStart: Colors.black,
-    gradientEnd: Color(0xFF3D3D3D),
+    secondary: Colors.white,
+    gradientStart: Colors.white,
+    gradientEnd: Colors.white,
     focus: Colors.white,
     onColors: const BrandOnColors(
       onPrimary: Colors.black,
@@ -117,7 +117,7 @@ class BrandThemePresets {
       onGradient: Colors.white,
       onCta: Colors.white,
     ),
-    background: Color(0xFF1E1E1E),
+    background: Colors.black,
   );
 
   static const List<BrandThemePreset> all = [

--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -171,7 +171,9 @@ class AppTheme {
       background: Colors.black,
       surface: Colors.black,
       onPrimary: Colors.black,
+      onSecondary: Colors.white,
       onSurface: Colors.white,
+      onBackground: Colors.white,
       outline: Colors.white,
     ),
     appBarTheme: const AppBarTheme(
@@ -184,6 +186,90 @@ class AppTheme {
       labelColor: Colors.white,
       unselectedLabelColor: Colors.white70,
       indicatorColor: Colors.white,
+    ),
+    bottomNavigationBarTheme: const BottomNavigationBarThemeData(
+      backgroundColor: Colors.black,
+      selectedItemColor: Colors.white,
+      unselectedItemColor: Colors.white70,
+      showUnselectedLabels: true,
+    ),
+    iconTheme: const IconThemeData(color: Colors.white),
+    primaryIconTheme: const IconThemeData(color: Colors.white),
+    cardTheme: const CardTheme(
+      color: Colors.black,
+      surfaceTintColor: Colors.black,
+    ),
+    dialogTheme: const DialogTheme(
+      backgroundColor: Colors.black,
+      surfaceTintColor: Colors.black,
+      titleTextStyle: TextStyle(
+        color: Colors.white,
+        fontWeight: FontWeight.w600,
+      ),
+      contentTextStyle: TextStyle(color: Colors.white),
+    ),
+    bottomSheetTheme: const BottomSheetThemeData(
+      backgroundColor: Colors.black,
+      modalBackgroundColor: Colors.black,
+      surfaceTintColor: Colors.black,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(AppRadius.card)),
+      ),
+    ),
+    popupMenuTheme: const PopupMenuThemeData(
+      color: Colors.black,
+      textStyle: TextStyle(color: Colors.white),
+    ),
+    listTileTheme: const ListTileThemeData(
+      textColor: Colors.white,
+      iconColor: Colors.white,
+      tileColor: Colors.black,
+    ),
+    snackBarTheme: const SnackBarThemeData(
+      backgroundColor: Colors.black,
+      contentTextStyle: TextStyle(color: Colors.white),
+      actionTextColor: Colors.white,
+      behavior: SnackBarBehavior.floating,
+    ),
+    floatingActionButtonTheme: const FloatingActionButtonThemeData(
+      backgroundColor: Colors.black,
+      foregroundColor: Colors.white,
+      elevation: 0,
+    ),
+    checkboxTheme: CheckboxThemeData(
+      checkColor: MaterialStateProperty.all(Colors.black),
+      fillColor: MaterialStateProperty.resolveWith((states) {
+        if (states.contains(MaterialState.disabled)) {
+          return Colors.white.withOpacity(0.3);
+        }
+        if (states.contains(MaterialState.selected)) {
+          return Colors.white;
+        }
+        return Colors.transparent;
+      }),
+      side: const BorderSide(color: Colors.white, width: 1.5),
+    ),
+    radioTheme: RadioThemeData(
+      fillColor: MaterialStateProperty.resolveWith((states) {
+        if (states.contains(MaterialState.disabled)) {
+          return Colors.white.withOpacity(0.3);
+        }
+        return Colors.white;
+      }),
+    ),
+    switchTheme: SwitchThemeData(
+      thumbColor: MaterialStateProperty.resolveWith((states) {
+        if (states.contains(MaterialState.disabled)) {
+          return Colors.white54;
+        }
+        return Colors.white;
+      }),
+      trackColor: MaterialStateProperty.resolveWith((states) {
+        if (states.contains(MaterialState.disabled)) {
+          return Colors.white.withOpacity(0.2);
+        }
+        return Colors.white24;
+      }),
     ),
     elevatedButtonTheme: ElevatedButtonThemeData(
       style: ElevatedButton.styleFrom(

--- a/lib/core/theme/theme_loader.dart
+++ b/lib/core/theme/theme_loader.dart
@@ -137,6 +137,11 @@ class ThemeLoader extends ChangeNotifier {
   }
 
   void _applyPreset(BrandThemePreset preset) {
+    if (preset.id == BrandThemeId.blackWhite) {
+      _applyBlackWhitePreset(preset);
+      return;
+    }
+
     _applyBrandColors(
       primary: preset.primary,
       secondary: preset.secondary,
@@ -153,6 +158,30 @@ class ThemeLoader extends ChangeNotifier {
     } else if (preset.useClubAktivTokens) {
       ClubAktivTones.normalizeFromGradient(AppGradients.brandGradient);
     }
+  }
+
+  void _applyBlackWhitePreset(BrandThemePreset preset) {
+    _currentTheme = AppTheme.neutralTheme;
+    final onColors = preset.onColors ??
+        const BrandOnColors(
+          onPrimary: Colors.black,
+          onSecondary: Colors.white,
+          onGradient: Colors.white,
+          onCta: Colors.white,
+        );
+    AppGradients.setBrandGradient(preset.gradientStart, preset.gradientEnd);
+    AppGradients.setCtaGlow(preset.focus);
+    _currentTheme = _currentTheme.copyWith(
+      colorScheme: _currentTheme.colorScheme.copyWith(
+        onPrimary: onColors.onPrimary,
+        onSecondary: onColors.onSecondary,
+      ),
+    );
+    _attachBrandTheme(
+      focus: preset.focus,
+      onColors: onColors,
+      useNeutral: true,
+    );
   }
 
   Color _parseHex(String hex) {
@@ -206,17 +235,46 @@ class ThemeLoader extends ChangeNotifier {
     required BrandOnColors onColors,
     bool useMagenta = false,
     bool useClubAktiv = false,
+    bool useNeutral = false,
   }) {
     final ext = useMagenta
         ? AppBrandTheme.magenta()
         : useClubAktiv
-        ? AppBrandTheme.clubAktiv()
-        : AppBrandTheme.defaultTheme().copyWith(
-            gradient: AppGradients.brandGradient,
-            outlineGradient: AppGradients.brandGradient,
-            focusRing: focus,
-            onBrand: onColors.onCta,
-          );
+            ? AppBrandTheme.clubAktiv()
+            : useNeutral
+                ? AppBrandTheme.defaultTheme().copyWith(
+                    gradient: const LinearGradient(
+                      begin: Alignment.centerLeft,
+                      end: Alignment.centerRight,
+                      colors: [Colors.black, Colors.black],
+                    ),
+                    outlineGradient: const LinearGradient(
+                      begin: Alignment.centerLeft,
+                      end: Alignment.centerRight,
+                      colors: [Colors.white, Colors.white],
+                    ),
+                    outline: Colors.white,
+                    outlineColorFallback: Colors.white,
+                    outlineShadow: const [
+                      BoxShadow(color: Colors.white24, blurRadius: 12),
+                    ],
+                    shadow: const [
+                      BoxShadow(
+                        color: Colors.black87,
+                        blurRadius: 16,
+                        offset: Offset(0, 8),
+                      ),
+                    ],
+                    pressedOverlay: Colors.white10,
+                    focusRing: focus,
+                    onBrand: onColors.onCta,
+                  )
+                : AppBrandTheme.defaultTheme().copyWith(
+                    gradient: AppGradients.brandGradient,
+                    outlineGradient: AppGradients.brandGradient,
+                    focusRing: focus,
+                    onBrand: onColors.onCta,
+                  );
     _currentTheme = _currentTheme.copyWith(extensions: [ext, onColors]);
   }
 }

--- a/lib/core/widgets/brand_gradient_icon.dart
+++ b/lib/core/widgets/brand_gradient_icon.dart
@@ -37,8 +37,14 @@ class BrandGradientIcon extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final brandTheme = theme.extension<AppBrandTheme>();
-    final effectiveGradient =
-        gradient ?? brandTheme?.gradient ?? AppGradients.brandGradient;
+    final isBlackWhiteTheme =
+        theme.colorScheme.background == Colors.black &&
+            theme.colorScheme.primary == Colors.white;
+    final effectiveGradient = gradient ??
+        (isBlackWhiteTheme
+            ? brandTheme?.outlineGradient
+            : brandTheme?.gradient) ??
+        AppGradients.brandGradient;
     return ShaderMask(
       shaderCallback: (bounds) {
         final rect = bounds.isEmpty

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -775,7 +775,10 @@ class _PlannedTableState extends State<_PlannedTable> {
         borderRadius: BorderRadius.circular(AppRadius.card),
       ),
       child: Container(
-        decoration: DeviceLevelStyle.widgetDecorationFor(prov.level),
+        decoration: DeviceLevelStyle.widgetDecorationFor(
+          prov.level,
+          theme: Theme.of(context),
+        ),
         padding: const EdgeInsets.all(AppSpacing.sm),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/features/rank/presentation/device_level_style.dart
+++ b/lib/features/rank/presentation/device_level_style.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 
 /// Provides widget styling for the device page depending on a user's level.
@@ -24,15 +25,18 @@ class DeviceLevelStyle {
     int level, {
     double opacity = 1.0,
     double brightness = -0.6,
+    ThemeData? theme,
   }) {
-    final colors = AppGradients.brandGradient.colors
+    final brandGradient = theme?.extension<AppBrandTheme>()?.gradient ??
+        AppGradients.brandGradient;
+    final colors = brandGradient.colors
         .map((c) => c.withOpacity(opacity))
         .toList();
 
     return BoxDecoration(
       gradient: LinearGradient(
-        begin: AppGradients.brandGradient.begin,
-        end: AppGradients.brandGradient.end,
+        begin: brandGradient.begin,
+        end: brandGradient.end,
         colors: colors,
       ),
       borderRadius: BorderRadius.circular(AppRadius.card),

--- a/test/theme/theme_loader_test.dart
+++ b/test/theme/theme_loader_test.dart
@@ -4,6 +4,7 @@ import 'package:tapem/core/theme/theme_loader.dart';
 import 'package:tapem/features/gym/domain/models/branding.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/theme/theme.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/core/theme/brand_on_colors.dart';
 import 'package:tapem/core/theme/brand_theme_preset.dart';
 
@@ -106,12 +107,17 @@ void main() {
         null,
         overridePreset: BrandThemeId.blackWhite,
       );
-      expect(loader.theme.colorScheme.primary, Colors.white);
-      expect(loader.theme.colorScheme.secondary, Colors.black);
-      expect(loader.theme.colorScheme.onSecondary, Colors.white);
-      final on = loader.theme.extension<BrandOnColors>()!;
-      expect(on.onSecondary, Colors.white);
+      final theme = loader.theme;
+      expect(theme.scaffoldBackgroundColor, Colors.black);
+      expect(theme.colorScheme.primary, Colors.white);
+      expect(theme.colorScheme.secondary, Colors.white);
+      expect(theme.colorScheme.onSecondary, Colors.white);
+      final on = theme.extension<BrandOnColors>()!;
+      expect(on.onGradient, Colors.white);
       expect(on.onCta, Colors.white);
+      final brandTheme = theme.extension<AppBrandTheme>()!;
+      expect(brandTheme.gradient.colors.first, Colors.black);
+      expect(brandTheme.outlineGradient.colors.first, Colors.white);
     });
 
     test('lifthouse_koblenz surfaces are normalised to reference luminance', () {


### PR DESCRIPTION
## Summary
- align the black/white preset with the dedicated neutral theme so authenticated screens reuse the same high-contrast styling
- expand the neutral theme configuration to ensure dialogs, navigation, inputs, controls, and feedback components render with black surfaces and white typography/outlines
- update gradient-based widgets, device styling, and tests to respect the refreshed theme tokens

## Testing
- Not run (flutter not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc22ee5894832083b112132bea3f8d