### PR TITLE
Improve bodyweight indicators on device set card

### DIFF
--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -425,12 +425,6 @@ class SetCardState extends State<SetCard> {
         ? (widget.groupedRadius as BorderRadius?)
         : null;
 
-    final weightPlaceholder =
-        prov.isBodyweightMode ? loc.bodyweight : 'kg';
-    const repsPlaceholder = 'wdh';
-    const dropWeightPlaceholder = 'kg';
-    const dropRepsPlaceholder = 'wdh';
-
     Widget content = SetRowContent(
       tokens: tokens,
       dense: dense,
@@ -488,10 +482,6 @@ class SetCardState extends State<SetCard> {
               ),
       dropValidator: _validateDrop,
       padding: contentPadding,
-      weightPlaceholder: weightPlaceholder,
-      repsPlaceholder: repsPlaceholder,
-      dropWeightPlaceholder: dropWeightPlaceholder,
-      dropRepsPlaceholder: dropRepsPlaceholder,
     );
 
     final backgroundRadius = rowRadius ??
@@ -547,10 +537,6 @@ class SetRowContent extends StatelessWidget {
   final VoidCallback? onTapDropReps;
   final FormFieldValidator<String>? dropValidator;
   final EdgeInsetsGeometry padding;
-  final String weightPlaceholder;
-  final String repsPlaceholder;
-  final String dropWeightPlaceholder;
-  final String dropRepsPlaceholder;
 
   const SetRowContent({
     super.key,
@@ -580,21 +566,17 @@ class SetRowContent extends StatelessWidget {
     required this.onTapDropReps,
     required this.dropValidator,
     this.padding = EdgeInsets.zero,
-    required this.weightPlaceholder,
-    required this.repsPlaceholder,
-    required this.dropWeightPlaceholder,
-    required this.dropRepsPlaceholder,
   });
 
   @override
   Widget build(BuildContext context) {
     final primaryColor = Theme.of(context).colorScheme.primary;
-    final placeholderStyle = TextStyle(
-      fontSize: dense ? 12 : 13,
-      fontWeight: FontWeight.w600,
-      letterSpacing: 0.3,
-      color: primaryColor.withOpacity(0.45),
-    );
+    final weightLabel = isBodyweightMode
+        ? loc.bodyweightFieldLabel(loc.tableHeaderKg)
+        : loc.weightFieldLabel(loc.tableHeaderKg);
+    final weightSupportingText =
+        isBodyweightMode ? loc.bodyweightModeActiveLabel : null;
+    final repsLabel = loc.tableHeaderReps;
 
     Widget body = Padding(
       padding: padding,
@@ -618,7 +600,7 @@ class SetRowContent extends StatelessWidget {
                 child: _InputPill(
                   controller: weightController,
                   focusNode: weightFocus,
-                  label: isBodyweightMode ? loc.bodyweight : 'kg',
+                  label: weightLabel,
                   readOnly: done || readOnly,
                   tokens: tokens,
                   dense: dense,
@@ -630,9 +612,8 @@ class SetRowContent extends StatelessWidget {
                     }
                     return null;
                   },
-                  showLabel: false,
-                  placeholder: weightPlaceholder,
-                  placeholderTextStyle: placeholderStyle,
+                  showLabel: true,
+                  supportingText: weightSupportingText,
                 ),
               ),
               SizedBox(width: dense ? 8 : 12),
@@ -640,7 +621,7 @@ class SetRowContent extends StatelessWidget {
                 child: _InputPill(
                   controller: repsController,
                   focusNode: repsFocus,
-                  label: 'x',
+                  label: repsLabel,
                   readOnly: done || readOnly,
                   tokens: tokens,
                   dense: dense,
@@ -650,9 +631,7 @@ class SetRowContent extends StatelessWidget {
                     if (int.tryParse(v) == null) return loc.intRequired;
                     return null;
                   },
-                  showLabel: false,
-                  placeholder: repsPlaceholder,
-                  placeholderTextStyle: placeholderStyle,
+                  showLabel: true,
                 ),
               ),
               SizedBox(width: dense ? 8 : 12),
@@ -695,7 +674,6 @@ class SetRowContent extends StatelessWidget {
                     dense: true,
                     onTap: onTapDropWeight,
                     validator: dropValidator,
-                    placeholder: dropWeightPlaceholder,
                   ),
                 ),
                 SizedBox(width: dense ? 8 : 12),
@@ -709,7 +687,6 @@ class SetRowContent extends StatelessWidget {
                     dense: true,
                     onTap: onTapDropReps,
                     validator: dropValidator,
-                    placeholder: dropRepsPlaceholder,
                   ),
                 ),
               ],
@@ -719,9 +696,12 @@ class SetRowContent extends StatelessWidget {
       ),
     );
 
-      return SizedBox(width: double.infinity, child: body);
-    }
+    return SizedBox(
+      width: double.infinity,
+      child: body,
+    );
   }
+}
 
 class _IndexBadge extends StatelessWidget {
   final SetCardTheme tokens;

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -640,6 +640,27 @@
     "description": "Tabellenkopf für Wiederholungen"
   },
 
+  "weightFieldLabel": "Gewicht ({unit})",
+  "@weightFieldLabel": {
+    "description": "Label für das normale Gewichtsfeld",
+    "placeholders": {
+      "unit": {}
+    }
+  },
+
+  "bodyweightFieldLabel": "Körpergewicht + Zusatz ({unit})",
+  "@bodyweightFieldLabel": {
+    "description": "Label für das Gewichtsfeld im Körpergewichtsmodus",
+    "placeholders": {
+      "unit": {}
+    }
+  },
+
+  "bodyweightModeActiveLabel": "Körpergewichtsmodus aktiv",
+  "@bodyweightModeActiveLabel": {
+    "description": "Hinweis, dass der Körpergewichtsmodus aktiv ist"
+  },
+
   "timerPauseLabel": "Pause",
   "@timerPauseLabel": {
     "description": "Prefix-Label für den Pausen-Timer"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -638,6 +638,27 @@
     "description": "Table header for reps column"
   },
 
+  "weightFieldLabel": "Weight ({unit})",
+  "@weightFieldLabel": {
+    "description": "Label for the standard weight input field",
+    "placeholders": {
+      "unit": {}
+    }
+  },
+
+  "bodyweightFieldLabel": "Bodyweight + extra ({unit})",
+  "@bodyweightFieldLabel": {
+    "description": "Label for the weight input field when bodyweight mode is active",
+    "placeholders": {
+      "unit": {}
+    }
+  },
+
+  "bodyweightModeActiveLabel": "Bodyweight mode active",
+  "@bodyweightModeActiveLabel": {
+    "description": "Indicator shown when bodyweight mode is enabled"
+  },
+
   "timerPauseLabel": "Rest",
   "@timerPauseLabel": {
     "description": "Prefix label for the rest timer"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -911,6 +911,24 @@ abstract class AppLocalizations {
   /// **'Reps'**
   String get tableHeaderReps;
 
+  /// Label for the standard weight input field
+  ///
+  /// In en, this message translates to:
+  /// **'Weight ({unit})'**
+  String weightFieldLabel(Object unit);
+
+  /// Label for the weight input field when bodyweight mode is active
+  ///
+  /// In en, this message translates to:
+  /// **'Bodyweight + extra ({unit})'**
+  String bodyweightFieldLabel(Object unit);
+
+  /// Indicator shown when bodyweight mode is enabled
+  ///
+  /// In en, this message translates to:
+  /// **'Bodyweight mode active'**
+  String get bodyweightModeActiveLabel;
+
   /// Prefix label for the rest timer
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -454,6 +454,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get tableHeaderReps => 'Wdh.';
 
   @override
+  String weightFieldLabel(Object unit) {
+    return 'Gewicht ($unit)';
+  }
+
+  @override
+  String bodyweightFieldLabel(Object unit) {
+    return 'Körpergewicht + Zusatz ($unit)';
+  }
+
+  @override
+  String get bodyweightModeActiveLabel => 'Körpergewichtsmodus aktiv';
+
+  @override
   String get timerPauseLabel => 'Pause';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -452,6 +452,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tableHeaderReps => 'Reps';
 
   @override
+  String weightFieldLabel(Object unit) {
+    return 'Weight ($unit)';
+  }
+
+  @override
+  String bodyweightFieldLabel(Object unit) {
+    return 'Bodyweight + extra ($unit)';
+  }
+
+  @override
+  String get bodyweightModeActiveLabel => 'Bodyweight mode active';
+
+  @override
   String get timerPauseLabel => 'Rest';
 
   @override


### PR DESCRIPTION
## Summary
- show explicit labels above the weight and reps inputs so the units remain visible outside the fields
- surface a textual indicator when bodyweight mode is active and add the required localization strings

## Testing
- not run (Flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68ddb4588bcc8320844872a57ed38d21