### PR TITLE
Fix unmatched parentheses in profile screen scaffold

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -517,44 +517,45 @@ class _ProfileScreenState extends State<ProfileScreen> {
             },
           ),
         ],
-        ),
+      ),
       body: DefaultTextStyle.merge(
         style: TextStyle(color: brandColor),
         child: buildBody(),
       ),
       bottomNavigationBar: SafeArea(
-          child: DefaultTextStyle.merge(
-            style: TextStyle(color: brandColor),
-            child: Padding(
-              padding: const EdgeInsets.all(AppSpacing.sm),
-              child: SizedBox(
-                width: double.infinity,
-                child: BrandActionTile(
-                  title: 'Umfragen',
-                  centerTitle: true,
-                  dense: true,
-                  minVerticalPadding: 0,
-                  padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
-                  onTap: () {
-                    final gymId = context.read<GymProvider>().currentGymId;
-                    final userId = context.read<AuthProvider>().userId ?? '';
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => SurveyVoteScreen(
-                          gymId: gymId,
-                          userId: userId,
-                        ),
+        child: DefaultTextStyle.merge(
+          style: TextStyle(color: brandColor),
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.sm),
+            child: SizedBox(
+              width: double.infinity,
+              child: BrandActionTile(
+                title: 'Umfragen',
+                centerTitle: true,
+                dense: true,
+                minVerticalPadding: 0,
+                padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+                onTap: () {
+                  final gymId = context.read<GymProvider>().currentGymId;
+                  final userId = context.read<AuthProvider>().userId ?? '';
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => SurveyVoteScreen(
+                        gymId: gymId,
+                        userId: userId,
                       ),
-                    );
-                  },
-                  variant: BrandActionTileVariant.outlined,
-                  showChevron: false,
-                  uiLogEvent: 'PROFILE_CARD_RENDER',
-                ),
+                    ),
+                  );
+                },
+                variant: BrandActionTileVariant.outlined,
+                showChevron: false,
+                uiLogEvent: 'PROFILE_CARD_RENDER',
               ),
             ),
           ),
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- fix the closing parenthesis on the profile screen AppBar definition to resolve the syntax error
- realign the bottom navigation SafeArea structure so the widget tree closes correctly

## Testing
- Not run (Flutter tooling is unavailable in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68dcecacbc3c8320a8cc6840428f2d79