### PR TITLE
Fix timer visibility on black/white device theme

### DIFF
--- a/lib/ui/timer/active_workout_timer.dart
+++ b/lib/ui/timer/active_workout_timer.dart
@@ -37,6 +37,14 @@ class ActiveWorkoutTimer extends StatelessWidget {
             final LinearGradient? resolvedGradient;
             Color foregroundColor;
 
+            final isBlackWhiteTheme =
+                !hasUsableGradient &&
+                    theme.colorScheme.background == Colors.black &&
+                    theme.colorScheme.primary == Colors.white &&
+                    (brand?.gradient.colors
+                            .every((c) => c.computeLuminance() < 0.05) ??
+                        false);
+
             if (hasUsableGradient) {
               resolvedGradient = gradient;
               backgroundColor = null;
@@ -50,7 +58,10 @@ class ActiveWorkoutTimer extends StatelessWidget {
               final brightness = ThemeData.estimateBrightnessForColor(
                 fallbackBackground,
               );
-              if (brightness == Brightness.dark &&
+              if (isBlackWhiteTheme) {
+                backgroundColor = Colors.white.withOpacity(0.12);
+                foregroundColor = Colors.white;
+              } else if (brightness == Brightness.dark &&
                   foregroundColor.computeLuminance() < 0.6) {
                 foregroundColor = Colors.white;
               } else if (brightness == Brightness.light &&


### PR DESCRIPTION
## Summary
- detect the black/white brand theme and override the workout timer colors for better contrast
- render the timer text and icon in white with a subtle translucent pill background so it stays visible on the device page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfa60402e4832088831f8319f0340b