### PR TITLE
Adjust device screen actions and keypad behavior

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -686,6 +686,21 @@ class DeviceProvider extends ChangeNotifier {
     return true;
   }
 
+  bool markSetNotDone(int index) {
+    if (index < 0 || index >= _sets.length) return false;
+    final s = _sets[index];
+    final current = s['done'] == true || s['done'] == 'true';
+    if (!current) return true;
+
+    final after = Map<String, dynamic>.from(s);
+    after['done'] = false;
+    _sets[index] = after;
+    _log('⬜️ [Provider] markSetNotDone($index)');
+    notifyListeners();
+    _onSessionMutated();
+    return true;
+  }
+
   int? nextPendingSetIndex(int afterIndex) {
     for (var i = afterIndex + 1; i < _sets.length; i++) {
       final s = _sets[i];

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -94,21 +94,18 @@ class _DeviceScreenState extends State<DeviceScreen> {
     _dlog('tap: +Set (before=${prov.sets.length})');
     prov.addSet();
 
-    // PostFrame #1: Keypad öffnen (fokussiert Gewicht)
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final index = prov.sets.length - 1;
       if (index >= 0 && index < _setKeys.length) {
         final key = _setKeys[index];
-        key.currentState?.focusWeight();
-
-        // PostFrame #2: erst NACH keypad-open scrollen (korrektes bottomPad)
         WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (key.currentContext != null) {
+          final context = key.currentContext;
+          if (context != null) {
             _dlog(
               'after add: sets=${prov.sets.length}, ensureVisible index=$index',
             );
             Scrollable.ensureVisible(
-              key.currentContext!,
+              context,
               alignment: 0.5,
               duration: const Duration(milliseconds: 200),
             );
@@ -354,19 +351,11 @@ class _DeviceScreenState extends State<DeviceScreen> {
         ),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          child: Row(
-            children: [
-              Expanded(
-                child: BrandOutlineButton(
-                  onPressed: () {
-                    _closeKeyboard();
-                    Navigator.pop(context);
-                  },
-                  child: Text(loc.cancelButton),
-                ),
-              ),
-              const SizedBox(width: 12),
-              Expanded(
+          child: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 360),
+              child: SizedBox(
+                width: double.infinity,
                 child: BrandOutlineButton(
                   onPressed: prov.hasSessionToday || prov.isSaving
                       ? null
@@ -489,7 +478,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                       : Text(loc.saveButton),
                 ),
               ),
-            ],
+            ),
           ),
         ),
       ],

--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -406,6 +406,7 @@ class OverlayNumericKeypad extends StatelessWidget {
                     },
                     onNavigate: () => _navigateNext(context, controller),
                     onNavigateBack: () => _navigatePrevious(context, controller),
+                    onAddSet: () => _addSet(context),
                     onDuplicate: () => _duplicateFromPrevious(context, controller),
                   ),
                 ),
@@ -610,12 +611,29 @@ class OverlayNumericKeypad extends StatelessWidget {
     }
 
     if (targetField != null) {
+      if (targetIndex != focusedIndex) {
+        prov.markSetNotDone(targetIndex);
+      }
       prov.requestFocus(
         index: targetIndex,
         field: targetField,
         dropIndex: targetDropIndex,
       );
     }
+
+    _haptic(context);
+  }
+
+  static void _addSet(BuildContext context) {
+    final prov = context.read<DeviceProvider>();
+
+    elogUi('OVERLAY_ADD_SET', {
+      'deviceId': prov.device?.uid,
+      'focusedIndex': prov.focusedIndex,
+      'focusedField': prov.focusedField?.name,
+    });
+
+    prov.addSet();
 
     _haptic(context);
   }
@@ -854,6 +872,7 @@ class _ActionRailCompact extends StatelessWidget {
   final VoidCallback onHide;
   final VoidCallback onNavigate;
   final VoidCallback onNavigateBack;
+  final VoidCallback onAddSet;
   final VoidCallback onDuplicate;
 
   const _ActionRailCompact({
@@ -865,6 +884,7 @@ class _ActionRailCompact extends StatelessWidget {
     required this.onHide,
     required this.onNavigate,
     required this.onNavigateBack,
+    required this.onAddSet,
     required this.onDuplicate,
   });
 
@@ -885,6 +905,11 @@ class _ActionRailCompact extends StatelessWidget {
         Icons.arrow_forward_rounded,
         loc.numericKeypadSemanticsNext,
         onNavigate,
+      ),
+      _RailAction(
+        Icons.add_rounded,
+        loc.addSetButton,
+        onAddSet,
       ),
       _RailAction(
         Icons.copy_all_rounded,


### PR DESCRIPTION
## Summary
- remove the cancel button from the device screen footer and center the save action
- avoid shifting focus when adding sets and expose an add-set shortcut on the overlay keypad
- reopen previous sets when navigating backwards from the keypad by marking them as not done

## Testing
- not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e08e3572d88320a880dde811e4157e