### PR TITLE
Fix Firebase initialization on Android

### DIFF
--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -3,7 +3,21 @@ import 'package:flutter/foundation.dart' show defaultTargetPlatform, kIsWeb, Tar
 
 class DefaultFirebaseOptions {
   static FirebaseOptions get currentPlatform {
-    return ios;
+    if (kIsWeb) {
+      throw UnsupportedError(
+        'DefaultFirebaseOptions are not configured for web. '
+        'Provide web Firebase configuration before targeting that platform.',
+      );
+    }
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.iOS:
+        return ios;
+      default:
+        throw UnsupportedError(
+          'DefaultFirebaseOptions are not configured for this platform. '
+          'Android and other native platforms should use their bundled Firebase config files.',
+        );
+    }
   }
 
   static const FirebaseOptions ios = FirebaseOptions(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -104,16 +104,24 @@ final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 /// Später auf `true` setzen, wenn APNs/FCM korrekt eingerichtet sind.
 const bool kEnablePush = false;
 
-@pragma('vm:entry-point')
-Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  // Falls der Prozess im Hintergrund startet, Firebase erneut initialisieren.
+Future<void> _initializeFirebaseApp() async {
   try {
-    await Firebase.initializeApp(
-      options: DefaultFirebaseOptions.currentPlatform,
-    );
+    if (!kIsWeb && (Platform.isAndroid || Platform.isIOS)) {
+      await Firebase.initializeApp();
+    } else {
+      await Firebase.initializeApp(
+        options: DefaultFirebaseOptions.currentPlatform,
+      );
+    }
   } on FirebaseException catch (e) {
     if (e.code != 'duplicate-app') rethrow;
   }
+}
+
+@pragma('vm:entry-point')
+Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  // Falls der Prozess im Hintergrund startet, Firebase erneut initialisieren.
+  await _initializeFirebaseApp();
   // Aktuell keine weitere Logik
 }
 
@@ -192,13 +200,7 @@ Future<void> main() async {
   await dotenv.load(fileName: '.env.dev').catchError((_) {});
 
   // Firebase init (einheitlich)
-  try {
-    await Firebase.initializeApp(
-      options: DefaultFirebaseOptions.currentPlatform,
-    );
-  } on FirebaseException catch (e) {
-    if (e.code != 'duplicate-app') rethrow;
-  }
+  await _initializeFirebaseApp();
   assert(() {
     debugPrint('[Firebase] projectId=' + Firebase.app().options.projectId);
     return true;


### PR DESCRIPTION
## Summary
- ensure the Flutter app relies on the native google-services configuration when initializing Firebase on Android
- centralize Firebase initialization logic so background handlers reuse the same safe path
- guard the generated firebase_options against accidental reuse on unsupported platforms

## Testing
- not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e04892546483209dbbb77e46cb53f1