### PR TITLE
Fix localization getter usage in profile avatar sheet

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -145,6 +145,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
   }
 
   void _showAvatarSheet(AuthProvider auth) {
+    final loc = AppLocalizations.of(context)!;
     showModalBottomSheet(
       context: context,
       builder: (_) {


### PR DESCRIPTION
## Summary
- initialize the localization helper before building the avatar picker sheet so error snackbar can use it

## Testing
- flutter analyze lib/features/profile/presentation/screens/profile_screen.dart *(fails: flutter SDK unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfcb53b0b88320b21b9e65719ea53d