### PR TITLE
Improve bodyweight set UI readability

### DIFF
--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -589,6 +589,12 @@ class SetRowContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final primaryColor = Theme.of(context).colorScheme.primary;
+    final placeholderStyle = TextStyle(
+      fontSize: dense ? 12 : 13,
+      fontWeight: FontWeight.w600,
+      letterSpacing: 0.3,
+      color: primaryColor.withOpacity(0.45),
+    );
 
     Widget body = Padding(
       padding: padding,
@@ -626,6 +632,7 @@ class SetRowContent extends StatelessWidget {
                   },
                   showLabel: false,
                   placeholder: weightPlaceholder,
+                  placeholderTextStyle: placeholderStyle,
                 ),
               ),
               SizedBox(width: dense ? 8 : 12),
@@ -645,6 +652,7 @@ class SetRowContent extends StatelessWidget {
                   },
                   showLabel: false,
                   placeholder: repsPlaceholder,
+                  placeholderTextStyle: placeholderStyle,
                 ),
               ),
               SizedBox(width: dense ? 8 : 12),
@@ -808,6 +816,7 @@ class _InputPill extends StatefulWidget {
   final String? supportingText;
   final bool showLabel;
   final String? placeholder;
+  final TextStyle? placeholderTextStyle;
 
   const _InputPill({
     required this.controller,
@@ -821,6 +830,7 @@ class _InputPill extends StatefulWidget {
     this.supportingText,
     this.showLabel = true,
     this.placeholder,
+    this.placeholderTextStyle,
   });
 
   @override
@@ -921,9 +931,11 @@ class _InputPillState extends State<_InputPill> {
       height: 1.15,
     );
 
-    final placeholderStyle = valueStyle.copyWith(
-      color: brandColor.withOpacity(0.35),
-    );
+    final basePlaceholderStyle = widget.placeholderTextStyle ?? valueStyle;
+    final placeholderColor =
+        widget.placeholderTextStyle?.color ?? brandColor.withOpacity(0.35);
+    final placeholderStyle =
+        basePlaceholderStyle.copyWith(color: placeholderColor);
 
     final supportingStyle = TextStyle(
       fontSize: widget.dense ? 11 : 12,
@@ -1005,6 +1017,9 @@ class _InputPillState extends State<_InputPill> {
                   widget.placeholder ?? widget.label,
                   style: placeholderStyle,
                   textAlign: TextAlign.center,
+                  maxLines: 1,
+                  overflow: TextOverflow.fade,
+                  softWrap: false,
                 ),
               ),
             textField,

--- a/lib/features/training_details/presentation/widgets/session_exercise_card.dart
+++ b/lib/features/training_details/presentation/widgets/session_exercise_card.dart
@@ -57,12 +57,18 @@ class SessionExerciseCard extends StatelessWidget {
                       const SizedBox(width: 4),
                       Builder(builder: (context) {
                         final loc = AppLocalizations.of(context)!;
-                        final wt = set.isBodyweight
-                            ? (set.weight == 0
-                                ? loc.bodyweight
-                                : loc.bodyweightPlus(
-                                    set.weight.toStringAsFixed(1)))
-                            : '${set.weight.toStringAsFixed(1)} kg';
+                        final wt = () {
+                          if (!set.isBodyweight) {
+                            return '${set.weight.toStringAsFixed(1)} kg';
+                          }
+                          final additional = set.weight.abs() < 0.01
+                              ? 0
+                              : set.weight;
+                          if (additional == 0) {
+                            return loc.bodyweightAbbrev;
+                          }
+                          return '${loc.bodyweightAbbrev} + ${additional.toStringAsFixed(1)} kg';
+                        }();
                         return Text(
                           wt,
                           style: const TextStyle(

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -921,6 +921,8 @@
   "friends_search_min_chars": "Mindestens 2 Zeichen eingeben"
   ,"bodyweight": "Körpergewicht"
   ,"@bodyweight": {"description": "Label für Körpergewicht"}
+  ,"bodyweightAbbrev": "BW"
+  ,"@bodyweightAbbrev": {"description": "Abkürzung für Bodyweight"}
   ,"bodyweightPlus": "Körpergewicht + {kg} kg"
   ,"@bodyweightPlus": {"description": "Körpergewicht plus Zusatzgewicht","placeholders": {"kg": {}}}
   ,"bodyweightToggleTooltip": "Körpergewicht umschalten"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -919,6 +919,8 @@
   "friends_search_min_chars": "Enter at least 2 characters"
   ,"bodyweight": "Bodyweight"
   ,"@bodyweight": {"description": "Label for bodyweight"}
+  ,"bodyweightAbbrev": "BW"
+  ,"@bodyweightAbbrev": {"description": "Abbreviation for bodyweight"}
   ,"bodyweightPlus": "Bodyweight + {kg} kg"
   ,"@bodyweightPlus": {"description": "Bodyweight plus additional weight","placeholders": {"kg": {}}}
   ,"bodyweightToggleTooltip": "Toggle bodyweight"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1721,6 +1721,12 @@ abstract class AppLocalizations {
   /// **'Bodyweight'**
   String get bodyweight;
 
+  /// Abbreviation for bodyweight
+  ///
+  /// In en, this message translates to:
+  /// **'BW'**
+  String get bodyweightAbbrev;
+
   /// Bodyweight plus additional weight
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -867,6 +867,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get bodyweight => 'Körpergewicht';
 
   @override
+  String get bodyweightAbbrev => 'BW';
+
+  @override
   String bodyweightPlus(Object kg) {
     return 'Körpergewicht + $kg kg';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -865,6 +865,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get bodyweight => 'Bodyweight';
 
   @override
+  String get bodyweightAbbrev => 'BW';
+
+  @override
   String bodyweightPlus(Object kg) {
     return 'Bodyweight + $kg kg';
   }


### PR DESCRIPTION
## Summary
- shrink the weight and reps placeholder styling in the SetCard so bodyweight labels stay readable
- allow InputPill placeholders to use a custom style and prevent overflow with fade handling
- add a localized bodyweight abbreviation and show "BW" on session cards for bodyweight sets

## Testing
- flutter test *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ddae1a7664832088ce821363e20e11