### PR TITLE
Enhance profile statistics call-to-action

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -14,6 +14,7 @@ import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/theme/brand_theme_preset.dart';
 import 'package:tapem/core/theme/app_brand_theme.dart';
+import 'package:tapem/core/theme/brand_on_colors.dart';
 import 'package:tapem/core/widgets/brand_action_tile.dart';
 import 'package:tapem/core/widgets/brand_gradient_icon.dart';
 import 'package:tapem/core/widgets/brand_gradient_text.dart';
@@ -535,12 +536,14 @@ class _ProfileScreenState extends State<ProfileScreen> {
                 SizedBox(
                   width: double.infinity,
                   child: BrandActionTile(
+                    leading: const _ProfileStatsLeadingIcon(),
                     title: loc.profileStatsButtonLabel,
-                    centerTitle: true,
-                    dense: true,
-                    minVerticalPadding: 0,
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+                    subtitle: loc.profileStatsButtonSubtitle,
+                    minVerticalPadding: AppSpacing.xs,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.sm,
+                      vertical: AppSpacing.sm,
+                    ),
                     onTap: () {
                       Navigator.push(
                         context,
@@ -549,7 +552,8 @@ class _ProfileScreenState extends State<ProfileScreen> {
                         ),
                       );
                     },
-                    variant: BrandActionTileVariant.outlined,
+                    trailing: const _ProfileStatsSparkline(),
+                    variant: BrandActionTileVariant.gradient,
                     showChevron: false,
                     uiLogEvent: 'PROFILE_STATS_CARD_RENDER',
                   ),
@@ -587,6 +591,78 @@ class _ProfileScreenState extends State<ProfileScreen> {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _ProfileStatsLeadingIcon extends StatelessWidget {
+  const _ProfileStatsLeadingIcon({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final brandTheme = theme.extension<AppBrandTheme>();
+    final gradient = brandTheme?.gradient ?? AppGradients.brandGradient;
+    final glowColor = gradient.colors.last;
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.xs),
+      decoration: BoxDecoration(
+        gradient: gradient,
+        borderRadius: BorderRadius.circular(AppRadius.button),
+        boxShadow: [
+          BoxShadow(
+            color: glowColor.withOpacity(0.35),
+            blurRadius: 20,
+            offset: const Offset(0, 10),
+          ),
+        ],
+      ),
+      child: const BrandGradientIcon(
+        Icons.auto_graph,
+        size: 28,
+      ),
+    );
+  }
+}
+
+class _ProfileStatsSparkline extends StatelessWidget {
+  const _ProfileStatsSparkline({super.key});
+
+  static const _bars = [10.0, 20.0, 14.0, 26.0, 18.0, 30.0];
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final onGradient =
+        theme.extension<BrandOnColors>()?.onGradient ?? Colors.black;
+    final barColor = Color.lerp(onGradient, Colors.white, 0.6) ?? onGradient;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: List.generate(_bars.length, (index) {
+        final target = _bars[index];
+        return TweenAnimationBuilder<double>(
+          tween: Tween(begin: 0, end: target),
+          duration: Duration(milliseconds: 500 + index * 90),
+          curve: Curves.easeOutCubic,
+          builder: (context, value, child) {
+            return Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 1.5),
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  color: barColor.withOpacity(0.85),
+                  borderRadius: BorderRadius.circular(AppRadius.button),
+                ),
+                child: SizedBox(
+                  width: 6,
+                  height: value,
+                ),
+              ),
+            );
+          },
+        );
+      }),
     );
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -343,6 +343,11 @@
     "description": "Button auf der Profilseite für die Statistik-Ansicht"
   },
 
+  "profileStatsButtonSubtitle": "Entdecke deine Fortschritte in Echtzeit",
+  "@profileStatsButtonSubtitle": {
+    "description": "Untertitel für den Statistik-Button auf der Profilseite"
+  },
+
   "profileStatsTitle": "Statistiken",
   "@profileStatsTitle": {
     "description": "Titel der Statistikseite im Profil"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -343,6 +343,11 @@
     "description": "Button label on profile screen to open the statistics page"
   },
 
+  "profileStatsButtonSubtitle": "Dive into your progress highlights",
+  "@profileStatsButtonSubtitle": {
+    "description": "Subtitle for the statistics call-to-action on the profile screen"
+  },
+
   "profileStatsTitle": "Statistics",
   "@profileStatsTitle": {
     "description": "Title of the profile statistics page"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -581,6 +581,12 @@ abstract class AppLocalizations {
   /// **'Statistics'**
   String get profileStatsButtonLabel;
 
+  /// Subtitle for the statistics call-to-action on the profile screen
+  ///
+  /// In en, this message translates to:
+  /// **'Dive into your progress highlights'**
+  String get profileStatsButtonSubtitle;
+
   /// Title of the profile statistics page
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -274,6 +274,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get profileStatsButtonLabel => 'Statistiken';
 
   @override
+  String get profileStatsButtonSubtitle => 'Entdecke deine Fortschritte in Echtzeit';
+
+  @override
   String get profileStatsTitle => 'Statistiken';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -274,6 +274,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileStatsButtonLabel => 'Statistics';
 
   @override
+  String get profileStatsButtonSubtitle => 'Dive into your progress highlights';
+
+  @override
   String get profileStatsTitle => 'Statistics';
 
   @override


### PR DESCRIPTION
## Summary
- restyle the profile statistics entry as a gradient call-to-action with icon glow and animated sparkline accent
- localize a subtitle that teases the insights available on the statistics screen in German and English

## Testing
- not run (Flutter SDK is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e05e1e3fd88320afb3f29f66319476