### PR TITLE
Add powerlifting stats overview

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -35,6 +35,7 @@ import 'package:tapem/features/admin/presentation/screens/user_symbols_screen.da
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/core/config/feature_flags.dart';
+import 'package:tapem/features/profile/presentation/screens/powerlifting_screen.dart';
 import 'main.dart';
 
 class AppRouter {
@@ -64,6 +65,7 @@ class AppRouter {
   static const manageChallenges = '/manage_challenges';
   static const adminSymbols = '/admin_symbols';
   static const userSymbols = '/user_symbols';
+  static const powerlifting = '/powerlifting';
   static const feedbackOverview = '/feedback_overview';
   static const surveyOverview = '/survey_overview';
   static const surveyVote = '/survey_vote';
@@ -248,6 +250,9 @@ class AppRouter {
 
       case creatine:
         return MaterialPageRoute(builder: (_) => const CreatineScreen());
+
+      case powerlifting:
+        return MaterialPageRoute(builder: (_) => const PowerliftingScreen());
 
       default:
         return MaterialPageRoute(

--- a/lib/features/profile/domain/models/powerlifting_assignment.dart
+++ b/lib/features/profile/domain/models/powerlifting_assignment.dart
@@ -1,0 +1,80 @@
+// lib/features/profile/domain/models/powerlifting_assignment.dart
+
+import 'powerlifting_discipline.dart';
+
+/// Represents a user-configured source (device/exercise) that contributes to a
+/// specific powerlifting discipline.
+class PowerliftingAssignment {
+  PowerliftingAssignment({
+    required this.id,
+    required this.discipline,
+    required this.gymId,
+    required this.deviceId,
+    required this.exerciseId,
+    required this.createdAt,
+  });
+
+  final String id;
+  final PowerliftingDiscipline discipline;
+  final String gymId;
+  final String deviceId;
+  final String exerciseId;
+  final DateTime createdAt;
+
+  String get sourceKey => '$gymId|$deviceId|$exerciseId';
+
+  Map<String, dynamic> toMap() => {
+        'discipline': discipline.id,
+        'gymId': gymId,
+        'deviceId': deviceId,
+        'exerciseId': exerciseId,
+        'createdAt': createdAt.toIso8601String(),
+      };
+
+  factory PowerliftingAssignment.fromMap(
+    String id,
+    Map<String, dynamic> data,
+  ) {
+    final discipline =
+        PowerliftingDisciplineX.fromId(data['discipline'] as String?) ??
+            PowerliftingDiscipline.benchPress;
+    final createdRaw = data['createdAt'];
+    DateTime createdAt;
+    if (createdRaw is DateTime) {
+      createdAt = createdRaw;
+    } else if (createdRaw is String) {
+      createdAt = DateTime.tryParse(createdRaw) ??
+          DateTime.fromMillisecondsSinceEpoch(0);
+    } else if (createdRaw is int) {
+      createdAt = DateTime.fromMillisecondsSinceEpoch(createdRaw);
+    } else {
+      createdAt = DateTime.fromMillisecondsSinceEpoch(0);
+    }
+    return PowerliftingAssignment(
+      id: id,
+      discipline: discipline,
+      gymId: (data['gymId'] as String?)?.trim() ?? '',
+      deviceId: (data['deviceId'] as String?)?.trim() ?? '',
+      exerciseId: (data['exerciseId'] as String?)?.trim() ?? '',
+      createdAt: createdAt,
+    );
+  }
+
+  PowerliftingAssignment copyWith({
+    String? id,
+    PowerliftingDiscipline? discipline,
+    String? gymId,
+    String? deviceId,
+    String? exerciseId,
+    DateTime? createdAt,
+  }) {
+    return PowerliftingAssignment(
+      id: id ?? this.id,
+      discipline: discipline ?? this.discipline,
+      gymId: gymId ?? this.gymId,
+      deviceId: deviceId ?? this.deviceId,
+      exerciseId: exerciseId ?? this.exerciseId,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+}

--- a/lib/features/profile/domain/models/powerlifting_discipline.dart
+++ b/lib/features/profile/domain/models/powerlifting_discipline.dart
@@ -1,0 +1,47 @@
+// lib/features/profile/domain/models/powerlifting_discipline.dart
+
+/// Represents the three core powerlifting disciplines supported by the app.
+enum PowerliftingDiscipline {
+  benchPress,
+  squat,
+  deadlift,
+}
+
+extension PowerliftingDisciplineX on PowerliftingDiscipline {
+  /// Stable identifier used for Firestore persistence.
+  String get id {
+    switch (this) {
+      case PowerliftingDiscipline.benchPress:
+        return 'bench_press';
+      case PowerliftingDiscipline.squat:
+        return 'squat';
+      case PowerliftingDiscipline.deadlift:
+        return 'deadlift';
+    }
+  }
+
+  /// Human readable ordering for UI presentation.
+  int get sortOrder {
+    switch (this) {
+      case PowerliftingDiscipline.benchPress:
+        return 0;
+      case PowerliftingDiscipline.squat:
+        return 1;
+      case PowerliftingDiscipline.deadlift:
+        return 2;
+    }
+  }
+
+  static PowerliftingDiscipline? fromId(String? value) {
+    switch (value) {
+      case 'bench_press':
+        return PowerliftingDiscipline.benchPress;
+      case 'squat':
+        return PowerliftingDiscipline.squat;
+      case 'deadlift':
+        return PowerliftingDiscipline.deadlift;
+      default:
+        return null;
+    }
+  }
+}

--- a/lib/features/profile/domain/models/powerlifting_record.dart
+++ b/lib/features/profile/domain/models/powerlifting_record.dart
@@ -1,0 +1,23 @@
+// lib/features/profile/domain/models/powerlifting_record.dart
+
+import 'powerlifting_discipline.dart';
+
+class PowerliftingRecord {
+  const PowerliftingRecord({
+    required this.id,
+    required this.discipline,
+    required this.weightKg,
+    required this.reps,
+    required this.performedAt,
+    required this.deviceName,
+    this.exerciseName,
+  });
+
+  final String id;
+  final PowerliftingDiscipline discipline;
+  final double weightKg;
+  final int reps;
+  final DateTime performedAt;
+  final String deviceName;
+  final String? exerciseName;
+}

--- a/lib/features/profile/presentation/providers/powerlifting_provider.dart
+++ b/lib/features/profile/presentation/providers/powerlifting_provider.dart
@@ -1,0 +1,421 @@
+// lib/features/profile/presentation/providers/powerlifting_provider.dart
+
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:tapem/features/device/domain/models/device.dart';
+import 'package:tapem/features/device/domain/models/exercise.dart';
+import 'package:tapem/features/device/domain/usecases/get_devices_for_gym.dart';
+import 'package:tapem/features/device/domain/usecases/get_exercises_for_device.dart';
+import 'package:tapem/features/profile/domain/models/powerlifting_assignment.dart';
+import 'package:tapem/features/profile/domain/models/powerlifting_discipline.dart';
+import 'package:tapem/features/profile/domain/models/powerlifting_record.dart';
+import 'package:tapem/services/membership_service.dart';
+
+class PowerliftingProvider extends ChangeNotifier {
+  PowerliftingProvider({
+    required FirebaseFirestore firestore,
+    required GetDevicesForGym getDevicesForGym,
+    required GetExercisesForDevice getExercisesForDevice,
+    required MembershipService membership,
+  })  : _firestore = firestore,
+        _getDevicesForGym = getDevicesForGym,
+        _getExercisesForDevice = getExercisesForDevice,
+        _membership = membership;
+
+  final FirebaseFirestore _firestore;
+  final GetDevicesForGym _getDevicesForGym;
+  final GetExercisesForDevice _getExercisesForDevice;
+  final MembershipService _membership;
+
+  static const _assignmentCollection = 'powerlifting_sources';
+  static const _logsLimitPerSource = 25;
+
+  String? _userId;
+  String? _activeGymId;
+
+  bool _isLoading = false;
+  bool _isSaving = false;
+  String? _error;
+
+  final Map<PowerliftingDiscipline, List<PowerliftingAssignment>> _assignments = {
+    for (final d in PowerliftingDiscipline.values) d: <PowerliftingAssignment>[],
+  };
+
+  final Map<PowerliftingDiscipline, List<PowerliftingRecord>> _records = {
+    for (final d in PowerliftingDiscipline.values) d: <PowerliftingRecord>[],
+  };
+
+  final Map<String, Device> _deviceCache = <String, Device>{};
+  final Map<String, List<Exercise>> _exerciseCache = <String, List<Exercise>>{};
+  final Set<String> _loadingExercises = <String>{};
+
+  bool get isLoading => _isLoading;
+  bool get isSaving => _isSaving;
+  String? get error => _error;
+  String? get activeGymId => _activeGymId;
+  bool get hasAssignments =>
+      _assignments.values.any((entries) => entries.isNotEmpty);
+
+  List<PowerliftingAssignment> assignmentsFor(PowerliftingDiscipline discipline) =>
+      List.unmodifiable(_assignments[discipline]!);
+
+  List<PowerliftingRecord> recordsFor(PowerliftingDiscipline discipline) =>
+      List.unmodifiable(_records[discipline]!);
+
+  Future<void> updateContext({
+    required String? userId,
+    required String? gymId,
+  }) async {
+    final normalizedGymId = (gymId ?? '').trim();
+    if (_userId == userId && _activeGymId == normalizedGymId) {
+      return;
+    }
+
+    _userId = userId;
+    _activeGymId = normalizedGymId.isEmpty ? null : normalizedGymId;
+
+    if (_userId == null || _userId!.isEmpty || _activeGymId == null) {
+      _clearState();
+      return;
+    }
+
+    await loadAssignments();
+  }
+
+  Future<void> loadAssignments() async {
+    final uid = _userId;
+    final gymId = _activeGymId;
+    if (uid == null || uid.isEmpty || gymId == null || gymId.isEmpty) {
+      _clearState();
+      return;
+    }
+
+    _isLoading = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      await _membership.ensureMembership(gymId, uid);
+      final snapshot = await _firestore
+          .collection('users')
+          .doc(uid)
+          .collection(_assignmentCollection)
+          .get();
+
+      for (final discipline in PowerliftingDiscipline.values) {
+        _assignments[discipline] = <PowerliftingAssignment>[];
+        _records[discipline] = <PowerliftingRecord>[];
+      }
+
+      for (final doc in snapshot.docs) {
+        final data = doc.data();
+        final createdAt = (data['createdAt'] as Timestamp?)?.toDate();
+        final assignment = PowerliftingAssignment.fromMap(doc.id, {
+          ...data,
+          'createdAt': createdAt ?? DateTime.fromMillisecondsSinceEpoch(0),
+        });
+        if (assignment.gymId.isEmpty || assignment.deviceId.isEmpty) {
+          continue;
+        }
+        _assignments[assignment.discipline]!.add(assignment);
+      }
+
+      for (final entries in _assignments.values) {
+        entries.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+      }
+
+      await _loadRecordsForAllDisciplines();
+    } catch (e) {
+      _error = e.toString();
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> refresh() async {
+    if (_userId == null || _activeGymId == null) return;
+    await loadAssignments();
+  }
+
+  Future<bool> addAssignment({
+    required PowerliftingDiscipline discipline,
+    required String gymId,
+    required String deviceId,
+    required String exerciseId,
+  }) async {
+    final uid = _userId;
+    if (uid == null || uid.isEmpty) {
+      _error = 'USER_MISSING';
+      notifyListeners();
+      return false;
+    }
+
+    final normalizedGymId = gymId.trim();
+    final normalizedDeviceId = deviceId.trim();
+    final normalizedExerciseId = exerciseId.trim();
+
+    if (normalizedGymId.isEmpty ||
+        normalizedDeviceId.isEmpty ||
+        normalizedExerciseId.isEmpty) {
+      return false;
+    }
+
+    final existing = _assignments[discipline]!.any(
+      (a) =>
+          a.gymId == normalizedGymId &&
+          a.deviceId == normalizedDeviceId &&
+          a.exerciseId == normalizedExerciseId,
+    );
+    if (existing) {
+      _error = 'POWERLIFTING_DUPLICATE';
+      notifyListeners();
+      return false;
+    }
+
+    final id =
+        '${discipline.id}|$normalizedGymId|$normalizedDeviceId|$normalizedExerciseId';
+
+    final assignment = PowerliftingAssignment(
+      id: id,
+      discipline: discipline,
+      gymId: normalizedGymId,
+      deviceId: normalizedDeviceId,
+      exerciseId: normalizedExerciseId,
+      createdAt: DateTime.now(),
+    );
+
+    _isSaving = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      await _membership.ensureMembership(normalizedGymId, uid);
+      await _firestore
+          .collection('users')
+          .doc(uid)
+          .collection(_assignmentCollection)
+          .doc(id)
+          .set({
+        'discipline': assignment.discipline.id,
+        'gymId': assignment.gymId,
+        'deviceId': assignment.deviceId,
+        'exerciseId': assignment.exerciseId,
+        'createdAt': Timestamp.fromDate(assignment.createdAt),
+      }, SetOptions(merge: true));
+
+      _assignments[discipline] = <PowerliftingAssignment>[...
+        _assignments[discipline]!,
+        assignment,
+      ]
+        ..sort((a, b) => a.createdAt.compareTo(b.createdAt));
+
+      await _loadRecordsForDiscipline(discipline);
+      return true;
+    } catch (e) {
+      _error = e.toString();
+      return false;
+    } finally {
+      _isSaving = false;
+      notifyListeners();
+    }
+  }
+
+  Future<List<Device>> loadDevicesForActiveGym() async {
+    final gymId = _activeGymId;
+    final uid = _userId;
+    if (gymId == null || gymId.isEmpty || uid == null || uid.isEmpty) {
+      return <Device>[];
+    }
+
+    await _membership.ensureMembership(gymId, uid);
+    final devices = await _getDevicesForGym.execute(gymId);
+    for (final device in devices) {
+      _deviceCache['$gymId|${device.uid}'] = device;
+    }
+    devices.sort((a, b) => a.name.compareTo(b.name));
+    return devices;
+  }
+
+  Future<List<Exercise>> loadExercisesForDevice(String deviceId) async {
+    final gymId = _activeGymId;
+    final uid = _userId;
+    if (gymId == null || gymId.isEmpty || uid == null || uid.isEmpty) {
+      return <Exercise>[];
+    }
+
+    final cacheKey = '$gymId|$deviceId';
+    if (_exerciseCache.containsKey(cacheKey) &&
+        _exerciseCache[cacheKey]!.isNotEmpty) {
+      return _exerciseCache[cacheKey]!;
+    }
+
+    if (_loadingExercises.contains(cacheKey)) {
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      return loadExercisesForDevice(deviceId);
+    }
+
+    _loadingExercises.add(cacheKey);
+    try {
+      await _membership.ensureMembership(gymId, uid);
+      final exercises =
+          await _getExercisesForDevice.execute(gymId, deviceId, uid);
+      exercises.sort((a, b) => a.name.compareTo(b.name));
+      _exerciseCache[cacheKey] = exercises;
+      return exercises;
+    } finally {
+      _loadingExercises.remove(cacheKey);
+    }
+  }
+
+  void _clearState() {
+    for (final discipline in PowerliftingDiscipline.values) {
+      _assignments[discipline] = <PowerliftingAssignment>[];
+      _records[discipline] = <PowerliftingRecord>[];
+    }
+    _deviceCache.clear();
+    _exerciseCache.clear();
+    _error = null;
+    _isLoading = false;
+    _isSaving = false;
+    notifyListeners();
+  }
+
+  Future<void> _loadRecordsForAllDisciplines() async {
+    for (final discipline in PowerliftingDiscipline.values) {
+      await _loadRecordsForDiscipline(discipline);
+    }
+  }
+
+  Future<void> _loadRecordsForDiscipline(
+    PowerliftingDiscipline discipline,
+  ) async {
+    final entries = _assignments[discipline]!;
+    if (entries.isEmpty) {
+      _records[discipline] = <PowerliftingRecord>[];
+      return;
+    }
+
+    final futures = entries.map(_fetchRecordsForAssignment);
+    final results = await Future.wait(futures);
+    final combined = results.expand((element) => element).toList();
+    combined.sort((a, b) {
+      final weightCompare = b.weightKg.compareTo(a.weightKg);
+      if (weightCompare != 0) return weightCompare;
+      return b.performedAt.compareTo(a.performedAt);
+    });
+    _records[discipline] = combined;
+  }
+
+  Future<List<PowerliftingRecord>> _fetchRecordsForAssignment(
+    PowerliftingAssignment assignment,
+  ) async {
+    final uid = _userId;
+    if (uid == null || uid.isEmpty) {
+      return <PowerliftingRecord>[];
+    }
+
+    final labels = await _resolveLabels(
+      assignment.gymId,
+      assignment.deviceId,
+      assignment.exerciseId,
+    );
+
+    final logsCollection = _firestore
+        .collection('gyms')
+        .doc(assignment.gymId)
+        .collection('devices')
+        .doc(assignment.deviceId)
+        .collection('logs');
+
+    Query<Map<String, dynamic>> query = logsCollection
+        .where('userId', isEqualTo: uid)
+        .where('exerciseId', isEqualTo: assignment.exerciseId);
+
+    List<QueryDocumentSnapshot<Map<String, dynamic>>> docs;
+    try {
+      query = query
+          .orderBy('weight', descending: true)
+          .orderBy('timestamp', descending: true)
+          .limit(_logsLimitPerSource);
+      final snapshot = await query.get();
+      docs = snapshot.docs;
+    } on FirebaseException {
+      final snapshot = await logsCollection
+          .where('userId', isEqualTo: uid)
+          .where('exerciseId', isEqualTo: assignment.exerciseId)
+          .orderBy('timestamp', descending: true)
+          .limit(_logsLimitPerSource)
+          .get();
+      docs = snapshot.docs;
+    }
+
+    final records = <PowerliftingRecord>[];
+    for (final doc in docs) {
+      final data = doc.data();
+      final weight = (data['weight'] as num?)?.toDouble() ?? 0;
+      final reps = (data['reps'] as num?)?.toInt() ?? 0;
+      final timestamp = (data['timestamp'] as Timestamp?)?.toDate() ??
+          DateTime.fromMillisecondsSinceEpoch(0);
+
+      records.add(
+        PowerliftingRecord(
+          id: doc.id,
+          discipline: assignment.discipline,
+          weightKg: weight,
+          reps: reps,
+          performedAt: timestamp,
+          deviceName: labels.deviceName,
+          exerciseName: labels.exerciseName,
+        ),
+      );
+    }
+    return records;
+  }
+
+  Future<_PowerliftingLabels> _resolveLabels(
+    String gymId,
+    String deviceId,
+    String exerciseId,
+  ) async {
+    final deviceKey = '$gymId|$deviceId';
+    Device? device = _deviceCache[deviceKey];
+    device ??= await _loadDevice(gymId, deviceId);
+
+    var deviceName = device?.name ?? deviceId;
+    String? exerciseName;
+
+    if ((device?.isMulti ?? false) || exerciseId != deviceId) {
+      final exercises = await loadExercisesForDevice(deviceId);
+      exerciseName = exercises
+          .firstWhere(
+            (element) => element.id == exerciseId,
+            orElse: () => Exercise(
+              id: exerciseId,
+              name: exerciseId,
+              userId: _userId ?? '',
+            ),
+          )
+          .name;
+    }
+
+    return _PowerliftingLabels(deviceName: deviceName, exerciseName: exerciseName);
+  }
+
+  Future<Device?> _loadDevice(String gymId, String deviceId) async {
+    final devices = await _getDevicesForGym.execute(gymId);
+    for (final device in devices) {
+      _deviceCache['$gymId|${device.uid}'] = device;
+    }
+    return _deviceCache['$gymId|$deviceId'];
+  }
+}
+
+class _PowerliftingLabels {
+  _PowerliftingLabels({required this.deviceName, this.exerciseName});
+
+  final String deviceName;
+  final String? exerciseName;
+}

--- a/lib/features/profile/presentation/screens/powerlifting_screen.dart
+++ b/lib/features/profile/presentation/screens/powerlifting_screen.dart
@@ -1,0 +1,463 @@
+// lib/features/profile/presentation/screens/powerlifting_screen.dart
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/features/device/domain/models/device.dart';
+import 'package:tapem/features/device/domain/models/exercise.dart';
+import 'package:tapem/features/profile/domain/models/powerlifting_discipline.dart';
+import 'package:tapem/features/profile/domain/models/powerlifting_record.dart';
+import 'package:tapem/features/profile/presentation/providers/powerlifting_provider.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
+class PowerliftingScreen extends StatefulWidget {
+  const PowerliftingScreen({super.key});
+
+  @override
+  State<PowerliftingScreen> createState() => _PowerliftingScreenState();
+}
+
+class _PowerliftingScreenState extends State<PowerliftingScreen> {
+  Future<void> _onAddPressed() async {
+    final provider = context.read<PowerliftingProvider>();
+    final loc = AppLocalizations.of(context)!;
+    final gymId = provider.activeGymId;
+
+    if (gymId == null || gymId.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(loc.powerliftingNoGymError)),
+      );
+      return;
+    }
+
+    final discipline = await _selectDiscipline(loc);
+    if (!mounted || discipline == null) return;
+
+    final devices = await provider.loadDevicesForActiveGym();
+    if (!mounted) return;
+
+    if (devices.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(loc.powerliftingNoDevicesError)),
+      );
+      return;
+    }
+
+    final device = await _selectDevice(loc, devices, discipline);
+    if (!mounted || device == null) return;
+
+    String exerciseId = device.uid;
+    if (device.isMulti) {
+      final exercises = await provider.loadExercisesForDevice(device.uid);
+      if (!mounted) return;
+
+      if (exercises.isEmpty) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(loc.powerliftingNoExercisesError(device.name))),
+        );
+        return;
+      }
+
+      final exercise = await _selectExercise(loc, device, exercises);
+      if (!mounted || exercise == null) return;
+      exerciseId = exercise.id;
+    }
+
+    final success = await provider.addAssignment(
+      discipline: discipline,
+      gymId: gymId,
+      deviceId: device.uid,
+      exerciseId: exerciseId,
+    );
+
+    if (!mounted) return;
+
+    if (!success) {
+      final message = provider.error == 'POWERLIFTING_DUPLICATE'
+          ? loc.powerliftingDuplicateError
+          : provider.error ?? loc.powerliftingAddError;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(message)));
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(loc.powerliftingAddSuccess)),
+      );
+    }
+  }
+
+  Future<PowerliftingDiscipline?> _selectDiscipline(AppLocalizations loc) {
+    final theme = Theme.of(context);
+    return showModalBottomSheet<PowerliftingDiscipline>(
+      context: context,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                title: Text(
+                  loc.powerliftingDisciplineSheetTitle,
+                  style: theme.textTheme.titleMedium,
+                ),
+              ),
+              const Divider(height: 1),
+              for (final discipline in PowerliftingDiscipline.values)
+                ListTile(
+                  title: Text(_disciplineLabel(loc, discipline)),
+                  onTap: () => Navigator.of(sheetContext).pop(discipline),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Future<Device?> _selectDevice(
+    AppLocalizations loc,
+    List<Device> devices,
+    PowerliftingDiscipline discipline,
+  ) {
+    final theme = Theme.of(context);
+    return showModalBottomSheet<Device>(
+      context: context,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: SizedBox(
+            height: 420,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ListTile(
+                  title: Text(
+                    loc.powerliftingDeviceSheetTitle(
+                      _disciplineLabel(loc, discipline),
+                    ),
+                    style: theme.textTheme.titleMedium,
+                  ),
+                ),
+                const Divider(height: 1),
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: devices.length,
+                    itemBuilder: (_, index) {
+                      final device = devices[index];
+                      final subtitle = device.isMulti
+                          ? loc.powerliftingDeviceIsMultiNote
+                          : null;
+                      return ListTile(
+                        title: Text(device.name),
+                        subtitle:
+                            subtitle == null ? null : Text(subtitle),
+                        onTap: () => Navigator.of(sheetContext).pop(device),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<Exercise?> _selectExercise(
+    AppLocalizations loc,
+    Device device,
+    List<Exercise> exercises,
+  ) {
+    final theme = Theme.of(context);
+    return showModalBottomSheet<Exercise>(
+      context: context,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: SizedBox(
+            height: 420,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ListTile(
+                  title: Text(
+                    loc.powerliftingExerciseSheetTitle(device.name),
+                    style: theme.textTheme.titleMedium,
+                  ),
+                ),
+                const Divider(height: 1),
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: exercises.length,
+                    itemBuilder: (_, index) {
+                      final exercise = exercises[index];
+                      return ListTile(
+                        title: Text(exercise.name),
+                        onTap: () => Navigator.of(sheetContext).pop(exercise),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    final provider = context.watch<PowerliftingProvider>();
+    final theme = Theme.of(context);
+    final brand = theme.extension<AppBrandTheme>();
+    final brandColor = brand?.outline ?? theme.colorScheme.secondary;
+    final locale = Localizations.localeOf(context).toString();
+    final dateFormat = DateFormat.yMMMd(locale);
+
+    Widget body;
+    if (provider.isLoading) {
+      body = const Center(child: CircularProgressIndicator());
+    } else if (!provider.hasAssignments) {
+      body = _EmptyState(
+        title: loc.powerliftingEmptyTitle,
+        description: loc.powerliftingEmptyDescription,
+        buttonLabel: loc.powerliftingAddButton,
+        onAdd: provider.isSaving ? null : _onAddPressed,
+      );
+    } else {
+      final columns = PowerliftingDiscipline.values
+          .map(
+            (discipline) => _DisciplineColumn(
+              label: _disciplineLabel(loc, discipline),
+              records: provider.recordsFor(discipline),
+              dateFormat: dateFormat,
+              emptyLabel: loc.powerliftingNoRecords,
+            ),
+          )
+          .toList();
+
+      body = Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            loc.powerliftingIntro,
+            style: theme.textTheme.bodyMedium?.copyWith(color: brandColor),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          Expanded(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(AppSpacing.md),
+                color: theme.colorScheme.surfaceVariant.withOpacity(0.2),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(AppSpacing.sm),
+                child: _PowerliftingTable(columns: columns),
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(loc.powerliftingTitle),
+        centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            tooltip: loc.powerliftingAddTooltip,
+            onPressed: provider.isSaving ? null : _onAddPressed,
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: DefaultTextStyle.merge(
+          style: TextStyle(color: brandColor),
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: body,
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _disciplineLabel(
+    AppLocalizations loc,
+    PowerliftingDiscipline discipline,
+  ) {
+    switch (discipline) {
+      case PowerliftingDiscipline.benchPress:
+        return loc.powerliftingBenchPress;
+      case PowerliftingDiscipline.squat:
+        return loc.powerliftingSquat;
+      case PowerliftingDiscipline.deadlift:
+        return loc.powerliftingDeadlift;
+    }
+  }
+}
+
+class _PowerliftingTable extends StatelessWidget {
+  const _PowerliftingTable({required this.columns});
+
+  final List<_DisciplineColumn> columns;
+
+  @override
+  Widget build(BuildContext context) {
+    final maxRows = columns
+        .map((column) => column.records.length)
+        .fold<int>(0, (prev, value) => value > prev ? value : prev);
+    final headerStyle = Theme.of(context)
+        .textTheme
+        .titleMedium
+        ?.copyWith(fontWeight: FontWeight.bold);
+
+    return Table(
+      columnWidths: const {
+        0: FlexColumnWidth(),
+        1: FlexColumnWidth(),
+        2: FlexColumnWidth(),
+      },
+      border: TableBorder.symmetric(
+        inside: BorderSide(
+          color: Theme.of(context).dividerColor.withOpacity(0.2),
+          width: 1,
+        ),
+      ),
+      children: [
+        TableRow(
+          children: [
+            for (final column in columns)
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  vertical: AppSpacing.sm,
+                  horizontal: AppSpacing.xs,
+                ),
+                child: Text(
+                  column.label,
+                  textAlign: TextAlign.center,
+                  style: headerStyle,
+                ),
+              ),
+          ],
+        ),
+        if (maxRows == 0)
+          TableRow(
+            children: [
+              for (final column in columns)
+                Padding(
+                  padding: const EdgeInsets.all(AppSpacing.sm),
+                  child: Text(
+                    column.emptyLabel,
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+            ],
+          )
+        else
+          for (var row = 0; row < maxRows; row++)
+            TableRow(
+              children: [
+                for (final column in columns)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                      vertical: AppSpacing.sm,
+                      horizontal: AppSpacing.xs,
+                    ),
+                    child: column.buildCell(row),
+                  ),
+              ],
+            ),
+      ],
+    );
+  }
+}
+
+class _DisciplineColumn {
+  _DisciplineColumn({
+    required this.label,
+    required this.records,
+    required this.dateFormat,
+    required this.emptyLabel,
+  });
+
+  final String label;
+  final List<PowerliftingRecord> records;
+  final DateFormat dateFormat;
+  final String emptyLabel;
+
+  Widget buildCell(int index) {
+    if (index >= records.length) {
+      return const Text('-', textAlign: TextAlign.center);
+    }
+
+    final record = records[index];
+    final dateText = dateFormat.format(record.performedAt);
+    final subtitle = record.exerciseName ?? record.deviceName;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Text('${record.weightKg.toStringAsFixed(1)} kg × ${record.reps}'),
+        const SizedBox(height: 4),
+        Text(
+          dateText,
+          style: const TextStyle(fontSize: 12),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          subtitle,
+          style: const TextStyle(fontSize: 12),
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({
+    required this.title,
+    required this.description,
+    required this.buttonLabel,
+    required this.onAdd,
+  });
+
+  final String title;
+  final String description;
+  final String buttonLabel;
+  final VoidCallback? onAdd;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Text(title, style: theme.textTheme.titleMedium),
+          const SizedBox(height: AppSpacing.sm),
+          SizedBox(
+            width: 320,
+            child: Text(
+              description,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          FilledButton.icon(
+            onPressed: onAdd,
+            icon: const Icon(Icons.add),
+            label: Text(buttonLabel),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/screens/profile_stats_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_stats_screen.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
+import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/profile_provider.dart';
 import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/core/widgets/brand_action_tile.dart';
 import 'package:tapem/core/widgets/brand_gradient_card.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 
@@ -86,6 +88,18 @@ class _ProfileStatsScreenState extends State<ProfileStatsScreen> {
                 favoriteExercise,
               ),
             ],
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          BrandActionTile(
+            title: loc.profileStatsPowerliftingButton,
+            centerTitle: true,
+            dense: true,
+            minVerticalPadding: 0,
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+            variant: BrandActionTileVariant.outlined,
+            showChevron: false,
+            onTap: () => Navigator.of(context).pushNamed(AppRouter.powerlifting),
+            uiLogEvent: 'PROFILE_STATS_POWERLIFTING',
           ),
         ],
       );

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -321,6 +321,11 @@
     "description": "Fallback-Text, wenn keine Lieblingsübung ermittelt werden kann"
   },
 
+  "profileStatsPowerliftingButton": "Powerlifting",
+  "@profileStatsPowerliftingButton": {
+    "description": "Button-Beschriftung, um die Powerlifting-Übersicht zu öffnen"
+  },
+
   "repsRequired": "Wdh?",
   "@repsRequired": {
     "description": "Validierungsmeldung, wenn Wiederholungen fehlen"
@@ -334,6 +339,121 @@
   "intRequired": "Ganzzahl",
   "@intRequired": {
     "description": "Validierung, wenn eine Ganzzahl erwartet wird"
+  },
+
+  "powerliftingTitle": "Powerlifting",
+  "@powerliftingTitle": {
+    "description": "Titel der Powerlifting-Statistikseite"
+  },
+
+  "powerliftingAddTooltip": "Geräte zuordnen",
+  "@powerliftingAddTooltip": {
+    "description": "Tooltip für den Hinzufügen-Button auf der Powerlifting-Seite"
+  },
+
+  "powerliftingIntro": "Verknüpfe deine Lieblingsgeräte und Übungen, um deine stärksten Bankdrück-, Kniebeugen- und Kreuzhebe-Sätze zu verfolgen.",
+  "@powerliftingIntro": {
+    "description": "Einleitungstext auf der Powerlifting-Seite"
+  },
+
+  "powerliftingEmptyTitle": "Baue dein Powerlifting-Board",
+  "@powerliftingEmptyTitle": {
+    "description": "Titel, wenn noch keine Powerlifting-Quellen vorhanden sind"
+  },
+
+  "powerliftingEmptyDescription": "Füge Geräte oder Übungen für Bankdrücken, Kniebeugen und Kreuzheben hinzu, um automatisch deine schwersten Sätze zu sammeln.",
+  "@powerliftingEmptyDescription": {
+    "description": "Beschreibung im Leerzustand der Powerlifting-Seite"
+  },
+
+  "powerliftingAddButton": "Powerlifting-Quelle hinzufügen",
+  "@powerliftingAddButton": {
+    "description": "Button-Text im Leerzustand zum Hinzufügen einer Quelle"
+  },
+
+  "powerliftingDisciplineSheetTitle": "Disziplin wählen",
+  "@powerliftingDisciplineSheetTitle": {
+    "description": "Titel des Bottom Sheets bei der Disziplinwahl"
+  },
+
+  "powerliftingDeviceSheetTitle": "Gerät für {discipline} wählen",
+  "@powerliftingDeviceSheetTitle": {
+    "description": "Titel des Bottom Sheets bei der Geräteauswahl",
+    "placeholders": {
+      "discipline": {
+        "type": "String"
+      }
+    }
+  },
+
+  "powerliftingDeviceIsMultiNote": "Multi-Gerät – wähle anschließend eine Übung",
+  "@powerliftingDeviceIsMultiNote": {
+    "description": "Hinweistext für Multi-Geräte in der Auswahl"
+  },
+
+  "powerliftingExerciseSheetTitle": "Übung an {device} wählen",
+  "@powerliftingExerciseSheetTitle": {
+    "description": "Titel des Bottom Sheets bei der Übungsauswahl",
+    "placeholders": {
+      "device": {
+        "type": "String"
+      }
+    }
+  },
+
+  "powerliftingNoGymError": "Wähle zuerst ein Studio, um Powerlifting zu verwalten.",
+  "@powerliftingNoGymError": {
+    "description": "Snackbar-Meldung, wenn kein Studio ausgewählt ist"
+  },
+
+  "powerliftingNoDevicesError": "Keine Geräte in diesem Studio gefunden.",
+  "@powerliftingNoDevicesError": {
+    "description": "Snackbar-Meldung, wenn keine Geräte vorhanden sind"
+  },
+
+  "powerliftingNoExercisesError": "Lege zuerst eine Übung an {device} an.",
+  "@powerliftingNoExercisesError": {
+    "description": "Snackbar-Meldung, wenn ein Multi-Gerät keine Übungen hat",
+    "placeholders": {
+      "device": {
+        "type": "String"
+      }
+    }
+  },
+
+  "powerliftingAddError": "Powerlifting-Quelle konnte nicht hinzugefügt werden.",
+  "@powerliftingAddError": {
+    "description": "Fehlermeldung, wenn das Zuordnen fehlschlägt"
+  },
+
+  "powerliftingDuplicateError": "Dieses Gerät bzw. diese Übung ist bereits verknüpft.",
+  "@powerliftingDuplicateError": {
+    "description": "Fehler, wenn die Quelle schon existiert"
+  },
+
+  "powerliftingAddSuccess": "Powerlifting-Quelle hinzugefügt.",
+  "@powerliftingAddSuccess": {
+    "description": "Bestätigung nach erfolgreichem Hinzufügen einer Quelle"
+  },
+
+  "powerliftingNoRecords": "Noch keine Bestwerte",
+  "@powerliftingNoRecords": {
+    "description": "Platzhalter, wenn keine Werte vorliegen"
+  },
+
+  "powerliftingBenchPress": "Bankdrücken",
+  "@powerliftingBenchPress": {
+    "description": "Bezeichnung für die Disziplin Bankdrücken"
+  },
+
+  "powerliftingSquat": "Kniebeugen",
+  "@powerliftingSquat": {
+    "description": "Bezeichnung für die Disziplin Kniebeugen"
+  },
+
+  "powerliftingDeadlift": "Kreuzheben",
+  "@powerliftingDeadlift": {
+    "description": "Bezeichnung für die Disziplin Kreuzheben"
   },
 
   "dropFillBoth": "Beide Drop-Felder ausfüllen oder leeren.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -321,6 +321,11 @@
     "description": "Fallback text when there is no favourite exercise"
   },
 
+  "profileStatsPowerliftingButton": "Powerlifting",
+  "@profileStatsPowerliftingButton": {
+    "description": "Button label that opens the powerlifting overview"
+  },
+
   "repsRequired": "reps?",
   "@repsRequired": {
     "description": "Validation when reps are missing"
@@ -334,6 +339,121 @@
   "intRequired": "Integer",
   "@intRequired": {
     "description": "Validation when an integer is expected"
+  },
+
+  "powerliftingTitle": "Powerlifting",
+  "@powerliftingTitle": {
+    "description": "Title of the powerlifting statistics page"
+  },
+
+  "powerliftingAddTooltip": "Assign devices",
+  "@powerliftingAddTooltip": {
+    "description": "Tooltip for the add button on the powerlifting page"
+  },
+
+  "powerliftingIntro": "Link your favourite devices and exercises to track your strongest bench press, squat and deadlift sets.",
+  "@powerliftingIntro": {
+    "description": "Introductory text on the powerlifting page"
+  },
+
+  "powerliftingEmptyTitle": "Build your powerlifting board",
+  "@powerliftingEmptyTitle": {
+    "description": "Title shown when no powerlifting sources are configured"
+  },
+
+  "powerliftingEmptyDescription": "Add devices or exercises for bench press, squat and deadlift to automatically collect your heaviest sets.",
+  "@powerliftingEmptyDescription": {
+    "description": "Description shown when there are no powerlifting assignments"
+  },
+
+  "powerliftingAddButton": "Add powerlifting source",
+  "@powerliftingAddButton": {
+    "description": "Button label in the empty state to add a source"
+  },
+
+  "powerliftingDisciplineSheetTitle": "Choose discipline",
+  "@powerliftingDisciplineSheetTitle": {
+    "description": "Bottom sheet title when selecting the discipline"
+  },
+
+  "powerliftingDeviceSheetTitle": "Select a device for {discipline}",
+  "@powerliftingDeviceSheetTitle": {
+    "description": "Bottom sheet title when choosing a device",
+    "placeholders": {
+      "discipline": {
+        "type": "String"
+      }
+    }
+  },
+
+  "powerliftingDeviceIsMultiNote": "Multi device – choose an exercise next",
+  "@powerliftingDeviceIsMultiNote": {
+    "description": "Subtitle for multi devices in the selection sheet"
+  },
+
+  "powerliftingExerciseSheetTitle": "Select exercise on {device}",
+  "@powerliftingExerciseSheetTitle": {
+    "description": "Bottom sheet title when choosing an exercise",
+    "placeholders": {
+      "device": {
+        "type": "String"
+      }
+    }
+  },
+
+  "powerliftingNoGymError": "Select a gym first to manage powerlifting.",
+  "@powerliftingNoGymError": {
+    "description": "Snackbar message when no gym is selected"
+  },
+
+  "powerliftingNoDevicesError": "No devices found in this gym.",
+  "@powerliftingNoDevicesError": {
+    "description": "Snackbar message when no devices are available"
+  },
+
+  "powerliftingNoExercisesError": "Create an exercise on {device} first.",
+  "@powerliftingNoExercisesError": {
+    "description": "Snackbar message when a multi device has no exercises",
+    "placeholders": {
+      "device": {
+        "type": "String"
+      }
+    }
+  },
+
+  "powerliftingAddError": "Could not add powerlifting source.",
+  "@powerliftingAddError": {
+    "description": "Fallback error when assigning a source fails"
+  },
+
+  "powerliftingDuplicateError": "This device or exercise is already linked.",
+  "@powerliftingDuplicateError": {
+    "description": "Error shown when the source already exists"
+  },
+
+  "powerliftingAddSuccess": "Powerlifting source added.",
+  "@powerliftingAddSuccess": {
+    "description": "Confirmation when a powerlifting source is added"
+  },
+
+  "powerliftingNoRecords": "No records yet",
+  "@powerliftingNoRecords": {
+    "description": "Placeholder when no records exist for a discipline"
+  },
+
+  "powerliftingBenchPress": "Bench press",
+  "@powerliftingBenchPress": {
+    "description": "Label for bench press discipline"
+  },
+
+  "powerliftingSquat": "Squat",
+  "@powerliftingSquat": {
+    "description": "Label for squat discipline"
+  },
+
+  "powerliftingDeadlift": "Deadlift",
+  "@powerliftingDeadlift": {
+    "description": "Label for deadlift discipline"
   },
 
   "dropFillBoth": "Fill both drop fields or clear them.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -539,6 +539,12 @@ abstract class AppLocalizations {
   /// **'No sessions yet'**
   String get profileStatsFavoriteExerciseFallback;
 
+  /// No description provided for @profileStatsPowerliftingButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Powerlifting'**
+  String get profileStatsPowerliftingButton;
+
   /// Validation when reps are missing
   ///
   /// In en, this message translates to:
@@ -556,6 +562,126 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Integer'**
   String get intRequired;
+
+  /// No description provided for @powerliftingTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Powerlifting'**
+  String get powerliftingTitle;
+
+  /// No description provided for @powerliftingAddTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Assign devices'**
+  String get powerliftingAddTooltip;
+
+  /// No description provided for @powerliftingIntro.
+  ///
+  /// In en, this message translates to:
+  /// **'Link your favourite devices and exercises to track your strongest bench press, squat and deadlift sets.'**
+  String get powerliftingIntro;
+
+  /// No description provided for @powerliftingEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Build your powerlifting board'**
+  String get powerliftingEmptyTitle;
+
+  /// No description provided for @powerliftingEmptyDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Add devices or exercises for bench press, squat and deadlift to automatically collect your heaviest sets.'**
+  String get powerliftingEmptyDescription;
+
+  /// No description provided for @powerliftingAddButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Add powerlifting source'**
+  String get powerliftingAddButton;
+
+  /// No description provided for @powerliftingDisciplineSheetTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose discipline'**
+  String get powerliftingDisciplineSheetTitle;
+
+  /// No description provided for @powerliftingDeviceSheetTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Select a device for {discipline}'**
+  String powerliftingDeviceSheetTitle(String discipline);
+
+  /// No description provided for @powerliftingDeviceIsMultiNote.
+  ///
+  /// In en, this message translates to:
+  /// **'Multi device – choose an exercise next'**
+  String get powerliftingDeviceIsMultiNote;
+
+  /// No description provided for @powerliftingExerciseSheetTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Select exercise on {device}'**
+  String powerliftingExerciseSheetTitle(String device);
+
+  /// No description provided for @powerliftingNoGymError.
+  ///
+  /// In en, this message translates to:
+  /// **'Select a gym first to manage powerlifting.'**
+  String get powerliftingNoGymError;
+
+  /// No description provided for @powerliftingNoDevicesError.
+  ///
+  /// In en, this message translates to:
+  /// **'No devices found in this gym.'**
+  String get powerliftingNoDevicesError;
+
+  /// No description provided for @powerliftingNoExercisesError.
+  ///
+  /// In en, this message translates to:
+  /// **'Create an exercise on {device} first.'**
+  String powerliftingNoExercisesError(String device);
+
+  /// No description provided for @powerliftingAddError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not add powerlifting source.'**
+  String get powerliftingAddError;
+
+  /// No description provided for @powerliftingDuplicateError.
+  ///
+  /// In en, this message translates to:
+  /// **'This device or exercise is already linked.'**
+  String get powerliftingDuplicateError;
+
+  /// No description provided for @powerliftingAddSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Powerlifting source added.'**
+  String get powerliftingAddSuccess;
+
+  /// No description provided for @powerliftingNoRecords.
+  ///
+  /// In en, this message translates to:
+  /// **'No records yet'**
+  String get powerliftingNoRecords;
+
+  /// No description provided for @powerliftingBenchPress.
+  ///
+  /// In en, this message translates to:
+  /// **'Bench press'**
+  String get powerliftingBenchPress;
+
+  /// No description provided for @powerliftingSquat.
+  ///
+  /// In en, this message translates to:
+  /// **'Squat'**
+  String get powerliftingSquat;
+
+  /// No description provided for @powerliftingDeadlift.
+  ///
+  /// In en, this message translates to:
+  /// **'Deadlift'**
+  String get powerliftingDeadlift;
 
   /// Validation when only one drop field is filled
   ///

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -250,6 +250,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get profileStatsFavoriteExerciseFallback => 'Noch keine Sessions';
 
   @override
+  String get profileStatsPowerliftingButton => 'Powerlifting';
+
+  @override
   String get repsRequired => 'Wdh?';
 
   @override
@@ -257,6 +260,79 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get intRequired => 'Ganzzahl';
+
+  @override
+  String get powerliftingTitle => 'Powerlifting';
+
+  @override
+  String get powerliftingAddTooltip => 'Geräte zuordnen';
+
+  @override
+  String get powerliftingIntro =>
+      'Verknüpfe deine Lieblingsgeräte und Übungen, um deine stärksten Bankdrück-, Kniebeugen- und Kreuzhebe-Sätze zu verfolgen.';
+
+  @override
+  String get powerliftingEmptyTitle => 'Baue dein Powerlifting-Board';
+
+  @override
+  String get powerliftingEmptyDescription =>
+      'Füge Geräte oder Übungen für Bankdrücken, Kniebeugen und Kreuzheben hinzu, um automatisch deine schwersten Sätze zu sammeln.';
+
+  @override
+  String get powerliftingAddButton => 'Powerlifting-Quelle hinzufügen';
+
+  @override
+  String get powerliftingDisciplineSheetTitle => 'Disziplin wählen';
+
+  @override
+  String powerliftingDeviceSheetTitle(String discipline) {
+    return 'Gerät für $discipline wählen';
+  }
+
+  @override
+  String get powerliftingDeviceIsMultiNote =>
+      'Multi-Gerät – wähle anschließend eine Übung';
+
+  @override
+  String powerliftingExerciseSheetTitle(String device) {
+    return 'Übung an $device wählen';
+  }
+
+  @override
+  String get powerliftingNoGymError =>
+      'Wähle zuerst ein Studio, um Powerlifting zu verwalten.';
+
+  @override
+  String get powerliftingNoDevicesError =>
+      'Keine Geräte in diesem Studio gefunden.';
+
+  @override
+  String powerliftingNoExercisesError(String device) {
+    return 'Lege zuerst eine Übung an $device an.';
+  }
+
+  @override
+  String get powerliftingAddError =>
+      'Powerlifting-Quelle konnte nicht hinzugefügt werden.';
+
+  @override
+  String get powerliftingDuplicateError =>
+      'Dieses Gerät bzw. diese Übung ist bereits verknüpft.';
+
+  @override
+  String get powerliftingAddSuccess => 'Powerlifting-Quelle hinzugefügt.';
+
+  @override
+  String get powerliftingNoRecords => 'Noch keine Bestwerte';
+
+  @override
+  String get powerliftingBenchPress => 'Bankdrücken';
+
+  @override
+  String get powerliftingSquat => 'Kniebeugen';
+
+  @override
+  String get powerliftingDeadlift => 'Kreuzheben';
 
   @override
   String get dropFillBoth => 'Beide Drop-Felder ausfüllen oder leeren.';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -250,6 +250,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileStatsFavoriteExerciseFallback => 'No sessions yet';
 
   @override
+  String get profileStatsPowerliftingButton => 'Powerlifting';
+
+  @override
   String get repsRequired => 'reps?';
 
   @override
@@ -257,6 +260,78 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get intRequired => 'Integer';
+
+  @override
+  String get powerliftingTitle => 'Powerlifting';
+
+  @override
+  String get powerliftingAddTooltip => 'Assign devices';
+
+  @override
+  String get powerliftingIntro =>
+      'Link your favourite devices and exercises to track your strongest bench press, squat and deadlift sets.';
+
+  @override
+  String get powerliftingEmptyTitle => 'Build your powerlifting board';
+
+  @override
+  String get powerliftingEmptyDescription =>
+      'Add devices or exercises for bench press, squat and deadlift to automatically collect your heaviest sets.';
+
+  @override
+  String get powerliftingAddButton => 'Add powerlifting source';
+
+  @override
+  String get powerliftingDisciplineSheetTitle => 'Choose discipline';
+
+  @override
+  String powerliftingDeviceSheetTitle(String discipline) {
+    return 'Select a device for $discipline';
+  }
+
+  @override
+  String get powerliftingDeviceIsMultiNote =>
+      'Multi device – choose an exercise next';
+
+  @override
+  String powerliftingExerciseSheetTitle(String device) {
+    return 'Select exercise on $device';
+  }
+
+  @override
+  String get powerliftingNoGymError =>
+      'Select a gym first to manage powerlifting.';
+
+  @override
+  String get powerliftingNoDevicesError => 'No devices found in this gym.';
+
+  @override
+  String powerliftingNoExercisesError(String device) {
+    return 'Create an exercise on $device first.';
+  }
+
+  @override
+  String get powerliftingAddError =>
+      'Could not add powerlifting source.';
+
+  @override
+  String get powerliftingDuplicateError =>
+      'This device or exercise is already linked.';
+
+  @override
+  String get powerliftingAddSuccess => 'Powerlifting source added.';
+
+  @override
+  String get powerliftingNoRecords => 'No records yet';
+
+  @override
+  String get powerliftingBenchPress => 'Bench press';
+
+  @override
+  String get powerliftingSquat => 'Squat';
+
+  @override
+  String get powerliftingDeadlift => 'Deadlift';
 
   @override
   String get dropFillBoth => 'Fill both drop fields or clear them.';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -56,6 +56,7 @@ import 'package:tapem/features/friends/providers/friend_presence_provider.dart';
 import 'package:tapem/features/creatine/data/creatine_repository.dart';
 import 'package:tapem/features/creatine/providers/creatine_provider.dart';
 import 'package:tapem/features/friends/providers/friend_search_provider.dart';
+import 'package:tapem/features/profile/presentation/providers/powerlifting_provider.dart';
 import 'features/gym/data/sources/firestore_gym_source.dart';
 import 'ui/numeric_keypad/overlay_numeric_keypad.dart';
 import 'core/drafts/session_draft_repository_impl.dart';
@@ -435,6 +436,28 @@ Future<void> main() async {
         ChangeNotifierProvider(create: (_) => TrainingPlanProvider()),
         ChangeNotifierProvider(create: (_) => HistoryProvider()),
         ChangeNotifierProvider(create: (_) => ProfileProvider()),
+        ChangeNotifierProxyProvider2<AuthProvider, GymProvider,
+            PowerliftingProvider>(
+          create: (c) => PowerliftingProvider(
+            firestore: FirebaseFirestore.instance,
+            getDevicesForGym: c.read<GetDevicesForGym>(),
+            getExercisesForDevice: c.read<GetExercisesForDevice>(),
+            membership: c.read<MembershipService>(),
+          ),
+          update: (context, auth, gym, provider) {
+            final prov = provider ?? PowerliftingProvider(
+              firestore: FirebaseFirestore.instance,
+              getDevicesForGym: context.read<GetDevicesForGym>(),
+              getExercisesForDevice: context.read<GetExercisesForDevice>(),
+              membership: context.read<MembershipService>(),
+            );
+            unawaited(prov.updateContext(
+              userId: auth.userId,
+              gymId: gym.currentGymId,
+            ));
+            return prov;
+          },
+        ),
         ChangeNotifierProvider(
           create: (_) => CreatineProvider(repository: CreatineRepository()),
         ),


### PR DESCRIPTION
## Summary
- add a dedicated powerlifting provider and screen to aggregate bench, squat, and deadlift records per user
- link the profile statistics view to the new powerlifting dashboard and register the route
- extend localizations with copy for the powerlifting workflow and assignment flows

## Testing
- Not run (flutter toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd2de3aca0832090035564a5344916