### PR TITLE
Fix survey overview list builder named arguments

### DIFF
--- a/lib/features/survey/presentation/screens/survey_overview_screen.dart
+++ b/lib/features/survey/presentation/screens/survey_overview_screen.dart
@@ -55,8 +55,8 @@ class _SurveyOverviewScreenState extends State<SurveyOverviewScreen>
       body: TabBarView(
         controller: _tabController,
         children: [
-          _buildList(context, surveyProv.openSurveys, loc, open: true),
-          _buildList(context, surveyProv.closedSurveys, loc, open: false),
+          _buildList(context, surveyProv.openSurveys, loc: loc, open: true),
+          _buildList(context, surveyProv.closedSurveys, loc: loc, open: false),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- update the survey overview TabBar view to pass the localization object using the named parameter expected by `_buildList`
- adjust both open and closed survey list calls to match the helper method signature and resolve the hot-reload runtime error

## Testing
- flutter analyze *(fails: `flutter` command is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd633252483208ea2b90ae4aa0cbf