### PR TITLE
Include British gyms in monitoring map query

### DIFF
--- a/website/src/server/monitoring.ts
+++ b/website/src/server/monitoring.ts
@@ -185,7 +185,7 @@ function isFailedPrecondition(error: unknown): boolean {
   return false;
 }
 
-const DACH_COUNTRY_CODES = ['DE', 'AT', 'CH'] as const;
+const DACH_COUNTRY_CODES = ['DE', 'AT', 'CH', 'GB'] as const;
 
 export async function fetchGymsForMap(options?: FetchGymsForMapOptions): Promise<FetchGymsForMapResult> {
   const firestore = adminDb();

--- a/website/tests/api-geojson.test.js
+++ b/website/tests/api-geojson.test.js
@@ -13,6 +13,11 @@ test('GeoJSON admin API exposes secure caching headers and properties', () => {
   const serverContent = readFileSync(serverPath, 'utf8');
   assert.match(
     serverContent,
+    /const DACH_COUNTRY_CODES = \['DE', 'AT', 'CH', 'GB'\] as const;/,
+    'Monitoring query should include British gyms'
+  );
+  assert.match(
+    serverContent,
     /properties:\s*\{\s*id: doc.id,\s*name,\s*slug,\s*code,/s,
     'GeoJSON features should expose id, name, slug and code'
   );


### PR DESCRIPTION
## Summary
- include Great Britain in the monitoring country code allow list
- cover the change with a regression test that checks the monitoring server module

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dfb62be30c832087fcf321d0ad8cb3