### PR TITLE
Ensure overlay keypad text contrasts in neutral theme

### DIFF
--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -53,7 +53,19 @@ class NumericKeypadTheme {
 
     final surface = theme.canvasColor;
     final sheetBg = blend(surface, Colors.black, 0.75);
-    final keyFg = brand?.gradient.colors.last ?? scheme.primary;
+    Color resolveKeyForeground() {
+      final candidate = brand?.gradient.colors.last ?? scheme.primary;
+
+      // Ensure the key foreground keeps enough contrast in high-contrast themes
+      // such as the black/white mode where the gradient collapses to black.
+      if (candidate.computeLuminance() < 0.2) {
+        return brand?.onBrand ?? Colors.white;
+      }
+
+      return candidate;
+    }
+
+    final keyFg = resolveKeyForeground();
     final press = brand?.pressedOverlay ?? keyFg.withOpacity(0.18);
 
     return NumericKeypadTheme(


### PR DESCRIPTION
## Summary
- adjust overlay numeric keypad theme to ensure button text stays visible in high-contrast themes
- fall back to the brand onBrand color when the gradient foreground would be too dark

## Testing
- flutter test test/ui/overlay_numeric_keypad_test.dart *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68dc28fb3b1483209836cb4775878763