### PR TITLE
Handle workout timer auto-stop after inactivity

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -659,6 +659,7 @@ class DeviceProvider extends ChangeNotifier {
     _onSessionMutated();
     if (toggledToDone) {
       _maybeStartSessionTimer();
+      _recordSetCompletionForTimer();
     }
     return true;
   }
@@ -683,6 +684,7 @@ class DeviceProvider extends ChangeNotifier {
     notifyListeners();
     _onSessionMutated();
     _maybeStartSessionTimer();
+    _recordSetCompletionForTimer();
     return true;
   }
 
@@ -736,6 +738,7 @@ class DeviceProvider extends ChangeNotifier {
     notifyListeners();
     _onSessionMutated();
     _maybeStartSessionTimer();
+    _recordSetCompletionForTimer();
     return idx;
   }
 
@@ -755,6 +758,7 @@ class DeviceProvider extends ChangeNotifier {
       notifyListeners();
       _onSessionMutated();
       _maybeStartSessionTimer();
+      _recordSetCompletionForTimer();
     }
     return count;
   }
@@ -817,6 +821,16 @@ class DeviceProvider extends ChangeNotifier {
     if (uid == null || gymId == null) return;
     if (!_hasCompletedSets()) return;
     unawaited(durationService.start(uid: uid, gymId: gymId));
+  }
+
+  void _recordSetCompletionForTimer() {
+    final durationService = _sessionDurationService;
+    if (durationService == null) return;
+    unawaited(
+      durationService.registerSetCompletion(
+        completedAt: DateTime.now(),
+      ),
+    );
   }
 
   void _onSessionMutated() {

--- a/lib/core/services/workout_session_duration_service.dart
+++ b/lib/core/services/workout_session_duration_service.dart
@@ -36,7 +36,7 @@ class WorkoutSessionDurationService extends ChangeNotifier {
   Timer? _autoStopTimer;
   String? _firstSessionId;
   String? _lastSessionId;
-  int? _lastSessionEpochMs;
+  int? _lastActivityEpochMs;
 
   WorkoutSessionDurationService({
     FirebaseFirestore? firestore,
@@ -83,7 +83,7 @@ class WorkoutSessionDurationService extends ChangeNotifier {
     _activePrefsKey = newKey;
     _firstSessionId = null;
     _lastSessionId = null;
-    _lastSessionEpochMs = null;
+    _lastActivityEpochMs = null;
     _startEpochMs = null;
     var shouldNotify = false;
 
@@ -95,11 +95,12 @@ class WorkoutSessionDurationService extends ChangeNotifier {
           _startEpochMs = data['startEpochMs'] as int?;
           _firstSessionId = data['firstSessionId'] as String?;
           _lastSessionId = data['lastSessionId'] as String?;
-          final lastMs = data['lastSessionEpochMs'];
+          final lastMs =
+              data['lastActivityEpochMs'] ?? data['lastSessionEpochMs'];
           if (lastMs is int) {
-            _lastSessionEpochMs = lastMs;
+            _lastActivityEpochMs = lastMs;
           } else if (lastMs is num) {
-            _lastSessionEpochMs = lastMs.toInt();
+            _lastActivityEpochMs = lastMs.toInt();
           }
         } catch (_) {
           // ignore malformed persisted state
@@ -142,7 +143,7 @@ class WorkoutSessionDurationService extends ChangeNotifier {
     _startEpochMs = now;
     _firstSessionId = null;
     _lastSessionId = null;
-    _lastSessionEpochMs = null;
+    _lastActivityEpochMs = null;
     _autoStopTimer?.cancel();
     _isRunning = true;
     await _persistState();
@@ -158,7 +159,16 @@ class WorkoutSessionDurationService extends ChangeNotifier {
     if (!_isRunning || _startEpochMs == null) return;
     _firstSessionId ??= sessionId;
     _lastSessionId = sessionId;
-    _lastSessionEpochMs = completedAt.millisecondsSinceEpoch;
+    _lastActivityEpochMs = completedAt.millisecondsSinceEpoch;
+    await _persistState();
+    _scheduleAutoStop();
+  }
+
+  Future<void> registerSetCompletion({
+    required DateTime completedAt,
+  }) async {
+    if (!_isRunning || _startEpochMs == null) return;
+    _lastActivityEpochMs = completedAt.millisecondsSinceEpoch;
     await _persistState();
     _scheduleAutoStop();
   }
@@ -293,7 +303,7 @@ class WorkoutSessionDurationService extends ChangeNotifier {
     _activePrefsKey = null;
     _firstSessionId = null;
     _lastSessionId = null;
-    _lastSessionEpochMs = null;
+    _lastActivityEpochMs = null;
     _ticker?.cancel();
     _autoStopTimer?.cancel();
     _autoStopTimer = null;
@@ -347,14 +357,17 @@ class WorkoutSessionDurationService extends ChangeNotifier {
       'gymId': gymId,
       if (_firstSessionId != null) 'firstSessionId': _firstSessionId,
       if (_lastSessionId != null) 'lastSessionId': _lastSessionId,
-      if (_lastSessionEpochMs != null) 'lastSessionEpochMs': _lastSessionEpochMs,
+      if (_lastActivityEpochMs != null) ...{
+        'lastActivityEpochMs': _lastActivityEpochMs,
+        'lastSessionEpochMs': _lastActivityEpochMs,
+      },
     };
     await prefs.setString(_prefsKeyFor(uid, gymId), jsonEncode(data));
     await prefs.remove('$_prefsKeyPrefix$uid');
   }
 
   void _scheduleAutoStop() {
-    if (!_isRunning || _lastSessionEpochMs == null) return;
+    if (!_isRunning || _lastActivityEpochMs == null) return;
     _autoStopTimer?.cancel();
     if (_autoStopDelay <= Duration.zero) {
       unawaited(_autoFinalize());
@@ -366,9 +379,9 @@ class WorkoutSessionDurationService extends ChangeNotifier {
   }
 
   void _resumeAutoStopTimer() {
-    if (!_isRunning || _lastSessionEpochMs == null) return;
+    if (!_isRunning || _lastActivityEpochMs == null) return;
     final nowMs = DateTime.now().millisecondsSinceEpoch;
-    final target = _lastSessionEpochMs! + _autoStopDelay.inMilliseconds;
+    final target = _lastActivityEpochMs! + _autoStopDelay.inMilliseconds;
     final remainingMs = target - nowMs;
     if (remainingMs <= 0) {
       unawaited(_autoFinalize());
@@ -381,10 +394,10 @@ class WorkoutSessionDurationService extends ChangeNotifier {
   }
 
   Future<void> _autoFinalize() async {
-    if (!_isRunning || _startEpochMs == null || _lastSessionEpochMs == null) {
+    if (!_isRunning || _startEpochMs == null || _lastActivityEpochMs == null) {
       return;
     }
-    final end = DateTime.fromMillisecondsSinceEpoch(_lastSessionEpochMs!);
+    final end = DateTime.fromMillisecondsSinceEpoch(_lastActivityEpochMs!);
     final sid = _firstSessionId ?? _lastSessionId;
     await save(endTime: end, sessionId: sid);
   }

--- a/test/core/services/workout_session_duration_service_test.dart
+++ b/test/core/services/workout_session_duration_service_test.dart
@@ -61,6 +61,40 @@ void main() {
     expect(data['durationMs'], expectedDuration);
   });
 
+  test('auto stop after inactivity uses last set completion timestamp', () async {
+    final firestore = FakeFirebaseFirestore();
+    final service = WorkoutSessionDurationService(
+      firestore: firestore,
+      autoStopDelay: const Duration(milliseconds: 50),
+    );
+    addTearDown(service.dispose);
+
+    await service.start(uid: 'u1', gymId: 'g1');
+    final setCompletion = DateTime.now().add(const Duration(minutes: 45));
+    await service.registerSetCompletion(completedAt: setCompletion);
+
+    await Future<void>.delayed(const Duration(milliseconds: 150));
+
+    expect(service.isRunning, isFalse);
+
+    final snap = await firestore
+        .collection('gyms')
+        .doc('g1')
+        .collection('users')
+        .doc('u1')
+        .collection('session_meta')
+        .get();
+
+    expect(snap.docs, hasLength(1));
+    final data = snap.docs.single.data();
+    final startTs = data['startTime'] as Timestamp;
+    final endTs = data['endTime'] as Timestamp;
+    expect(endTs.toDate(), setCompletion);
+    final expectedDuration = setCompletion.millisecondsSinceEpoch -
+        startTs.toDate().millisecondsSinceEpoch;
+    expect(data['durationMs'], expectedDuration);
+  });
+
   test('setActiveContext isolates timers per user and gym', () async {
     final firestore = FakeFirebaseFirestore();
     final service = WorkoutSessionDurationService(firestore: firestore);


### PR DESCRIPTION
## Summary
- track the latest workout activity timestamp in the session duration service and expose a registration hook for set completions
- notify the timer service from the device provider whenever sets are completed so inactivity auto-stop uses the final set time
- add coverage to ensure auto-stop persists the last set completion duration when the timer finalizes automatically

## Testing
- not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e106323df08320a9c0fcf5d52be4df