### PR TITLE
Add E1RM table toggle to powerlifting screen

### DIFF
--- a/lib/features/profile/domain/models/powerlifting_record.dart
+++ b/lib/features/profile/domain/models/powerlifting_record.dart
@@ -20,4 +20,6 @@ class PowerliftingRecord {
   final DateTime performedAt;
   final String deviceName;
   final String? exerciseName;
+
+  double get e1rm => weightKg * (1 + reps / 30);
 }

--- a/lib/features/profile/presentation/providers/powerlifting_provider.dart
+++ b/lib/features/profile/presentation/providers/powerlifting_provider.dart
@@ -13,6 +13,11 @@ import 'package:tapem/features/profile/domain/models/powerlifting_discipline.dar
 import 'package:tapem/features/profile/domain/models/powerlifting_record.dart';
 import 'package:tapem/services/membership_service.dart';
 
+enum PowerliftingMetric {
+  heaviest,
+  e1rm,
+}
+
 class PowerliftingProvider extends ChangeNotifier {
   PowerliftingProvider({
     required FirebaseFirestore firestore,
@@ -43,8 +48,13 @@ class PowerliftingProvider extends ChangeNotifier {
     for (final d in PowerliftingDiscipline.values) d: <PowerliftingAssignment>[],
   };
 
-  final Map<PowerliftingDiscipline, List<PowerliftingRecord>> _records = {
-    for (final d in PowerliftingDiscipline.values) d: <PowerliftingRecord>[],
+  final Map<PowerliftingDiscipline,
+          Map<PowerliftingMetric, List<PowerliftingRecord>>> _records = {
+    for (final d in PowerliftingDiscipline.values)
+      d: {
+        for (final metric in PowerliftingMetric.values)
+          metric: <PowerliftingRecord>[],
+      },
   };
 
   final Map<String, Device> _deviceCache = <String, Device>{};
@@ -64,8 +74,11 @@ class PowerliftingProvider extends ChangeNotifier {
   List<PowerliftingAssignment> assignmentsFor(PowerliftingDiscipline discipline) =>
       List.unmodifiable(_assignments[discipline]!);
 
-  List<PowerliftingRecord> recordsFor(PowerliftingDiscipline discipline) =>
-      List.unmodifiable(_records[discipline]!);
+  List<PowerliftingRecord> recordsFor(
+    PowerliftingDiscipline discipline, {
+    PowerliftingMetric metric = PowerliftingMetric.heaviest,
+  }) =>
+      List.unmodifiable(_records[discipline]?[metric] ?? const []);
 
   @override
   void dispose() {
@@ -334,6 +347,10 @@ class PowerliftingProvider extends ChangeNotifier {
     }
   }
 
+  Map<PowerliftingMetric, List<PowerliftingRecord>> _createEmptyRecordMap() => {
+        for (final metric in PowerliftingMetric.values) metric: <PowerliftingRecord>[],
+      };
+
   Future<void> _reloadDisciplineRecords(
     PowerliftingDiscipline discipline,
   ) async {
@@ -346,7 +363,7 @@ class PowerliftingProvider extends ChangeNotifier {
   ) async {
     final entries = _assignments[discipline]!;
     if (entries.isEmpty) {
-      _records[discipline] = <PowerliftingRecord>[];
+      _records[discipline] = _createEmptyRecordMap();
       return;
     }
 
@@ -355,29 +372,46 @@ class PowerliftingProvider extends ChangeNotifier {
     final combined = results.expand((element) => element).toList();
     combined.removeWhere((record) => record.weightKg <= 0);
     if (combined.isEmpty) {
-      _records[discipline] = <PowerliftingRecord>[];
+      _records[discipline] = _createEmptyRecordMap();
       return;
     }
 
     final sortedByDate = List<PowerliftingRecord>.from(combined)
       ..sort((a, b) => a.performedAt.compareTo(b.performedAt));
 
-    final progressive = <PowerliftingRecord>[];
+    final heaviest = <PowerliftingRecord>[];
+    final e1rm = <PowerliftingRecord>[];
     var bestWeight = -double.infinity;
+    var bestE1rm = -double.infinity;
     for (final record in sortedByDate) {
       if (record.weightKg > bestWeight) {
-        progressive.add(record);
+        heaviest.add(record);
         bestWeight = record.weightKg;
+      }
+
+      final recordE1rm = record.e1rm;
+      if (recordE1rm > bestE1rm) {
+        e1rm.add(record);
+        bestE1rm = recordE1rm;
       }
     }
 
-    progressive.sort((a, b) {
+    heaviest.sort((a, b) {
       final weightCompare = b.weightKg.compareTo(a.weightKg);
       if (weightCompare != 0) return weightCompare;
       return b.performedAt.compareTo(a.performedAt);
     });
 
-    _records[discipline] = progressive;
+    e1rm.sort((a, b) {
+      final e1rmCompare = b.e1rm.compareTo(a.e1rm);
+      if (e1rmCompare != 0) return e1rmCompare;
+      return b.performedAt.compareTo(a.performedAt);
+    });
+
+    _records[discipline] = {
+      PowerliftingMetric.heaviest: heaviest,
+      PowerliftingMetric.e1rm: e1rm,
+    };
   }
 
   Future<List<PowerliftingRecord>> _fetchRecordsForAssignment(
@@ -503,7 +537,7 @@ class PowerliftingProvider extends ChangeNotifier {
     _disposeLogSubscriptions();
     for (final discipline in PowerliftingDiscipline.values) {
       _assignments[discipline] = <PowerliftingAssignment>[];
-      _records[discipline] = <PowerliftingRecord>[];
+      _records[discipline] = _createEmptyRecordMap();
     }
   }
 

--- a/lib/features/profile/presentation/screens/powerlifting_screen.dart
+++ b/lib/features/profile/presentation/screens/powerlifting_screen.dart
@@ -20,6 +20,8 @@ class PowerliftingScreen extends StatefulWidget {
 }
 
 class _PowerliftingScreenState extends State<PowerliftingScreen> {
+  PowerliftingMetric _selectedMetric = PowerliftingMetric.heaviest;
+
   Future<void> _onAddPressed() async {
     final provider = context.read<PowerliftingProvider>();
     final loc = AppLocalizations.of(context)!;
@@ -401,9 +403,13 @@ class _PowerliftingScreenState extends State<PowerliftingScreen> {
           .map(
             (discipline) => _DisciplineColumn(
               label: _disciplineLabel(loc, discipline),
-              records: provider.recordsFor(discipline),
+              records: provider.recordsFor(
+                discipline,
+                metric: _selectedMetric,
+              ),
               dateFormat: dateFormat,
               emptyLabel: loc.powerliftingNoRecords,
+              metric: _selectedMetric,
             ),
           )
           .toList();
@@ -422,12 +428,48 @@ class _PowerliftingScreenState extends State<PowerliftingScreen> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
-                      Text(
-                        loc.powerliftingIntro,
-                        style: theme.textTheme.bodyLarge?.copyWith(
-                          color: theme.colorScheme.onSurface.withOpacity(0.9),
-                          height: 1.4,
-                        ),
+                      LayoutBuilder(
+                        builder: (context, constraints) {
+                          final introText = Text(
+                            loc.powerliftingIntro,
+                            style: theme.textTheme.bodyLarge?.copyWith(
+                              color: theme.colorScheme.onSurface
+                                  .withOpacity(0.9),
+                              height: 1.4,
+                            ),
+                          );
+                          final switcher = _PowerliftingTableSwitcher(
+                            selectedMetric: _selectedMetric,
+                            onMetricChanged: (metric) {
+                              setState(() {
+                                _selectedMetric = metric;
+                              });
+                            },
+                          );
+
+                          if (constraints.maxWidth < 520) {
+                            return Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                introText,
+                                const SizedBox(height: AppSpacing.md),
+                                Align(
+                                  alignment: Alignment.centerLeft,
+                                  child: switcher,
+                                ),
+                              ],
+                            );
+                          }
+
+                          return Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Expanded(child: introText),
+                              const SizedBox(width: AppSpacing.md),
+                              switcher,
+                            ],
+                          );
+                        },
                       ),
                       const SizedBox(height: AppSpacing.lg),
                       _GradientFrame(
@@ -484,6 +526,43 @@ class _PowerliftingScreenState extends State<PowerliftingScreen> {
       case PowerliftingDiscipline.deadlift:
         return loc.powerliftingDeadlift;
     }
+  }
+}
+
+class _PowerliftingTableSwitcher extends StatelessWidget {
+  const _PowerliftingTableSwitcher({
+    required this.selectedMetric,
+    required this.onMetricChanged,
+  });
+
+  final PowerliftingMetric selectedMetric;
+  final ValueChanged<PowerliftingMetric> onMetricChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+
+    return SegmentedButton<PowerliftingMetric>(
+      segments: [
+        ButtonSegment<PowerliftingMetric>(
+          value: PowerliftingMetric.heaviest,
+          label: Text(loc.powerliftingHeaviestTable),
+          icon: const Icon(Icons.monitor_weight_outlined),
+        ),
+        ButtonSegment<PowerliftingMetric>(
+          value: PowerliftingMetric.e1rm,
+          label: Text(loc.powerliftingE1rmTable),
+          icon: const Icon(Icons.trending_up_outlined),
+        ),
+      ],
+      selected: <PowerliftingMetric>{selectedMetric},
+      onSelectionChanged: (selection) {
+        if (selection.isEmpty) {
+          return;
+        }
+        onMetricChanged(selection.first);
+      },
+    );
   }
 }
 
@@ -624,12 +703,14 @@ class _DisciplineColumn {
     required this.records,
     required this.dateFormat,
     required this.emptyLabel,
+    required this.metric,
   });
 
   final String label;
   final List<PowerliftingRecord> records;
   final DateFormat dateFormat;
   final String emptyLabel;
+  final PowerliftingMetric metric;
 
   Widget buildCell(int index, TextStyle? valueStyle, TextStyle? metaStyle) {
     if (index >= records.length) {
@@ -639,34 +720,67 @@ class _DisciplineColumn {
     final record = records[index];
     final dateText = dateFormat.format(record.performedAt);
     final subtitle = record.exerciseName ?? record.deviceName;
-    final weight = record.weightKg % 1 == 0
-        ? record.weightKg.toStringAsFixed(0)
-        : record.weightKg.toStringAsFixed(1);
+    final mainValue = switch (metric) {
+      PowerliftingMetric.heaviest =>
+          '${_formatWeight(record.weightKg)} kg × ${record.reps}',
+      PowerliftingMetric.e1rm =>
+          '${_formatWeight(record.e1rm)} kg E1RM',
+    };
+    final supportingValue =
+        metric == PowerliftingMetric.e1rm
+            ? '${_formatWeight(record.weightKg)} kg × ${record.reps}'
+            : null;
+
+    final children = <Widget>[
+      Text(
+        mainValue,
+        style: valueStyle,
+        textAlign: TextAlign.center,
+      ),
+    ];
+
+    if (supportingValue != null) {
+      children.addAll([
+        const SizedBox(height: 4),
+        Text(
+          supportingValue,
+          style: metaStyle,
+          textAlign: TextAlign.center,
+        ),
+      ]);
+    }
+
+    children.addAll([
+      const SizedBox(height: 6),
+      Text(
+        dateText,
+        style: metaStyle,
+        textAlign: TextAlign.center,
+      ),
+    ]);
+
+    if (subtitle.isNotEmpty) {
+      children.addAll([
+        const SizedBox(height: 4),
+        Text(
+          subtitle,
+          style: metaStyle,
+          textAlign: TextAlign.center,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ]);
+    }
 
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        Text('$weight kg × ${record.reps}', style: valueStyle, textAlign: TextAlign.center),
-        const SizedBox(height: 6),
-        Text(
-          dateText,
-          style: metaStyle,
-          textAlign: TextAlign.center,
-        ),
-        if (subtitle.isNotEmpty) ...[
-          const SizedBox(height: 4),
-          Text(
-            subtitle,
-            style: metaStyle,
-            textAlign: TextAlign.center,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-          ),
-        ],
-      ],
+      children: children,
     );
   }
+
+  String _formatWeight(double value) =>
+      value % 1 == 0 ? value.toStringAsFixed(0) : value.toStringAsFixed(1);
 }
 
 class _EmptyState extends StatelessWidget {

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -386,6 +386,16 @@
     "description": "Einleitungstext auf der Powerlifting-Seite"
   },
 
+  "powerliftingHeaviestTable": "Schwerste Sätze",
+  "@powerliftingHeaviestTable": {
+    "description": "Beschriftung für die Ansicht der schwersten Sätze"
+  },
+
+  "powerliftingE1rmTable": "E1RM",
+  "@powerliftingE1rmTable": {
+    "description": "Beschriftung für die E1RM-Ansicht"
+  },
+
   "powerliftingEmptyTitle": "Baue dein Powerlifting-Board",
   "@powerliftingEmptyTitle": {
     "description": "Titel, wenn noch keine Powerlifting-Quellen vorhanden sind"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -386,6 +386,16 @@
     "description": "Introductory text on the powerlifting page"
   },
 
+  "powerliftingHeaviestTable": "Heaviest sets",
+  "@powerliftingHeaviestTable": {
+    "description": "Label for the heaviest set table view"
+  },
+
+  "powerliftingE1rmTable": "E1RM",
+  "@powerliftingE1rmTable": {
+    "description": "Label for the E1RM table view"
+  },
+
   "powerliftingEmptyTitle": "Build your powerlifting board",
   "@powerliftingEmptyTitle": {
     "description": "Title shown when no powerlifting sources are configured"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -617,6 +617,18 @@ abstract class AppLocalizations {
   /// **'Link your favourite devices and exercises to track your strongest bench press, squat and deadlift sets.'**
   String get powerliftingIntro;
 
+  /// No description provided for @powerliftingHeaviestTable.
+  ///
+  /// In en, this message translates to:
+  /// **'Heaviest sets'**
+  String get powerliftingHeaviestTable;
+
+  /// No description provided for @powerliftingE1rmTable.
+  ///
+  /// In en, this message translates to:
+  /// **'E1RM'**
+  String get powerliftingE1rmTable;
+
   /// No description provided for @powerliftingEmptyTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -293,6 +293,12 @@ class AppLocalizationsDe extends AppLocalizations {
       'Verknüpfe alle Geräte mit der jeweiligen Disziplin um deinen PR Fortschritt zu tracken.';
 
   @override
+  String get powerliftingHeaviestTable => 'Schwerste Sätze';
+
+  @override
+  String get powerliftingE1rmTable => 'E1RM';
+
+  @override
   String get powerliftingEmptyTitle => 'Baue dein Powerlifting-Board';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -292,6 +292,12 @@ class AppLocalizationsEn extends AppLocalizations {
       'Link every device to its discipline to keep track of your PR progress.';
 
   @override
+  String get powerliftingHeaviestTable => 'Heaviest sets';
+
+  @override
+  String get powerliftingE1rmTable => 'E1RM';
+
+  @override
   String get powerliftingEmptyTitle => 'Build your powerlifting board';
 
   @override


### PR DESCRIPTION
## Summary
- add a segmented button on the powerlifting screen to switch between heaviest and E1RM leaderboards and adjust the table rendering
- compute progressive E1RM records alongside heaviest sets in the powerlifting provider and expose a shared record metric type
- localize the new leaderboard labels in German and English

## Testing
- Not run (flutter is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dd6bba2dfc8320b9e16a84833b51a5