### PR TITLE
Adjust set card pill spacing

### DIFF
--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -931,7 +931,7 @@ class _InputPillState extends State<_InputPill> {
     final colorScheme = theme.colorScheme;
     final brandColor = colorScheme.primary;
 
-    final radius = BorderRadius.circular(widget.dense ? 18 : 22);
+    final radius = BorderRadius.circular(widget.dense ? 16 : 20);
     final baseOverlay = Colors.transparent;
     final haloColor = Colors.black.withOpacity(
       hasFocus
@@ -976,9 +976,9 @@ class _InputPillState extends State<_InputPill> {
     );
 
     final double horizontalPadding =
-        showLabel ? (widget.dense ? 16 : 18) : (widget.dense ? 18 : 22);
+        showLabel ? (widget.dense ? 12 : 14) : (widget.dense ? 12 : 16);
     final double verticalPadding =
-        showLabel ? (widget.dense ? 9 : 12) : (widget.dense ? 12 : 16);
+        showLabel ? (widget.dense ? 6 : 8) : (widget.dense ? 8 : 10);
 
     final Widget textField = SizedBox(
       width: double.infinity,
@@ -1018,7 +1018,7 @@ class _InputPillState extends State<_InputPill> {
           vertical: verticalPadding,
         ),
         constraints:
-            showLabel ? null : BoxConstraints(minHeight: widget.dense ? 58 : 68),
+            showLabel ? null : BoxConstraints(minHeight: widget.dense ? 48 : 56),
         decoration: BoxDecoration(
           color: baseOverlay,
           borderRadius: radius,


### PR DESCRIPTION
## Summary
- tighten the padding and radius on the set card input pills to shrink their visual footprint
- lower the minimum height for dense mode so grouped set cards sit closer together

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddc213819483209fd8477ec57b06b2