### PR TITLE
Aggregate powerlifting records across devices

### DIFF
--- a/lib/features/profile/presentation/providers/powerlifting_provider.dart
+++ b/lib/features/profile/presentation/providers/powerlifting_provider.dart
@@ -353,6 +353,7 @@ class PowerliftingProvider extends ChangeNotifier {
     final futures = entries.map(_fetchRecordsForAssignment);
     final results = await Future.wait(futures);
     final combined = results.expand((element) => element).toList();
+    combined.removeWhere((record) => record.weightKg <= 0);
     if (combined.isEmpty) {
       _records[discipline] = <PowerliftingRecord>[];
       return;
@@ -400,30 +401,45 @@ class PowerliftingProvider extends ChangeNotifier {
         .doc(assignment.deviceId)
         .collection('logs');
 
-    Query<Map<String, dynamic>> query = logsCollection
+    final baseQuery = logsCollection
         .where('userId', isEqualTo: uid)
         .where('exerciseId', isEqualTo: assignment.exerciseId);
 
-    List<QueryDocumentSnapshot<Map<String, dynamic>>> docs;
-    try {
-      query = query
-          .orderBy('weight', descending: true)
-          .orderBy('timestamp', descending: true)
-          .limit(1);
+    final Map<String, QueryDocumentSnapshot<Map<String, dynamic>>> docs =
+        <String, QueryDocumentSnapshot<Map<String, dynamic>>>{};
+
+    Future<void> collect(
+      Query<Map<String, dynamic>> query,
+    ) async {
       final snapshot = await query.get();
-      docs = snapshot.docs;
-    } on FirebaseException {
-      final snapshot = await logsCollection
-          .where('userId', isEqualTo: uid)
-          .where('exerciseId', isEqualTo: assignment.exerciseId)
-          .orderBy('timestamp', descending: true)
-          .limit(_logsLimitPerSource)
-          .get();
-      docs = snapshot.docs;
+      for (final doc in snapshot.docs) {
+        docs[doc.id] = doc;
+      }
     }
 
-    PowerliftingRecord? bestRecord;
-    for (final doc in docs) {
+    try {
+      await collect(
+        baseQuery
+            .orderBy('weight', descending: true)
+            .orderBy('timestamp', descending: true)
+            .limit(_logsLimitPerSource),
+      );
+    } on FirebaseException catch (error) {
+      if (error.code != 'failed-precondition') rethrow;
+    }
+
+    await collect(
+      baseQuery.orderBy('timestamp', descending: true).limit(
+            _logsLimitPerSource,
+          ),
+    );
+
+    if (docs.isEmpty) {
+      return <PowerliftingRecord>[];
+    }
+
+    final records = <PowerliftingRecord>[];
+    for (final doc in docs.values) {
       final data = doc.data();
       final weight = (data['weight'] as num?)?.toDouble() ?? 0;
       final reps = (data['reps'] as num?)?.toInt() ?? 0;
@@ -440,19 +456,10 @@ class PowerliftingProvider extends ChangeNotifier {
         exerciseName: labels.exerciseName,
       );
 
-      if (bestRecord == null ||
-          record.weightKg > bestRecord.weightKg ||
-          (record.weightKg == bestRecord.weightKg &&
-              record.performedAt.isAfter(bestRecord.performedAt))) {
-        bestRecord = record;
-      }
+      records.add(record);
     }
 
-    if (bestRecord == null) {
-      return <PowerliftingRecord>[];
-    }
-
-    return <PowerliftingRecord>[bestRecord];
+    return records;
   }
 
   Future<_PowerliftingLabels> _resolveLabels(

--- a/lib/features/profile/presentation/screens/powerlifting_screen.dart
+++ b/lib/features/profile/presentation/screens/powerlifting_screen.dart
@@ -498,29 +498,30 @@ class _PowerliftingTable extends StatelessWidget {
         .map((column) => column.records.length)
         .fold<int>(0, (prev, value) => value > prev ? value : prev);
     final theme = Theme.of(context);
+    const tableBackground = Colors.black;
+    const headerBackground = Color(0xFF121212);
+    const alternateRowBackground = Color(0xFF181818);
+    final dividerColor = Colors.white.withOpacity(0.14);
+
     final headerStyle = theme.textTheme.titleSmall?.copyWith(
-      color: theme.colorScheme.onSurface,
+      color: Colors.white,
       fontWeight: FontWeight.w700,
       letterSpacing: 0.6,
     );
     final valueStyle = theme.textTheme.bodyMedium?.copyWith(
-      color: theme.colorScheme.onSurface,
+      color: Colors.white,
       fontWeight: FontWeight.w600,
     );
     final metaStyle = theme.textTheme.bodySmall?.copyWith(
-      color: theme.colorScheme.onSurface.withOpacity(0.7),
+      color: Colors.white.withOpacity(0.7),
       height: 1.3,
     );
-    final dividerColor = theme.colorScheme.outline.withOpacity(0.4);
-
-    final headerBackground =
-        theme.colorScheme.surfaceVariant.withOpacity(0.35);
 
     final tableBorder = TableBorder(
-      top: BorderSide(color: dividerColor, width: 1),
-      bottom: BorderSide(color: dividerColor, width: 1),
-      left: BorderSide(color: dividerColor, width: 1),
-      right: BorderSide(color: dividerColor, width: 1),
+      top: const BorderSide(color: Colors.transparent, width: 0),
+      bottom: const BorderSide(color: Colors.transparent, width: 0),
+      left: const BorderSide(color: Colors.transparent, width: 0),
+      right: const BorderSide(color: Colors.transparent, width: 0),
       horizontalInside: BorderSide(color: dividerColor, width: 1),
       verticalInside: BorderSide(color: dividerColor, width: 1),
     );
@@ -535,7 +536,7 @@ class _PowerliftingTable extends StatelessWidget {
       border: tableBorder,
       children: [
         TableRow(
-          decoration: BoxDecoration(color: headerBackground),
+          decoration: const BoxDecoration(color: headerBackground),
           children: [
             for (final column in columns)
               Padding(
@@ -556,26 +557,25 @@ class _PowerliftingTable extends StatelessWidget {
           ],
         ),
         if (maxRows == 0)
-          TableRow(
-            children: [
-              for (final column in columns)
-                Padding(
-                  padding: const EdgeInsets.all(AppSpacing.sm),
-                  child: Text(
-                    column.emptyLabel,
-                    textAlign: TextAlign.center,
-                    style: metaStyle,
+            TableRow(
+              decoration: const BoxDecoration(color: tableBackground),
+              children: [
+                for (final column in columns)
+                  Padding(
+                    padding: const EdgeInsets.all(AppSpacing.sm),
+                    child: Text(
+                      column.emptyLabel,
+                      textAlign: TextAlign.center,
+                      style: metaStyle,
+                    ),
                   ),
-                ),
-            ],
-          )
+              ],
+            )
         else
           for (var row = 0; row < maxRows; row++)
             TableRow(
               decoration: BoxDecoration(
-                color: row.isEven
-                    ? theme.colorScheme.surfaceVariant.withOpacity(0.1)
-                    : Colors.transparent,
+                color: row.isEven ? tableBackground : alternateRowBackground,
               ),
               children: [
                 for (final column in columns)
@@ -738,7 +738,7 @@ class _GradientFrame extends StatelessWidget {
     final gradient = brand?.gradient ?? AppGradients.brandGradient;
     final resolvedRadius = (brand?.outlineRadius ?? BorderRadius.circular(AppRadius.card))
         .resolve(Directionality.of(context));
-    final background = theme.colorScheme.surface.withOpacity(0.85);
+    const background = Colors.black;
 
     return DecoratedBox(
       decoration: BoxDecoration(


### PR DESCRIPTION
## Summary
- combine logs from every assigned exercise when building powerlifting records so only progressive max sets per discipline are shown
- fetch both heaviest and most recent entries per assignment, deduplicate them, and ignore zero-weight sets before deriving records
- restyle the powerlifting table to keep the gradient outline while rendering the interior on a black surface with white typography

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd625fd0d48320bae915784d4eae92