### PR TITLE
Improve session timer visibility in neutral theme

### DIFF
--- a/lib/ui/timer/session_timer_bar.dart
+++ b/lib/ui/timer/session_timer_bar.dart
@@ -93,6 +93,34 @@ class _SessionTimerBarState extends State<SessionTimerBar>
         if (isBlackWhiteTheme) {
           textColor = Colors.white;
         }
+
+        final backgroundColor = isBlackWhiteTheme
+            ? Colors.white.withOpacity(0.12)
+            : theme.colorScheme.surfaceVariant;
+        final borderColor = isBlackWhiteTheme
+            ? Colors.white.withOpacity(0.24)
+            : Colors.transparent;
+        final progressDecoration = BoxDecoration(
+          gradient: highContrast
+              ? null
+              : isBlackWhiteTheme
+                  ? LinearGradient(
+                      colors: [
+                        Colors.white.withOpacity(0.45),
+                        Colors.white,
+                      ],
+                    )
+                  : brand?.gradient ??
+                      LinearGradient(
+                        colors: [
+                          theme.colorScheme.primaryContainer,
+                          theme.colorScheme.primary,
+                        ],
+                      ),
+          color: highContrast
+              ? brand?.outlineColorFallback ?? theme.colorScheme.primary
+              : null,
+        );
         return Semantics(
           label: loc.timerPauseLabel,
           value: _fmt(remaining),
@@ -102,7 +130,8 @@ class _SessionTimerBarState extends State<SessionTimerBar>
             child: Container(
               height: 60,
               decoration: BoxDecoration(
-                color: theme.colorScheme.surfaceVariant,
+                color: backgroundColor,
+                border: Border.all(color: borderColor),
                 borderRadius: BorderRadius.circular(12),
               ),
               clipBehavior: Clip.hardEdge,
@@ -112,25 +141,7 @@ class _SessionTimerBarState extends State<SessionTimerBar>
                     alignment: Alignment.centerLeft,
                     widthFactor: progress,
                     child: Container(
-                      decoration: BoxDecoration(
-                        gradient: highContrast
-                            ? null
-                            : brand?.gradient ??
-                                LinearGradient(
-                                  colors: isBlackWhiteTheme
-                                      ? [
-                                          Colors.white.withOpacity(0.7),
-                                          Colors.white,
-                                        ]
-                                      : [
-                                          theme.colorScheme.primaryContainer,
-                                          theme.colorScheme.primary,
-                                        ],
-                                ),
-                        color: highContrast
-                            ? brand?.outlineColorFallback ?? theme.colorScheme.primary
-                            : null,
-                      ),
+                      decoration: progressDecoration,
                     ),
                   ),
                   Row(


### PR DESCRIPTION
## Summary
- adjust session timer bar styling to provide a visible fill in the neutral black/white theme
- add a subtle border and background track to highlight the countdown progress
- tweak gradient handling to keep accessibility support for high contrast modes

## Testing
- flutter test test/ui/timer/session_timer_bar_test.dart *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdbf77c1c832085c1f7c458b47b75