### PR TITLE
Enable multiple drop sets per session set

### DIFF
--- a/lib/core/drafts/session_draft.dart
+++ b/lib/core/drafts/session_draft.dart
@@ -23,6 +23,7 @@ class SetDraft {
   final String? dropReps;
   final bool done;
   final bool isBodyweight;
+  final List<DropDraft> drops;
 
   SetDraft({
     required this.index,
@@ -33,6 +34,7 @@ class SetDraft {
     this.dropReps,
     this.done = false,
     this.isBodyweight = false,
+    this.drops = const [],
   });
 
   factory SetDraft.fromJson(Map<String, dynamic> json) => SetDraft(
@@ -44,6 +46,9 @@ class SetDraft {
         dropReps: json['dropReps'] as String?,
         done: json['done'] as bool? ?? false,
         isBodyweight: json['isBodyweight'] as bool? ?? false,
+        drops: (json['drops'] as List<dynamic>? ?? [])
+            .map((e) => DropDraft.fromJson(Map<String, dynamic>.from(e)))
+            .toList(),
       );
 
   Map<String, dynamic> toJson() => {
@@ -55,6 +60,27 @@ class SetDraft {
         if (dropReps != null) 'dropReps': dropReps,
         'done': done,
         if (isBodyweight) 'isBodyweight': true,
+        if (drops.isNotEmpty) 'drops': drops.map((d) => d.toJson()).toList(),
+      };
+}
+
+class DropDraft {
+  final String weight;
+  final String reps;
+
+  DropDraft({
+    this.weight = '',
+    this.reps = '',
+  });
+
+  factory DropDraft.fromJson(Map<String, dynamic> json) => DropDraft(
+        weight: json['weight'] as String? ?? '',
+        reps: json['reps'] as String? ?? '',
+      );
+
+  Map<String, dynamic> toJson() => {
+        'weight': weight,
+        'reps': reps,
       };
 }
 

--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -49,8 +49,87 @@ void _defaultLog(String message, [StackTrace? stack]) {
   }
 }
 
+List<Map<String, String>> _sanitizeDrops(List<Map<String, String>> drops) {
+  return [
+    for (final drop in drops)
+      () {
+        final weight = (drop['weight'] ?? '').toString().trim();
+        final reps = (drop['reps'] ?? '').toString().trim();
+        if (weight.isEmpty || reps.isEmpty) {
+          return {'weight': '', 'reps': ''};
+        }
+        return {'weight': weight, 'reps': reps};
+      }(),
+  ];
+}
+
+bool _dropHasValue(Map<String, String> drop) {
+  return drop['weight']!.isNotEmpty && drop['reps']!.isNotEmpty;
+}
+
+List<Map<String, String>> _dropsFromSet(Map<String, dynamic> set) {
+  final raw = set['drops'];
+  final drops = <Map<String, String>>[];
+  if (raw is List) {
+    for (final entry in raw) {
+      if (entry is Map) {
+        final map = Map<String, dynamic>.from(entry);
+        drops.add({
+          'weight': (map['weight'] ?? map['kg'] ?? '').toString(),
+          'reps': (map['reps'] ?? map['wdh'] ?? '').toString(),
+        });
+      }
+    }
+  }
+  if (drops.isEmpty) {
+    final legacyWeight = (set['dropWeight'] ?? '').toString();
+    final legacyReps = (set['dropReps'] ?? '').toString();
+    if (legacyWeight.isNotEmpty && legacyReps.isNotEmpty) {
+      drops.add({'weight': legacyWeight, 'reps': legacyReps});
+    }
+  }
+  return _sanitizeDrops(drops);
+}
+
+List<Map<String, String>> _cloneDrops(List<Map<String, String>> drops) {
+  return [
+    for (final drop in drops)
+      {'weight': drop['weight'] ?? '', 'reps': drop['reps'] ?? ''},
+  ];
+}
+
+void _applyDropsToSet(Map<String, dynamic> target, List<Map<String, String>> drops) {
+  final normalized = _sanitizeDrops(drops);
+  target['drops'] = [
+    for (final drop in normalized)
+      {'weight': drop['weight'] ?? '', 'reps': drop['reps'] ?? ''},
+  ];
+  final firstWithValue = normalized.firstWhere(
+    _dropHasValue,
+    orElse: () => const {'weight': '', 'reps': ''},
+  );
+  target['dropWeight'] = firstWithValue['weight'] ?? '';
+  target['dropReps'] = firstWithValue['reps'] ?? '';
+}
+
+Map<String, dynamic> _withNormalizedDrops(Map<String, dynamic> set) {
+  final result = Map<String, dynamic>.from(set);
+  final drops = _dropsFromSet(result);
+  _applyDropsToSet(result, drops);
+  return result;
+}
+
 String _setsBrief(List<Map<String, dynamic>> sets) {
-  return '[${sets.map((s) => '{#${s['number']}:w=${s['weight']},r=${s['reps']},dw=${s['dropWeight']},dr=${s['dropReps']},d=${s['done']}}').join(', ')}]';
+  return '[${sets.map((s) {
+        final drops = _dropsFromSet(s);
+        final dropSummary = drops.where(_dropHasValue).isEmpty
+            ? '-'
+            : drops
+                .where(_dropHasValue)
+                .map((d) => '${d['weight']}x${d['reps']}')
+                .join('|');
+        return '{#${s['number']}:w=${s['weight']},r=${s['reps']},drops=$dropSummary,d=${s['done']}}';
+      }).join(', ')}]';
 }
 
 String? resolveDeviceId(DeviceSessionSnapshot snap) {
@@ -322,7 +401,7 @@ class DeviceProvider extends ChangeNotifier {
       _level = 1;
 
       _sets = [
-        {
+        _withNormalizedDrops({
           'number': '1',
           'weight': '',
           'reps': '',
@@ -330,7 +409,7 @@ class DeviceProvider extends ChangeNotifier {
           'dropReps': '',
           'done': false, // bool statt String
           'isBodyweight': false,
-        },
+        }),
       ];
       _lastSessionSets = [];
       _lastSessionDate = null;
@@ -366,15 +445,17 @@ class DeviceProvider extends ChangeNotifier {
   }
 
   void addSet() {
-    _sets.add({
-      'number': '${_sets.length + 1}',
-      'weight': '',
-      'reps': '',
-      'dropWeight': '',
-      'dropReps': '',
-      'done': false,
-      'isBodyweight': _isBodyweightMode,
-    });
+    _sets.add(
+      _withNormalizedDrops({
+        'number': '${_sets.length + 1}',
+        'weight': '',
+        'reps': '',
+        'dropWeight': '',
+        'dropReps': '',
+        'done': false,
+        'isBodyweight': _isBodyweightMode,
+      }),
+    );
     _log('➕ [Provider] addSet → count=${_sets.length} ${_setsBrief(_sets)}');
     notifyListeners();
     _onSessionMutated();
@@ -383,7 +464,7 @@ class DeviceProvider extends ChangeNotifier {
   void insertSetAt(int index, Map<String, dynamic> set) {
     final s = Map<String, dynamic>.from(set);
     s.putIfAbsent('isBodyweight', () => _isBodyweightMode);
-    _sets.insert(index, s);
+    _sets.insert(index, _withNormalizedDrops(s));
     for (var i = 0; i < _sets.length; i++) {
       _sets[i]['number'] = '${i + 1}';
     }
@@ -407,16 +488,26 @@ class DeviceProvider extends ChangeNotifier {
 
     if (weight != null) after['weight'] = weight;
     if (reps != null) after['reps'] = reps;
-    if (dropWeight != null) after['dropWeight'] = dropWeight;
-    if (dropReps != null) after['dropReps'] = dropReps;
     if (isBodyweight != null) after['isBodyweight'] = isBodyweight;
 
-    final dw = (after['dropWeight'] ?? '').toString().trim();
-    final dr = (after['dropReps'] ?? '').toString().trim();
-    if (dw.isEmpty || dr.isEmpty) {
-      after['dropWeight'] = '';
-      after['dropReps'] = '';
+    var drops = _dropsFromSet(after);
+    if (dropWeight != null || dropReps != null) {
+      if (drops.isEmpty) {
+        drops = [
+          {
+            'weight': dropWeight ?? '',
+            'reps': dropReps ?? '',
+          },
+        ];
+      } else {
+        final first = Map<String, String>.from(drops.first);
+        if (dropWeight != null) first['weight'] = dropWeight;
+        if (dropReps != null) first['reps'] = dropReps;
+        drops[0] = first;
+      }
     }
+    drops = _sanitizeDrops(drops);
+    _applyDropsToSet(after, drops);
 
     after['number'] = '${index + 1}';
     after['done'] = (after['done'] == true || after['done'] == 'true');
@@ -429,6 +520,68 @@ class DeviceProvider extends ChangeNotifier {
     _log('✏️ [Provider] updateSet($index) $before → $after');
     notifyListeners();
     _onSessionMutated();
+  }
+
+  int addDropToSet(int index) {
+    final before = Map<String, dynamic>.from(_sets[index]);
+    final drops = _cloneDrops(_dropsFromSet(before));
+    drops.add({'weight': '', 'reps': ''});
+    final after = Map<String, dynamic>.from(before);
+    _applyDropsToSet(after, drops);
+    after['number'] = '${index + 1}';
+
+    if (mapEquals(before, after)) {
+      return drops.length - 1;
+    }
+
+    _sets[index] = after;
+    _log('➕ [Provider] addDropToSet($index) drops=${drops.length}');
+    notifyListeners();
+    _onSessionMutated();
+    return drops.length - 1;
+  }
+
+  void updateDrop(
+    int setIndex,
+    int dropIndex, {
+    String? weight,
+    String? reps,
+  }) {
+    final before = Map<String, dynamic>.from(_sets[setIndex]);
+    final drops = _cloneDrops(_dropsFromSet(before));
+    if (dropIndex >= drops.length) {
+      drops.addAll(
+        List.generate(
+          dropIndex - drops.length + 1,
+          (_) => {'weight': '', 'reps': ''},
+        ),
+      );
+    }
+    final drop = Map<String, String>.from(drops[dropIndex]);
+    if (weight != null) drop['weight'] = weight;
+    if (reps != null) drop['reps'] = reps;
+    drops[dropIndex] = drop;
+
+    final after = Map<String, dynamic>.from(before);
+    _applyDropsToSet(after, drops);
+    after['number'] = '${setIndex + 1}';
+
+    if (mapEquals(before, after)) {
+      return;
+    }
+
+    _sets[setIndex] = after;
+    _log('✏️ [Provider] updateDrop($setIndex,$dropIndex) $before → $after');
+    notifyListeners();
+    _onSessionMutated();
+  }
+
+  int ensureDropSlot(int index) {
+    final drops = _dropsFromSet(_sets[index]);
+    if (drops.isEmpty) {
+      return addDropToSet(index);
+    }
+    return drops.length - 1;
   }
 
   void removeSet(int index) {
@@ -456,18 +609,22 @@ class DeviceProvider extends ChangeNotifier {
 
   DeviceSetFieldFocus? _focusedField;
   int? _focusedIndex;
+  int? _focusedDropIndex;
   int _focusRequestId = 0;
 
   int? get focusedIndex => _focusedIndex;
   DeviceSetFieldFocus? get focusedField => _focusedField;
+  int? get focusedDropIndex => _focusedDropIndex;
   int get focusRequestId => _focusRequestId;
 
   int requestFocus({
     required int index,
     required DeviceSetFieldFocus field,
+    int? dropIndex,
   }) {
     _focusedIndex = index;
     _focusedField = field;
+    _focusedDropIndex = dropIndex;
     _focusRequestId++;
     notifyListeners();
     return _focusRequestId;
@@ -476,6 +633,7 @@ class DeviceProvider extends ChangeNotifier {
   int clearFocus() {
     _focusedIndex = null;
     _focusedField = null;
+    _focusedDropIndex = null;
     _focusRequestId++;
     notifyListeners();
     return _focusRequestId;
@@ -623,14 +781,9 @@ class DeviceProvider extends ChangeNotifier {
     for (final s in _sets) {
       final w = (s['weight'] ?? '').toString().trim();
       final r = (s['reps'] ?? '').toString().trim();
-      final dw = (s['dropWeight'] ?? '').toString().trim();
-      final dr = (s['dropReps'] ?? '').toString().trim();
       final d = s['done'] == true || s['done'] == 'true';
-      if (w.isNotEmpty ||
-          r.isNotEmpty ||
-          dw.isNotEmpty ||
-          dr.isNotEmpty ||
-          d) {
+      final hasDropValues = _dropsFromSet(s).any(_dropHasValue);
+      if (w.isNotEmpty || r.isNotEmpty || hasDropValues || d) {
         return false;
       }
     }
@@ -717,19 +870,30 @@ class DeviceProvider extends ChangeNotifier {
       showInLeaderboard: _showInLeaderboardPreference,
       sets: [
         for (var i = 0; i < _sets.length; i++)
-          SetDraft(
-            index: i + 1,
-            weight: (_sets[i]['weight'] ?? '').toString(),
-            reps: (_sets[i]['reps'] ?? '').toString(),
-            dropWeight: (_sets[i]['dropWeight'] ?? '').toString().isEmpty
-                ? null
-                : (_sets[i]['dropWeight']).toString(),
-            dropReps: (_sets[i]['dropReps'] ?? '').toString().isEmpty
-                ? null
-                : (_sets[i]['dropReps']).toString(),
-            done: _sets[i]['done'] == true || _sets[i]['done'] == 'true',
-            isBodyweight: _sets[i]['isBodyweight'] == true,
-          ),
+          () {
+            final drops = _dropsFromSet(_sets[i]);
+            final first = drops.firstWhere(
+              _dropHasValue,
+              orElse: () => const {'weight': '', 'reps': ''},
+            );
+            return SetDraft(
+              index: i + 1,
+              weight: (_sets[i]['weight'] ?? '').toString(),
+              reps: (_sets[i]['reps'] ?? '').toString(),
+              dropWeight: _dropHasValue(first) ? first['weight'] : null,
+              dropReps: _dropHasValue(first) ? first['reps'] : null,
+              drops: [
+                for (final drop in drops)
+                  if (_dropHasValue(drop))
+                    DropDraft(
+                      weight: drop['weight']!,
+                      reps: drop['reps']!,
+                    ),
+              ],
+              done: _sets[i]['done'] == true || _sets[i]['done'] == 'true',
+              isBodyweight: _sets[i]['isBodyweight'] == true,
+            );
+          }(),
       ],
     );
     await _draftRepo.put(key, draft);
@@ -759,7 +923,7 @@ class DeviceProvider extends ChangeNotifier {
     _showInLeaderboardPreference = draft.showInLeaderboard;
     _sets = [
       for (var i = 0; i < draft.sets.length; i++)
-        {
+        _withNormalizedDrops({
           'number': '${i + 1}',
           'weight': draft.sets[i].weight,
           'reps': draft.sets[i].reps,
@@ -767,7 +931,11 @@ class DeviceProvider extends ChangeNotifier {
           'dropReps': draft.sets[i].dropReps ?? '',
           'done': draft.sets[i].done,
           'isBodyweight': draft.sets[i].isBodyweight,
-        },
+          'drops': [
+            for (final drop in draft.sets[i].drops)
+              {'weight': drop.weight, 'reps': drop.reps},
+          ],
+        }),
     ];
     _lastActivityMs = draft.updatedAt;
     notifyListeners();
@@ -910,12 +1078,23 @@ class DeviceProvider extends ChangeNotifier {
           'tz': tz,
           if (isBw) 'isBodyweight': true,
         };
-        if ((set['dropWeight'] ?? '').toString().isNotEmpty &&
-            (set['dropReps'] ?? '').toString().isNotEmpty) {
-          data['dropWeightKg'] = double.parse(
-            set['dropWeight']!.replaceAll(',', '.'),
-          );
-          data['dropReps'] = int.parse(set['dropReps']!);
+        final dropEntriesForLog = <Map<String, dynamic>>[];
+        for (final drop in _dropsFromSet(set)) {
+          if (_dropHasValue(drop)) {
+            final weight = double.tryParse(
+              drop['weight']!.replaceAll(',', '.'),
+            );
+            final repsVal = int.tryParse(drop['reps']!);
+            if (weight != null && repsVal != null) {
+              dropEntriesForLog.add({'kg': weight, 'reps': repsVal});
+            }
+          }
+        }
+        if (dropEntriesForLog.isNotEmpty) {
+          final firstDrop = dropEntriesForLog.first;
+          data['dropWeightKg'] = firstDrop['kg'];
+          data['dropReps'] = firstDrop['reps'];
+          data['drops'] = dropEntriesForLog;
         }
         batch.set(ref, data);
       }
@@ -1019,14 +1198,18 @@ class DeviceProvider extends ChangeNotifier {
 
       _lastSessionSets = [
         for (final s in savedSets)
-          {
+          _withNormalizedDrops({
             'number': s['number'].toString(),
             'weight': s['weight'].toString(),
             'reps': s['reps'].toString(),
             'dropWeight': (s['dropWeight'] ?? '').toString(),
             'dropReps': (s['dropReps'] ?? '').toString(),
             'isBodyweight': s['isBodyweight'] == true,
-          },
+            'drops': [
+              for (final drop in _dropsFromSet(s))
+                {'weight': drop['weight'] ?? '', 'reps': drop['reps'] ?? ''},
+            ],
+          }),
       ];
       _lastSessionDate = ts.toDate();
       _lastSessionNote = _note;
@@ -1035,7 +1218,7 @@ class DeviceProvider extends ChangeNotifier {
       _sets.removeWhere((s) => (s['done'] == true || s['done'] == 'true'));
       if (_sets.isEmpty) {
         _sets = [
-          {
+          _withNormalizedDrops({
             'number': '1',
             'weight': '',
             'reps': '',
@@ -1043,7 +1226,7 @@ class DeviceProvider extends ChangeNotifier {
             'dropWeight': '',
             'dropReps': '',
             'isBodyweight': _isBodyweightMode,
-          },
+          }),
         ];
       }
       for (var i = 0; i < _sets.length; i++) {
@@ -1088,30 +1271,30 @@ class DeviceProvider extends ChangeNotifier {
       note: _note,
       sets: _sets
           .map(
-            (s) => SetEntry(
-              kg:
-                  num.tryParse(
-                    s['weight']?.toString().replaceAll(',', '.') ?? '0',
-                  ) ??
-                  0,
-              reps: int.tryParse(s['reps']?.toString() ?? '0') ?? 0,
-              done: s['done'] == true || s['done'] == 'true',
-              drops:
-                  (s['dropWeight']?.toString().isNotEmpty == true &&
-                      s['dropReps']?.toString().isNotEmpty == true)
-                  ? [
-                      DropEntry(
-                        kg:
-                            num.tryParse(
-                              s['dropWeight']!.toString().replaceAll(',', '.'),
-                            ) ??
-                            0,
-                        reps: int.tryParse(s['dropReps']!.toString()) ?? 0,
-                      ),
-                    ]
-                  : const [],
-              isBodyweight: s['isBodyweight'] == true,
-            ),
+            (s) {
+              final drops = <DropEntry>[];
+              for (final drop in _dropsFromSet(s)) {
+                if (_dropHasValue(drop)) {
+                  final kg = num.tryParse(
+                        drop['weight']!.replaceAll(',', '.'),
+                      ) ??
+                      0;
+                  final reps = int.tryParse(drop['reps']!) ?? 0;
+                  drops.add(DropEntry(kg: kg, reps: reps));
+                }
+              }
+              return SetEntry(
+                kg:
+                    num.tryParse(
+                      s['weight']?.toString().replaceAll(',', '.') ?? '0',
+                    ) ??
+                    0,
+                reps: int.tryParse(s['reps']?.toString() ?? '0') ?? 0,
+                done: s['done'] == true || s['done'] == 'true',
+                drops: drops,
+                isBodyweight: s['isBodyweight'] == true,
+              );
+            },
           )
           .toList(),
       renderVersion: 1,
@@ -1154,14 +1337,38 @@ class DeviceProvider extends ChangeNotifier {
 
     _lastSessionSets = [
       for (var entry in sessionDocs.docs.asMap().entries)
-        {
-          'number': '${entry.key + 1}',
-          'weight': '${entry.value.data()['weight']}',
-          'reps': '${entry.value.data()['reps']}',
-          'dropWeight': '${entry.value.data()['dropWeightKg'] ?? ''}',
-          'dropReps': '${entry.value.data()['dropReps'] ?? ''}',
-          'isBodyweight': entry.value.data()['isBodyweight'] ?? false,
-        },
+        () {
+          final data = entry.value.data();
+          final dropList = <Map<String, String>>[];
+          final rawDrops = data['drops'];
+          if (rawDrops is List) {
+            for (final drop in rawDrops) {
+              if (drop is Map) {
+                final map = Map<String, dynamic>.from(drop);
+                dropList.add({
+                  'weight': '${map['kg'] ?? map['weight'] ?? ''}',
+                  'reps': '${map['reps'] ?? map['wdh'] ?? ''}',
+                });
+              }
+            }
+          }
+          if (dropList.isEmpty) {
+            final legacyWeight = '${data['dropWeightKg'] ?? ''}';
+            final legacyReps = '${data['dropReps'] ?? ''}';
+            if (legacyWeight.isNotEmpty && legacyReps.isNotEmpty) {
+              dropList.add({'weight': legacyWeight, 'reps': legacyReps});
+            }
+          }
+          return _withNormalizedDrops({
+            'number': '${entry.key + 1}',
+            'weight': '${data['weight']}',
+            'reps': '${data['reps']}',
+            'dropWeight': '${data['dropWeightKg'] ?? ''}',
+            'dropReps': '${data['dropReps'] ?? ''}',
+            'isBodyweight': data['isBodyweight'] ?? false,
+            'drops': dropList,
+          });
+        }(),
     ];
     _lastSessionDate = ts;
     _lastSessionNote = note;

--- a/lib/features/device/presentation/models/session_set_vm.dart
+++ b/lib/features/device/presentation/models/session_set_vm.dart
@@ -34,16 +34,32 @@ List<SessionSetVM> mapLegacySetsToVM(List<Map<String, dynamic>> sets) {
   final vm = <SessionSetVM>[];
   var ordinal = 1;
   for (final s in sets) {
-    final List<DropEntry> drops =
-        (s['dropWeight'] != null && s['dropWeight']!.isNotEmpty &&
-                s['dropReps'] != null && s['dropReps']!.isNotEmpty)
-            ? [
-                DropEntry(
-                  kg: num.tryParse(s['dropWeight']!) ?? 0,
-                  reps: int.tryParse(s['dropReps']!) ?? 0,
-                )
-              ]
-            : <DropEntry>[];
+    final drops = <DropEntry>[];
+    final rawDrops = s['drops'];
+    if (rawDrops is List) {
+      for (final drop in rawDrops) {
+        if (drop is Map) {
+          final map = Map<String, dynamic>.from(drop);
+          final weightText = (map['weight'] ?? map['kg'] ?? '').toString();
+          final repsText = (map['reps'] ?? map['wdh'] ?? '').toString();
+          if (weightText.isEmpty || repsText.isEmpty) continue;
+          final weight = num.tryParse(weightText.replaceAll(',', '.')) ?? 0;
+          final reps = int.tryParse(repsText) ?? 0;
+          drops.add(DropEntry(kg: weight, reps: reps));
+        }
+      }
+    } else {
+      final dropWeight = (s['dropWeight'] ?? '').toString();
+      final dropReps = (s['dropReps'] ?? '').toString();
+      if (dropWeight.isNotEmpty && dropReps.isNotEmpty) {
+        drops.add(
+          DropEntry(
+            kg: num.tryParse(dropWeight.replaceAll(',', '.')) ?? 0,
+            reps: int.tryParse(dropReps) ?? 0,
+          ),
+        );
+      }
+    }
     vm.add(SessionSetVM(
       ordinal: ordinal++,
       kg: num.tryParse(s['weight']?.toString() ?? '0') ?? 0,

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -740,8 +740,21 @@ class _GroupedSetList extends StatelessWidget {
     final innerRadius = outlineRadius - BorderRadius.circular(outlineWidth);
 
     bool dropActiveFor(Map<String, dynamic> set) {
-      final dropWeight = (set['dropWeight'] ?? '').toString();
-      final dropReps = (set['dropReps'] ?? '').toString();
+      final rawDrops = set['drops'];
+      if (rawDrops is List) {
+        for (final drop in rawDrops) {
+          if (drop is Map) {
+            final weight =
+                (drop['weight'] ?? drop['kg'] ?? '').toString().trim();
+            final reps = (drop['reps'] ?? drop['wdh'] ?? '').toString().trim();
+            if (weight.isNotEmpty && reps.isNotEmpty) {
+              return true;
+            }
+          }
+        }
+      }
+      final dropWeight = (set['dropWeight'] ?? '').toString().trim();
+      final dropReps = (set['dropReps'] ?? '').toString().trim();
       return dropWeight.isNotEmpty && dropReps.isNotEmpty;
     }
 

--- a/lib/features/device/presentation/widgets/read_only_snapshot_page.dart
+++ b/lib/features/device/presentation/widgets/read_only_snapshot_page.dart
@@ -54,6 +54,13 @@ class ReadOnlySnapshotPage extends StatelessWidget {
                       'dropReps': '',
                       'done': s.done,
                       'isBodyweight': s.isBodyweight,
+                      'drops': [
+                        for (final d in drops)
+                          {
+                            'weight': d.kg.toString(),
+                            'reps': d.reps.toString(),
+                          },
+                      ],
                     },
                     readOnly: true,
                     size: SetCardSize.dense,

--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -124,12 +124,14 @@ class SetCard extends StatefulWidget {
 class SetCardState extends State<SetCard> {
   late final TextEditingController _weightCtrl;
   late final TextEditingController _repsCtrl;
-  late final TextEditingController _dropWeightCtrl;
-  late final TextEditingController _dropRepsCtrl;
+  final List<TextEditingController> _dropWeightCtrls = [];
+  final List<TextEditingController> _dropRepsCtrls = [];
   late final FocusNode _weightFocus;
   late final FocusNode _repsFocus;
-  late final FocusNode _dropWeightFocus;
-  late final FocusNode _dropRepsFocus;
+  final List<FocusNode> _dropWeightFocuses = [];
+  final List<FocusNode> _dropRepsFocuses = [];
+  final List<VoidCallback?> _dropWeightListeners = [];
+  final List<VoidCallback?> _dropRepsListeners = [];
 
   bool _showExtras = false;
   int _lastFocusRequestId = -1;
@@ -159,19 +161,154 @@ class SetCardState extends State<SetCard> {
     );
   }
 
+  List<Map<String, String>> _dropMapsFromSet(Map<String, dynamic> set) {
+    final raw = set['drops'];
+    final drops = <Map<String, String>>[];
+    if (raw is List) {
+      for (final entry in raw) {
+        if (entry is Map) {
+          final map = Map<String, dynamic>.from(entry);
+          drops.add({
+            'weight': (map['weight'] ?? map['kg'] ?? '').toString(),
+            'reps': (map['reps'] ?? map['wdh'] ?? '').toString(),
+          });
+        }
+      }
+    }
+    if (drops.isEmpty) {
+      final legacyWeight = (set['dropWeight'] ?? '').toString();
+      final legacyReps = (set['dropReps'] ?? '').toString();
+      if (legacyWeight.isNotEmpty && legacyReps.isNotEmpty) {
+        drops.add({'weight': legacyWeight, 'reps': legacyReps});
+      }
+    }
+    return drops;
+  }
+
+  void _handleDropWeightChanged(TextEditingController controller) {
+    if (_muteCtrls) return;
+    final index = _dropWeightCtrls.indexOf(controller);
+    if (index == -1) return;
+    _slog(widget.index, 'dropWeight[$index] → "${controller.text}"');
+    context.read<DeviceProvider>().updateDrop(
+          widget.index,
+          index,
+          weight: controller.text,
+        );
+  }
+
+  void _handleDropRepsChanged(TextEditingController controller) {
+    if (_muteCtrls) return;
+    final index = _dropRepsCtrls.indexOf(controller);
+    if (index == -1) return;
+    _slog(widget.index, 'dropReps[$index] → "${controller.text}"');
+    context.read<DeviceProvider>().updateDrop(
+          widget.index,
+          index,
+          reps: controller.text,
+        );
+  }
+
+  void _addDropController() {
+    final weightCtrl = TextEditingController();
+    final repsCtrl = TextEditingController();
+    final weightFocus = FocusNode();
+    final repsFocus = FocusNode();
+    _dropWeightCtrls.add(weightCtrl);
+    _dropRepsCtrls.add(repsCtrl);
+    _dropWeightFocuses.add(weightFocus);
+    _dropRepsFocuses.add(repsFocus);
+    if (!widget.readOnly) {
+      final weightListener = () => _handleDropWeightChanged(weightCtrl);
+      final repsListener = () => _handleDropRepsChanged(repsCtrl);
+      weightCtrl.addListener(weightListener);
+      repsCtrl.addListener(repsListener);
+      _dropWeightListeners.add(weightListener);
+      _dropRepsListeners.add(repsListener);
+    } else {
+      _dropWeightListeners.add(null);
+      _dropRepsListeners.add(null);
+    }
+  }
+
+  void _removeDropController(int index) {
+    final weightCtrl = _dropWeightCtrls.removeAt(index);
+    final repsCtrl = _dropRepsCtrls.removeAt(index);
+    final weightFocus = _dropWeightFocuses.removeAt(index);
+    final repsFocus = _dropRepsFocuses.removeAt(index);
+    final weightListener = _dropWeightListeners.removeAt(index);
+    final repsListener = _dropRepsListeners.removeAt(index);
+    if (weightListener != null) weightCtrl.removeListener(weightListener);
+    if (repsListener != null) repsCtrl.removeListener(repsListener);
+    weightCtrl.dispose();
+    repsCtrl.dispose();
+    weightFocus.dispose();
+    repsFocus.dispose();
+  }
+
+  void _setDropControllerCount(int count) {
+    final current = _dropWeightCtrls.length;
+    if (current < count) {
+      for (var i = current; i < count; i++) {
+        _addDropController();
+      }
+    } else if (current > count) {
+      for (var i = current - 1; i >= count; i--) {
+        _removeDropController(i);
+      }
+    }
+  }
+
+  void _syncDropControllersFromWidget() {
+    final drops = _dropMapsFromSet(widget.set);
+    _setDropControllerCount(drops.length);
+    for (var i = 0; i < drops.length; i++) {
+      final weight = drops[i]['weight'] ?? '';
+      final reps = drops[i]['reps'] ?? '';
+      if (_dropWeightCtrls[i].text != weight) {
+        _setTextSilently(_dropWeightCtrls[i], weight, 'dropWeight[$i]');
+      }
+      if (_dropRepsCtrls[i].text != reps) {
+        _setTextSilently(_dropRepsCtrls[i], reps, 'dropReps[$i]');
+      }
+    }
+    if (drops.isEmpty) {
+      _setDropControllerCount(0);
+    }
+  }
+
+  void _clearDropControllers() {
+    for (var i = _dropWeightCtrls.length - 1; i >= 0; i--) {
+      _removeDropController(i);
+    }
+  }
+
+  void _handleAddDrop() {
+    final prov = context.read<DeviceProvider>();
+    final newIndex = prov.addDropToSet(widget.index);
+    HapticFeedback.lightImpact();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      if (newIndex < _dropWeightCtrls.length) {
+        _openKeypad(
+          _dropWeightCtrls[newIndex],
+          _dropWeightFocuses[newIndex],
+          allowDecimal: true,
+          field: DeviceSetFieldFocus.dropWeight,
+          dropIndex: newIndex,
+        );
+      }
+    });
+  }
+
   @override
   void initState() {
     super.initState();
     _weightCtrl = TextEditingController(text: widget.set['weight'] as String?);
     _repsCtrl = TextEditingController(text: widget.set['reps'] as String?);
-    _dropWeightCtrl =
-        TextEditingController(text: widget.set['dropWeight'] as String?);
-    _dropRepsCtrl =
-        TextEditingController(text: widget.set['dropReps'] as String?);
     _weightFocus = FocusNode();
     _repsFocus = FocusNode();
-    _dropWeightFocus = FocusNode();
-    _dropRepsFocus = FocusNode();
+    _syncDropControllersFromWidget();
 
     if (!widget.readOnly) {
       _weightCtrl.addListener(() {
@@ -192,24 +329,6 @@ class SetCardState extends State<SetCard> {
           reps: _repsCtrl.text,
         );
       });
-      _dropWeightCtrl.addListener(() {
-        if (_muteCtrls) return;
-        _slog(widget.index, 'dropWeight → "${_dropWeightCtrl.text}"');
-        context.read<DeviceProvider>().updateSet(
-          widget.index,
-          dropWeight: _dropWeightCtrl.text,
-          dropReps: _dropRepsCtrl.text,
-        );
-      });
-      _dropRepsCtrl.addListener(() {
-        if (_muteCtrls) return;
-        _slog(widget.index, 'dropReps → "${_dropRepsCtrl.text}"');
-        context.read<DeviceProvider>().updateSet(
-          widget.index,
-          dropWeight: _dropWeightCtrl.text,
-          dropReps: _dropRepsCtrl.text,
-        );
-      });
     }
   }
 
@@ -218,8 +337,6 @@ class SetCardState extends State<SetCard> {
     super.didUpdateWidget(oldWidget);
     final w = widget.set['weight'] as String? ?? '';
     final r = widget.set['reps'] as String? ?? '';
-    final dw = widget.set['dropWeight'] as String? ?? '';
-    final dr = widget.set['dropReps'] as String? ?? '';
     if (oldWidget.set['weight'] != w) {
       _slog(widget.index, 'didUpdateWidget sync weight "$w"');
       _setTextSilently(_weightCtrl, w, 'weight');
@@ -228,14 +345,7 @@ class SetCardState extends State<SetCard> {
       _slog(widget.index, 'didUpdateWidget sync reps "$r"');
       _setTextSilently(_repsCtrl, r, 'reps');
     }
-    if (oldWidget.set['dropWeight'] != dw) {
-      _slog(widget.index, 'didUpdateWidget sync dropWeight "$dw"');
-      _setTextSilently(_dropWeightCtrl, dw, 'dropWeight');
-    }
-    if (oldWidget.set['dropReps'] != dr) {
-      _slog(widget.index, 'didUpdateWidget sync dropReps "$dr"');
-      _setTextSilently(_dropRepsCtrl, dr, 'dropReps');
-    }
+    _syncDropControllersFromWidget();
   }
 
   @override
@@ -243,12 +353,9 @@ class SetCardState extends State<SetCard> {
     _slog(widget.index, 'dispose()');
     _weightCtrl.dispose();
     _repsCtrl.dispose();
-    _dropWeightCtrl.dispose();
-    _dropRepsCtrl.dispose();
     _weightFocus.dispose();
     _repsFocus.dispose();
-    _dropWeightFocus.dispose();
-    _dropRepsFocus.dispose();
+    _clearDropControllers();
     super.dispose();
   }
 
@@ -258,6 +365,7 @@ class SetCardState extends State<SetCard> {
     required bool allowDecimal,
     required DeviceSetFieldFocus field,
     bool notifyFocus = true,
+    int? dropIndex,
   }) {
     _slog(
       widget.index,
@@ -268,6 +376,7 @@ class SetCardState extends State<SetCard> {
       _lastFocusRequestId = prov.requestFocus(
         index: widget.index,
         field: field,
+        dropIndex: dropIndex,
       );
     } else {
       _lastFocusRequestId = prov.focusRequestId;
@@ -293,12 +402,15 @@ class SetCardState extends State<SetCard> {
     );
   }
 
-  String? _validateDrop(String? _) {
+  String? _validateDrop(int index) {
     final loc = AppLocalizations.of(context)!;
-    final dw = _dropWeightCtrl.text.trim();
-    final dr = _dropRepsCtrl.text.trim();
+    if (index >= _dropWeightCtrls.length || index >= _dropRepsCtrls.length) {
+      return null;
+    }
+    final dw = _dropWeightCtrls[index].text.trim();
+    final dr = _dropRepsCtrls[index].text.trim();
     if (dw.isEmpty && dr.isEmpty) return null;
-    if (dw.isEmpty || dr.isEmpty) return null;
+    if (dw.isEmpty || dr.isEmpty) return loc.dropFillBoth;
     final base = double.tryParse(_weightCtrl.text.replaceAll(',', '.'));
     final drop = double.tryParse(dw.replaceAll(',', '.'));
     if (base == null || drop == null) return loc.numberInvalid;
@@ -321,9 +433,12 @@ class SetCardState extends State<SetCard> {
     }
     final doneVal = widget.set['done'];
     final done = doneVal == true || doneVal == 'true';
-    final dropActive =
-        (widget.set['dropWeight'] ?? '').toString().isNotEmpty &&
-            (widget.set['dropReps'] ?? '').toString().isNotEmpty;
+    final dropMaps = _dropMapsFromSet(widget.set);
+    final dropActive = dropMaps.any((d) {
+      final weightText = (d['weight'] ?? '').toString().trim();
+      final repsText = (d['reps'] ?? '').toString().trim();
+      return weightText.isNotEmpty && repsText.isNotEmpty;
+    });
     final weight = (widget.set['weight'] ?? '').toString().trim();
     final reps = (widget.set['reps'] ?? '').toString().trim();
     final isBw = widget.set['isBodyweight'] == true;
@@ -364,22 +479,30 @@ class SetCardState extends State<SetCard> {
             );
             break;
           case DeviceSetFieldFocus.dropWeight:
-            _openKeypad(
-              _dropWeightCtrl,
-              _dropWeightFocus,
-              allowDecimal: true,
-              field: focusField,
-              notifyFocus: false,
-            );
+            final dropIndex = prov.focusedDropIndex ?? 0;
+            if (dropIndex < _dropWeightCtrls.length) {
+              _openKeypad(
+                _dropWeightCtrls[dropIndex],
+                _dropWeightFocuses[dropIndex],
+                allowDecimal: true,
+                field: focusField,
+                notifyFocus: false,
+                dropIndex: dropIndex,
+              );
+            }
             break;
           case DeviceSetFieldFocus.dropReps:
-            _openKeypad(
-              _dropRepsCtrl,
-              _dropRepsFocus,
-              allowDecimal: false,
-              field: focusField,
-              notifyFocus: false,
-            );
+            final dropIndex = prov.focusedDropIndex ?? 0;
+            if (dropIndex < _dropRepsCtrls.length) {
+              _openKeypad(
+                _dropRepsCtrls[dropIndex],
+                _dropRepsFocuses[dropIndex],
+                allowDecimal: false,
+                field: focusField,
+                notifyFocus: false,
+                dropIndex: dropIndex,
+              );
+            }
             break;
         }
       });
@@ -392,7 +515,11 @@ class SetCardState extends State<SetCard> {
           'tap: more options → ${!_showExtras}',
         );
         HapticFeedback.lightImpact();
-        setState(() => _showExtras = !_showExtras);
+        final next = !_showExtras;
+        setState(() => _showExtras = next);
+        if (next && _dropWeightCtrls.isEmpty) {
+          context.read<DeviceProvider>().ensureDropSlot(widget.index);
+        }
       };
     }
 
@@ -417,6 +544,38 @@ class SetCardState extends State<SetCard> {
         }
       };
     }
+
+    final canMutateDrops = !widget.readOnly && !done;
+    final dropRows = <_DropRowConfig>[
+      for (var i = 0; i < _dropWeightCtrls.length; i++)
+        _DropRowConfig(
+          weightController: _dropWeightCtrls[i],
+          weightFocus: _dropWeightFocuses[i],
+          repsController: _dropRepsCtrls[i],
+          repsFocus: _dropRepsFocuses[i],
+          onTapWeight: widget.readOnly
+              ? null
+              : () => _openKeypad(
+                    _dropWeightCtrls[i],
+                    _dropWeightFocuses[i],
+                    allowDecimal: true,
+                    field: DeviceSetFieldFocus.dropWeight,
+                    dropIndex: i,
+                  ),
+          onTapReps: widget.readOnly
+              ? null
+              : () => _openKeypad(
+                    _dropRepsCtrls[i],
+                    _dropRepsFocuses[i],
+                    allowDecimal: false,
+                    field: DeviceSetFieldFocus.dropReps,
+                    dropIndex: i,
+                  ),
+          validator: (_) => _validateDrop(i),
+          showAddButton: canMutateDrops && i == _dropWeightCtrls.length - 1,
+          onAdd: canMutateDrops ? _handleAddDrop : null,
+        ),
+    ];
 
     final displayMode = widget.displayMode;
     final paddingBase = tokens.padding;
@@ -450,10 +609,6 @@ class SetCardState extends State<SetCard> {
       weightFocus: _weightFocus,
       repsController: _repsCtrl,
       repsFocus: _repsFocus,
-      dropWeightController: _dropWeightCtrl,
-      dropWeightFocus: _dropWeightFocus,
-      dropRepsController: _dropRepsCtrl,
-      dropRepsFocus: _dropRepsFocus,
       onToggleExtras: toggleExtras,
       onToggleDone: toggleDone,
       onTapWeight:
@@ -474,23 +629,7 @@ class SetCardState extends State<SetCard> {
                     allowDecimal: false,
                     field: DeviceSetFieldFocus.reps,
                   ),
-      onTapDropWeight: done || widget.readOnly
-          ? null
-          : () => _openKeypad(
-                _dropWeightCtrl,
-                _dropWeightFocus,
-                allowDecimal: true,
-                field: DeviceSetFieldFocus.dropWeight,
-              ),
-      onTapDropReps: done || widget.readOnly
-          ? null
-          : () => _openKeypad(
-                _dropRepsCtrl,
-                _dropRepsFocus,
-                allowDecimal: false,
-                field: DeviceSetFieldFocus.dropReps,
-              ),
-      dropValidator: _validateDrop,
+      dropRows: dropRows,
       padding: contentPadding,
     );
 
@@ -536,17 +675,11 @@ class SetRowContent extends StatelessWidget {
   final FocusNode weightFocus;
   final TextEditingController repsController;
   final FocusNode repsFocus;
-  final TextEditingController dropWeightController;
-  final FocusNode dropWeightFocus;
-  final TextEditingController dropRepsController;
-  final FocusNode dropRepsFocus;
   final VoidCallback? onToggleExtras;
   final VoidCallback? onToggleDone;
   final VoidCallback? onTapWeight;
   final VoidCallback? onTapReps;
-  final VoidCallback? onTapDropWeight;
-  final VoidCallback? onTapDropReps;
-  final FormFieldValidator<String>? dropValidator;
+  final List<_DropRowConfig> dropRows;
   final EdgeInsetsGeometry padding;
 
   const SetRowContent({
@@ -566,17 +699,11 @@ class SetRowContent extends StatelessWidget {
     required this.weightFocus,
     required this.repsController,
     required this.repsFocus,
-    required this.dropWeightController,
-    required this.dropWeightFocus,
-    required this.dropRepsController,
-    required this.dropRepsFocus,
     required this.onToggleExtras,
     required this.onToggleDone,
     required this.onTapWeight,
     required this.onTapReps,
-    required this.onTapDropWeight,
-    required this.onTapDropReps,
-    required this.dropValidator,
+    required this.dropRows,
     this.padding = EdgeInsets.zero,
   });
 
@@ -705,38 +832,57 @@ class SetRowContent extends StatelessWidget {
       ),
     );
     if (showExtras) {
-      children.addAll([
-        SizedBox(height: dense ? 8 : 12),
-        Row(
-          children: [
-            Expanded(
-              child: _InputPill(
-                controller: dropWeightController,
-                focusNode: dropWeightFocus,
-                label: loc.dropKgFieldLabel,
-                readOnly: readOnly || done,
-                tokens: tokens,
-                dense: true,
-                onTap: onTapDropWeight,
-                validator: dropValidator,
+      children.add(SizedBox(height: dense ? 8 : 12));
+      for (var i = 0; i < dropRows.length; i++) {
+        final drop = dropRows[i];
+        children.add(
+          Row(
+            children: [
+              Expanded(
+                child: _InputPill(
+                  controller: drop.weightController,
+                  focusNode: drop.weightFocus,
+                  label: loc.dropKgFieldLabel,
+                  readOnly: readOnly || done,
+                  tokens: tokens,
+                  dense: true,
+                  onTap: drop.onTapWeight,
+                  validator: drop.validator,
+                ),
               ),
-            ),
-            SizedBox(width: dense ? 8 : 12),
-            Expanded(
-              child: _InputPill(
-                controller: dropRepsController,
-                focusNode: dropRepsFocus,
-                label: loc.dropRepsFieldLabel,
-                readOnly: readOnly || done,
-                tokens: tokens,
-                dense: true,
-                onTap: onTapDropReps,
-                validator: dropValidator,
+              SizedBox(width: dense ? 8 : 12),
+              Expanded(
+                child: _InputPill(
+                  controller: drop.repsController,
+                  focusNode: drop.repsFocus,
+                  label: loc.dropRepsFieldLabel,
+                  readOnly: readOnly || done,
+                  tokens: tokens,
+                  dense: true,
+                  onTap: drop.onTapReps,
+                  validator: drop.validator,
+                ),
               ),
-            ),
-          ],
-        ),
-      ]);
+              if (!readOnly && drop.showAddButton) ...[
+                SizedBox(width: dense ? 8 : 12),
+                _RoundButton(
+                  tokens: tokens,
+                  icon: Icons.add,
+                  filled: false,
+                  semantics: loc.addSetButton,
+                  dense: true,
+                  onTap: drop.onAdd,
+                  iconColor: primaryColor,
+                  disabledIconColor: primaryColor.withOpacity(0.4),
+                ),
+              ],
+            ],
+          ),
+        );
+        if (i != dropRows.length - 1) {
+          children.add(SizedBox(height: dense ? 8 : 12));
+        }
+      }
     }
 
     Widget body = Padding(
@@ -753,6 +899,30 @@ class SetRowContent extends StatelessWidget {
       child: body,
     );
   }
+}
+
+class _DropRowConfig {
+  final TextEditingController weightController;
+  final FocusNode weightFocus;
+  final TextEditingController repsController;
+  final FocusNode repsFocus;
+  final VoidCallback? onTapWeight;
+  final VoidCallback? onTapReps;
+  final FormFieldValidator<String>? validator;
+  final bool showAddButton;
+  final VoidCallback? onAdd;
+
+  const _DropRowConfig({
+    required this.weightController,
+    required this.weightFocus,
+    required this.repsController,
+    required this.repsFocus,
+    this.onTapWeight,
+    this.onTapReps,
+    this.validator,
+    this.showAddButton = false,
+    this.onAdd,
+  });
 }
 
 class _IndexBadge extends StatelessWidget {

--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -446,6 +446,7 @@ class OverlayNumericKeypad extends StatelessWidget {
       return;
     }
 
+    final dropIndex = prov.focusedDropIndex ?? 0;
     final targetController = controller.target;
     if (targetController != null) {
       final text = targetController.text;
@@ -457,16 +458,17 @@ class OverlayNumericKeypad extends StatelessWidget {
           prov.updateSet(focusedIndex, reps: text);
           break;
         case DeviceSetFieldFocus.dropWeight:
-          prov.updateSet(focusedIndex, dropWeight: text);
+          prov.updateDrop(focusedIndex, dropIndex, weight: text);
           break;
         case DeviceSetFieldFocus.dropReps:
-          prov.updateSet(focusedIndex, dropReps: text);
+          prov.updateDrop(focusedIndex, dropIndex, reps: text);
           break;
       }
     }
 
     int targetIndex = focusedIndex;
     DeviceSetFieldFocus? targetField;
+    int? targetDropIndex;
 
     switch (focusedField) {
       case DeviceSetFieldFocus.weight:
@@ -496,6 +498,7 @@ class OverlayNumericKeypad extends StatelessWidget {
         break;
       case DeviceSetFieldFocus.dropWeight:
         targetField = DeviceSetFieldFocus.dropReps;
+        targetDropIndex = dropIndex;
         break;
       case DeviceSetFieldFocus.dropReps:
         final done = prov.markSetDone(focusedIndex);
@@ -522,7 +525,11 @@ class OverlayNumericKeypad extends StatelessWidget {
     }
 
     if (targetField != null) {
-      prov.requestFocus(index: targetIndex, field: targetField);
+      prov.requestFocus(
+        index: targetIndex,
+        field: targetField,
+        dropIndex: targetDropIndex,
+      );
     }
 
     _haptic(context);


### PR DESCRIPTION
## Summary
- normalize device sets to persist a list of drops, update draft serialization, and keep focus tracking for individual drop fields
- adjust keypad navigation and set card UI to manage multiple drop inputs with an inline add button
- update snapshot and view-model mapping so historical sessions render all stored drop entries

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfdf7ae2c0832090ec272ac2c67196