### PR TITLE
Align app bar titles with branding gradient

### DIFF
--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -149,19 +149,33 @@ class _DeviceScreenState extends State<DeviceScreen> {
       }
     }
 
-    final Widget titleWidget = headerTitle != null
-        ? Text(
-            headerTitle!,
-            key: ValueKey(headerTitle),
-            style: titleStyle,
-            textAlign: TextAlign.center,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          )
-        : const ActiveWorkoutTimer(
-            key: ValueKey('activeWorkoutTimer'),
-            padding: EdgeInsets.zero,
-          );
+    Widget titleWidget;
+    if (headerTitle != null) {
+      final gradientTitle = BrandGradientText(
+        headerTitle!,
+        key: ValueKey(headerTitle),
+        style: titleStyle,
+        textAlign: TextAlign.center,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      );
+      if (prov.device != null) {
+        titleWidget = Hero(
+          tag: 'device-${prov.device!.uid}',
+          child: Material(
+            type: MaterialType.transparency,
+            child: gradientTitle,
+          ),
+        );
+      } else {
+        titleWidget = gradientTitle;
+      }
+    } else {
+      titleWidget = const ActiveWorkoutTimer(
+        key: ValueKey('activeWorkoutTimer'),
+        padding: EdgeInsets.zero,
+      );
+    }
 
     return AppBar(
       foregroundColor: accentColor,
@@ -183,7 +197,6 @@ class _DeviceScreenState extends State<DeviceScreen> {
           ? null
           : _DeviceAppBarFooter(
               provider: prov,
-              titleStyle: titleStyle,
               gymId: widget.gymId,
               deviceId: widget.deviceId,
               exerciseId: widget.exerciseId,
@@ -526,7 +539,6 @@ class _DeviceScreenState extends State<DeviceScreen> {
 class _DeviceAppBarFooter extends StatelessWidget
     implements PreferredSizeWidget {
   final DeviceProvider provider;
-  final TextStyle titleStyle;
   final String gymId;
   final String deviceId;
   final String exerciseId;
@@ -534,7 +546,6 @@ class _DeviceAppBarFooter extends StatelessWidget
 
   const _DeviceAppBarFooter({
     required this.provider,
-    required this.titleStyle,
     required this.gymId,
     required this.deviceId,
     required this.exerciseId,
@@ -558,32 +569,7 @@ class _DeviceAppBarFooter extends StatelessWidget
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            Expanded(
-              child: Hero(
-                tag: 'device-${provider.device!.uid}',
-                child: Material(
-                  type: MaterialType.transparency,
-                  child: LayoutBuilder(
-                    builder: (context, constraints) {
-                      return ConstrainedBox(
-                        constraints:
-                            BoxConstraints(maxWidth: constraints.maxWidth),
-                        child: FittedBox(
-                          fit: BoxFit.scaleDown,
-                          alignment: Alignment.centerLeft,
-                          child: BrandGradientText(
-                            provider.device!.name,
-                            style: titleStyle,
-                            textAlign: TextAlign.left,
-                            softWrap: false,
-                          ),
-                        ),
-                      );
-                    },
-                  ),
-                ),
-              ),
-            ),
+            const Expanded(child: SizedBox()),
             const SizedBox(width: 8),
             XpInfoButton(
               xp: provider.xp,

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -18,6 +18,7 @@ import 'package:tapem/core/config/feature_flags.dart';
 import 'package:tapem/features/nfc/widgets/nfc_scan_button.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/ui/timer/active_workout_timer.dart';
+import 'package:tapem/core/widgets/brand_gradient_text.dart';
 
 class HomeScreen extends StatefulWidget {
   final int initialIndex;
@@ -140,7 +141,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
     switch (_currentIndex) {
       case 0:
-        return Text(
+        return BrandGradientText(
           loc.gymTitle,
           textAlign: TextAlign.center,
           style: Theme.of(context).textTheme.titleLarge,
@@ -149,7 +150,7 @@ class _HomeScreenState extends State<HomeScreen> {
         );
       case 1:
         final username = auth.userName ?? auth.userEmail ?? loc.profileTitle;
-        return Text(
+        return BrandGradientText(
           username,
           textAlign: TextAlign.center,
           style: Theme.of(context).textTheme.titleLarge,


### PR DESCRIPTION
## Summary
- render the gym and profile tab app bar titles using the branded gradient text
- update the device screen app bar to show the exercise/device name once with brand styling and keep footer actions

## Testing
- `flutter analyze` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc668ce3048320b22e27789a3dd121