### PR TITLE
Fix neutral theme card and dialog theme types

### DIFF
--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -195,11 +195,11 @@ class AppTheme {
     ),
     iconTheme: const IconThemeData(color: Colors.white),
     primaryIconTheme: const IconThemeData(color: Colors.white),
-    cardTheme: const CardTheme(
+    cardTheme: const CardThemeData(
       color: Colors.black,
       surfaceTintColor: Colors.black,
     ),
-    dialogTheme: const DialogTheme(
+    dialogTheme: const DialogThemeData(
       backgroundColor: Colors.black,
       surfaceTintColor: Colors.black,
       titleTextStyle: TextStyle(


### PR DESCRIPTION
## Summary
- replace the neutral theme's deprecated CardTheme/DialogTheme usage with the updated CardThemeData/DialogThemeData types introduced upstream

## Testing
- flutter analyze *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc27985db08320bd5f4f2477ff985f