### PR TITLE
Fix session timer visibility in black/white theme

### DIFF
--- a/lib/ui/timer/session_timer_bar.dart
+++ b/lib/ui/timer/session_timer_bar.dart
@@ -79,11 +79,20 @@ class _SessionTimerBarState extends State<SessionTimerBar>
       builder: (context, remaining, _) {
         final progress =
             1 - (remaining.inMilliseconds / _controller.total.inMilliseconds).clamp(0.0, 1.0);
-        final textColor = Color.lerp(
+        Color? textColor = Color.lerp(
           theme.colorScheme.onSurface,
           theme.colorScheme.onPrimary,
           progress,
         );
+
+        final isBlackWhiteTheme =
+            theme.colorScheme.background == Colors.black &&
+                theme.colorScheme.primary == Colors.white &&
+                theme.colorScheme.onPrimary == Colors.black;
+
+        if (isBlackWhiteTheme) {
+          textColor = Colors.white;
+        }
         return Semantics(
           label: loc.timerPauseLabel,
           value: _fmt(remaining),


### PR DESCRIPTION
## Summary
- ensure the session timer text remains white when the black/white theme is active so it stays visible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfaedc18b48320ab8c9d55a3b14c80