### PR TITLE
Fix timer progress visibility in black/white theme

### DIFF
--- a/lib/ui/timer/session_timer_bar.dart
+++ b/lib/ui/timer/session_timer_bar.dart
@@ -117,10 +117,15 @@ class _SessionTimerBarState extends State<SessionTimerBar>
                             ? null
                             : brand?.gradient ??
                                 LinearGradient(
-                                  colors: [
-                                    theme.colorScheme.primaryContainer,
-                                    theme.colorScheme.primary,
-                                  ],
+                                  colors: isBlackWhiteTheme
+                                      ? [
+                                          Colors.white.withOpacity(0.7),
+                                          Colors.white,
+                                        ]
+                                      : [
+                                          theme.colorScheme.primaryContainer,
+                                          theme.colorScheme.primary,
+                                        ],
                                 ),
                         color: highContrast
                             ? brand?.outlineColorFallback ?? theme.colorScheme.primary


### PR DESCRIPTION
## Summary
- ensure the session timer bar uses a white gradient when the black/white theme is active to keep the progress visible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfdaa174a48320a317ca23d5ad939b