### PR TITLE
Fix syntax errors in powerlifting table empty state

### DIFF
--- a/lib/features/profile/presentation/screens/powerlifting_screen.dart
+++ b/lib/features/profile/presentation/screens/powerlifting_screen.dart
@@ -556,7 +556,8 @@ class _PowerliftingTable extends StatelessWidget {
           ],
         ),
         if (maxRows == 0)
-          TableRow(children: [
+          TableRow(
+            children: [
               for (final column in columns)
                 Padding(
                   padding: const EdgeInsets.all(AppSpacing.sm),
@@ -566,8 +567,8 @@ class _PowerliftingTable extends StatelessWidget {
                     style: metaStyle,
                   ),
                 ),
-                ),
-            ])
+            ],
+          )
         else
           for (var row = 0; row < maxRows; row++)
             TableRow(


### PR DESCRIPTION
## Summary
- correct the empty-state TableRow syntax so the table children list compiles

## Testing
- `flutter analyze lib/features/profile/presentation/screens/powerlifting_screen.dart` *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd5c7613d08320a601a1c13d40cfa1