### PR TITLE
Add missing appTitle localization fallback

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1,6 +1,11 @@
 {
   "@@locale": "de",
 
+  "appTitle": "Tapem",
+  "@appTitle": {
+    "description": "Fallback-App-Titel für den Homescreen"
+  },
+
   "addSetButton": "Set hinzufügen",
   "@addSetButton": {
     "description": "Button-Label um ein neues Set hinzuzufügen"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,6 +1,11 @@
 {
   "@@locale": "en",
 
+  "appTitle": "Tapem",
+  "@appTitle": {
+    "description": "Fallback application title for the home screen"
+  },
+
   "addSetButton": "Add set",
   "@addSetButton": {
     "description": "Button label to add a new set"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -95,6 +95,12 @@ abstract class AppLocalizations {
     Locale('en')
   ];
 
+  /// Fallback application title for the home screen
+  ///
+  /// In en, this message translates to:
+  /// **'Tapem'**
+  String get appTitle;
+
   /// Button label to add a new set
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -9,6 +9,9 @@ class AppLocalizationsDe extends AppLocalizations {
   AppLocalizationsDe([String locale = 'de']) : super(locale);
 
   @override
+  String get appTitle => 'Tapem';
+
+  @override
   String get addSetButton => 'Set hinzufügen';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -9,6 +9,9 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
+  String get appTitle => 'Tapem';
+
+  @override
   String get addSetButton => 'Add set';
 
   @override


### PR DESCRIPTION
## Summary
- add the missing `appTitle` key to the English and German localization resources
- expose the new getter in the generated localization classes for use as a home screen fallback title

## Testing
- not run (Flutter SDK unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e013f03ee08320a0608d830578a544