### PR TITLE
Fix drop input sanitization for partial values

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -55,7 +55,7 @@ List<Map<String, String>> _sanitizeDrops(List<Map<String, String>> drops) {
       () {
         final weight = (drop['weight'] ?? '').toString().trim();
         final reps = (drop['reps'] ?? '').toString().trim();
-        if (weight.isEmpty || reps.isEmpty) {
+        if (weight.isEmpty && reps.isEmpty) {
           return {'weight': '', 'reps': ''};
         }
         return {'weight': weight, 'reps': reps};


### PR DESCRIPTION
## Summary
- allow drop set values to retain partially entered numbers instead of clearing them
- keep sanitization trimming whitespace while only removing fully empty drops

## Testing
- Not run (flutter tool not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e02267ebd483209b03ab462cce263e