### PR TITLE
Refine powerlifting record handling

### DIFF
--- a/lib/features/profile/presentation/providers/powerlifting_provider.dart
+++ b/lib/features/profile/presentation/providers/powerlifting_provider.dart
@@ -104,10 +104,7 @@ class PowerliftingProvider extends ChangeNotifier {
           .collection(_assignmentCollection)
           .get();
 
-      for (final discipline in PowerliftingDiscipline.values) {
-        _assignments[discipline] = <PowerliftingAssignment>[];
-        _records[discipline] = <PowerliftingRecord>[];
-      }
+      _resetAssignmentsAndRecords();
 
       for (final doc in snapshot.docs) {
         final data = doc.data();
@@ -271,16 +268,53 @@ class PowerliftingProvider extends ChangeNotifier {
   }
 
   void _clearState() {
-    for (final discipline in PowerliftingDiscipline.values) {
-      _assignments[discipline] = <PowerliftingAssignment>[];
-      _records[discipline] = <PowerliftingRecord>[];
-    }
+    _resetAssignmentsAndRecords();
     _deviceCache.clear();
     _exerciseCache.clear();
     _error = null;
     _isLoading = false;
     _isSaving = false;
     notifyListeners();
+  }
+
+  Future<bool> clearAssignments() async {
+    final uid = _userId;
+    final gymId = _activeGymId;
+    if (uid == null || uid.isEmpty || gymId == null || gymId.isEmpty) {
+      return false;
+    }
+
+    _isSaving = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      await _membership.ensureMembership(gymId, uid);
+      final collection = _firestore
+          .collection('users')
+          .doc(uid)
+          .collection(_assignmentCollection);
+      final snapshot = await collection.get();
+
+      if (snapshot.docs.isNotEmpty) {
+        final batch = _firestore.batch();
+        for (final doc in snapshot.docs) {
+          batch.delete(doc.reference);
+        }
+        await batch.commit();
+      }
+
+      _resetAssignmentsAndRecords();
+      _deviceCache.clear();
+      _exerciseCache.clear();
+      return true;
+    } catch (e) {
+      _error = e.toString();
+      return false;
+    } finally {
+      _isSaving = false;
+      notifyListeners();
+    }
   }
 
   Future<void> _loadRecordsForAllDisciplines() async {
@@ -301,12 +335,30 @@ class PowerliftingProvider extends ChangeNotifier {
     final futures = entries.map(_fetchRecordsForAssignment);
     final results = await Future.wait(futures);
     final combined = results.expand((element) => element).toList();
-    combined.sort((a, b) {
+    if (combined.isEmpty) {
+      _records[discipline] = <PowerliftingRecord>[];
+      return;
+    }
+
+    final sortedByDate = List<PowerliftingRecord>.from(combined)
+      ..sort((a, b) => a.performedAt.compareTo(b.performedAt));
+
+    final progressive = <PowerliftingRecord>[];
+    var bestWeight = -double.infinity;
+    for (final record in sortedByDate) {
+      if (record.weightKg > bestWeight) {
+        progressive.add(record);
+        bestWeight = record.weightKg;
+      }
+    }
+
+    progressive.sort((a, b) {
       final weightCompare = b.weightKg.compareTo(a.weightKg);
       if (weightCompare != 0) return weightCompare;
       return b.performedAt.compareTo(a.performedAt);
     });
-    _records[discipline] = combined;
+
+    _records[discipline] = progressive;
   }
 
   Future<List<PowerliftingRecord>> _fetchRecordsForAssignment(
@@ -339,7 +391,7 @@ class PowerliftingProvider extends ChangeNotifier {
       query = query
           .orderBy('weight', descending: true)
           .orderBy('timestamp', descending: true)
-          .limit(_logsLimitPerSource);
+          .limit(1);
       final snapshot = await query.get();
       docs = snapshot.docs;
     } on FirebaseException {
@@ -352,7 +404,7 @@ class PowerliftingProvider extends ChangeNotifier {
       docs = snapshot.docs;
     }
 
-    final records = <PowerliftingRecord>[];
+    PowerliftingRecord? bestRecord;
     for (final doc in docs) {
       final data = doc.data();
       final weight = (data['weight'] as num?)?.toDouble() ?? 0;
@@ -360,19 +412,29 @@ class PowerliftingProvider extends ChangeNotifier {
       final timestamp = (data['timestamp'] as Timestamp?)?.toDate() ??
           DateTime.fromMillisecondsSinceEpoch(0);
 
-      records.add(
-        PowerliftingRecord(
-          id: doc.id,
-          discipline: assignment.discipline,
-          weightKg: weight,
-          reps: reps,
-          performedAt: timestamp,
-          deviceName: labels.deviceName,
-          exerciseName: labels.exerciseName,
-        ),
+      final record = PowerliftingRecord(
+        id: doc.id,
+        discipline: assignment.discipline,
+        weightKg: weight,
+        reps: reps,
+        performedAt: timestamp,
+        deviceName: labels.deviceName,
+        exerciseName: labels.exerciseName,
       );
+
+      if (bestRecord == null ||
+          record.weightKg > bestRecord.weightKg ||
+          (record.weightKg == bestRecord.weightKg &&
+              record.performedAt.isAfter(bestRecord.performedAt))) {
+        bestRecord = record;
+      }
     }
-    return records;
+
+    if (bestRecord == null) {
+      return <PowerliftingRecord>[];
+    }
+
+    return <PowerliftingRecord>[bestRecord];
   }
 
   Future<_PowerliftingLabels> _resolveLabels(
@@ -410,6 +472,13 @@ class PowerliftingProvider extends ChangeNotifier {
       _deviceCache['$gymId|${device.uid}'] = device;
     }
     return _deviceCache['$gymId|$deviceId'];
+  }
+
+  void _resetAssignmentsAndRecords() {
+    for (final discipline in PowerliftingDiscipline.values) {
+      _assignments[discipline] = <PowerliftingAssignment>[];
+      _records[discipline] = <PowerliftingRecord>[];
+    }
   }
 }
 

--- a/lib/features/profile/presentation/screens/powerlifting_screen.dart
+++ b/lib/features/profile/presentation/screens/powerlifting_screen.dart
@@ -87,6 +87,50 @@ class _PowerliftingScreenState extends State<PowerliftingScreen> {
     }
   }
 
+  Future<void> _onClearPressed() async {
+    final provider = context.read<PowerliftingProvider>();
+    final loc = AppLocalizations.of(context)!;
+
+    final shouldReset = await showDialog<bool>(
+          context: context,
+          builder: (dialogContext) => AlertDialog(
+            title: Text(loc.powerliftingClearConfirmTitle),
+            content: Text(loc.powerliftingClearConfirmMessage),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(dialogContext).pop(false),
+                child: Text(loc.commonCancel),
+              ),
+              FilledButton(
+                onPressed: () => Navigator.of(dialogContext).pop(true),
+                child: Text(loc.powerliftingClearConfirmAction),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+
+    if (!mounted || !shouldReset) {
+      return;
+    }
+
+    final success = await provider.clearAssignments();
+    if (!mounted) {
+      return;
+    }
+
+    if (success) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(loc.powerliftingClearSuccess)),
+      );
+    } else {
+      final message = provider.error ?? loc.powerliftingClearError;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(message)),
+      );
+    }
+  }
+
   Future<PowerliftingDiscipline?> _selectDiscipline(AppLocalizations loc) {
     final theme = Theme.of(context);
     return showModalBottomSheet<PowerliftingDiscipline>(
@@ -267,6 +311,13 @@ class _PowerliftingScreenState extends State<PowerliftingScreen> {
         title: Text(loc.powerliftingTitle),
         centerTitle: true,
         actions: [
+          IconButton(
+            icon: const Icon(Icons.delete_outline),
+            tooltip: loc.powerliftingClearTooltip,
+            onPressed: provider.isSaving || !provider.hasAssignments
+                ? null
+                : _onClearPressed,
+          ),
           IconButton(
             icon: const Icon(Icons.add),
             tooltip: loc.powerliftingAddTooltip,

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -351,6 +351,36 @@
     "description": "Tooltip für den Hinzufügen-Button auf der Powerlifting-Seite"
   },
 
+  "powerliftingClearTooltip": "Board zurücksetzen",
+  "@powerliftingClearTooltip": {
+    "description": "Tooltip für den Zurücksetzen-Button auf der Powerlifting-Seite"
+  },
+
+  "powerliftingClearConfirmTitle": "Powerlifting-Board zurücksetzen?",
+  "@powerliftingClearConfirmTitle": {
+    "description": "Dialogtitel vor dem Zurücksetzen der Powerlifting-Zuordnungen"
+  },
+
+  "powerliftingClearConfirmMessage": "Dadurch werden alle verknüpften Geräte aus deinem Powerlifting-Board entfernt. Möchtest du fortfahren?",
+  "@powerliftingClearConfirmMessage": {
+    "description": "Dialogtext vor dem Zurücksetzen der Powerlifting-Zuordnungen"
+  },
+
+  "powerliftingClearConfirmAction": "Zurücksetzen",
+  "@powerliftingClearConfirmAction": {
+    "description": "Bestätigungsaktion zum Zurücksetzen der Powerlifting-Zuordnungen"
+  },
+
+  "powerliftingClearSuccess": "Powerlifting-Board zurückgesetzt.",
+  "@powerliftingClearSuccess": {
+    "description": "Snackbar nach erfolgreichem Zurücksetzen"
+  },
+
+  "powerliftingClearError": "Powerlifting-Board konnte nicht zurückgesetzt werden.",
+  "@powerliftingClearError": {
+    "description": "Snackbar, wenn das Zurücksetzen fehlgeschlagen ist"
+  },
+
   "powerliftingIntro": "Verknüpfe deine Lieblingsgeräte und Übungen, um deine stärksten Bankdrück-, Kniebeugen- und Kreuzhebe-Sätze zu verfolgen.",
   "@powerliftingIntro": {
     "description": "Einleitungstext auf der Powerlifting-Seite"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -351,6 +351,36 @@
     "description": "Tooltip for the add button on the powerlifting page"
   },
 
+  "powerliftingClearTooltip": "Reset powerlifting board",
+  "@powerliftingClearTooltip": {
+    "description": "Tooltip for the reset button on the powerlifting page"
+  },
+
+  "powerliftingClearConfirmTitle": "Reset powerlifting board?",
+  "@powerliftingClearConfirmTitle": {
+    "description": "Confirmation dialog title before clearing assignments"
+  },
+
+  "powerliftingClearConfirmMessage": "This removes all linked devices for your powerlifting board. Do you want to continue?",
+  "@powerliftingClearConfirmMessage": {
+    "description": "Confirmation dialog message before clearing assignments"
+  },
+
+  "powerliftingClearConfirmAction": "Reset",
+  "@powerliftingClearConfirmAction": {
+    "description": "Confirmation dialog action to clear assignments"
+  },
+
+  "powerliftingClearSuccess": "Powerlifting board reset.",
+  "@powerliftingClearSuccess": {
+    "description": "Snackbar shown after clearing assignments"
+  },
+
+  "powerliftingClearError": "Powerlifting board could not be reset.",
+  "@powerliftingClearError": {
+    "description": "Snackbar shown when clearing assignments fails"
+  },
+
   "powerliftingIntro": "Link your favourite devices and exercises to track your strongest bench press, squat and deadlift sets.",
   "@powerliftingIntro": {
     "description": "Introductory text on the powerlifting page"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -575,6 +575,42 @@ abstract class AppLocalizations {
   /// **'Assign devices'**
   String get powerliftingAddTooltip;
 
+  /// No description provided for @powerliftingClearTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Reset powerlifting board'**
+  String get powerliftingClearTooltip;
+
+  /// No description provided for @powerliftingClearConfirmTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Reset powerlifting board?'**
+  String get powerliftingClearConfirmTitle;
+
+  /// No description provided for @powerliftingClearConfirmMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'This removes all linked devices for your powerlifting board. Do you want to continue?'**
+  String get powerliftingClearConfirmMessage;
+
+  /// No description provided for @powerliftingClearConfirmAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Reset'**
+  String get powerliftingClearConfirmAction;
+
+  /// No description provided for @powerliftingClearSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Powerlifting board reset.'**
+  String get powerliftingClearSuccess;
+
+  /// No description provided for @powerliftingClearError.
+  ///
+  /// In en, this message translates to:
+  /// **'Powerlifting board could not be reset.'**
+  String get powerliftingClearError;
+
   /// No description provided for @powerliftingIntro.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -268,6 +268,27 @@ class AppLocalizationsDe extends AppLocalizations {
   String get powerliftingAddTooltip => 'Geräte zuordnen';
 
   @override
+  String get powerliftingClearTooltip => 'Board zurücksetzen';
+
+  @override
+  String get powerliftingClearConfirmTitle =>
+      'Powerlifting-Board zurücksetzen?';
+
+  @override
+  String get powerliftingClearConfirmMessage =>
+      'Dadurch werden alle verknüpften Geräte aus deinem Powerlifting-Board entfernt. Möchtest du fortfahren?';
+
+  @override
+  String get powerliftingClearConfirmAction => 'Zurücksetzen';
+
+  @override
+  String get powerliftingClearSuccess => 'Powerlifting-Board zurückgesetzt.';
+
+  @override
+  String get powerliftingClearError =>
+      'Powerlifting-Board konnte nicht zurückgesetzt werden.';
+
+  @override
   String get powerliftingIntro =>
       'Verknüpfe deine Lieblingsgeräte und Übungen, um deine stärksten Bankdrück-, Kniebeugen- und Kreuzhebe-Sätze zu verfolgen.';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -268,6 +268,26 @@ class AppLocalizationsEn extends AppLocalizations {
   String get powerliftingAddTooltip => 'Assign devices';
 
   @override
+  String get powerliftingClearTooltip => 'Reset powerlifting board';
+
+  @override
+  String get powerliftingClearConfirmTitle => 'Reset powerlifting board?';
+
+  @override
+  String get powerliftingClearConfirmMessage =>
+      'This removes all linked devices for your powerlifting board. Do you want to continue?';
+
+  @override
+  String get powerliftingClearConfirmAction => 'Reset';
+
+  @override
+  String get powerliftingClearSuccess => 'Powerlifting board reset.';
+
+  @override
+  String get powerliftingClearError =>
+      'Powerlifting board could not be reset.';
+
+  @override
   String get powerliftingIntro =>
       'Link your favourite devices and exercises to track your strongest bench press, squat and deadlift sets.';
 


### PR DESCRIPTION
## Summary
- only surface progressive one-rep-max style records per discipline and reuse shared reset helpers
- add a reset control with confirmation to clear powerlifting assignments from the UI
- localize the new reset workflow strings in English and German

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd3652d4bc83208b59791e270e9ee1