### PR TITLE
Add shared pressable feedback to outlined controls

### DIFF
--- a/lib/core/widgets/brand_outline.dart
+++ b/lib/core/widgets/brand_outline.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../theme/app_brand_theme.dart';
+import 'pressable_surface.dart';
 
 /// Generic container with a branded gradient outline.
 ///
@@ -33,6 +34,73 @@ class BrandOutline extends StatefulWidget {
 }
 
 class _BrandOutlineState extends State<BrandOutline> {
+  static const _overlayOpacity = 0.35;
+  static const _animationDuration = Duration(milliseconds: 180);
+
+  Widget _buildSurface(
+    BuildContext context,
+    AppBrandTheme brand,
+    BorderRadius radius,
+    BorderRadius innerRadius,
+    bool highContrast,
+    bool isPressed,
+  ) {
+    final theme = Theme.of(context);
+    final overlayColor = brand.pressedOverlay.withOpacity(_overlayOpacity);
+    final decoration = BoxDecoration(
+      gradient: highContrast ? null : brand.outlineGradient,
+      color: highContrast ? brand.outlineColorFallback : null,
+      borderRadius: radius,
+      boxShadow: widget.isSelected ? brand.outlineShadow : null,
+    );
+
+    Widget inner = DecoratedBox(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        borderRadius: innerRadius,
+      ),
+      child: Padding(
+        padding: widget.padding ?? EdgeInsets.zero,
+        child: widget.child,
+      ),
+    );
+
+    if (widget.onTap != null && !widget.isDisabled) {
+      inner = Stack(
+        clipBehavior: Clip.hardEdge,
+        children: [
+          inner,
+          Positioned.fill(
+            child: IgnorePointer(
+              child: AnimatedOpacity(
+                opacity: isPressed ? 1 : 0,
+                duration: _animationDuration,
+                curve: Curves.easeOutCubic,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: overlayColor,
+                    borderRadius: innerRadius,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
+    return Container(
+      margin: widget.margin,
+      decoration: decoration,
+      padding: EdgeInsets.all(brand.outlineWidth),
+      child: AnimatedContainer(
+        duration: _animationDuration,
+        curve: Curves.easeOutCubic,
+        child: inner,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final brand = Theme.of(context).extension<AppBrandTheme>()!;
@@ -41,44 +109,36 @@ class _BrandOutlineState extends State<BrandOutline> {
         (widget.radiusOverride ?? brand.outlineRadius) as BorderRadius;
     final BorderRadius innerRadius =
         radius - BorderRadius.circular(brand.outlineWidth);
-    final decoration = BoxDecoration(
-      gradient: highContrast ? null : brand.outlineGradient,
-      color: highContrast ? brand.outlineColorFallback : null,
-      borderRadius: radius,
-      boxShadow: widget.isSelected ? brand.outlineShadow : null,
-    );
 
-    Widget content = Container(
-      margin: widget.margin,
-      decoration: decoration,
-      padding: EdgeInsets.all(brand.outlineWidth),
-      child: Container(
-        padding: widget.padding,
-        decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.surface,
-          borderRadius: innerRadius,
-        ),
-        child: widget.child,
-      ),
-    );
+    Widget content;
+    final isInteractive = widget.onTap != null && !widget.isDisabled;
 
-    if (widget.onTap != null) {
-      content = Material(
-        type: MaterialType.transparency,
-        child: InkWell(
-          borderRadius: innerRadius,
-          onTap: widget.isDisabled ? null : widget.onTap,
-          overlayColor: MaterialStateProperty.resolveWith((states) {
-            if (states.contains(MaterialState.pressed)) {
-              return brand.pressedOverlay;
-            }
-            if (states.contains(MaterialState.focused)) {
-              return brand.focusRing.withOpacity(0.3);
-            }
-            return null;
-          }),
-          child: content,
+    if (isInteractive) {
+      content = PressableSurface(
+        onTap: widget.onTap,
+        borderRadius: radius,
+        showOverlay: false,
+        duration: _animationDuration,
+        overlayColor: brand.pressedOverlay.withOpacity(0.2),
+        focusColor: brand.focusRing.withOpacity(0.3),
+        hoverColor: brand.focusRing.withOpacity(0.16),
+        builder: (context, isPressed) => _buildSurface(
+          context,
+          brand,
+          radius,
+          innerRadius,
+          highContrast,
+          isPressed,
         ),
+      );
+    } else {
+      content = _buildSurface(
+        context,
+        brand,
+        radius,
+        innerRadius,
+        highContrast,
+        false,
       );
     }
 
@@ -89,9 +149,11 @@ class _BrandOutlineState extends State<BrandOutline> {
       );
     }
 
-    if (widget.semanticLabel != null) {
+    if (widget.semanticLabel != null || widget.onTap != null) {
       content = Semantics(
         label: widget.semanticLabel,
+        button: widget.onTap != null,
+        enabled: !widget.isDisabled,
         container: true,
         child: content,
       );

--- a/lib/core/widgets/pressable_surface.dart
+++ b/lib/core/widgets/pressable_surface.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+
+/// Generic pressable surface that provides a consistent scale and overlay
+/// feedback based on the profile screen action buttons.
+///
+/// The [builder] is invoked with the current pressed state so callers can
+/// update their decoration (for example by tweaking shadows or borders).
+class PressableSurface extends StatefulWidget {
+  const PressableSurface({
+    super.key,
+    required this.builder,
+    this.onTap,
+    this.borderRadius = BorderRadius.zero,
+    this.overlayColor,
+    this.showOverlay = true,
+    this.pressedScale = 0.985,
+    this.duration = const Duration(milliseconds: 160),
+    this.curve = Curves.easeOutCubic,
+    this.enabled = true,
+    this.focusColor,
+    this.hoverColor,
+  });
+
+  final Widget Function(BuildContext context, bool isPressed) builder;
+  final VoidCallback? onTap;
+  final BorderRadiusGeometry borderRadius;
+  final Color? overlayColor;
+  final Color? focusColor;
+  final Color? hoverColor;
+  final bool showOverlay;
+  final double pressedScale;
+  final Duration duration;
+  final Curve curve;
+  final bool enabled;
+
+  @override
+  State<PressableSurface> createState() => _PressableSurfaceState();
+}
+
+class _PressableSurfaceState extends State<PressableSurface> {
+  bool _isPressed = false;
+
+  void _handleHighlight(bool value) {
+    if (!mounted || _isPressed == value) return;
+    setState(() => _isPressed = value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final borderRadius =
+        widget.borderRadius.resolve(Directionality.of(context));
+    final overlay = widget.overlayColor ??
+        Theme.of(context).colorScheme.onSurface.withOpacity(0.12);
+
+    Widget child = widget.builder(context, widget.enabled && _isPressed);
+
+    if (!widget.enabled || widget.onTap == null) {
+      return child;
+    }
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: borderRadius,
+        splashColor: overlay.withOpacity(0.35),
+        highlightColor: Colors.transparent,
+        focusColor: widget.focusColor ?? overlay.withOpacity(0.25),
+        hoverColor: widget.hoverColor ?? overlay.withOpacity(0.18),
+        onTap: widget.onTap,
+        onHighlightChanged: _handleHighlight,
+        child: AnimatedScale(
+          scale: _isPressed ? widget.pressedScale : 1,
+          duration: widget.duration,
+          curve: widget.curve,
+          child: Stack(
+            clipBehavior: Clip.none,
+            children: [
+              child,
+              if (widget.showOverlay)
+                Positioned.fill(
+                  child: IgnorePointer(
+                    child: AnimatedOpacity(
+                      opacity: _isPressed ? 1 : 0,
+                      duration: widget.duration,
+                      curve: widget.curve,
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          borderRadius: borderRadius,
+                          color: overlay,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/gym/presentation/widgets/device_card.dart
+++ b/lib/features/gym/presentation/widgets/device_card.dart
@@ -6,89 +6,70 @@ import 'package:tapem/core/theme/design_tokens.dart';
 import 'package:tapem/core/widgets/brand_outline.dart';
 import 'package:tapem/core/theme/brand_on_colors.dart';
 
-class DeviceCard extends StatefulWidget {
+class DeviceCard extends StatelessWidget {
   final Device device;
   final VoidCallback? onTap;
   const DeviceCard({Key? key, required this.device, this.onTap})
     : super(key: key);
 
   @override
-  State<DeviceCard> createState() => _DeviceCardState();
-}
-
-class _DeviceCardState extends State<DeviceCard> {
-  double _scale = 1;
-
-  void _onTapDown(TapDownDetails d) => setState(() => _scale = 0.97);
-  void _onTapEnd([_]) => setState(() => _scale = 1);
-
-  @override
   Widget build(BuildContext context) {
     final theme = context.theme;
-    final device = widget.device;
+    final device = this.device;
     final initial = device.name.isNotEmpty ? device.name[0].toUpperCase() : '?';
     final subtitle = device.description;
     final idText = device.id > 0 ? device.id.toString() : '–';
     final onBrand = Theme.of(context).extension<BrandOnColors>()?.onGradient ?? Colors.black;
     return Hero(
       tag: 'device-${device.uid}',
-      child: AnimatedScale(
-        duration: AppDurations.short,
-        scale: _scale,
-        child: GestureDetector(
-          onTapDown: _onTapDown,
-          onTapCancel: _onTapEnd,
-          onTapUp: _onTapEnd,
-          child: BrandOutline(
-            onTap: widget.onTap,
-            child: SizedBox(
-              height: 140,
-              child: Padding(
-                padding: const EdgeInsets.all(AppSpacing.sm),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    CircleAvatar(
-                      radius: 28,
-                      backgroundColor: Colors.transparent,
-                      child: DecoratedBox(
-                        decoration: BoxDecoration(
-                          shape: BoxShape.circle,
-                          gradient: AppGradients.brandGradient,
-                        ),
-                        child: Center(
-                          child: Text(
-                            initial,
-                            style: theme.textTheme.titleLarge?.copyWith(color: onBrand),
-                          ),
-                        ),
+      child: BrandOutline(
+        onTap: onTap,
+        child: SizedBox(
+          height: 140,
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.sm),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                CircleAvatar(
+                  radius: 28,
+                  backgroundColor: Colors.transparent,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      gradient: AppGradients.brandGradient,
+                    ),
+                    child: Center(
+                      child: Text(
+                        initial,
+                        style: theme.textTheme.titleLarge?.copyWith(color: onBrand),
                       ),
                     ),
-                    const SizedBox(height: AppSpacing.xs),
-                    Text(
-                      device.name,
-                      style: theme.textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                    if (subtitle.isNotEmpty)
-                      Text(
-                        subtitle,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.bodyMedium,
-                      ),
-                    const SizedBox(height: AppSpacing.xs),
-                    Text(
-                      'ID: $idText',
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: theme.textTheme.bodySmall,
-                    ),
-                  ],
+                  ),
                 ),
-              ),
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  device.name,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                if (subtitle.isNotEmpty)
+                  Text(
+                    subtitle,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  'ID: $idText',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodySmall,
+                ),
+              ],
             ),
           ),
         ),


### PR DESCRIPTION
## Summary
- add a reusable PressableSurface widget that mirrors the profile button feedback
- update BrandOutline to use the shared press effect, covering ranking buttons and outline actions
- simplify the gym DeviceCard to rely on the enhanced BrandOutline interactions

## Testing
- not run (Flutter tooling unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e111e9fbec8320980ed528ff733083