### PR TITLE
Adjust powerlifting segmented button contrast in neutral theme

### DIFF
--- a/lib/features/profile/presentation/screens/powerlifting_screen.dart
+++ b/lib/features/profile/presentation/screens/powerlifting_screen.dart
@@ -542,6 +542,15 @@ class _PowerliftingTableSwitcher extends StatelessWidget {
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
 
+    final colorScheme = Theme.of(context).colorScheme;
+
+    Color resolveForeground(Set<MaterialState> states) {
+      if (states.contains(MaterialState.selected)) {
+        return colorScheme.onPrimary;
+      }
+      return colorScheme.onSurface;
+    }
+
     return SegmentedButton<PowerliftingMetric>(
       segments: [
         ButtonSegment<PowerliftingMetric>(
@@ -555,6 +564,10 @@ class _PowerliftingTableSwitcher extends StatelessWidget {
           icon: const Icon(Icons.trending_up_outlined),
         ),
       ],
+      style: ButtonStyle(
+        foregroundColor: MaterialStateProperty.resolveWith(resolveForeground),
+        iconColor: MaterialStateProperty.resolveWith(resolveForeground),
+      ),
       selected: <PowerliftingMetric>{selectedMetric},
       onSelectionChanged: (selection) {
         if (selection.isEmpty) {


### PR DESCRIPTION
## Summary
- ensure the powerlifting metric segmented button adapts its text/icon color to the active theme
- fix readability of the selected segment in the neutral black and white branding

## Testing
- not run (Flutter tooling not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e05497a9988320914282fd2fb48216