### PR TITLE
Remove history sessions chart and apply brand text styling

### DIFF
--- a/lib/core/providers/history_provider.dart
+++ b/lib/core/providers/history_provider.dart
@@ -28,8 +28,8 @@ class HistoryProvider extends ChangeNotifier {
   int _workoutCount = 0;
   double _setsPerSessionAvg = 0;
   double _heaviest = 0;
+  double _maxE1rm = 0;
   List<ChartPoint> _e1rmChart = [];
-  List<ChartPoint> _sessionsChart = [];
 
   bool get isLoading => _isLoading;
   String? get error => _error;
@@ -37,8 +37,8 @@ class HistoryProvider extends ChangeNotifier {
   int get workoutCount => _workoutCount;
   double get setsPerSessionAvg => _setsPerSessionAvg;
   double get heaviest => _heaviest;
+  double get maxE1rm => _maxE1rm;
   List<ChartPoint> get e1rmChart => List.unmodifiable(_e1rmChart);
-  List<ChartPoint> get sessionsChart => List.unmodifiable(_sessionsChart);
 
   /// Lädt die Historie für [deviceId] und den aktuell eingeloggten User.
   Future<void> loadHistory({
@@ -80,8 +80,8 @@ class HistoryProvider extends ChangeNotifier {
       _workoutCount = 0;
       _setsPerSessionAvg = 0;
       _heaviest = 0;
+      _maxE1rm = 0;
       _e1rmChart = [];
-      _sessionsChart = [];
       return;
     }
 
@@ -108,18 +108,7 @@ class HistoryProvider extends ChangeNotifier {
       return ChartPoint(date, e1rm);
     }).toList();
 
-    final perDay = <DateTime, int>{};
-    for (final entry in sessionEntries) {
-      final day = DateTime(entry.value.first.timestamp.year,
-          entry.value.first.timestamp.month, entry.value.first.timestamp.day);
-      perDay.update(day, (v) => v + 1, ifAbsent: () => 1);
-    }
-    final sortedDays = perDay.entries.toList()
-      ..sort((a, b) => a.key.compareTo(b.key));
-    var cumulative = 0;
-    _sessionsChart = sortedDays.map((e) {
-      cumulative += e.value;
-      return ChartPoint(e.key, cumulative.toDouble());
-    }).toList();
+    _maxE1rm =
+        _e1rmChart.map((e) => e.value).reduce((a, b) => a > b ? a : b);
   }
 }

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -483,6 +483,9 @@ class _DeviceScreenState extends State<DeviceScreen> {
     prov.updateAutoSavePreference(auth.showInLeaderboard ?? true);
     final locale = Localizations.localeOf(context).toString();
     final loc = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final brandColor =
+        theme.extension<AppBrandTheme>()?.outline ?? theme.colorScheme.secondary;
     final planProv = context.watch<TrainingPlanProvider>();
     final plannedEntry = planProv.entryForDate(
       widget.deviceId,
@@ -502,26 +505,32 @@ class _DeviceScreenState extends State<DeviceScreen> {
     } else if (prov.error != null || prov.device == null) {
       scaffold = Scaffold(
         appBar: _buildAppBar(context, prov),
-        body: Center(child: Text('Fehler: ${prov.error ?? "Unbekannt"}')),
+        body: DefaultTextStyle.merge(
+          style: TextStyle(color: brandColor),
+          child: Center(child: Text('Fehler: ${prov.error ?? "Unbekannt"}')),
+        ),
       );
     } else {
       scaffold = Scaffold(
         appBar: _buildAppBar(context, prov),
         floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
         floatingActionButton: NoteButtonWidget(deviceId: widget.deviceId),
-        body: DevicePager(
-          key: _pagerKey,
-          gymId: widget.gymId,
-          deviceId: prov.device!.uid,
-          userId: auth.userId!,
-          provider: prov,
-          editablePage:
-              _buildEditablePage(
-                prov,
-                loc,
-                locale,
-                plannedEntry,
-              ),
+        body: DefaultTextStyle.merge(
+          style: TextStyle(color: brandColor),
+          child: DevicePager(
+            key: _pagerKey,
+            gymId: widget.gymId,
+            deviceId: prov.device!.uid,
+            userId: auth.userId!,
+            provider: prov,
+            editablePage:
+                _buildEditablePage(
+                  prov,
+                  loc,
+                  locale,
+                  plannedEntry,
+                ),
+          ),
         ),
       );
     }

--- a/lib/features/gym/presentation/screens/gym_screen.dart
+++ b/lib/features/gym/presentation/screens/gym_screen.dart
@@ -10,6 +10,7 @@ import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/ui/common/search_and_filters.dart';
 import 'package:tapem/ui/devices/device_card.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
 
 class GymScreen extends StatefulWidget {
   const GymScreen({super.key});
@@ -86,13 +87,21 @@ class _GymScreenState extends State<GymScreen>
     final auth = context.read<AuthProvider>();
     final gymProv = context.watch<GymProvider>();
     final gymId = auth.gymCode ?? '';
+    final theme = Theme.of(context);
+    final brandColor =
+        theme.extension<AppBrandTheme>()?.outline ?? theme.colorScheme.secondary;
 
     if (gymProv.isLoading) {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
     if (gymProv.error != null) {
       return Scaffold(
-        body: Center(child: Text('${loc.errorPrefix}: ${gymProv.error}')),
+        body: Center(
+          child: Text(
+            '${loc.errorPrefix}: ${gymProv.error}',
+            style: TextStyle(color: brandColor),
+          ),
+        ),
       );
     }
     if (_sort == SortOrder.recent) {
@@ -100,82 +109,85 @@ class _GymScreenState extends State<GymScreen>
     }
     final devices = _filtered(gymProv.devices);
 
-    final theme = Theme.of(context);
-
     return Scaffold(
-      body: SafeArea(
-        child: Column(
-          children: [
-            Padding(
-              padding: const EdgeInsets.all(16),
-              child: SearchAndFilters(
-                query: _query,
-                onQuery: (v) => setState(() => _query = v),
-                sort: _sort,
-                onSort: (v) {
-                  setState(() => _sort = v);
-                  if (v == SortOrder.recent) {
-                    _loadRecent(gymId);
-                  }
-                },
-                muscleFilterIds: _muscles,
-                onMuscleFilter: (v) => setState(() => _muscles = v),
+      body: DefaultTextStyle.merge(
+        style: TextStyle(color: brandColor),
+        child: SafeArea(
+          child: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: SearchAndFilters(
+                  query: _query,
+                  onQuery: (v) => setState(() => _query = v),
+                  sort: _sort,
+                  onSort: (v) {
+                    setState(() => _sort = v);
+                    if (v == SortOrder.recent) {
+                      _loadRecent(gymId);
+                    }
+                  },
+                  muscleFilterIds: _muscles,
+                  onMuscleFilter: (v) => setState(() => _muscles = v),
+                ),
               ),
-            ),
-            Expanded(
-              child: RefreshIndicator(
-                onRefresh: () async => gymProv.loadGymData(gymId),
-                child: devices.isEmpty
-                    ? ListView(
-                        physics: const AlwaysScrollableScrollPhysics(),
-                        children: [
-                          SizedBox(
-                            height: MediaQuery.of(context).size.height * 0.5,
-                            child: Center(child: Text(loc.gymNoDevices)),
+                Expanded(
+                  child: RefreshIndicator(
+                    onRefresh: () async => gymProv.loadGymData(gymId),
+                    child: devices.isEmpty
+                        ? ListView(
+                            physics: const AlwaysScrollableScrollPhysics(),
+                            children: [
+                              SizedBox(
+                                height: MediaQuery.of(context).size.height * 0.5,
+                                child: Center(child: Text(loc.gymNoDevices)),
+                              ),
+                            ],
+                          )
+                        : ListView.builder(
+                            physics: const AlwaysScrollableScrollPhysics(),
+                            itemCount: devices.length,
+                            itemBuilder: (ctx, i) {
+                              final d = devices[i];
+                              return Padding(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 16,
+                                  vertical: 8,
+                                ),
+                                child: DeviceCard(
+                                  device: d,
+                                  onTap: () {
+                                    final nav = Navigator.of(context);
+                                    final idStr = d.uid;
+                                    if (d.isMulti) {
+                                      nav.pushNamed(
+                                        AppRouter.exerciseList,
+                                        arguments: {
+                                          'gymId': gymId,
+                                          'deviceId': idStr,
+                                        },
+                                      );
+                                    } else {
+                                      nav.pushNamed(
+                                        AppRouter.device,
+                                        arguments: {
+                                          'gymId': gymId,
+                                          'deviceId': idStr,
+                                          'exerciseId': idStr,
+                                        },
+                                      );
+                                    }
+                                  },
+                                ),
+                              );
+                            },
                           ),
-                        ],
-                      )
-                    : ListView.builder(
-                        physics: const AlwaysScrollableScrollPhysics(),
-                        itemCount: devices.length,
-                        itemBuilder: (ctx, i) {
-                          final d = devices[i];
-                          return Padding(
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 16, vertical: 8),
-                            child: DeviceCard(
-                              device: d,
-                              onTap: () {
-                                final nav = Navigator.of(context);
-                                final idStr = d.uid;
-                                if (d.isMulti) {
-                                  nav.pushNamed(
-                                    AppRouter.exerciseList,
-                                    arguments: {
-                                      'gymId': gymId,
-                                      'deviceId': idStr,
-                                    },
-                                  );
-                                } else {
-                                  nav.pushNamed(
-                                    AppRouter.device,
-                                    arguments: {
-                                      'gymId': gymId,
-                                      'deviceId': idStr,
-                                      'exerciseId': idStr,
-                                    },
-                                  );
-                                }
-                              },
-                            ),
-                          );
-                        },
-                      ),
-              ),
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
-      ),
     );
   }
 }

--- a/lib/features/history/presentation/screens/history_screen.dart
+++ b/lib/features/history/presentation/screens/history_screen.dart
@@ -10,6 +10,7 @@ import 'package:tapem/features/training_details/domain/models/session.dart';
 import 'package:tapem/features/training_details/presentation/widgets/session_exercise_card.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
+import 'package:tapem/core/widgets/brand_gradient_text.dart';
 import 'package:tapem/core/widgets/brand_outline.dart';
 import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
@@ -54,9 +55,11 @@ class _HistoryScreenState extends State<HistoryScreen> {
     final loc = AppLocalizations.of(context)!;
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
+    final brandColor =
+        theme.extension<AppBrandTheme>()?.outline ?? theme.colorScheme.secondary;
     final prov = context.watch<HistoryProvider>();
     final smallStyle = textTheme.bodySmall?.copyWith(
-      color: theme.colorScheme.onSurface.withOpacity(0.6),
+      color: brandColor.withOpacity(0.7),
       fontSize: 10,
     );
 
@@ -69,13 +72,26 @@ class _HistoryScreenState extends State<HistoryScreen> {
         subtitle.isNotEmpty ? '$title — $subtitle' : title;
     if (prov.error != null) {
       return Scaffold(
-        appBar: AppBar(title: Text(fullTitle)),
-        body: Center(child: Text('${loc.errorPrefix}: ${prov.error}')),
+        appBar: AppBar(
+          title: BrandGradientText(
+            fullTitle,
+            style: textTheme.titleLarge,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          centerTitle: true,
+          foregroundColor: brandColor,
+        ),
+        body: DefaultTextStyle.merge(
+          style: TextStyle(color: brandColor),
+          child: Center(
+            child: Text('${loc.errorPrefix}: ${prov.error}'),
+          ),
+        ),
       );
     }
 
     final e1rmPoints = prov.e1rmChart;
-    final sessionPoints = prov.sessionsChart;
     final localeString = Localizations.localeOf(context).toString();
 
     final e1rmValues = e1rmPoints.map((e) => e.value).toList();
@@ -88,18 +104,6 @@ class _HistoryScreenState extends State<HistoryScreen> {
         .toList();
     final e1rmDateInterval =
         e1rmPoints.isEmpty ? 1 : (e1rmPoints.length / 6).ceil().clamp(1, e1rmPoints.length);
-
-    final sessionValues = sessionPoints.map((e) => e.value).toList();
-    final sessionScale = NiceScale.fromValues(sessionValues,
-        tickCount: 6, forceMinZero: true);
-    final sessionSpots = sessionValues
-        .asMap()
-        .entries
-        .map((e) => FlSpot(e.key.toDouble(), e.value))
-        .toList();
-    final sessionDateInterval = sessionPoints.isEmpty
-        ? 1
-        : (sessionPoints.length / 6).ceil().clamp(1, sessionPoints.length);
 
     final sessionsMap = <String, List<WorkoutLog>>{};
     for (var log in prov.logs) {
@@ -187,207 +191,134 @@ class _HistoryScreenState extends State<HistoryScreen> {
       );
     }
 
-    Widget buildSessionsChart() {
-      if (sessionPoints.isEmpty) {
-        return SizedBox(
-            height: 200,
-            child: Center(child: Text(loc.historyNoData, style: textTheme.bodySmall)));
-      }
-      final dates = sessionPoints.map((e) => e.date).toList();
-      return Semantics(
-        label: loc.historySessionsChartSemantics,
-        child: SizedBox(
-          height: 200,
-          child: LineChart(
-            LineChartData(
-              minY: sessionScale.min,
-              maxY: sessionScale.max,
-              gridData: FlGridData(
-                show: true,
-                drawVerticalLine: false,
-                horizontalInterval: sessionScale.tickSpacing,
-              ),
-              borderData: FlBorderData(show: false),
-              titlesData: FlTitlesData(
-                bottomTitles: AxisTitles(
-                  axisNameWidget: Text(loc.historyAxisDate, style: smallStyle),
-                  sideTitles: SideTitles(
-                    showTitles: true,
-                    reservedSize: 28,
-                    interval: sessionDateInterval.toDouble(),
-                    getTitlesWidget: (value, meta) {
-                      final i = value.toInt();
-                      if (i < 0 || i >= dates.length) {
-                        return const SizedBox();
-                      }
-                      final d = dates[i];
-                      return Padding(
-                        padding: const EdgeInsets.only(top: 4),
-                        child: Text(
-                          DateFormat.Md(localeString).format(d),
-                          style: smallStyle,
-                        ),
-                      );
-                    },
-                  ),
-                ),
-                leftTitles: AxisTitles(
-                  axisNameWidget: Text(loc.historyAxisSessions, style: smallStyle),
-                  sideTitles: SideTitles(
-                    showTitles: true,
-                    reservedSize: 40,
-                    interval: sessionScale.tickSpacing,
-                    getTitlesWidget: (value, meta) => Text(
-                      value.toStringAsFixed(0),
-                      style: smallStyle,
-                    ),
-                  ),
-                ),
-                topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
-                rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
-              ),
-              lineBarsData: [
-                LineChartBarData(
-                  spots: sessionSpots,
-                  isCurved: true,
-                  curveSmoothness: 0.2,
-                  barWidth: 3,
-                  isStrokeCapRound: true,
-                  dotData: FlDotData(show: false),
-                  belowBarData: BarAreaData(show: false),
-                ),
-              ],
-              lineTouchData: LineTouchData(enabled: false),
-            ),
-          ),
-        ),
-      );
-    }
-
     return Scaffold(
-        appBar: AppBar(title: Text(fullTitle)),
-      body: CustomScrollView(
-        slivers: [
-          SliverPadding(
-            padding: const EdgeInsets.all(16),
-            sliver: SliverToBoxAdapter(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Text(
-                    loc.historyOverviewTitle,
-                    style:
-                        textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
-                  ),
-                  const SizedBox(height: 8),
-                  Wrap(
-                    alignment: WrapAlignment.center,
-                    spacing: 12,
-                    runSpacing: 12,
-                    children: [
-                      _kpiRing(loc.historyWorkouts, prov.workoutCount.toString()),
-                      _kpiRing(loc.historySetsAvg,
-                          prov.setsPerSessionAvg.toStringAsFixed(1)),
-                      _kpiRing(loc.historyHeaviest,
-                          '${prov.heaviest.toStringAsFixed(1)} kg'),
-                    ],
-                  ),
-                  const SizedBox(height: 16),
-                ],
-              ),
-            ),
-          ),
-          SliverPadding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            sliver: SliverToBoxAdapter(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    loc.historyChartTitle,
-                    style:
-                        textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
-                  ),
-                  const SizedBox(height: 8),
-                  buildE1rmChart(),
-                  const SizedBox(height: 16),
-                ],
-              ),
-            ),
-          ),
-          SliverPadding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            sliver: SliverToBoxAdapter(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    loc.historySessionsChartTitle,
-                    style:
-                        textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
-                  ),
-                  const SizedBox(height: 8),
-                  buildSessionsChart(),
-                  const SizedBox(height: 16),
-                ],
-              ),
-            ),
-          ),
-          SliverPadding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            sliver: SliverToBoxAdapter(
-              child: Text(
-                loc.historyListTitle,
-                style:
-                    textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
-              ),
-            ),
-          ),
-          SliverList(
-            delegate: SliverChildBuilderDelegate(
-              (context, idx) {
-                final logs = sessionEntries[idx].value;
-                final titleDate = DateFormat.yMMMMd(localeString)
-                    .format(logs.first.timestamp);
-
-                final sets = logs
-                    .map((e) => SessionSet(
-                          weight: e.weight,
-                          reps: e.reps,
-                          setNumber: e.setNumber,
-                          dropWeightKg: e.dropWeightKg,
-                          dropReps: e.dropReps,
-                          isBodyweight: e.isBodyweight,
-                        ))
-                    .toList();
-                elogUi('HISTORY_CARD_RENDER', {
-                  'sessionId': sessionEntries[idx].key,
-                  'setNumbers': sets.take(10).map((s) => s.setNumber).toList(),
-                });
-                return Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-                  child: _HistoryExpansionTile(
-                    title: titleDate,
-                    child: SessionExerciseCard(
-                      title: title,
-                      subtitle: subtitle.isNotEmpty ? subtitle : null,
-                      sets: sets,
-                      padding: const EdgeInsets.all(12),
+      appBar: AppBar(
+        title: BrandGradientText(
+          fullTitle,
+          style: textTheme.titleLarge,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+        centerTitle: true,
+        foregroundColor: brandColor,
+      ),
+      body: DefaultTextStyle.merge(
+        style: TextStyle(color: brandColor),
+        child: CustomScrollView(
+          slivers: [
+            SliverPadding(
+              padding: const EdgeInsets.all(16),
+              sliver: SliverToBoxAdapter(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Text(
+                      loc.historyOverviewTitle,
+                      style:
+                          textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
                     ),
-                  ),
-                );
-              },
-              childCount: sessionEntries.length,
+                    const SizedBox(height: 8),
+                    Wrap(
+                      alignment: WrapAlignment.center,
+                      spacing: 12,
+                      runSpacing: 12,
+                      children: [
+                        _kpiRing(loc.historyWorkouts, prov.workoutCount.toString()),
+                        _kpiRing(
+                          loc.historySetsAvg,
+                          prov.setsPerSessionAvg.toStringAsFixed(1),
+                        ),
+                        _kpiRing(
+                          loc.historyHeaviest,
+                          '${prov.heaviest.toStringAsFixed(1)} kg',
+                        ),
+                        _kpiRing(
+                          loc.historyAxisE1rm,
+                          '${prov.maxE1rm.toStringAsFixed(1)} kg',
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 16),
+                  ],
+                ),
+              ),
             ),
-          ),
-          const SliverToBoxAdapter(child: SizedBox(height: 16)),
-        ],
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              sliver: SliverToBoxAdapter(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      loc.historyChartTitle,
+                      style:
+                          textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+                    ),
+                    const SizedBox(height: 8),
+                    buildE1rmChart(),
+                    const SizedBox(height: 16),
+                  ],
+                ),
+              ),
+            ),
+            SliverPadding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              sliver: SliverToBoxAdapter(
+                child: Text(
+                  loc.historyListTitle,
+                  style:
+                      textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+                ),
+              ),
+            ),
+            SliverList(
+              delegate: SliverChildBuilderDelegate(
+                (context, idx) {
+                  final logs = sessionEntries[idx].value;
+                  final titleDate =
+                      DateFormat.yMMMMd(localeString).format(logs.first.timestamp);
+
+                  final sets = logs
+                      .map((e) => SessionSet(
+                            weight: e.weight,
+                            reps: e.reps,
+                            setNumber: e.setNumber,
+                            dropWeightKg: e.dropWeightKg,
+                            dropReps: e.dropReps,
+                            isBodyweight: e.isBodyweight,
+                          ))
+                      .toList();
+                  elogUi('HISTORY_CARD_RENDER', {
+                    'sessionId': sessionEntries[idx].key,
+                    'setNumbers': sets.take(10).map((s) => s.setNumber).toList(),
+                  });
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                    child: _HistoryExpansionTile(
+                      title: titleDate,
+                      child: SessionExerciseCard(
+                        title: title,
+                        subtitle: subtitle.isNotEmpty ? subtitle : null,
+                        sets: sets,
+                        padding: const EdgeInsets.all(12),
+                      ),
+                    ),
+                  );
+                },
+                childCount: sessionEntries.length,
+              ),
+            ),
+            const SliverToBoxAdapter(child: SizedBox(height: 16)),
+          ],
+        ),
       ),
     );
   }
 
   Widget _kpiRing(String label, String value) {
     final theme = Theme.of(context);
+    final brand = theme.extension<AppBrandTheme>();
+    final onBrandColor = brand?.onBrand ?? theme.colorScheme.onPrimary;
     return Semantics(
       label: '$label: $value',
       child: SizedBox(
@@ -402,13 +333,17 @@ class _HistoryScreenState extends State<HistoryScreen> {
               children: [
                 Text(
                   value,
-                  style: theme.textTheme.titleMedium
-                      ?.copyWith(fontWeight: FontWeight.bold),
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: onBrandColor,
+                  ),
                 ),
                 const SizedBox(height: 4),
                 Text(
                   label,
-                  style: theme.textTheme.bodySmall,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: onBrandColor,
+                  ),
                 ),
               ],
             ),

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -13,6 +13,7 @@ import 'package:tapem/features/friends/providers/friends_provider.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/theme/brand_theme_preset.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/core/widgets/brand_action_tile.dart';
 import 'package:tapem/core/widgets/brand_gradient_icon.dart';
 import 'package:tapem/core/widgets/brand_gradient_text.dart';
@@ -388,9 +389,48 @@ class _ProfileScreenState extends State<ProfileScreen> {
     const avatarSize = 44.0;
 
     final theme = Theme.of(context);
+    final brandColor =
+        theme.extension<AppBrandTheme>()?.outline ?? theme.colorScheme.secondary;
+
+    Widget buildBody() {
+      if (prov.isLoading) {
+        return const Center(child: CircularProgressIndicator());
+      }
+      if (prov.error != null) {
+        return Center(child: Text('Fehler: ${prov.error}'));
+      }
+      return Padding(
+        padding: const EdgeInsets.all(AppSpacing.sm),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            BrandGradientText(
+              'Trainingstage',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Expanded(
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () => _openCalendarPopup(userId, prov.trainingDates),
+                child: Calendar(
+                  trainingDates: prov.trainingDates,
+                  showNavigation: false,
+                  year: DateTime.now().year,
+                ),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
 
     return Scaffold(
       appBar: AppBar(
+        foregroundColor: brandColor,
         automaticallyImplyLeading: false,
         leadingWidth: avatarSize + AppSpacing.md * 2,
         leading: Padding(
@@ -477,70 +517,44 @@ class _ProfileScreenState extends State<ProfileScreen> {
             },
           ),
         ],
+        ),
+      body: DefaultTextStyle.merge(
+        style: TextStyle(color: brandColor),
+        child: buildBody(),
       ),
-      body:
-          prov.isLoading
-              ? const Center(child: CircularProgressIndicator())
-              : prov.error != null
-              ? Center(child: Text('Fehler: ${prov.error}'))
-              : Padding(
-                  padding: const EdgeInsets.all(AppSpacing.sm),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      BrandGradientText(
-                        'Trainingstage',
-                        textAlign: TextAlign.center,
-                        style: theme.textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      const SizedBox(height: AppSpacing.sm),
-                      Expanded(
-                        child: GestureDetector(
-                          behavior: HitTestBehavior.opaque,
-                          onTap: () => _openCalendarPopup(userId, prov.trainingDates),
-                          child: Calendar(
-                            trainingDates: prov.trainingDates,
-                            showNavigation: false,
-                            year: DateTime.now().year,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
       bottomNavigationBar: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpacing.sm),
-          child: SizedBox(
-            width: double.infinity,
-            child: BrandActionTile(
-              title: 'Umfragen',
-              centerTitle: true,
-              dense: true,
-              minVerticalPadding: 0,
-              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
-              onTap: () {
-                final gymId = context.read<GymProvider>().currentGymId;
-                final userId = context.read<AuthProvider>().userId ?? '';
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => SurveyVoteScreen(
-                      gymId: gymId,
-                      userId: userId,
-                    ),
-                  ),
-                );
-              },
-              variant: BrandActionTileVariant.outlined,
-              showChevron: false,
-              uiLogEvent: 'PROFILE_CARD_RENDER',
+          child: DefaultTextStyle.merge(
+            style: TextStyle(color: brandColor),
+            child: Padding(
+              padding: const EdgeInsets.all(AppSpacing.sm),
+              child: SizedBox(
+                width: double.infinity,
+                child: BrandActionTile(
+                  title: 'Umfragen',
+                  centerTitle: true,
+                  dense: true,
+                  minVerticalPadding: 0,
+                  padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+                  onTap: () {
+                    final gymId = context.read<GymProvider>().currentGymId;
+                    final userId = context.read<AuthProvider>().userId ?? '';
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => SurveyVoteScreen(
+                          gymId: gymId,
+                          userId: userId,
+                        ),
+                      ),
+                    );
+                  },
+                  variant: BrandActionTileVariant.outlined,
+                  showChevron: false,
+                  uiLogEvent: 'PROFILE_CARD_RENDER',
+                ),
+              ),
             ),
           ),
-        ),
-      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- remove the "Sitzungen im Verlauf" chart from the history screen, add an E1RM KPI, and render history copy in the brand colour
- compute the highest E1RM value inside the history provider to back the new overview metric
- apply the AppBrandTheme text colour across the history, profile, gym, and device screens for consistent typography

## Testing
- not run (flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dce78087fc8320a2d4a4b4e826fa90