### PR TITLE
Restore workout timer visibility in app headers

### DIFF
--- a/lib/core/widgets/base_screen.dart
+++ b/lib/core/widgets/base_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:tapem/features/nfc/widgets/nfc_scan_button.dart';
-import 'package:tapem/ui/timer/active_workout_timer.dart';
+import 'package:tapem/ui/timer/timer_app_bar_title.dart';
 
 /// BaseScreen: Gemeinsamer Scaffold mit AppBar-Titel und NFC-Scan-Button.
 /// Alle Screens, die diese Basisklasse nutzen, erhalten automatisch den NFC-Button.
@@ -14,11 +14,12 @@ class BaseScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Row(
-          children: [
-            Expanded(child: Text(title)),
-            const ActiveWorkoutTimer(padding: EdgeInsets.zero),
-          ],
+        title: TimerAppBarTitle(
+          centerTitle: false,
+          title: Text(
+            title,
+            overflow: TextOverflow.ellipsis,
+          ),
         ),
         actions: const [
           NfcScanButton(), // Button-getriggertes NFC-Scanning

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -29,6 +29,7 @@ import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/ui/numeric_keypad/overlay_numeric_keypad.dart';
 import 'package:tapem/ui/timer/active_workout_timer.dart';
 import 'package:tapem/ui/timer/session_timer_bar.dart';
+import 'package:tapem/ui/timer/timer_app_bar_title.dart';
 
 import '../models/session_set_vm.dart';
 import '../widgets/device_pager.dart';
@@ -165,11 +166,15 @@ class _DeviceScreenState extends State<DeviceScreen> {
           tag: 'device-${prov.device!.uid}',
           child: Material(
             type: MaterialType.transparency,
-            child: gradientTitle,
+            child: TimerAppBarTitle(
+              title: gradientTitle,
+            ),
           ),
         );
       } else {
-        titleWidget = gradientTitle;
+        titleWidget = TimerAppBarTitle(
+          title: gradientTitle,
+        );
       }
     } else {
       titleWidget = const ActiveWorkoutTimer(

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -17,7 +17,7 @@ import 'package:tapem/features/auth/presentation/widgets/username_dialog.dart';
 import 'package:tapem/core/config/feature_flags.dart';
 import 'package:tapem/features/nfc/widgets/nfc_scan_button.dart';
 import 'package:tapem/l10n/app_localizations.dart';
-import 'package:tapem/ui/timer/active_workout_timer.dart';
+import 'package:tapem/ui/timer/timer_app_bar_title.dart';
 import 'package:tapem/core/widgets/brand_gradient_text.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -134,17 +134,20 @@ class _HomeScreenState extends State<HomeScreen> {
     if (_currentIndex >= tabs.length) {
       _currentIndex = 0;
     }
+    final currentTab = tabs[_currentIndex];
+    final currentLabel = currentTab.item.label ?? '';
+
     return Scaffold(
       appBar: AppBar(
         titleSpacing: 0,
         centerTitle: true,
-        title: _buildAppBarTitle(context),
+        title: _buildAppBarTitle(context, currentLabel),
         actions: const [
           NfcScanButton(),
           SizedBox(width: 8),
         ],
       ),
-      body: tabs[_currentIndex].page,
+      body: currentTab.page,
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _currentIndex,
         type: BottomNavigationBarType.fixed,
@@ -154,30 +157,43 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 
-  Widget _buildAppBarTitle(BuildContext context) {
+  Widget _buildAppBarTitle(BuildContext context, String currentLabel) {
     final loc = AppLocalizations.of(context)!;
     final auth = context.watch<AuthProvider>();
 
     switch (_currentIndex) {
       case 0:
-        return BrandGradientText(
-          loc.gymTitle,
-          textAlign: TextAlign.center,
-          style: Theme.of(context).textTheme.titleLarge,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
+        return TimerAppBarTitle(
+          title: BrandGradientText(
+            loc.gymTitle,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.titleLarge,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
         );
       case 1:
         final username = auth.userName ?? auth.userEmail ?? loc.profileTitle;
-        return BrandGradientText(
-          username,
-          textAlign: TextAlign.center,
-          style: Theme.of(context).textTheme.titleLarge,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
+        return TimerAppBarTitle(
+          title: BrandGradientText(
+            username,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.titleLarge,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
         );
       default:
-        return const ActiveWorkoutTimer();
+        final resolvedLabel = currentLabel.isNotEmpty ? currentLabel : loc.appTitle;
+        return TimerAppBarTitle(
+          title: BrandGradientText(
+            resolvedLabel,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.titleLarge,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        );
     }
   }
 }

--- a/lib/ui/timer/active_workout_timer.dart
+++ b/lib/ui/timer/active_workout_timer.dart
@@ -7,8 +7,9 @@ import 'package:tapem/core/utils/duration_format.dart';
 
 class ActiveWorkoutTimer extends StatelessWidget {
   final EdgeInsetsGeometry? padding;
+  final bool compact;
 
-  const ActiveWorkoutTimer({super.key, this.padding});
+  const ActiveWorkoutTimer({super.key, this.padding, this.compact = false});
 
   @override
   Widget build(BuildContext context) {
@@ -71,6 +72,16 @@ class ActiveWorkoutTimer extends StatelessWidget {
             }
 
             final borderRadius = BorderRadius.circular(AppRadius.button);
+            final iconSize = compact ? 16.0 : 18.0;
+            final resolvedPadding = padding ??
+                (compact
+                    ? const EdgeInsets.symmetric(horizontal: 8, vertical: 4)
+                    : const EdgeInsets.symmetric(horizontal: 16));
+            final baseTextStyle = (compact
+                    ? theme.textTheme.titleSmall
+                    : theme.textTheme.titleMedium) ??
+                theme.textTheme.bodyMedium ??
+                const TextStyle(fontSize: 14);
             final content = DecoratedBox(
               decoration: BoxDecoration(
                 gradient: resolvedGradient,
@@ -84,13 +95,13 @@ class ActiveWorkoutTimer extends StatelessWidget {
                   children: [
                     Icon(
                       Icons.timer_outlined,
-                      size: 18,
+                      size: iconSize,
                       color: foregroundColor,
                     ),
                     const SizedBox(width: 6),
                     Text(
                       formatted,
-                      style: theme.textTheme.titleMedium?.copyWith(
+                      style: baseTextStyle.copyWith(
                         color: foregroundColor,
                         fontWeight: FontWeight.w600,
                       ),
@@ -100,7 +111,6 @@ class ActiveWorkoutTimer extends StatelessWidget {
               ),
             );
 
-            final resolvedPadding = padding ?? const EdgeInsets.symmetric(horizontal: 16);
             return Padding(
               padding: resolvedPadding,
               child: Material(

--- a/lib/ui/timer/timer_app_bar_title.dart
+++ b/lib/ui/timer/timer_app_bar_title.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:tapem/ui/timer/active_workout_timer.dart';
+
+class TimerAppBarTitle extends StatelessWidget {
+  final Widget title;
+  final bool centerTitle;
+
+  const TimerAppBarTitle({
+    super.key,
+    required this.title,
+    this.centerTitle = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final alignment = centerTitle ? Alignment.center : Alignment.centerLeft;
+    final mainAxisAlignment =
+        centerTitle ? MainAxisAlignment.center : MainAxisAlignment.start;
+
+    return Row(
+      mainAxisSize: MainAxisSize.max,
+      mainAxisAlignment: mainAxisAlignment,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        const ActiveWorkoutTimer(
+          padding: EdgeInsets.only(right: 12),
+          compact: true,
+        ),
+        Flexible(
+          child: Align(
+            alignment: alignment,
+            child: title,
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable timer-aware app bar title widget with a compact timer style
- update shared base, home, and device screens to display the timer alongside their titles
- refine the workout timer widget to support a compact layout for header usage

## Testing
- `flutter test` *(fails: flutter is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfea3f600883208bf1ddd816b0427a