### PR TITLE
Adjust header titles across key screens

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -136,6 +136,33 @@ class _DeviceScreenState extends State<DeviceScreen> {
         );
     final titleStyle = titleBase.copyWith(fontWeight: FontWeight.w600);
 
+    String? headerTitle;
+    final device = prov.device;
+    if (device != null) {
+      if (device.isMulti) {
+        final exercises =
+            context.select<ExerciseProvider, List<Exercise>>((p) => p.exercises);
+        final match = exercises.where((e) => e.id == widget.exerciseId);
+        headerTitle = match.isNotEmpty ? match.first.name : device.name;
+      } else {
+        headerTitle = device.name;
+      }
+    }
+
+    final Widget titleWidget = headerTitle != null
+        ? Text(
+            headerTitle!,
+            key: ValueKey(headerTitle),
+            style: titleStyle,
+            textAlign: TextAlign.center,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          )
+        : const ActiveWorkoutTimer(
+            key: ValueKey('activeWorkoutTimer'),
+            padding: EdgeInsets.zero,
+          );
+
     return AppBar(
       foregroundColor: accentColor,
       iconTheme: IconThemeData(color: accentColor),
@@ -144,7 +171,10 @@ class _DeviceScreenState extends State<DeviceScreen> {
       toolbarTextStyle:
           theme.textTheme.titleMedium?.copyWith(color: accentColor),
       centerTitle: true,
-      title: const ActiveWorkoutTimer(padding: EdgeInsets.zero),
+      title: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 200),
+        child: titleWidget,
+      ),
       actions: const [
         NfcScanButton(),
         SizedBox(width: 8),

--- a/lib/features/gym/presentation/screens/gym_screen.dart
+++ b/lib/features/gym/presentation/screens/gym_screen.dart
@@ -7,7 +7,6 @@ import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/core/recent_devices_store.dart';
 import 'package:tapem/app_router.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
-import 'package:tapem/core/widgets/brand_gradient_text.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/ui/common/search_and_filters.dart';
 import 'package:tapem/ui/devices/device_card.dart';
@@ -93,12 +92,6 @@ class _GymScreenState extends State<GymScreen>
     }
     if (gymProv.error != null) {
       return Scaffold(
-        appBar: AppBar(
-          title: BrandGradientText(
-            loc.gymTitle,
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
-        ),
         body: Center(child: Text('${loc.errorPrefix}: ${gymProv.error}')),
       );
     }
@@ -110,12 +103,6 @@ class _GymScreenState extends State<GymScreen>
     final theme = Theme.of(context);
 
     return Scaffold(
-      appBar: AppBar(
-        title: BrandGradientText(
-          loc.gymTitle,
-          style: theme.textTheme.titleLarge,
-        ),
-      ),
       body: SafeArea(
         child: Column(
           children: [

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -16,6 +16,7 @@ import 'package:tapem/features/training_plan/presentation/screens/plan_overview_
 import 'package:tapem/features/auth/presentation/widgets/username_dialog.dart';
 import 'package:tapem/core/config/feature_flags.dart';
 import 'package:tapem/features/nfc/widgets/nfc_scan_button.dart';
+import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/ui/timer/active_workout_timer.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -116,7 +117,8 @@ class _HomeScreenState extends State<HomeScreen> {
     return Scaffold(
       appBar: AppBar(
         titleSpacing: 0,
-        title: const ActiveWorkoutTimer(),
+        centerTitle: true,
+        title: _buildAppBarTitle(context),
         actions: const [
           NfcScanButton(),
           SizedBox(width: 8),
@@ -130,6 +132,33 @@ class _HomeScreenState extends State<HomeScreen> {
         items: [for (final t in tabs) t.item],
       ),
     );
+  }
+
+  Widget _buildAppBarTitle(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    final auth = context.watch<AuthProvider>();
+
+    switch (_currentIndex) {
+      case 0:
+        return Text(
+          loc.gymTitle,
+          textAlign: TextAlign.center,
+          style: Theme.of(context).textTheme.titleLarge,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        );
+      case 1:
+        final username = auth.userName ?? auth.userEmail ?? loc.profileTitle;
+        return Text(
+          username,
+          textAlign: TextAlign.center,
+          style: Theme.of(context).textTheme.titleLarge,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        );
+      default:
+        return const ActiveWorkoutTimer();
+    }
   }
 }
 

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -388,7 +388,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
     const avatarSize = 44.0;
 
     final theme = Theme.of(context);
-    final profileTitle = auth.userName ?? auth.userEmail ?? loc.profileTitle;
 
     return Scaffold(
       appBar: AppBar(
@@ -430,10 +429,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
             ),
           ),
         ),
-        title: BrandGradientText(
-          profileTitle,
-          style: theme.textTheme.titleLarge,
-        ),
+        title: const SizedBox.shrink(),
         actions: [
           if (enableFriends)
             Consumer<FriendsProvider>(


### PR DESCRIPTION
## Summary
- show context-aware titles in the shared app bar for the gym, profile, and other tabs
- surface the active exercise name in the device screen header and animate updates
- remove redundant in-page app bars now that titles move into the shared header

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc624d34d483209589ce96e7c47bec