### PR TITLE
Center device timer and theme overlay keypad

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -125,7 +125,6 @@ class _DeviceScreenState extends State<DeviceScreen> {
   AppBar _buildAppBar(
     BuildContext context,
     DeviceProvider prov,
-    AppLocalizations loc,
   ) {
     final theme = Theme.of(context);
     final accentColor = theme.colorScheme.secondary;
@@ -135,7 +134,6 @@ class _DeviceScreenState extends State<DeviceScreen> {
           fontWeight: FontWeight.w600,
         );
     final titleStyle = titleBase.copyWith(fontWeight: FontWeight.w600);
-    final deviceTitle = prov.device?.name ?? loc.deviceNotFound;
 
     return AppBar(
       foregroundColor: accentColor,
@@ -144,19 +142,8 @@ class _DeviceScreenState extends State<DeviceScreen> {
       titleTextStyle: titleStyle,
       toolbarTextStyle:
           theme.textTheme.titleMedium?.copyWith(color: accentColor),
-      centerTitle: false,
-      title: Row(
-        children: [
-          Expanded(
-            child: Text(
-              deviceTitle,
-              overflow: TextOverflow.ellipsis,
-              style: titleStyle,
-            ),
-          ),
-          const ActiveWorkoutTimer(padding: EdgeInsets.zero),
-        ],
-      ),
+      centerTitle: true,
+      title: const ActiveWorkoutTimer(padding: EdgeInsets.zero),
       actions: const [
         NfcScanButton(),
         SizedBox(width: 8),
@@ -465,17 +452,17 @@ class _DeviceScreenState extends State<DeviceScreen> {
     Widget scaffold;
     if (prov.isLoading) {
       scaffold = Scaffold(
-        appBar: _buildAppBar(context, prov, loc),
+        appBar: _buildAppBar(context, prov),
         body: const Center(child: CircularProgressIndicator()),
       );
     } else if (prov.error != null || prov.device == null) {
       scaffold = Scaffold(
-        appBar: _buildAppBar(context, prov, loc),
+        appBar: _buildAppBar(context, prov),
         body: Center(child: Text('Fehler: ${prov.error ?? "Unbekannt"}')),
       );
     } else {
       scaffold = Scaffold(
-        appBar: _buildAppBar(context, prov, loc),
+        appBar: _buildAppBar(context, prov),
         floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
         floatingActionButton: NoteButtonWidget(deviceId: widget.deviceId),
         body: DevicePager(

--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -51,29 +51,48 @@ class NumericKeypadTheme {
       return Color.alphaBlend(overlay.withOpacity(opacity), base);
     }
 
-    final surface = theme.canvasColor;
-    final sheetBg = blend(surface, Colors.black, 0.75);
-    Color resolveKeyForeground() {
-      final candidate = brand?.gradient.colors.last ?? scheme.primary;
-
-      // Ensure the key foreground keeps enough contrast in high-contrast themes
-      // such as the black/white mode where the gradient collapses to black.
-      if (candidate.computeLuminance() < 0.2) {
-        return brand?.onBrand ?? Colors.white;
-      }
-
-      return candidate;
+    Color tintTowards(Color source, Color target, double amount) {
+      return Color.lerp(source, target, amount) ?? source;
     }
 
-    final keyFg = resolveKeyForeground();
-    final press = brand?.pressedOverlay ?? keyFg.withOpacity(0.18);
+    Color adjustForeground(Color foreground, Color background) {
+      final brightness = ThemeData.estimateBrightnessForColor(background);
+      final lum = foreground.computeLuminance();
+      if (brightness == Brightness.dark && lum < 0.35) {
+        return tintTowards(foreground, Colors.white, 0.35);
+      }
+      if (brightness == Brightness.light && lum > 0.65) {
+        return tintTowards(foreground, Colors.black, 0.4);
+      }
+      return foreground;
+    }
+
+    final gradientColors = brand?.gradient.colors ?? const <Color>[];
+    final accentBase =
+        gradientColors.isNotEmpty ? gradientColors.last : scheme.secondary;
+    final accent = accentBase.computeLuminance() < 0.08
+        ? scheme.primary
+        : accentBase;
+
+    final sheetBase = theme.canvasColor;
+    final keyBase = theme.colorScheme.surface;
+    final railBase = theme.colorScheme.surface;
+
+    final sheetBg = blend(sheetBase, accent, 0.32);
+    final keyBg = blend(keyBase, accent, 0.28);
+    final railBg = blend(railBase, accent, 0.22);
+
+    final keyFg = adjustForeground(accent, keyBg);
+    final railIcon = adjustForeground(accent, railBg);
+    final press = brand?.pressedOverlay ??
+        adjustForeground(accent, keyBg).withOpacity(0.18);
 
     return NumericKeypadTheme(
       sheetBg: sheetBg,
-      keyBg: Colors.black,
+      keyBg: keyBg,
       keyFg: keyFg,
-      railBg: Colors.black,
-      railIcon: keyFg,
+      railBg: railBg,
+      railIcon: railIcon,
       press: press,
     );
   }

--- a/lib/ui/timer/active_workout_timer.dart
+++ b/lib/ui/timer/active_workout_timer.dart
@@ -29,17 +29,40 @@ class ActiveWorkoutTimer extends StatelessWidget {
             final brand = theme.extension<AppBrandTheme>();
             final gradient = brand?.gradient;
             final colors = theme.colorScheme;
-            final backgroundColor = gradient == null
-                ? colors.secondaryContainer
-                : null;
-            final foregroundColor = gradient == null
-                ? colors.onSecondaryContainer
-                : colors.onPrimary;
+            final gradientColors = gradient?.colors ?? const <Color>[];
+            final hasUsableGradient = gradientColors.isNotEmpty &&
+                gradientColors.any((c) => c.computeLuminance() > 0.2);
+
+            final Color? backgroundColor;
+            final LinearGradient? resolvedGradient;
+            Color foregroundColor;
+
+            if (hasUsableGradient) {
+              resolvedGradient = gradient;
+              backgroundColor = null;
+              foregroundColor = brand?.onBrand ?? colors.onSecondaryContainer;
+            } else {
+              resolvedGradient = null;
+              final fallbackBackground = colors.primary;
+              backgroundColor = fallbackBackground;
+              foregroundColor = colors.onPrimary;
+
+              final brightness = ThemeData.estimateBrightnessForColor(
+                fallbackBackground,
+              );
+              if (brightness == Brightness.dark &&
+                  foregroundColor.computeLuminance() < 0.6) {
+                foregroundColor = Colors.white;
+              } else if (brightness == Brightness.light &&
+                  foregroundColor.computeLuminance() > 0.6) {
+                foregroundColor = Colors.black;
+              }
+            }
 
             final borderRadius = BorderRadius.circular(AppRadius.button);
             final content = DecoratedBox(
               decoration: BoxDecoration(
-                gradient: gradient,
+                gradient: resolvedGradient,
                 color: backgroundColor,
                 borderRadius: borderRadius,
               ),


### PR DESCRIPTION
## Summary
- center the active workout timer in the device screen app bar and remove the duplicated exercise title
- ensure the workout timer pill falls back to a contrasting solid fill when the brand gradient is too dark (e.g. black/white theme)
- derive the overlay keypad colours from the active brand palette so digits, backgrounds and rails follow each theme

## Testing
- flutter analyze *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc36a3b7488320b887c3a9f13167a2