### PR TITLE
Add profile statistics overview page

### DIFF
--- a/lib/core/providers/auth_provider.dart
+++ b/lib/core/providers/auth_provider.dart
@@ -63,6 +63,7 @@ class AuthProvider extends ChangeNotifier {
   String? get userId => _user?.id;
   String? get role => _user?.role;
   bool get isAdmin => role == 'admin';
+  DateTime? get createdAt => _user?.createdAt;
 
   /// Opt-out für Leaderboard
   bool? get showInLeaderboard => _user?.showInLeaderboard;

--- a/lib/core/providers/profile_provider.dart
+++ b/lib/core/providers/profile_provider.dart
@@ -1,5 +1,7 @@
 // lib/core/providers/profile_provider.dart
 
+import 'dart:math';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
@@ -12,10 +14,18 @@ class ProfileProvider extends ChangeNotifier {
   bool _isLoading = false;
   String? _error;
   List<String> _trainingDates = [];
+  List<DateTime> _trainingDayDates = [];
+  int _totalTrainingDays = 0;
+  double _avgTrainingDaysPerWeek = 0;
+  String? _favoriteExerciseName;
 
   bool get isLoading => _isLoading;
   String? get error => _error;
   List<String> get trainingDates => List.unmodifiable(_trainingDates);
+  List<DateTime> get trainingDayDates => List.unmodifiable(_trainingDayDates);
+  int get totalTrainingDays => _totalTrainingDays;
+  double get averageTrainingDaysPerWeek => _avgTrainingDaysPerWeek;
+  String? get favoriteExerciseName => _favoriteExerciseName;
 
   /// Lädt alle Trainingstage (YYYY-MM-DD) des aktuellen Users.
   Future<void> loadTrainingDates(BuildContext context) async {
@@ -36,15 +46,52 @@ class ProfileProvider extends ChangeNotifier {
           .where('userId', isEqualTo: userId)
           .get();
 
-      final datesSet = <String>{};
+      final dateSet = <DateTime>{};
+      final sessionAggregates = <String, _ExerciseAggregate>{};
+
       for (final doc in snapshot.docs) {
-        final dt = (doc['timestamp'] as Timestamp).toDate();
-        final key =
-            '${dt.year}-${dt.month.toString().padLeft(2, '0')}-${dt.day.toString().padLeft(2, '0')}';
-        datesSet.add(key);
+        final data = doc.data();
+        final timestamp = (data['timestamp'] as Timestamp).toDate();
+        final day = DateTime(timestamp.year, timestamp.month, timestamp.day);
+        dateSet.add(day);
+
+        final sessionId = (data['sessionId'] as String?)?.trim() ?? '';
+        if (sessionId.isEmpty) {
+          continue;
+        }
+
+        final deviceRef = doc.reference.parent.parent;
+        final deviceId = deviceRef?.id ?? '';
+        final gymRef = deviceRef?.parent.parent;
+        final gymId = gymRef?.id ?? '';
+        if (deviceId.isEmpty || gymId.isEmpty) {
+          continue;
+        }
+
+        final exerciseId = (data['exerciseId'] as String?)?.trim() ?? '';
+        final key = '$gymId|$deviceId|$exerciseId';
+        final aggregate = sessionAggregates.putIfAbsent(
+          key,
+          () => _ExerciseAggregate(
+            gymId: gymId,
+            deviceId: deviceId,
+            exerciseId: exerciseId,
+          ),
+        );
+        aggregate.sessionIds.add(sessionId);
       }
 
-      _trainingDates = datesSet.toList()..sort();
+      _trainingDayDates = dateSet.toList()
+        ..sort((a, b) => a.compareTo(b));
+      _trainingDates = _trainingDayDates
+          .map((dt) =>
+              '${dt.year}-${dt.month.toString().padLeft(2, '0')}-${dt.day.toString().padLeft(2, '0')}')
+          .toList();
+      _totalTrainingDays = _trainingDates.length;
+      _avgTrainingDaysPerWeek =
+          _calculateAverageTrainingDaysPerWeek(authProv.createdAt);
+      _favoriteExerciseName =
+          await _resolveFavoriteExerciseName(sessionAggregates.values);
     } catch (e, st) {
       _error = 'Fehler beim Laden der Trainingstage: ${e.toString()}';
       if (e is FirebaseException && e.code == 'failed-precondition') {
@@ -59,4 +106,105 @@ class ProfileProvider extends ChangeNotifier {
       notifyListeners();
     }
   }
+
+  double _calculateAverageTrainingDaysPerWeek(DateTime? createdAt) {
+    if (_trainingDayDates.isEmpty) {
+      return 0;
+    }
+
+    final normalizedCreatedAt = createdAt == null
+        ? _trainingDayDates.first
+        : DateTime(createdAt.year, createdAt.month, createdAt.day);
+    final firstMonday = _firstMondayAfter(normalizedCreatedAt);
+    final filteredDays =
+        _trainingDayDates.where((day) => !day.isBefore(firstMonday)).toList();
+    if (filteredDays.isEmpty) {
+      return 0;
+    }
+
+    final now = DateTime.now();
+    final lastRelevantDay = filteredDays.last.isAfter(now)
+        ? filteredDays.last
+        : now;
+    final spanDays = max(1, lastRelevantDay.difference(firstMonday).inDays + 1);
+    final weeks = spanDays / 7.0;
+    if (weeks <= 0) {
+      return filteredDays.length.toDouble();
+    }
+    return filteredDays.length / weeks;
+  }
+
+  DateTime _firstMondayAfter(DateTime date) {
+    final normalized = DateTime(date.year, date.month, date.day);
+    final offset = (DateTime.monday - normalized.weekday + 7) % 7;
+    final daysToAdd = offset == 0 ? 7 : offset;
+    return normalized.add(Duration(days: daysToAdd));
+  }
+
+  Future<String?> _resolveFavoriteExerciseName(
+    Iterable<_ExerciseAggregate> aggregates,
+  ) async {
+    if (aggregates.isEmpty) {
+      return null;
+    }
+
+    _ExerciseAggregate? best;
+    for (final aggregate in aggregates) {
+      if (best == null ||
+          aggregate.sessionIds.length > best.sessionIds.length) {
+        best = aggregate;
+      }
+    }
+
+    if (best == null || best.sessionIds.isEmpty) {
+      return null;
+    }
+
+    try {
+      final deviceRef = FirebaseFirestore.instance
+          .collection('gyms')
+          .doc(best.gymId)
+          .collection('devices')
+          .doc(best.deviceId);
+      final deviceSnap = await deviceRef.get();
+      String deviceName = best.deviceId;
+      if (deviceSnap.exists) {
+        final data = deviceSnap.data();
+        final name = data?['name'] as String?;
+        if (name != null && name.trim().isNotEmpty) {
+          deviceName = name.trim();
+        }
+      }
+
+      final exerciseId = best.exerciseId;
+      if (exerciseId != null && exerciseId.isNotEmpty) {
+        try {
+          final exerciseSnap =
+              await deviceRef.collection('exercises').doc(exerciseId).get();
+          final exerciseName = exerciseSnap.data()?['name'] as String?;
+          if (exerciseName != null && exerciseName.trim().isNotEmpty) {
+            return exerciseName.trim();
+          }
+        } catch (_) {}
+      }
+
+      return deviceName;
+    } catch (e, st) {
+      elogError('PROFILE_FAVORITE_EXERCISE', e.toString(), st);
+      return null;
+    }
+  }
+}
+
+class _ExerciseAggregate {
+  _ExerciseAggregate({
+    required this.gymId,
+    required this.deviceId,
+    required this.exerciseId,
+  });
+
+  final String gymId;
+  final String deviceId;
+  final String? exerciseId;
+  final Set<String> sessionIds = <String>{};
 }

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -29,6 +29,7 @@ import '../../../survey/presentation/screens/survey_vote_screen.dart';
 import 'package:tapem/features/friends/presentation/screens/friends_home_screen.dart';
 import '../widgets/change_username_sheet.dart';
 import 'package:tapem/app_router.dart';
+import 'profile_stats_screen.dart';
 
 const bool enableFriends = true;
 
@@ -527,31 +528,60 @@ class _ProfileScreenState extends State<ProfileScreen> {
           style: TextStyle(color: brandColor),
           child: Padding(
             padding: const EdgeInsets.all(AppSpacing.sm),
-            child: SizedBox(
-              width: double.infinity,
-              child: BrandActionTile(
-                title: 'Umfragen',
-                centerTitle: true,
-                dense: true,
-                minVerticalPadding: 0,
-                padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
-                onTap: () {
-                  final gymId = context.read<GymProvider>().currentGymId;
-                  final userId = context.read<AuthProvider>().userId ?? '';
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => SurveyVoteScreen(
-                        gymId: gymId,
-                        userId: userId,
-                      ),
-                    ),
-                  );
-                },
-                variant: BrandActionTileVariant.outlined,
-                showChevron: false,
-                uiLogEvent: 'PROFILE_CARD_RENDER',
-              ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SizedBox(
+                  width: double.infinity,
+                  child: BrandActionTile(
+                    title: loc.profileStatsButtonLabel,
+                    centerTitle: true,
+                    dense: true,
+                    minVerticalPadding: 0,
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => const ProfileStatsScreen(),
+                        ),
+                      );
+                    },
+                    variant: BrandActionTileVariant.outlined,
+                    showChevron: false,
+                    uiLogEvent: 'PROFILE_STATS_CARD_RENDER',
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.xs),
+                SizedBox(
+                  width: double.infinity,
+                  child: BrandActionTile(
+                    title: 'Umfragen',
+                    centerTitle: true,
+                    dense: true,
+                    minVerticalPadding: 0,
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+                    onTap: () {
+                      final gymId = context.read<GymProvider>().currentGymId;
+                      final userId = context.read<AuthProvider>().userId ?? '';
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => SurveyVoteScreen(
+                            gymId: gymId,
+                            userId: userId,
+                          ),
+                        ),
+                      );
+                    },
+                    variant: BrandActionTileVariant.outlined,
+                    showChevron: false,
+                    uiLogEvent: 'PROFILE_CARD_RENDER',
+                  ),
+                ),
+              ],
             ),
           ),
         ),

--- a/lib/features/profile/presentation/screens/profile_stats_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_stats_screen.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/profile_provider.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/core/widgets/brand_gradient_card.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
+class ProfileStatsScreen extends StatefulWidget {
+  const ProfileStatsScreen({super.key});
+
+  @override
+  State<ProfileStatsScreen> createState() => _ProfileStatsScreenState();
+}
+
+class _ProfileStatsScreenState extends State<ProfileStatsScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final prov = context.read<ProfileProvider>();
+      if (!prov.isLoading && prov.trainingDates.isEmpty) {
+        prov.loadTrainingDates(context);
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final prov = context.watch<ProfileProvider>();
+    final loc = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final brandColor =
+        theme.extension<AppBrandTheme>()?.outline ?? theme.colorScheme.secondary;
+    final numberFormat = NumberFormat(
+      '0.0',
+      Localizations.localeOf(context).toString(),
+    );
+
+    final totalTrainingDays = prov.totalTrainingDays;
+    final avgTrainingDays = prov.averageTrainingDaysPerWeek;
+    final favoriteExercise =
+        prov.favoriteExerciseName ?? loc.profileStatsFavoriteExerciseFallback;
+
+    String formatAverage(double value) {
+      if (value == 0) {
+        return '0';
+      }
+      return numberFormat.format(value);
+    }
+
+    Widget buildContent() {
+      if (prov.isLoading && totalTrainingDays == 0) {
+        return const Center(child: CircularProgressIndicator());
+      }
+
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Text(
+            loc.historyOverviewTitle,
+            style: theme.textTheme.titleLarge?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          Wrap(
+            alignment: WrapAlignment.center,
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              _kpiRing(
+                context,
+                loc.profileStatsTotalTrainingDays,
+                totalTrainingDays.toString(),
+              ),
+              _kpiRing(
+                context,
+                loc.profileStatsAverageTrainingDaysPerWeek,
+                formatAverage(avgTrainingDays),
+              ),
+              _kpiRing(
+                context,
+                loc.profileStatsFavoriteExercise,
+                favoriteExercise,
+              ),
+            ],
+          ),
+        ],
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(loc.profileStatsTitle),
+        centerTitle: true,
+        foregroundColor: brandColor,
+      ),
+      body: DefaultTextStyle.merge(
+        style: TextStyle(color: brandColor),
+        child: SafeArea(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: buildContent(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _kpiRing(BuildContext context, String label, String value) {
+    final theme = Theme.of(context);
+    final brand = theme.extension<AppBrandTheme>();
+    final onBrandColor = brand?.onBrand ?? theme.colorScheme.onPrimary;
+    return Semantics(
+      label: '$label: $value',
+      child: SizedBox(
+        width: 112,
+        height: 112,
+        child: BrandGradientCard(
+          borderRadius: BorderRadius.circular(56),
+          padding: EdgeInsets.zero,
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  value,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: onBrandColor,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  label,
+                  textAlign: TextAlign.center,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: onBrandColor,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -291,6 +291,36 @@
     "description": "Überschrift für den Kalender auf der Profilseite"
   },
 
+  "profileStatsButtonLabel": "Statistiken",
+  "@profileStatsButtonLabel": {
+    "description": "Button auf der Profilseite für die Statistik-Ansicht"
+  },
+
+  "profileStatsTitle": "Statistiken",
+  "@profileStatsTitle": {
+    "description": "Titel der Statistikseite im Profil"
+  },
+
+  "profileStatsTotalTrainingDays": "Trainingstage insgesamt",
+  "@profileStatsTotalTrainingDays": {
+    "description": "KPI-Bezeichnung für die Gesamtzahl der Trainingstage"
+  },
+
+  "profileStatsAverageTrainingDaysPerWeek": "Durchschnittliche Trainingstage/Woche",
+  "@profileStatsAverageTrainingDaysPerWeek": {
+    "description": "KPI-Bezeichnung für durchschnittliche Trainingstage je Woche"
+  },
+
+  "profileStatsFavoriteExercise": "Lieblingsübung",
+  "@profileStatsFavoriteExercise": {
+    "description": "KPI-Bezeichnung für die Lieblingsübung"
+  },
+
+  "profileStatsFavoriteExerciseFallback": "Noch keine Sessions",
+  "@profileStatsFavoriteExerciseFallback": {
+    "description": "Fallback-Text, wenn keine Lieblingsübung ermittelt werden kann"
+  },
+
   "repsRequired": "Wdh?",
   "@repsRequired": {
     "description": "Validierungsmeldung, wenn Wiederholungen fehlen"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -291,6 +291,36 @@
     "description": "Heading for the calendar on profile screen"
   },
 
+  "profileStatsButtonLabel": "Statistics",
+  "@profileStatsButtonLabel": {
+    "description": "Button label on profile screen to open the statistics page"
+  },
+
+  "profileStatsTitle": "Statistics",
+  "@profileStatsTitle": {
+    "description": "Title of the profile statistics page"
+  },
+
+  "profileStatsTotalTrainingDays": "Total training days",
+  "@profileStatsTotalTrainingDays": {
+    "description": "KPI label for total number of training days"
+  },
+
+  "profileStatsAverageTrainingDaysPerWeek": "Avg. training days per week",
+  "@profileStatsAverageTrainingDaysPerWeek": {
+    "description": "KPI label for average training days per week"
+  },
+
+  "profileStatsFavoriteExercise": "Favourite exercise",
+  "@profileStatsFavoriteExercise": {
+    "description": "KPI label for favourite exercise"
+  },
+
+  "profileStatsFavoriteExerciseFallback": "No sessions yet",
+  "@profileStatsFavoriteExerciseFallback": {
+    "description": "Fallback text when there is no favourite exercise"
+  },
+
   "repsRequired": "reps?",
   "@repsRequired": {
     "description": "Validation when reps are missing"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -503,6 +503,42 @@ abstract class AppLocalizations {
   /// **'Your training days of the year'**
   String get profileTrainingDaysTitle;
 
+  /// No description provided for @profileStatsButtonLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Statistics'**
+  String get profileStatsButtonLabel;
+
+  /// No description provided for @profileStatsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Statistics'**
+  String get profileStatsTitle;
+
+  /// No description provided for @profileStatsTotalTrainingDays.
+  ///
+  /// In en, this message translates to:
+  /// **'Total training days'**
+  String get profileStatsTotalTrainingDays;
+
+  /// No description provided for @profileStatsAverageTrainingDaysPerWeek.
+  ///
+  /// In en, this message translates to:
+  /// **'Avg. training days per week'**
+  String get profileStatsAverageTrainingDaysPerWeek;
+
+  /// No description provided for @profileStatsFavoriteExercise.
+  ///
+  /// In en, this message translates to:
+  /// **'Favourite exercise'**
+  String get profileStatsFavoriteExercise;
+
+  /// No description provided for @profileStatsFavoriteExerciseFallback.
+  ///
+  /// In en, this message translates to:
+  /// **'No sessions yet'**
+  String get profileStatsFavoriteExerciseFallback;
+
   /// Validation when reps are missing
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -231,6 +231,25 @@ class AppLocalizationsDe extends AppLocalizations {
   String get profileTrainingDaysTitle => 'Deine Trainingstage im Jahr';
 
   @override
+  String get profileStatsButtonLabel => 'Statistiken';
+
+  @override
+  String get profileStatsTitle => 'Statistiken';
+
+  @override
+  String get profileStatsTotalTrainingDays => 'Trainingstage insgesamt';
+
+  @override
+  String get profileStatsAverageTrainingDaysPerWeek =>
+      'Durchschnittliche Trainingstage/Woche';
+
+  @override
+  String get profileStatsFavoriteExercise => 'Lieblingsübung';
+
+  @override
+  String get profileStatsFavoriteExerciseFallback => 'Noch keine Sessions';
+
+  @override
   String get repsRequired => 'Wdh?';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -231,6 +231,25 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileTrainingDaysTitle => 'Your training days of the year';
 
   @override
+  String get profileStatsButtonLabel => 'Statistics';
+
+  @override
+  String get profileStatsTitle => 'Statistics';
+
+  @override
+  String get profileStatsTotalTrainingDays => 'Total training days';
+
+  @override
+  String get profileStatsAverageTrainingDaysPerWeek =>
+      'Avg. training days per week';
+
+  @override
+  String get profileStatsFavoriteExercise => 'Favourite exercise';
+
+  @override
+  String get profileStatsFavoriteExerciseFallback => 'No sessions yet';
+
+  @override
   String get repsRequired => 'reps?';
 
   @override

--- a/test/features/profile/profile_screen_test.dart
+++ b/test/features/profile/profile_screen_test.dart
@@ -206,6 +206,7 @@ void main() {
 
     expect(find.text('Admin'), findsNothing);
     expect(find.text('Trainingstage'), findsOneWidget);
+    expect(find.text('Statistiken'), findsOneWidget);
     expect(find.byTooltip('Profilbild ändern'), findsOneWidget);
   });
 


### PR DESCRIPTION
## Summary
- add a profile statistics screen that mirrors the history overview layout and highlights total training days, average weekly days, and the favourite exercise
- extend the profile provider to derive the necessary metrics from training logs and expose them to the new UI
- wire the statistics entry point into the profile screen, add localizations, and update the existing test coverage

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd21b1c92c83209aae959ddab171f1