### PR TITLE
Improve localization coverage for English UI

### DIFF
--- a/lib/features/challenges/presentation/screens/challenge_screen.dart
+++ b/lib/features/challenges/presentation/screens/challenge_screen.dart
@@ -1,14 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:tapem/features/challenges/presentation/screens/challenge_tab.dart';
+import 'package:tapem/l10n/app_localizations.dart';
 
 class ChallengeScreen extends StatelessWidget {
   const ChallengeScreen({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
     return Scaffold(
-      appBar: AppBar(title: Text('Challenges')),
-      body: ChallengeTab(),
+      appBar: AppBar(title: Text(loc.leaderboardChallengesTab)),
+      body: const ChallengeTab(),
     );
   }
 }

--- a/lib/features/challenges/presentation/screens/challenge_tab.dart
+++ b/lib/features/challenges/presentation/screens/challenge_tab.dart
@@ -5,6 +5,7 @@ import '../../../../core/providers/gym_provider.dart';
 import '../widgets/active_challenges_widget.dart';
 import '../widgets/completed_challenges_widget.dart';
 import '../../../../core/providers/challenge_provider.dart';
+import 'package:tapem/l10n/app_localizations.dart';
 
 class ChallengeTab extends StatefulWidget {
   const ChallengeTab({Key? key}) : super(key: key);
@@ -36,11 +37,15 @@ class _ChallengeTabState extends State<ChallengeTab>
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
     return Column(
       children: [
         TabBar(
           controller: _tabController,
-          tabs: const [Tab(text: 'Aktiv'), Tab(text: 'Abgeschlossen')],
+          tabs: [
+            Tab(text: loc.challengeTabActive),
+            Tab(text: loc.challengeTabCompleted),
+          ],
         ),
         Expanded(
           child: TabBarView(

--- a/lib/features/challenges/presentation/widgets/active_challenges_widget.dart
+++ b/lib/features/challenges/presentation/widgets/active_challenges_widget.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
 import '../../../../core/providers/challenge_provider.dart';
 
 class ActiveChallengesWidget extends StatelessWidget {
@@ -8,8 +10,9 @@ class ActiveChallengesWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final challenges = context.watch<ChallengeProvider>().challenges;
+    final loc = AppLocalizations.of(context)!;
     if (challenges.isEmpty) {
-      return const Center(child: Text('Keine aktiven Challenges'));
+      return Center(child: Text(loc.challengeEmptyActive));
     }
     return ListView.builder(
       itemCount: challenges.length,
@@ -31,15 +34,15 @@ class ActiveChallengesWidget extends StatelessWidget {
                         children: [
                           Text(c.description),
                           const SizedBox(height: 8),
-                          Text('XP: ${c.xpReward}'),
+                          Text(loc.challengeDetailXpReward(c.xpReward)),
                           const SizedBox(height: 8),
-                          Text('Geräte: ${c.deviceIds.join(', ')}'),
+                          Text(loc.challengeDetailDevices(c.deviceIds.join(', '))),
                         ],
                       ),
                       actions: [
                         TextButton(
                           onPressed: () => Navigator.pop(context),
-                          child: const Text('Schließen'),
+                          child: Text(loc.commonOk),
                         ),
                       ],
                     ),

--- a/lib/features/challenges/presentation/widgets/completed_challenges_widget.dart
+++ b/lib/features/challenges/presentation/widgets/completed_challenges_widget.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
 import '../../../../core/providers/challenge_provider.dart';
 
 class CompletedChallengesWidget extends StatelessWidget {
@@ -8,8 +10,9 @@ class CompletedChallengesWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final completed = context.watch<ChallengeProvider>().completed;
+    final loc = AppLocalizations.of(context)!;
     if (completed.isEmpty) {
-      return const Center(child: Text('Keine abgeschlossenen Challenges'));
+      return Center(child: Text(loc.challengeEmptyCompleted));
     }
     return ListView.builder(
       itemCount: completed.length,

--- a/lib/features/feedback/presentation/widgets/feedback_button.dart
+++ b/lib/features/feedback/presentation/widgets/feedback_button.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import 'package:tapem/features/feedback/feedback_provider.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
+import 'package:tapem/l10n/app_localizations.dart';
 class FeedbackButton extends StatelessWidget {
   final String gymId;
   final String deviceId;
@@ -17,33 +18,35 @@ class FeedbackButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
     final iconColor = color ?? Theme.of(context).iconTheme.color;
     return IconButton(
       icon: Icon(Icons.feedback_outlined, color: iconColor),
-      tooltip: 'Feedback',
+      tooltip: loc.feedbackTooltip,
       onPressed: () => _showDialog(context),
     );
   }
 
   void _showDialog(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
     final TextEditingController controller = TextEditingController();
     showDialog(
       context: context,
       builder: (ctx) {
         return AlertDialog(
-          title: const Text('Feedback'),
+          title: Text(loc.feedbackDialogTitle),
           content: TextField(
             controller: controller,
             maxLines: 4,
-            decoration: const InputDecoration(
-              hintText: 'Dein Feedback...',
-              border: OutlineInputBorder(),
+            decoration: InputDecoration(
+              hintText: loc.feedbackPlaceholder,
+              border: const OutlineInputBorder(),
             ),
           ),
           actions: [
             TextButton(
               onPressed: () => Navigator.of(ctx).pop(),
-              child: const Text('Abbrechen'),
+              child: Text(loc.cancelButton),
             ),
             ElevatedButton(
               onPressed: () async {
@@ -59,11 +62,11 @@ class FeedbackButton extends StatelessWidget {
                   );
                   Navigator.of(ctx).pop();
                   ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Feedback gesendet')),
+                    SnackBar(content: Text(loc.feedbackSent)),
                   );
                 }
               },
-              child: const Text('Senden'),
+              child: Text(loc.feedbackSubmit),
             ),
           ],
         );

--- a/lib/features/friends/presentation/screens/friend_training_calendar_screen.dart
+++ b/lib/features/friends/presentation/screens/friend_training_calendar_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:tapem/features/friends/providers/friend_calendar_provider.dart';
 import 'package:tapem/features/profile/presentation/widgets/calendar.dart';
 import 'package:tapem/features/profile/presentation/widgets/calendar_popup.dart';
+import 'package:tapem/l10n/app_localizations.dart';
 
 class FriendTrainingCalendarScreen extends StatefulWidget {
   final String friendUid;
@@ -43,21 +44,22 @@ class _FriendTrainingCalendarScreenState extends State<FriendTrainingCalendarScr
   Widget build(BuildContext context) {
     final prov = context.watch<FriendCalendarProvider>();
     final dates = prov.trainingDates;
+    final loc = AppLocalizations.of(context)!;
 
     Widget body;
     if (prov.isLoading) {
       body = const Center(child: CircularProgressIndicator());
     } else if (prov.error != null) {
-      body = const Center(child: Text('Nur für Freunde sichtbar'));
+      body = Center(child: Text(loc.friends_privacy_no_access));
     } else {
       body = Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
-              'Trainingstage',
-              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+            Text(
+              loc.friends_action_training_days,
+              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
             ),
             const SizedBox(height: 8),
             Expanded(

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -407,7 +407,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             BrandGradientText(
-              'Trainingstage',
+              loc.profileTrainingDaysHeading,
               textAlign: TextAlign.center,
               style: theme.textTheme.titleMedium?.copyWith(
                 fontWeight: FontWeight.bold,
@@ -558,7 +558,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                 SizedBox(
                   width: double.infinity,
                   child: BrandActionTile(
-                    title: 'Umfragen',
+                    title: loc.surveyListTitle,
                     centerTitle: true,
                     dense: true,
                     minVerticalPadding: 0,

--- a/lib/features/rank/presentation/screens/rank_screen.dart
+++ b/lib/features/rank/presentation/screens/rank_screen.dart
@@ -42,11 +42,12 @@ class _RankScreenState extends State<RankScreen>
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final loc = AppLocalizations.of(context)!;
 
     return Scaffold(
       appBar: AppBar(
         title: BrandGradientText(
-          'Leaderboard',
+          loc.leaderboardTitle,
           style: theme.textTheme.titleLarge,
         ),
         bottom: TabBar(
@@ -54,13 +55,13 @@ class _RankScreenState extends State<RankScreen>
           tabs: [
             Tab(
               child: BrandGradientText(
-                'Rank',
+                loc.leaderboardRankTab,
                 style: theme.textTheme.titleMedium,
               ),
             ),
             Tab(
               child: BrandGradientText(
-                'Challenges',
+                loc.leaderboardChallengesTab,
                 style: theme.textTheme.titleMedium,
               ),
             ),
@@ -76,7 +77,7 @@ class _RankScreenState extends State<RankScreen>
                 padding: const EdgeInsets.all(AppSpacing.sm),
                 children: [
                   BrandActionTile(
-                    title: AppLocalizations.of(context)!.rankExperience,
+                    title: loc.rankExperience,
                     onTap: () =>
                         Navigator.of(context).pushNamed(AppRouter.dayXp),
                     centerTitle: true,
@@ -88,7 +89,7 @@ class _RankScreenState extends State<RankScreen>
                   ),
                   const SizedBox(height: AppSpacing.sm),
                   BrandActionTile(
-                    title: AppLocalizations.of(context)!.rankDeviceLevel,
+                    title: loc.rankDeviceLevel,
                     onTap: () =>
                         Navigator.of(context).pushNamed(AppRouter.deviceXp),
                     centerTitle: true,
@@ -100,7 +101,7 @@ class _RankScreenState extends State<RankScreen>
                   ),
                   const SizedBox(height: AppSpacing.sm),
                   BrandActionTile(
-                    title: AppLocalizations.of(context)!.rankMuscleLevel,
+                    title: loc.rankMuscleLevel,
                     onTap: () =>
                         Navigator.of(context).pushNamed(AppRouter.xpOverview),
                     centerTitle: true,

--- a/lib/features/rank/presentation/widgets/xp_info_button.dart
+++ b/lib/features/rank/presentation/widgets/xp_info_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tapem/features/rank/domain/services/level_service.dart';
 import 'package:tapem/app_router.dart';
+import 'package:tapem/l10n/app_localizations.dart';
 
 class XpInfoButton extends StatelessWidget {
   final int xp;
@@ -16,44 +17,46 @@ class XpInfoButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
     final iconColor = color ?? Theme.of(context).iconTheme.color;
     return IconButton(
       icon: Icon(Icons.auto_awesome, color: iconColor),
-      tooltip: 'XP',
+      tooltip: loc.xpInfoTooltip,
       onPressed: () => _showInfo(context),
     );
   }
 
   void _showInfo(BuildContext context) {
+    final loc = AppLocalizations.of(context)!;
+    final xpRemaining = LevelService.xpPerLevel - xp;
+    final nextLevel = level + 1;
     showDialog(
       context: context,
       builder:
           (_) => AlertDialog(
-            title: const Text('XP Info'),
+            title: Text(loc.xpInfoTitle),
             content: Column(
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text('XP: $xp'),
-                Text('Level: ${_toRoman(level)}'),
+                Text(loc.xpInfoCurrentXp(xp)),
+                Text(loc.xpInfoLevel(_toRoman(level))),
                 const SizedBox(height: 8),
                 LinearProgressIndicator(value: xp / LevelService.xpPerLevel),
-                Text(
-                  '${LevelService.xpPerLevel - xp} XP bis Level ${level + 1}',
-                ),
+                Text(loc.xpInfoProgress(xpRemaining, nextLevel)),
               ],
             ),
             actions: [
               TextButton(
                 onPressed: () => Navigator.of(context).pop(),
-                child: const Text('OK'),
+                child: Text(loc.commonOk),
               ),
               TextButton(
                 onPressed: () {
                   Navigator.of(context).pop();
                   Navigator.of(context).pushNamed(AppRouter.xpOverview);
                 },
-                child: const Text('Details'),
+                child: Text(loc.xpInfoDetails),
               ),
             ],
           ),

--- a/lib/features/survey/presentation/screens/survey_overview_screen.dart
+++ b/lib/features/survey/presentation/screens/survey_overview_screen.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 import '../../survey_provider.dart';
 import '../../survey.dart';
 import 'survey_detail_screen.dart';
+import 'package:tapem/l10n/app_localizations.dart';
 
 class SurveyOverviewScreen extends StatefulWidget {
   final String gymId;
@@ -39,19 +40,23 @@ class _SurveyOverviewScreenState extends State<SurveyOverviewScreen>
   @override
   Widget build(BuildContext context) {
     final surveyProv = context.watch<SurveyProvider>();
+    final loc = AppLocalizations.of(context)!;
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Umfragen'),
+        title: Text(loc.surveyListTitle),
         bottom: TabBar(
           controller: _tabController,
-          tabs: const [Tab(text: 'Offen'), Tab(text: 'Abgeschlossen')],
+          tabs: [
+            Tab(text: loc.surveyTabOpen),
+            Tab(text: loc.surveyTabClosed),
+          ],
         ),
       ),
       body: TabBarView(
         controller: _tabController,
         children: [
-          _buildList(context, surveyProv.openSurveys, open: true),
-          _buildList(context, surveyProv.closedSurveys, open: false),
+          _buildList(context, surveyProv.openSurveys, loc, open: true),
+          _buildList(context, surveyProv.closedSurveys, loc, open: false),
         ],
       ),
     );
@@ -60,10 +65,11 @@ class _SurveyOverviewScreenState extends State<SurveyOverviewScreen>
   Widget _buildList(
     BuildContext context,
     List<Survey> surveys, {
+    required AppLocalizations loc,
     required bool open,
   }) {
     if (surveys.isEmpty) {
-      return const Center(child: Text('Keine Umfragen'));
+      return Center(child: Text(open ? loc.surveyEmpty : loc.surveyEmptyClosed));
     }
     return ListView.builder(
       itemCount: surveys.length,

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -22,6 +22,11 @@
     "description": "Beschriftung für den Abbrechen-Button"
   },
 
+  "commonOk": "OK",
+  "@commonOk": {
+    "description": "Beschriftung für eine generische OK-Aktion"
+  },
+
   "deviceHistoryTooltip": "Verlauf anzeigen",
   "@deviceHistoryTooltip": {
     "description": "Tooltip für den Verlauf-Button auf der Geräte-Seite"
@@ -97,6 +102,38 @@
   "@rankMuscleLevel": {
     "description": "Titelkarte für Muskelgruppenstatistik im Rank-Tab"
   },
+
+  "leaderboardTitle": "Leaderboard",
+  "@leaderboardTitle": {"description": "AppBar-Titel für die Rangliste"},
+  "leaderboardRankTab": "Rank",
+  "@leaderboardRankTab": {"description": "Tab-Label für die Rangliste"},
+  "leaderboardChallengesTab": "Challenges",
+  "@leaderboardChallengesTab": {"description": "Tab-Label für Challenges"},
+
+  "xpInfoTooltip": "XP-Info",
+  "@xpInfoTooltip": {"description": "Tooltip für den XP-Info-Button"},
+  "xpInfoTitle": "XP-Info",
+  "@xpInfoTitle": {"description": "Titel des XP-Info-Dialogs"},
+  "xpInfoCurrentXp": "XP: {xp}",
+  "@xpInfoCurrentXp": {
+    "description": "Anzeige der aktuellen XP im Dialog",
+    "placeholders": {"xp": {"type": "int"}}
+  },
+  "xpInfoLevel": "Level: {level}",
+  "@xpInfoLevel": {
+    "description": "Anzeige des aktuellen Levels im Dialog",
+    "placeholders": {"level": {}}
+  },
+  "xpInfoProgress": "{xpRemaining} XP bis Level {nextLevel}",
+  "@xpInfoProgress": {
+    "description": "Fortschrittsmeldung bis zum nächsten Level",
+    "placeholders": {
+      "xpRemaining": {"type": "int"},
+      "nextLevel": {"type": "int"}
+    }
+  },
+  "xpInfoDetails": "Details",
+  "@xpInfoDetails": {"description": "Button um XP-Details zu öffnen"},
 
   "gymCodeFieldLabel": "Gym-Code",
   "@gymCodeFieldLabel": {
@@ -289,6 +326,11 @@
   "profileTrainingDaysTitle": "Deine Trainingstage im Jahr",
   "@profileTrainingDaysTitle": {
     "description": "Überschrift für den Kalender auf der Profilseite"
+  },
+
+  "profileTrainingDaysHeading": "Trainingstage",
+  "@profileTrainingDaysHeading": {
+    "description": "Kurze Überschrift für den Trainingskalender im Profil"
   },
 
   "profileStatsButtonLabel": "Statistiken",
@@ -892,6 +934,12 @@
   "@filterNameChip": {"description": "Chip-Label für Sortierung nach Name"},
   "filterMuscleChip": "Muskel",
   "@filterMuscleChip": {"description": "Chip-Label für Muskel-Filter"},
+  "filterRecentChip": "Zuletzt",
+  "@filterRecentChip": {"description": "Chip-Label für Sortierung nach letzter Nutzung"},
+  "filterSortAz": "A→Z",
+  "@filterSortAz": {"description": "Sortieroption von A nach Z"},
+  "filterSortZa": "Z→A",
+  "@filterSortZa": {"description": "Sortieroption von Z nach A"},
   "a11yMgSelected": "Muskelgruppe: {name}, ausgewählt",
   "@a11yMgSelected": {
     "description": "Semantik für ausgewählte Muskelgruppe",
@@ -990,6 +1038,16 @@
   ,"@reportFeedbackOpenEntries": {"description": "Untertitel für offene Feedback-Einträge","placeholders": {"count": {"type": "int"}}}
   ,"reportFeedbackNoOpenEntries": "Kein offenes Feedback"
   ,"@reportFeedbackNoOpenEntries": {"description": "Untertitel wenn kein offenes Feedback vorhanden ist"}
+  ,"feedbackDialogTitle": "Feedback"
+  ,"@feedbackDialogTitle": {"description": "Titel des Feedback-Dialogs"}
+  ,"feedbackTooltip": "Feedback"
+  ,"@feedbackTooltip": {"description": "Tooltip für den Feedback-Button"}
+  ,"feedbackPlaceholder": "Dein Feedback..."
+  ,"@feedbackPlaceholder": {"description": "Platzhaltertext für das Feedbackfeld"}
+  ,"feedbackSubmit": "Senden"
+  ,"@feedbackSubmit": {"description": "Absende-Button für Feedback"}
+  ,"feedbackSent": "Feedback gesendet"
+  ,"@feedbackSent": {"description": "Snackbar nach dem Senden von Feedback"}
   ,"reportCreateSurveyTitle": "Umfrage erstellen"
   ,"@reportCreateSurveyTitle": {"description": "Aktion zum Erstellen einer Umfrage"}
   ,"reportViewSurveysTitle": "Umfragen ansehen"
@@ -1048,6 +1106,18 @@
   ,"@challengeAdminFieldXpReward": {"description": "Label für das XP-Reward-Feld"}
   ,"challengeAdminFieldType": "Typ"
   ,"@challengeAdminFieldType": {"description": "Label für den Challenge-Typ"}
+  ,"challengeTabActive": "Aktiv"
+  ,"@challengeTabActive": {"description": "Tab-Label für aktive Challenges"}
+  ,"challengeTabCompleted": "Abgeschlossen"
+  ,"@challengeTabCompleted": {"description": "Tab-Label für abgeschlossene Challenges"}
+  ,"challengeEmptyActive": "Keine aktiven Challenges"
+  ,"@challengeEmptyActive": {"description": "Meldung wenn keine aktiven Challenges vorhanden sind"}
+  ,"challengeEmptyCompleted": "Keine abgeschlossenen Challenges"
+  ,"@challengeEmptyCompleted": {"description": "Meldung wenn keine abgeschlossenen Challenges vorhanden sind"}
+  ,"challengeDetailXpReward": "XP: {xp}"
+  ,"@challengeDetailXpReward": {"description": "XP-Belohnung im Challenge-Dialog","placeholders": {"xp": {"type": "int"}}}
+  ,"challengeDetailDevices": "Geräte: {devices}"
+  ,"@challengeDetailDevices": {"description": "Geräteliste im Challenge-Dialog","placeholders": {"devices": {}}}
   ,"challengeAdminTypeWeekly": "Wöchentlich"
   ,"@challengeAdminTypeWeekly": {"description": "Option für wöchentliche Challenges"}
   ,"challengeAdminTypeMonthly": "Monatlich"
@@ -1132,8 +1202,14 @@
   ,"@surveyVotesCountWithPercent": {"description": "Anzeige der Stimmenzahl mit Prozentangabe","placeholders": {"count": {"type": "int"}, "percent": {}}}
   ,"surveyListTitle": "Umfragen"
   ,"@surveyListTitle": {"description": "AppBar-Titel für die Umfragenliste"}
+  ,"surveyTabOpen": "Offen"
+  ,"@surveyTabOpen": {"description": "Tab-Label für offene Umfragen"}
+  ,"surveyTabClosed": "Abgeschlossen"
+  ,"@surveyTabClosed": {"description": "Tab-Label für abgeschlossene Umfragen"}
   ,"surveyEmpty": "Keine offenen Umfragen"
   ,"@surveyEmpty": {"description": "Hinweis wenn keine offenen Umfragen vorhanden sind"}
+  ,"surveyEmptyClosed": "Keine abgeschlossenen Umfragen"
+  ,"@surveyEmptyClosed": {"description": "Hinweis wenn keine abgeschlossenen Umfragen vorhanden sind"}
   ,"surveyResultsTitle": "Ergebnisse"
   ,"@surveyResultsTitle": {"description": "Überschrift über den Umfrageergebnissen"}
   ,"selectGymTitle": "Gym auswählen"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -22,6 +22,11 @@
     "description": "Label for the cancel button"
   },
 
+  "commonOk": "OK",
+  "@commonOk": {
+    "description": "Label for a generic OK action"
+  },
+
   "deviceHistoryTooltip": "Show history",
   "@deviceHistoryTooltip": {
     "description": "Tooltip for the history button on device screen"
@@ -97,6 +102,38 @@
   "@rankMuscleLevel": {
     "description": "Title card for muscle group stats on rank tab"
   },
+
+  "leaderboardTitle": "Leaderboard",
+  "@leaderboardTitle": {"description": "App bar title for the leaderboard"},
+  "leaderboardRankTab": "Rank",
+  "@leaderboardRankTab": {"description": "Tab label for ranking view"},
+  "leaderboardChallengesTab": "Challenges",
+  "@leaderboardChallengesTab": {"description": "Tab label for challenges view"},
+
+  "xpInfoTooltip": "XP info",
+  "@xpInfoTooltip": {"description": "Tooltip for the XP info button"},
+  "xpInfoTitle": "XP info",
+  "@xpInfoTitle": {"description": "Title of the XP info dialog"},
+  "xpInfoCurrentXp": "XP: {xp}",
+  "@xpInfoCurrentXp": {
+    "description": "Label for current XP in the XP dialog",
+    "placeholders": {"xp": {"type": "int"}}
+  },
+  "xpInfoLevel": "Level: {level}",
+  "@xpInfoLevel": {
+    "description": "Label for the current level in the XP dialog",
+    "placeholders": {"level": {}}
+  },
+  "xpInfoProgress": "{xpRemaining} XP to level {nextLevel}",
+  "@xpInfoProgress": {
+    "description": "Progress message towards the next level",
+    "placeholders": {
+      "xpRemaining": {"type": "int"},
+      "nextLevel": {"type": "int"}
+    }
+  },
+  "xpInfoDetails": "Details",
+  "@xpInfoDetails": {"description": "Button to open XP details"},
 
   "gymCodeFieldLabel": "Gym Code",
   "@gymCodeFieldLabel": {
@@ -289,6 +326,11 @@
   "profileTrainingDaysTitle": "Your training days of the year",
   "@profileTrainingDaysTitle": {
     "description": "Heading for the calendar on profile screen"
+  },
+
+  "profileTrainingDaysHeading": "Training days",
+  "@profileTrainingDaysHeading": {
+    "description": "Short heading for the training days calendar on the profile"
   },
 
   "profileStatsButtonLabel": "Statistics",
@@ -890,6 +932,12 @@
   "@filterNameChip": {"description": "Chip label for sorting by name"},
   "filterMuscleChip": "Muscle",
   "@filterMuscleChip": {"description": "Chip label for muscle filter"},
+  "filterRecentChip": "Recent",
+  "@filterRecentChip": {"description": "Chip label for recent sort"},
+  "filterSortAz": "A→Z",
+  "@filterSortAz": {"description": "Sort option from A to Z"},
+  "filterSortZa": "Z→A",
+  "@filterSortZa": {"description": "Sort option from Z to A"},
   "a11yMgSelected": "Muscle group: {name}, selected",
   "@a11yMgSelected": {
     "description": "Semantics for selected muscle group",
@@ -988,6 +1036,16 @@
   ,"@reportFeedbackOpenEntries": {"description": "Subtitle showing open feedback entries","placeholders": {"count": {"type": "int"}}}
   ,"reportFeedbackNoOpenEntries": "No open feedback"
   ,"@reportFeedbackNoOpenEntries": {"description": "Subtitle shown when there are no open feedback entries"}
+  ,"feedbackDialogTitle": "Feedback"
+  ,"@feedbackDialogTitle": {"description": "Title of the feedback dialog"}
+  ,"feedbackTooltip": "Feedback"
+  ,"@feedbackTooltip": {"description": "Tooltip for the feedback button"}
+  ,"feedbackPlaceholder": "Your feedback..."
+  ,"@feedbackPlaceholder": {"description": "Placeholder text for the feedback input"}
+  ,"feedbackSubmit": "Send"
+  ,"@feedbackSubmit": {"description": "Submit button label for feedback"}
+  ,"feedbackSent": "Feedback sent"
+  ,"@feedbackSent": {"description": "Snackbar shown after sending feedback"}
   ,"reportCreateSurveyTitle": "Create survey"
   ,"@reportCreateSurveyTitle": {"description": "Action title to create a survey"}
   ,"reportViewSurveysTitle": "View surveys"
@@ -1046,6 +1104,18 @@
   ,"@challengeAdminFieldXpReward": {"description": "Label for the XP reward field"}
   ,"challengeAdminFieldType": "Type"
   ,"@challengeAdminFieldType": {"description": "Label for the challenge type field"}
+  ,"challengeTabActive": "Active"
+  ,"@challengeTabActive": {"description": "Tab label for active challenges"}
+  ,"challengeTabCompleted": "Completed"
+  ,"@challengeTabCompleted": {"description": "Tab label for completed challenges"}
+  ,"challengeEmptyActive": "No active challenges"
+  ,"@challengeEmptyActive": {"description": "Message shown when there are no active challenges"}
+  ,"challengeEmptyCompleted": "No completed challenges"
+  ,"@challengeEmptyCompleted": {"description": "Message shown when there are no completed challenges"}
+  ,"challengeDetailXpReward": "XP: {xp}"
+  ,"@challengeDetailXpReward": {"description": "XP reward shown in the challenge dialog","placeholders": {"xp": {"type": "int"}}}
+  ,"challengeDetailDevices": "Devices: {devices}"
+  ,"@challengeDetailDevices": {"description": "Device list shown in the challenge dialog","placeholders": {"devices": {}}}
   ,"challengeAdminTypeWeekly": "Weekly"
   ,"@challengeAdminTypeWeekly": {"description": "Weekly challenge option"}
   ,"challengeAdminTypeMonthly": "Monthly"
@@ -1130,8 +1200,14 @@
   ,"@surveyVotesCountWithPercent": {"description": "Displays vote count with percentage","placeholders": {"count": {"type": "int"}, "percent": {}}}
   ,"surveyListTitle": "Surveys"
   ,"@surveyListTitle": {"description": "AppBar title for the survey list"}
+  ,"surveyTabOpen": "Open"
+  ,"@surveyTabOpen": {"description": "Tab label for open surveys"}
+  ,"surveyTabClosed": "Completed"
+  ,"@surveyTabClosed": {"description": "Tab label for completed surveys"}
   ,"surveyEmpty": "No open surveys"
   ,"@surveyEmpty": {"description": "Message shown when there are no open surveys"}
+  ,"surveyEmptyClosed": "No completed surveys"
+  ,"@surveyEmptyClosed": {"description": "Message shown when there are no completed surveys"}
   ,"surveyResultsTitle": "Results"
   ,"@surveyResultsTitle": {"description": "Heading shown above survey results"}
   ,"selectGymTitle": "Select gym"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -119,6 +119,12 @@ abstract class AppLocalizations {
   /// **'Cancel'**
   String get cancelButton;
 
+  /// Label for a generic OK action
+  ///
+  /// In en, this message translates to:
+  /// **'OK'**
+  String get commonOk;
+
   /// Tooltip for the history button on device screen
   ///
   /// In en, this message translates to:
@@ -262,6 +268,60 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Muscle level'**
   String get rankMuscleLevel;
+
+  /// App bar title for the leaderboard
+  ///
+  /// In en, this message translates to:
+  /// **'Leaderboard'**
+  String get leaderboardTitle;
+
+  /// Tab label for ranking view
+  ///
+  /// In en, this message translates to:
+  /// **'Rank'**
+  String get leaderboardRankTab;
+
+  /// Tab label for challenges view
+  ///
+  /// In en, this message translates to:
+  /// **'Challenges'**
+  String get leaderboardChallengesTab;
+
+  /// Tooltip for the XP info button
+  ///
+  /// In en, this message translates to:
+  /// **'XP info'**
+  String get xpInfoTooltip;
+
+  /// Title of the XP info dialog
+  ///
+  /// In en, this message translates to:
+  /// **'XP info'**
+  String get xpInfoTitle;
+
+  /// Label for current XP in the XP dialog
+  ///
+  /// In en, this message translates to:
+  /// **'XP: {xp}'**
+  String xpInfoCurrentXp(int xp);
+
+  /// Label for the current level in the XP dialog
+  ///
+  /// In en, this message translates to:
+  /// **'Level: {level}'**
+  String xpInfoLevel(Object level);
+
+  /// Progress message towards the next level
+  ///
+  /// In en, this message translates to:
+  /// **'{xpRemaining} XP to level {nextLevel}'**
+  String xpInfoProgress(int xpRemaining, int nextLevel);
+
+  /// Button to open XP details
+  ///
+  /// In en, this message translates to:
+  /// **'Details'**
+  String get xpInfoDetails;
 
   /// Label for the gym code input
   ///
@@ -502,6 +562,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Your training days of the year'**
   String get profileTrainingDaysTitle;
+
+  /// Short heading for the training days calendar on the profile
+  ///
+  /// In en, this message translates to:
+  /// **'Training days'**
+  String get profileTrainingDaysHeading;
 
   /// Button label on profile screen to open the statistics page
   ///
@@ -1517,6 +1583,24 @@ abstract class AppLocalizations {
   /// **'Muscle'**
   String get filterMuscleChip;
 
+  /// Chip label for recent sort
+  ///
+  /// In en, this message translates to:
+  /// **'Recent'**
+  String get filterRecentChip;
+
+  /// Sort option from A to Z
+  ///
+  /// In en, this message translates to:
+  /// **'A→Z'**
+  String get filterSortAz;
+
+  /// Sort option from Z to A
+  ///
+  /// In en, this message translates to:
+  /// **'Z→A'**
+  String get filterSortZa;
+
   /// Semantics for selected muscle group
   ///
   /// In en, this message translates to:
@@ -1892,6 +1976,21 @@ abstract class AppLocalizations {
   /// No description provided for @reportFeedbackNoOpenEntries.
   String get reportFeedbackNoOpenEntries;
 
+  /// No description provided for @feedbackDialogTitle.
+  String get feedbackDialogTitle;
+
+  /// No description provided for @feedbackTooltip.
+  String get feedbackTooltip;
+
+  /// No description provided for @feedbackPlaceholder.
+  String get feedbackPlaceholder;
+
+  /// No description provided for @feedbackSubmit.
+  String get feedbackSubmit;
+
+  /// No description provided for @feedbackSent.
+  String get feedbackSent;
+
   /// No description provided for @reportCreateSurveyTitle.
   String get reportCreateSurveyTitle;
 
@@ -1978,6 +2077,24 @@ abstract class AppLocalizations {
 
   /// No description provided for @challengeAdminFieldType.
   String get challengeAdminFieldType;
+
+  /// No description provided for @challengeTabActive.
+  String get challengeTabActive;
+
+  /// No description provided for @challengeTabCompleted.
+  String get challengeTabCompleted;
+
+  /// No description provided for @challengeEmptyActive.
+  String get challengeEmptyActive;
+
+  /// No description provided for @challengeEmptyCompleted.
+  String get challengeEmptyCompleted;
+
+  /// No description provided for @challengeDetailXpReward.
+  String challengeDetailXpReward(int xp);
+
+  /// No description provided for @challengeDetailDevices.
+  String challengeDetailDevices(Object devices);
 
   /// No description provided for @challengeAdminTypeWeekly.
   String get challengeAdminTypeWeekly;
@@ -2084,8 +2201,17 @@ abstract class AppLocalizations {
   /// No description provided for @surveyListTitle.
   String get surveyListTitle;
 
+  /// No description provided for @surveyTabOpen.
+  String get surveyTabOpen;
+
+  /// No description provided for @surveyTabClosed.
+  String get surveyTabClosed;
+
   /// No description provided for @surveyEmpty.
   String get surveyEmpty;
+
+  /// No description provided for @surveyEmptyClosed.
+  String get surveyEmptyClosed;
 
   /// No description provided for @surveyResultsTitle.
   String get surveyResultsTitle;

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -21,6 +21,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get cancelButton => 'Abbrechen';
+  String get commonOk => 'OK';
 
   @override
   String get deviceHistoryTooltip => 'Verlauf anzeigen';
@@ -103,6 +104,39 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get rankMuscleLevel => 'Mucki level';
+
+  @override
+  String get leaderboardTitle => 'Leaderboard';
+
+  @override
+  String get leaderboardRankTab => 'Rank';
+
+  @override
+  String get leaderboardChallengesTab => 'Challenges';
+
+  @override
+  String get xpInfoTooltip => 'XP-Info';
+
+  @override
+  String get xpInfoTitle => 'XP-Info';
+
+  @override
+  String xpInfoCurrentXp(int xp) {
+    return 'XP: $xp';
+  }
+
+  @override
+  String xpInfoLevel(Object level) {
+    return 'Level: $level';
+  }
+
+  @override
+  String xpInfoProgress(int xpRemaining, int nextLevel) {
+    return '$xpRemaining XP bis Level $nextLevel';
+  }
+
+  @override
+  String get xpInfoDetails => 'Details';
 
   @override
   String get gymCodeFieldLabel => 'Gym-Code';
@@ -229,6 +263,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get profileTrainingDaysTitle => 'Deine Trainingstage im Jahr';
+
+  @override
+  String get profileTrainingDaysHeading => 'Trainingstage';
 
   @override
   String get profileStatsButtonLabel => 'Statistiken';
@@ -752,6 +789,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get filterMuscleChip => 'Muskel';
 
   @override
+  String get filterRecentChip => 'Zuletzt';
+
+  @override
+  String get filterSortAz => 'A→Z';
+
+  @override
+  String get filterSortZa => 'Z→A';
+
+  @override
   String a11yMgSelected(Object name) {
     return 'Muskelgruppe: $name, ausgewählt';
   }
@@ -965,6 +1011,21 @@ class AppLocalizationsDe extends AppLocalizations {
   String get reportFeedbackNoOpenEntries => 'Kein offenes Feedback';
 
   @override
+  String get feedbackDialogTitle => 'Feedback';
+
+  @override
+  String get feedbackTooltip => 'Feedback';
+
+  @override
+  String get feedbackPlaceholder => 'Dein Feedback...';
+
+  @override
+  String get feedbackSubmit => 'Senden';
+
+  @override
+  String get feedbackSent => 'Feedback gesendet';
+
+  @override
   String get reportCreateSurveyTitle => 'Umfrage erstellen';
 
   @override
@@ -1056,6 +1117,28 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get challengeAdminFieldType => 'Typ';
+
+  @override
+  String get challengeTabActive => 'Aktiv';
+
+  @override
+  String get challengeTabCompleted => 'Abgeschlossen';
+
+  @override
+  String get challengeEmptyActive => 'Keine aktiven Challenges';
+
+  @override
+  String get challengeEmptyCompleted => 'Keine abgeschlossenen Challenges';
+
+  @override
+  String challengeDetailXpReward(int xp) {
+    return 'XP: $xp';
+  }
+
+  @override
+  String challengeDetailDevices(Object devices) {
+    return 'Geräte: $devices';
+  }
 
   @override
   String get challengeAdminTypeWeekly => 'Wöchentlich';
@@ -1181,7 +1264,16 @@ class AppLocalizationsDe extends AppLocalizations {
   String get surveyListTitle => 'Umfragen';
 
   @override
+  String get surveyTabOpen => 'Offen';
+
+  @override
+  String get surveyTabClosed => 'Abgeschlossen';
+
+  @override
   String get surveyEmpty => 'Keine offenen Umfragen';
+
+  @override
+  String get surveyEmptyClosed => 'Keine abgeschlossenen Umfragen';
 
   @override
   String get surveyResultsTitle => 'Ergebnisse';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -21,6 +21,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get cancelButton => 'Cancel';
+  String get commonOk => 'OK';
 
   @override
   String get deviceHistoryTooltip => 'Show history';
@@ -103,6 +104,39 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get rankMuscleLevel => 'Muscle level';
+
+  @override
+  String get leaderboardTitle => 'Leaderboard';
+
+  @override
+  String get leaderboardRankTab => 'Rank';
+
+  @override
+  String get leaderboardChallengesTab => 'Challenges';
+
+  @override
+  String get xpInfoTooltip => 'XP info';
+
+  @override
+  String get xpInfoTitle => 'XP info';
+
+  @override
+  String xpInfoCurrentXp(int xp) {
+    return 'XP: $xp';
+  }
+
+  @override
+  String xpInfoLevel(Object level) {
+    return 'Level: $level';
+  }
+
+  @override
+  String xpInfoProgress(int xpRemaining, int nextLevel) {
+    return '$xpRemaining XP to level $nextLevel';
+  }
+
+  @override
+  String get xpInfoDetails => 'Details';
 
   @override
   String get gymCodeFieldLabel => 'Gym Code';
@@ -229,6 +263,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get profileTrainingDaysTitle => 'Your training days of the year';
+
+  @override
+  String get profileTrainingDaysHeading => 'Training days';
 
   @override
   String get profileStatsButtonLabel => 'Statistics';
@@ -752,6 +789,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get filterMuscleChip => 'Muscle';
 
   @override
+  String get filterRecentChip => 'Recent';
+
+  @override
+  String get filterSortAz => 'A→Z';
+
+  @override
+  String get filterSortZa => 'Z→A';
+
+  @override
   String a11yMgSelected(Object name) {
     return 'Muscle group: $name, selected';
   }
@@ -965,6 +1011,21 @@ class AppLocalizationsEn extends AppLocalizations {
   String get reportFeedbackNoOpenEntries => 'No open feedback';
 
   @override
+  String get feedbackDialogTitle => 'Feedback';
+
+  @override
+  String get feedbackTooltip => 'Feedback';
+
+  @override
+  String get feedbackPlaceholder => 'Your feedback...';
+
+  @override
+  String get feedbackSubmit => 'Send';
+
+  @override
+  String get feedbackSent => 'Feedback sent';
+
+  @override
   String get reportCreateSurveyTitle => 'Create survey';
 
   @override
@@ -1056,6 +1117,28 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get challengeAdminFieldType => 'Type';
+
+  @override
+  String get challengeTabActive => 'Active';
+
+  @override
+  String get challengeTabCompleted => 'Completed';
+
+  @override
+  String get challengeEmptyActive => 'No active challenges';
+
+  @override
+  String get challengeEmptyCompleted => 'No completed challenges';
+
+  @override
+  String challengeDetailXpReward(int xp) {
+    return 'XP: $xp';
+  }
+
+  @override
+  String challengeDetailDevices(Object devices) {
+    return 'Devices: $devices';
+  }
 
   @override
   String get challengeAdminTypeWeekly => 'Weekly';
@@ -1181,7 +1264,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get surveyListTitle => 'Surveys';
 
   @override
+  String get surveyTabOpen => 'Open';
+
+  @override
+  String get surveyTabClosed => 'Completed';
+
+  @override
   String get surveyEmpty => 'No open surveys';
+
+  @override
+  String get surveyEmptyClosed => 'No completed surveys';
 
   @override
   String get surveyResultsTitle => 'Results';

--- a/lib/ui/common/search_and_filters.dart
+++ b/lib/ui/common/search_and_filters.dart
@@ -64,6 +64,7 @@ class _SearchAndFiltersState extends State<SearchAndFilters> {
   }
 
   Future<void> _showSortSheet() async {
+    final loc = AppLocalizations.of(context)!;
     final res = await showModalBottomSheet<SortOrder>(
       context: context,
       builder: (ctx) => SafeArea(
@@ -71,11 +72,11 @@ class _SearchAndFiltersState extends State<SearchAndFilters> {
           mainAxisSize: MainAxisSize.min,
           children: [
             ListTile(
-              title: const Text('A→Z'),
+              title: Text(loc.filterSortAz),
               onTap: () => Navigator.pop(ctx, SortOrder.az),
             ),
             ListTile(
-              title: const Text('Z→A'),
+              title: Text(loc.filterSortZa),
               onTap: () => Navigator.pop(ctx, SortOrder.za),
             ),
           ],
@@ -86,6 +87,7 @@ class _SearchAndFiltersState extends State<SearchAndFilters> {
   }
 
   Future<void> _showMuscleSheet() async {
+    final loc = AppLocalizations.of(context)!;
     final prov = context.read<MuscleGroupProvider>();
     final groups = prov.groups;
     final selected = Set<String>.from(widget.muscleFilterIds);
@@ -124,7 +126,7 @@ class _SearchAndFiltersState extends State<SearchAndFilters> {
                   alignment: Alignment.centerRight,
                   child: TextButton(
                     onPressed: () => Navigator.pop(ctx),
-                    child: const Text('OK'),
+                    child: Text(loc.commonOk),
                   ),
                 ),
               ],
@@ -162,7 +164,7 @@ class _SearchAndFiltersState extends State<SearchAndFilters> {
           children: [
             FilterChip(
               label: BrandGradientText(
-                'Name',
+                loc.filterNameChip,
                 style: theme.textTheme.labelLarge,
               ),
               selected: widget.sort == SortOrder.za,
@@ -174,7 +176,7 @@ class _SearchAndFiltersState extends State<SearchAndFilters> {
             const SizedBox(width: 8),
             FilterChip(
               label: BrandGradientText(
-                'Muskel',
+                loc.filterMuscleChip,
                 style: theme.textTheme.labelLarge,
               ),
               selected: widget.muscleFilterIds.isNotEmpty,
@@ -186,7 +188,7 @@ class _SearchAndFiltersState extends State<SearchAndFilters> {
             const SizedBox(width: 8),
             FilterChip(
               label: BrandGradientText(
-                'Zuletzt',
+                loc.filterRecentChip,
                 style: theme.textTheme.labelLarge,
               ),
               selected: widget.sort == SortOrder.recent,

--- a/test/ui/gym/search_and_filters_test.dart
+++ b/test/ui/gym/search_and_filters_test.dart
@@ -16,6 +16,7 @@ import 'package:tapem/features/device/domain/usecases/set_device_muscle_groups_u
 import 'package:tapem/ui/common/search_and_filters.dart';
 import 'package:tapem/features/device/domain/models/device_session_snapshot.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tapem/l10n/app_localizations.dart';
 
 class _DummyMuscleGroupRepo implements MuscleGroupRepository {
   @override
@@ -171,6 +172,9 @@ void main() {
   testWidgets('muscle filter reduces list', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
+        locale: const Locale('en'),
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
         home: ChangeNotifierProvider<MuscleGroupProvider>.value(
           value: _TestMuscleGroupProvider(groups),
           child: const Scaffold(body: _Harness()),
@@ -180,7 +184,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Alpha'), findsOneWidget);
     expect(find.text('Beta'), findsOneWidget);
-    await tester.tap(find.text('Muskel'));
+    await tester.tap(find.text('Muscle'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Chest'));
     await tester.tap(find.text('OK'));
@@ -192,6 +196,9 @@ void main() {
   testWidgets('sort name Z→A', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
+        locale: const Locale('en'),
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
         home: ChangeNotifierProvider<MuscleGroupProvider>.value(
           value: _TestMuscleGroupProvider(groups),
           child: const Scaffold(body: _Harness()),
@@ -210,6 +217,9 @@ void main() {
   testWidgets('recent filter sorts by last usage', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
+        locale: const Locale('en'),
+        supportedLocales: AppLocalizations.supportedLocales,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
         home: ChangeNotifierProvider<MuscleGroupProvider>.value(
           value: _TestMuscleGroupProvider(groups),
           child: const Scaffold(body: _Harness()),
@@ -217,7 +227,7 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Zuletzt'));
+    await tester.tap(find.text('Recent'));
     await tester.pumpAndSettle();
     final first = tester.widget<Text>(find.byKey(const ValueKey('device-0')));
     expect(first.data, 'Beta');


### PR DESCRIPTION
## Summary
- add localization entries for XP info, feedback, challenges, surveys, and search filter labels in English and German
- replace hard-coded German strings with localized values across profile, friends, gym filters, rank, challenge, survey, and feedback interfaces
- update widget tests to load localization delegates and expect the translated labels

## Testing
- not run (Flutter/Dart tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dfce21564c8320ad181f5cd8adafb3