### PR TITLE
Ensure theme override persists until user changes it

### DIFF
--- a/lib/core/providers/theme_preference_provider.dart
+++ b/lib/core/providers/theme_preference_provider.dart
@@ -1,13 +1,21 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../theme/brand_theme_preset.dart';
 
 class ThemePreferenceProvider extends ChangeNotifier {
-  ThemePreferenceProvider({FirebaseFirestore? firestore})
-      : _firestore = firestore ?? FirebaseFirestore.instance;
+  ThemePreferenceProvider({
+    FirebaseFirestore? firestore,
+    SharedPreferences? preferences,
+    Future<Map<String, dynamic>?> Function(String uid)? fetchOverride,
+  })  : _firestore = firestore ?? FirebaseFirestore.instance,
+        _preferences = preferences,
+        _fetchOverride = fetchOverride;
 
   final FirebaseFirestore _firestore;
+  SharedPreferences? _preferences;
+  final Future<Map<String, dynamic>?> Function(String uid)? _fetchOverride;
 
   String? _uid;
   bool _isLoading = false;
@@ -19,6 +27,20 @@ class ThemePreferenceProvider extends ChangeNotifier {
   String? get error => _error;
   BrandThemeId? get override => _override;
   bool get hasLoaded => _hasLoaded;
+
+  static const _prefsKeyPrefix = 'theme_override_';
+
+  Future<SharedPreferences> _prefs() async {
+    final existing = _preferences;
+    if (existing != null) {
+      return existing;
+    }
+    final prefs = await SharedPreferences.getInstance();
+    _preferences = prefs;
+    return prefs;
+  }
+
+  String _prefsKey(String uid) => '$_prefsKeyPrefix$uid';
 
   DocumentReference<Map<String, dynamic>> _doc(String uid) {
     return _firestore
@@ -39,6 +61,10 @@ class ThemePreferenceProvider extends ChangeNotifier {
     if (_uid == uid && _hasLoaded) {
       return;
     }
+    if (_uid != uid) {
+      _override = null;
+      _hasLoaded = false;
+    }
     _uid = uid;
     _load();
   }
@@ -48,16 +74,20 @@ class ThemePreferenceProvider extends ChangeNotifier {
     if (uid == null) return;
     _isLoading = true;
     _error = null;
+
+    await _loadCachedOverride(uid);
     notifyListeners();
     try {
-      final snap = await _doc(uid).get();
-      final data = snap.data();
+      final data = _fetchOverride != null
+          ? await _fetchOverride!(uid)
+          : (await _doc(uid).get()).data();
       final value = data != null ? data['themeId'] as String? : null;
-      _override = value != null ? BrandThemeIdX.fromStorage(value) : null;
+      final resolved = value != null ? BrandThemeIdX.fromStorage(value) : null;
+      _override = resolved;
       _hasLoaded = true;
+      await _persistOverride(uid, resolved);
     } catch (e) {
       _error = e.toString();
-      _override = null;
       _hasLoaded = false;
     } finally {
       _isLoading = false;
@@ -77,14 +107,35 @@ class ThemePreferenceProvider extends ChangeNotifier {
       final ref = _doc(uid);
       if (theme == null) {
         await ref.set({'themeId': FieldValue.delete()}, SetOptions(merge: true));
+        await _persistOverride(uid, null);
       } else {
         await ref.set({'themeId': theme.storageValue}, SetOptions(merge: true));
+        await _persistOverride(uid, theme);
       }
     } catch (e) {
       _override = previous;
       _error = e.toString();
+      await _persistOverride(uid, previous);
       notifyListeners();
       rethrow;
+    }
+  }
+
+  Future<void> _loadCachedOverride(String uid) async {
+    final prefs = await _prefs();
+    final cached = prefs.getString(_prefsKey(uid));
+    final cachedId = cached != null ? BrandThemeIdX.fromStorage(cached) : null;
+    if (cachedId != null && cachedId != _override) {
+      _override = cachedId;
+    }
+  }
+
+  Future<void> _persistOverride(String uid, BrandThemeId? theme) async {
+    final prefs = await _prefs();
+    if (theme == null) {
+      await prefs.remove(_prefsKey(uid));
+    } else {
+      await prefs.setString(_prefsKey(uid), theme.storageValue);
     }
   }
 

--- a/test/providers/theme_preference_provider_test.dart
+++ b/test/providers/theme_preference_provider_test.dart
@@ -1,0 +1,72 @@
+import 'dart:async';
+
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:tapem/core/providers/theme_preference_provider.dart';
+import 'package:tapem/core/theme/brand_theme_preset.dart';
+
+Future<void> pumpEventQueue([int times = 10]) async {
+  for (var i = 0; i < times; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ThemePreferenceProvider', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('setTheme persists override locally and remotely', () async {
+      final prefs = await SharedPreferences.getInstance();
+      final firestore = FakeFirebaseFirestore();
+      final provider = ThemePreferenceProvider(
+        firestore: firestore,
+        preferences: prefs,
+      );
+
+      provider.setUser('uid');
+      await pumpEventQueue();
+
+      await provider.setTheme(BrandThemeId.magentaViolet);
+
+      expect(prefs.getString('theme_override_uid'), 'magentaViolet');
+      final doc = await firestore
+          .collection('users')
+          .doc('uid')
+          .collection('settings')
+          .doc('theme')
+          .get();
+      expect(doc.data()?['themeId'], 'magentaViolet');
+    });
+
+    test('cached override is used until remote data is available', () async {
+      SharedPreferences.setMockInitialValues({
+        'theme_override_uid': 'redOrange',
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final completer = Completer<Map<String, dynamic>?>();
+      final firestore = FakeFirebaseFirestore();
+      final provider = ThemePreferenceProvider(
+        firestore: firestore,
+        preferences: prefs,
+        fetchOverride: (_) => completer.future,
+      );
+
+      provider.setUser('uid');
+      await pumpEventQueue();
+
+      expect(provider.override, BrandThemeId.redOrange);
+      expect(provider.hasLoaded, isFalse);
+
+      completer.complete({'themeId': 'magentaViolet'});
+      await pumpEventQueue();
+
+      expect(provider.override, BrandThemeId.magentaViolet);
+      expect(provider.hasLoaded, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- cache the manually selected brand theme override per user in shared preferences
- restore the cached override while Firestore data loads and keep it across remote failures
- add unit tests covering persistence and cached override behaviour

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfb81b3eec83208aee7f80a71ffed4