### PR TITLE
Enhance profile survey CTA and gradient card feedback

### DIFF
--- a/lib/core/widgets/brand_gradient_card.dart
+++ b/lib/core/widgets/brand_gradient_card.dart
@@ -4,7 +4,7 @@ import '../theme/design_tokens.dart';
 import '../theme/brand_on_colors.dart';
 
 /// Reusable card container with the brand gradient and rounded corners.
-class BrandGradientCard extends StatelessWidget {
+class BrandGradientCard extends StatefulWidget {
   final Widget child;
   final EdgeInsetsGeometry? padding;
   final BorderRadiusGeometry? borderRadius;
@@ -19,11 +19,24 @@ class BrandGradientCard extends StatelessWidget {
   });
 
   @override
+  State<BrandGradientCard> createState() => _BrandGradientCardState();
+}
+
+class _BrandGradientCardState extends State<BrandGradientCard> {
+  bool _isPressed = false;
+
+  void _handleHighlight(bool value) {
+    if (!mounted) return;
+    if (value == _isPressed) return;
+    setState(() => _isPressed = value);
+  }
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final surface = theme.extension<AppBrandTheme>();
     final BorderRadius radius =
-        (borderRadius ?? surface?.radius ?? BorderRadius.circular(AppRadius.card))
+        (widget.borderRadius ?? surface?.radius ?? BorderRadius.circular(AppRadius.card))
             as BorderRadius;
     final gradient = surface?.gradient ?? AppGradients.brandGradient;
     final shadow = surface?.shadow;
@@ -32,30 +45,55 @@ class BrandGradientCard extends StatelessWidget {
         Theme.of(context).extension<BrandOnColors>()?.onGradient ??
             Colors.black;
 
-    Widget content = Container(
+    final cardBody = Container(
       decoration: BoxDecoration(
         gradient: gradient,
         borderRadius: radius,
         boxShadow: shadow,
       ),
-      padding: padding ?? const EdgeInsets.all(AppSpacing.sm),
+      padding: widget.padding ?? const EdgeInsets.all(AppSpacing.sm),
       child: DefaultTextStyle.merge(
         style: TextStyle(color: onBrand),
         child: IconTheme(
           data: IconThemeData(color: onBrand),
-          child: child,
+          child: widget.child,
         ),
       ),
     );
 
-    if (onTap != null) {
+    Widget content = AnimatedScale(
+      scale: _isPressed ? 0.97 : 1,
+      duration: const Duration(milliseconds: 140),
+      curve: Curves.easeOutCubic,
+      child: Stack(
+        children: [
+          cardBody,
+          Positioned.fill(
+            child: AnimatedOpacity(
+              opacity: _isPressed ? 1 : 0,
+              duration: const Duration(milliseconds: 120),
+              curve: Curves.easeOutCubic,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  borderRadius: radius,
+                  color: overlay.withOpacity(0.45),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    if (widget.onTap != null) {
       content = Material(
         type: MaterialType.transparency,
         child: InkWell(
           borderRadius: radius,
-          splashColor: overlay,
-          highlightColor: overlay,
-          onTap: onTap,
+          splashColor: overlay.withOpacity(0.35),
+          highlightColor: Colors.transparent,
+          onHighlightChanged: _handleHighlight,
+          onTap: widget.onTap,
           child: content,
         ),
       );

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -561,13 +561,9 @@ class _ProfileScreenState extends State<ProfileScreen> {
                 const SizedBox(height: AppSpacing.xs),
                 SizedBox(
                   width: double.infinity,
-                  child: BrandActionTile(
+                  child: _SurveyButton(
                     title: loc.surveyListTitle,
-                    centerTitle: true,
-                    dense: true,
-                    minVerticalPadding: 0,
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+                    subtitle: loc.reportViewSurveysTitle,
                     onTap: () {
                       final gymId = context.read<GymProvider>().currentGymId;
                       final userId = context.read<AuthProvider>().userId ?? '';
@@ -581,9 +577,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
                         ),
                       );
                     },
-                    variant: BrandActionTileVariant.outlined,
-                    showChevron: false,
-                    uiLogEvent: 'PROFILE_CARD_RENDER',
                   ),
                 ),
               ],
@@ -663,6 +656,198 @@ class _ProfileStatsSparkline extends StatelessWidget {
           },
         );
       }),
+    );
+  }
+}
+
+class _SurveyButton extends StatefulWidget {
+  const _SurveyButton({
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  @override
+  State<_SurveyButton> createState() => _SurveyButtonState();
+}
+
+class _SurveyButtonState extends State<_SurveyButton> {
+  bool _isPressed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    elogUi('PROFILE_CARD_RENDER', {'title': widget.title});
+  }
+
+  void _handleHighlight(bool value) {
+    if (value == _isPressed || !mounted) return;
+    setState(() => _isPressed = value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final brandTheme = theme.extension<AppBrandTheme>();
+    final gradient = brandTheme?.gradient ?? AppGradients.brandGradient;
+    final radius =
+        (brandTheme?.radius ?? BorderRadius.circular(AppRadius.card)) as BorderRadius;
+    final overlay = brandTheme?.pressedOverlay ?? Colors.white24;
+    final onSurface = theme.colorScheme.onSurface;
+    final onGradient =
+        theme.extension<BrandOnColors>()?.onGradient ?? Colors.black;
+    final accentShadow = gradient.colors.last;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: radius,
+        splashColor: overlay.withOpacity(0.3),
+        highlightColor: Colors.transparent,
+        onHighlightChanged: _handleHighlight,
+        onTap: widget.onTap,
+        child: AnimatedScale(
+          scale: _isPressed ? 0.97 : 1,
+          duration: const Duration(milliseconds: 140),
+          curve: Curves.easeOutCubic,
+          child: Container(
+            decoration: BoxDecoration(
+              gradient: gradient,
+              borderRadius: radius,
+              boxShadow: [
+                BoxShadow(
+                  color: accentShadow.withOpacity(_isPressed ? 0.35 : 0.45),
+                  blurRadius: _isPressed ? 16 : 26,
+                  offset: const Offset(0, 18),
+                ),
+              ],
+            ),
+            padding: const EdgeInsets.all(1.5),
+            child: ClipRRect(
+              borderRadius: radius,
+              child: Stack(
+                children: [
+                  Container(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        colors: [
+                          theme.colorScheme.surface
+                              .withOpacity(_isPressed ? 0.72 : 0.65),
+                          theme.colorScheme.surface
+                              .withOpacity(_isPressed ? 0.95 : 0.85),
+                        ],
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    right: -40,
+                    top: -20,
+                    child: Container(
+                      width: 150,
+                      height: 150,
+                      decoration: BoxDecoration(
+                        gradient: RadialGradient(
+                          colors: [
+                            accentShadow.withOpacity(0.35),
+                            Colors.transparent,
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    left: -20,
+                    bottom: -50,
+                    child: Container(
+                      width: 130,
+                      height: 130,
+                      decoration: BoxDecoration(
+                        gradient: RadialGradient(
+                          colors: [
+                            gradient.colors.first.withOpacity(0.3),
+                            Colors.transparent,
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.lg,
+                      vertical: AppSpacing.md,
+                    ),
+                    child: Row(
+                      children: [
+                        Container(
+                          width: 48,
+                          height: 48,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            gradient: gradient,
+                            boxShadow: [
+                              BoxShadow(
+                                color: accentShadow.withOpacity(0.45),
+                                blurRadius: 20,
+                                offset: const Offset(0, 10),
+                              ),
+                            ],
+                          ),
+                          child: Icon(
+                            Icons.poll,
+                            color: onGradient,
+                          ),
+                        ),
+                        const SizedBox(width: AppSpacing.md),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              BrandGradientText(
+                                widget.title,
+                                style: theme.textTheme.titleMedium?.copyWith(
+                                  fontWeight: FontWeight.w700,
+                                  letterSpacing: 0.3,
+                                ),
+                              ),
+                              const SizedBox(height: AppSpacing.xs),
+                              Text(
+                                widget.subtitle,
+                                style: theme.textTheme.bodySmall?.copyWith(
+                                  color: onSurface.withOpacity(0.7),
+                                  letterSpacing: 0.2,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(width: AppSpacing.md),
+                        Container(
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: Colors.white.withOpacity(0.12),
+                          ),
+                          padding: const EdgeInsets.all(AppSpacing.xs),
+                          child: Icon(
+                            Icons.chevron_right,
+                            color: onSurface.withOpacity(0.85),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- add animated press feedback to `BrandGradientCard` so gradient tiles respond visually to taps
- replace the survey tile on the profile screen with a stylised gradient CTA that keeps analytics logging

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e066e1e0448320b7c907fdaca3fb81