### PR TITLE
Fix overlay keypad theming to use black background

### DIFF
--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -74,18 +74,18 @@ class NumericKeypadTheme {
         ? scheme.primary
         : accentBase;
 
-    final sheetBase = theme.canvasColor;
-    final keyBase = theme.colorScheme.surface;
-    final railBase = theme.colorScheme.surface;
+    const sheetBase = Colors.black;
+    const keyBase = Colors.black;
+    const railBase = Colors.black;
 
-    final sheetBg = blend(sheetBase, accent, 0.32);
-    final keyBg = blend(keyBase, accent, 0.28);
-    final railBg = blend(railBase, accent, 0.22);
+    const sheetBg = sheetBase;
+    const keyBg = keyBase;
+    const railBg = railBase;
 
     final keyFg = adjustForeground(accent, keyBg);
     final railIcon = adjustForeground(accent, railBg);
     final press = brand?.pressedOverlay ??
-        adjustForeground(accent, keyBg).withOpacity(0.18);
+        accent.withOpacity(0.2);
 
     return NumericKeypadTheme(
       sheetBg: sheetBg,


### PR DESCRIPTION
## Summary
- keep the overlay numeric keypad sheet, keys, and action rail backgrounds pure black regardless of the selected theme
- continue deriving key glyph colors from the theme accent while using the accent color for the pressed overlay

## Testing
- Not run (flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc3b67ad708320a1b17f124d4e80f5