### PR TITLE
Fix background color reassignment in ActiveWorkoutTimer

### DIFF
--- a/lib/ui/timer/active_workout_timer.dart
+++ b/lib/ui/timer/active_workout_timer.dart
@@ -33,7 +33,7 @@ class ActiveWorkoutTimer extends StatelessWidget {
             final hasUsableGradient = gradientColors.isNotEmpty &&
                 gradientColors.any((c) => c.computeLuminance() > 0.2);
 
-            final Color? backgroundColor;
+            Color? backgroundColor;
             final LinearGradient? resolvedGradient;
             Color foregroundColor;
 


### PR DESCRIPTION
## Summary
- make the ActiveWorkoutTimer background color mutable to allow theme overrides

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfad6512c083208846efb24d48b04a