### PR TITLE
Adjust black-and-white timer background color

### DIFF
--- a/lib/ui/timer/session_timer_bar.dart
+++ b/lib/ui/timer/session_timer_bar.dart
@@ -95,7 +95,7 @@ class _SessionTimerBarState extends State<SessionTimerBar>
         }
 
         final backgroundColor = isBlackWhiteTheme
-            ? Colors.white.withOpacity(0.12)
+            ? Colors.black
             : theme.colorScheme.surfaceVariant;
         final borderColor = isBlackWhiteTheme
             ? Colors.white.withOpacity(0.24)


### PR DESCRIPTION
## Summary
- update the session timer background to use pure black in the black-and-white theme so the unfilled area matches the page background

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfddbdc8888320af186cf66d6480b2