### PR TITLE
Align device app bar icons with brand color

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -127,7 +127,8 @@ class _DeviceScreenState extends State<DeviceScreen> {
     DeviceProvider prov,
   ) {
     final theme = Theme.of(context);
-    final accentColor = theme.colorScheme.secondary;
+    final accentColor =
+        theme.extension<AppBrandTheme>()?.outline ?? theme.colorScheme.secondary;
     final titleBase = theme.textTheme.titleLarge ??
         const TextStyle(
           fontSize: 20,
@@ -516,7 +517,8 @@ class _DeviceAppBarFooter extends StatelessWidget
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final accentColor = theme.colorScheme.secondary;
+    final accentColor =
+        theme.extension<AppBrandTheme>()?.outline ?? theme.colorScheme.secondary;
     final loc = AppLocalizations.of(context)!;
 
     return SafeArea(
@@ -553,9 +555,17 @@ class _DeviceAppBarFooter extends StatelessWidget
               ),
             ),
             const SizedBox(width: 8),
-            XpInfoButton(xp: provider.xp, level: provider.level),
+            XpInfoButton(
+              xp: provider.xp,
+              level: provider.level,
+              color: accentColor,
+            ),
             const SizedBox(width: 4),
-            FeedbackButton(gymId: gymId, deviceId: deviceId),
+            FeedbackButton(
+              gymId: gymId,
+              deviceId: deviceId,
+              color: accentColor,
+            ),
             const SizedBox(width: 4),
             IconButton(
               icon: Icon(
@@ -575,7 +585,7 @@ class _DeviceAppBarFooter extends StatelessWidget
               },
             ),
             IconButton(
-              icon: const Icon(Icons.history),
+              icon: Icon(Icons.history, color: accentColor),
               tooltip: loc.deviceHistoryTooltip,
               onPressed: () {
                 closeKeyboard();

--- a/lib/features/feedback/presentation/widgets/feedback_button.dart
+++ b/lib/features/feedback/presentation/widgets/feedback_button.dart
@@ -6,14 +6,20 @@ import 'package:tapem/core/providers/auth_provider.dart';
 class FeedbackButton extends StatelessWidget {
   final String gymId;
   final String deviceId;
+  final Color? color;
 
-  const FeedbackButton({Key? key, required this.gymId, required this.deviceId})
-      : super(key: key);
+  const FeedbackButton({
+    Key? key,
+    required this.gymId,
+    required this.deviceId,
+    this.color,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final iconColor = color ?? Theme.of(context).iconTheme.color;
     return IconButton(
-      icon: const Icon(Icons.feedback_outlined),
+      icon: Icon(Icons.feedback_outlined, color: iconColor),
       tooltip: 'Feedback',
       onPressed: () => _showDialog(context),
     );

--- a/lib/features/rank/presentation/widgets/xp_info_button.dart
+++ b/lib/features/rank/presentation/widgets/xp_info_button.dart
@@ -5,14 +5,20 @@ import 'package:tapem/app_router.dart';
 class XpInfoButton extends StatelessWidget {
   final int xp;
   final int level;
+  final Color? color;
 
-  const XpInfoButton({Key? key, required this.xp, required this.level})
-    : super(key: key);
+  const XpInfoButton({
+    Key? key,
+    required this.xp,
+    required this.level,
+    this.color,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final iconColor = color ?? Theme.of(context).iconTheme.color;
     return IconButton(
-      icon: const Icon(Icons.auto_awesome),
+      icon: Icon(Icons.auto_awesome, color: iconColor),
       tooltip: 'XP',
       onPressed: () => _showInfo(context),
     );


### PR DESCRIPTION
## Summary
- apply the app brand accent color to the XP, feedback, and history icons on the device screen header
- allow the XP info and feedback buttons to receive a custom icon color so they can follow the theme tint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc416a257883208e4cac8195f7ce9c