### PR TITLE
Align gym and rank cards with profile action style

### DIFF
--- a/lib/core/widgets/brand_interactive_card.dart
+++ b/lib/core/widgets/brand_interactive_card.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/material.dart';
+
+import '../logging/elog.dart';
+import '../theme/app_brand_theme.dart';
+import '../theme/design_tokens.dart';
+
+/// Animated surface matching the outline style used on the profile actions.
+class BrandInteractiveCard extends StatefulWidget {
+  const BrandInteractiveCard({
+    super.key,
+    required this.child,
+    this.onTap,
+    this.padding = const EdgeInsets.symmetric(
+      horizontal: AppSpacing.lg,
+      vertical: AppSpacing.md,
+    ),
+    this.margin,
+    this.backgroundColor,
+    this.restingBorderColor,
+    this.activeBorderColor,
+    this.shadowColor,
+    this.borderRadius,
+    this.showShadow = true,
+    this.showPressedOverlay = true,
+    this.enableScaleAnimation = true,
+    this.semanticLabel,
+    this.uiLogEvent,
+  });
+
+  /// Content rendered inside the card.
+  final Widget child;
+
+  /// Callback executed when the card is tapped.
+  final VoidCallback? onTap;
+
+  /// Padding applied to [child].
+  final EdgeInsetsGeometry padding;
+
+  /// Optional outer margin for the card.
+  final EdgeInsetsGeometry? margin;
+
+  /// Background color of the card. Defaults to the scaffold background colour.
+  final Color? backgroundColor;
+
+  /// Border color when the card is idle.
+  final Color? restingBorderColor;
+
+  /// Border color when the card is pressed.
+  final Color? activeBorderColor;
+
+  /// Shadow tint for the card.
+  final Color? shadowColor;
+
+  /// Corner radius applied to the card.
+  final BorderRadiusGeometry? borderRadius;
+
+  /// Whether a drop shadow should be drawn.
+  final bool showShadow;
+
+  /// Whether a pressed overlay is drawn when the card is held down.
+  final bool showPressedOverlay;
+
+  /// Whether the scale animation is played on press.
+  final bool enableScaleAnimation;
+
+  /// Optional semantic label announced to assistive technologies.
+  final String? semanticLabel;
+
+  /// Event name for UI telemetry.
+  final String? uiLogEvent;
+
+  @override
+  State<BrandInteractiveCard> createState() => _BrandInteractiveCardState();
+}
+
+class _BrandInteractiveCardState extends State<BrandInteractiveCard> {
+  bool _isPressed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.uiLogEvent != null) {
+      elogUi(widget.uiLogEvent!, {'label': widget.semanticLabel});
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant BrandInteractiveCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.uiLogEvent != oldWidget.uiLogEvent && widget.uiLogEvent != null) {
+      elogUi(widget.uiLogEvent!, {'label': widget.semanticLabel});
+    }
+  }
+
+  void _handleHighlight(bool value) {
+    if (_isPressed == value || !mounted) return;
+    setState(() => _isPressed = value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final brandTheme = theme.extension<AppBrandTheme>();
+    final radius = (widget.borderRadius ??
+            brandTheme?.radius ??
+            BorderRadius.circular(AppRadius.card))
+        as BorderRadius;
+    final onSurface = theme.colorScheme.onSurface;
+    final brandColor = brandTheme?.outline ?? theme.colorScheme.secondary;
+    final overlay = brandTheme?.pressedOverlay ?? onSurface.withOpacity(0.08);
+    final backgroundColor =
+        widget.backgroundColor ?? theme.scaffoldBackgroundColor;
+    final restingBorder =
+        widget.restingBorderColor ?? onSurface.withOpacity(0.12);
+    final activeBorder =
+        widget.activeBorderColor ?? brandColor.withOpacity(0.45);
+    final borderColor =
+        Color.lerp(restingBorder, activeBorder, _isPressed ? 1 : 0)!;
+    final canTap = widget.onTap != null;
+    final shadowBase =
+        (widget.shadowColor ?? theme.shadowColor).withOpacity(_isPressed ? 0.08 : 0.16);
+
+    final card = AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeOutCubic,
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: radius,
+        border: Border.all(color: borderColor),
+        boxShadow: widget.showShadow
+            ? [
+                BoxShadow(
+                  color: shadowBase,
+                  blurRadius: _isPressed ? 10 : 20,
+                  offset: Offset(0, _isPressed ? 6 : 14),
+                ),
+              ]
+            : const [],
+      ),
+      child: Stack(
+        children: [
+          if (widget.showPressedOverlay)
+            Positioned.fill(
+              child: AnimatedOpacity(
+                opacity: _isPressed ? 1 : 0,
+                duration: const Duration(milliseconds: 150),
+                curve: Curves.easeOutCubic,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: overlay.withOpacity(0.35),
+                    borderRadius: radius,
+                  ),
+                ),
+              ),
+            ),
+          Padding(
+            padding: widget.padding,
+            child: widget.child,
+          ),
+        ],
+      ),
+    );
+
+    final animated = widget.enableScaleAnimation
+        ? AnimatedScale(
+            scale: _isPressed ? 0.985 : 1,
+            duration: const Duration(milliseconds: 160),
+            curve: Curves.easeOutCubic,
+            child: card,
+          )
+        : card;
+
+    final ink = Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: radius,
+        splashColor: canTap ? overlay.withOpacity(0.3) : Colors.transparent,
+        highlightColor: Colors.transparent,
+        onHighlightChanged: canTap ? _handleHighlight : null,
+        onTap: widget.onTap,
+        child: animated,
+      ),
+    );
+
+    final semantics = Semantics(
+      button: canTap,
+      enabled: canTap,
+      label: widget.semanticLabel,
+      child: ink,
+    );
+
+    return Container(
+      margin: widget.margin,
+      child: semantics,
+    );
+  }
+}

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -16,6 +16,7 @@ import 'package:tapem/core/theme/brand_theme_preset.dart';
 import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/core/widgets/brand_gradient_icon.dart';
 import 'package:tapem/core/widgets/brand_gradient_text.dart';
+import 'package:tapem/core/widgets/brand_interactive_card.dart';
 import 'package:tapem/core/logging/elog.dart';
 import 'package:tapem/core/utils/avatar_assets.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
@@ -684,7 +685,7 @@ class _ProfileStatsSparkline extends StatelessWidget {
   }
 }
 
-class _ProfileActionButton extends StatefulWidget {
+class _ProfileActionButton extends StatelessWidget {
   const _ProfileActionButton({
     required this.title,
     required this.subtitle,
@@ -704,26 +705,6 @@ class _ProfileActionButton extends StatefulWidget {
   final String? uiLogEvent;
 
   @override
-  State<_ProfileActionButton> createState() => _ProfileActionButtonState();
-}
-
-class _ProfileActionButtonState extends State<_ProfileActionButton> {
-  bool _isPressed = false;
-
-  @override
-  void initState() {
-    super.initState();
-    if (widget.uiLogEvent != null) {
-      elogUi(widget.uiLogEvent!, {'title': widget.title});
-    }
-  }
-
-  void _handleHighlight(bool value) {
-    if (value == _isPressed || !mounted) return;
-    setState(() => _isPressed = value);
-  }
-
-  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final brandTheme = theme.extension<AppBrandTheme>();
@@ -731,108 +712,53 @@ class _ProfileActionButtonState extends State<_ProfileActionButton> {
         (brandTheme?.radius ?? BorderRadius.circular(AppRadius.card)) as BorderRadius;
     final onSurface = theme.colorScheme.onSurface;
     final brandColor = brandTheme?.outline ?? theme.colorScheme.secondary;
-    final overlay = brandTheme?.pressedOverlay ?? onSurface.withOpacity(0.08);
-    final backgroundColor = theme.scaffoldBackgroundColor;
-    final restingBorder = onSurface.withOpacity(0.12);
-    final activeBorder = brandColor.withOpacity(0.45);
-    final borderColor =
-        Color.lerp(restingBorder, activeBorder, _isPressed ? 1 : 0)!;
-    final shadowColor = theme.shadowColor.withOpacity(_isPressed ? 0.08 : 0.16);
 
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        borderRadius: radius,
-        splashColor: overlay.withOpacity(0.3),
-        highlightColor: Colors.transparent,
-        onHighlightChanged: _handleHighlight,
-        onTap: widget.onTap,
-        child: AnimatedScale(
-          scale: _isPressed ? 0.985 : 1,
-          duration: const Duration(milliseconds: 160),
-          curve: Curves.easeOutCubic,
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 200),
-            curve: Curves.easeOutCubic,
-            decoration: BoxDecoration(
-              color: backgroundColor,
-              borderRadius: radius,
-              border: Border.all(color: borderColor),
-              boxShadow: [
-                BoxShadow(
-                  color: shadowColor,
-                  blurRadius: _isPressed ? 10 : 20,
-                  offset: Offset(0, _isPressed ? 6 : 14),
-                ),
-              ],
-            ),
-            child: Stack(
+    return BrandInteractiveCard(
+      onTap: onTap,
+      uiLogEvent: uiLogEvent,
+      borderRadius: radius,
+      semanticLabel: '$title, $subtitle',
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          leading,
+          const SizedBox(width: AppSpacing.md),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
               children: [
-                Positioned.fill(
-                  child: AnimatedOpacity(
-                    opacity: _isPressed ? 1 : 0,
-                    duration: const Duration(milliseconds: 150),
-                    curve: Curves.easeOutCubic,
-                    child: DecoratedBox(
-                      decoration: BoxDecoration(
-                        color: overlay.withOpacity(0.35),
-                        borderRadius: radius,
-                      ),
-                    ),
+                Text(
+                  title,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: brandColor,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 0.3,
                   ),
                 ),
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppSpacing.lg,
-                    vertical: AppSpacing.md,
-                  ),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      widget.leading,
-                      const SizedBox(width: AppSpacing.md),
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Text(
-                              widget.title,
-                              style: theme.textTheme.titleMedium?.copyWith(
-                                color: brandColor,
-                                fontWeight: FontWeight.w700,
-                                letterSpacing: 0.3,
-                              ),
-                            ),
-                            const SizedBox(height: AppSpacing.xs),
-                            Text(
-                              widget.subtitle,
-                              style: theme.textTheme.bodySmall?.copyWith(
-                                color: onSurface.withOpacity(0.7),
-                                letterSpacing: 0.2,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      if (widget.trailing != null) ...[
-                        const SizedBox(width: AppSpacing.md),
-                        widget.trailing!,
-                      ],
-                      if (widget.showChevron) ...[
-                        const SizedBox(width: AppSpacing.md),
-                        Icon(
-                          Icons.chevron_right,
-                          color: brandColor,
-                        ),
-                      ],
-                    ],
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  subtitle,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: onSurface.withOpacity(0.7),
+                    letterSpacing: 0.2,
                   ),
                 ),
               ],
             ),
           ),
-        ),
+          if (trailing != null) ...[
+            const SizedBox(width: AppSpacing.md),
+            trailing!,
+          ],
+          if (showChevron) ...[
+            const SizedBox(width: AppSpacing.md),
+            Icon(
+              Icons.chevron_right,
+              color: brandColor,
+            ),
+          ],
+        ],
       ),
     );
   }

--- a/lib/features/rank/presentation/screens/rank_screen.dart
+++ b/lib/features/rank/presentation/screens/rank_screen.dart
@@ -4,10 +4,10 @@ import 'package:tapem/core/providers/rank_provider.dart';
 import 'package:tapem/app_router.dart';
 import 'package:tapem/features/challenges/presentation/screens/challenge_tab.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
-import 'package:tapem/core/widgets/brand_action_tile.dart';
 import 'package:tapem/core/widgets/brand_gradient_text.dart';
+import 'package:tapem/core/widgets/brand_interactive_card.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/l10n/app_localizations.dart';
-import 'package:tapem/core/logging/elog.dart';
 
 /// Rank landing displayed in the "Rank" tab of the leaderboard.
 class RankScreen extends StatefulWidget {
@@ -76,40 +76,28 @@ class _RankScreenState extends State<RankScreen>
               ListView(
                 padding: const EdgeInsets.all(AppSpacing.sm),
                 children: [
-                  BrandActionTile(
+                  _RankCard(
                     title: loc.rankExperience,
+                    icon: Icons.auto_graph,
+                    subtitle: loc.profileStatsButtonSubtitle,
                     onTap: () =>
                         Navigator.of(context).pushNamed(AppRouter.dayXp),
-                    centerTitle: true,
-                    showChevron: false,
-                    variant: BrandActionTileVariant.outlined,
-                    margin: const EdgeInsets.symmetric(
-                        horizontal: AppSpacing.sm),
-                    uiLogEvent: 'RANK_CARD_RENDER',
                   ),
                   const SizedBox(height: AppSpacing.sm),
-                  BrandActionTile(
+                  _RankCard(
                     title: loc.rankDeviceLevel,
+                    icon: Icons.fitness_center,
+                    subtitle: loc.profileStatsButtonSubtitle,
                     onTap: () =>
                         Navigator.of(context).pushNamed(AppRouter.deviceXp),
-                    centerTitle: true,
-                    showChevron: false,
-                    variant: BrandActionTileVariant.outlined,
-                    margin: const EdgeInsets.symmetric(
-                        horizontal: AppSpacing.sm),
-                    uiLogEvent: 'RANK_CARD_RENDER',
                   ),
                   const SizedBox(height: AppSpacing.sm),
-                  BrandActionTile(
+                  _RankCard(
                     title: loc.rankMuscleLevel,
+                    icon: Icons.bolt,
+                    subtitle: loc.profileStatsButtonSubtitle,
                     onTap: () =>
                         Navigator.of(context).pushNamed(AppRouter.xpOverview),
-                    centerTitle: true,
-                    showChevron: false,
-                    variant: BrandActionTileVariant.outlined,
-                    margin: const EdgeInsets.symmetric(
-                        horizontal: AppSpacing.sm),
-                    uiLogEvent: 'RANK_CARD_RENDER',
                   ),
                 ],
               ),
@@ -118,6 +106,94 @@ class _RankScreenState extends State<RankScreen>
           );
         },
       ),
+    );
+  }
+}
+
+class _RankCard extends StatelessWidget {
+  const _RankCard({
+    required this.title,
+    required this.icon,
+    required this.onTap,
+    this.subtitle,
+  });
+
+  final String title;
+  final String? subtitle;
+  final IconData icon;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final brandTheme = theme.extension<AppBrandTheme>();
+    final brandColor = brandTheme?.outline ?? theme.colorScheme.secondary;
+    final secondary = theme.colorScheme.onSurface.withOpacity(0.7);
+
+    return BrandInteractiveCard(
+      onTap: onTap,
+      margin: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+      semanticLabel: subtitle != null ? '$title, $subtitle' : title,
+      uiLogEvent: 'RANK_CARD_RENDER',
+      child: Row(
+        children: [
+          _RankIcon(icon: icon),
+          const SizedBox(width: AppSpacing.md),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  title,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: brandColor,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 0.3,
+                  ),
+                ),
+                if (subtitle != null) ...[
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    subtitle!,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: secondary,
+                      letterSpacing: 0.2,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          const SizedBox(width: AppSpacing.md),
+          Icon(Icons.chevron_right, color: brandColor),
+        ],
+      ),
+    );
+  }
+}
+
+class _RankIcon extends StatelessWidget {
+  const _RankIcon({required this.icon});
+
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final brandTheme = theme.extension<AppBrandTheme>();
+    final brandColor = brandTheme?.outline ?? theme.colorScheme.secondary;
+    final borderColor = theme.colorScheme.onSurface.withOpacity(0.08);
+    final background = theme.scaffoldBackgroundColor;
+
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.xs),
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(AppRadius.button),
+        border: Border.all(color: borderColor),
+      ),
+      child: Icon(icon, color: brandColor, size: 28),
     );
   }
 }

--- a/lib/ui/devices/device_card.dart
+++ b/lib/ui/devices/device_card.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:tapem/core/widgets/brand_gradient_icon.dart';
-import 'package:tapem/core/widgets/brand_gradient_text.dart';
-import 'package:tapem/core/widgets/brand_outline.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/core/widgets/brand_interactive_card.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
 import 'package:tapem/features/device/presentation/widgets/muscle_chips.dart';
 import 'package:tapem/l10n/app_localizations.dart';
@@ -26,100 +26,116 @@ class DeviceCard extends StatelessWidget {
     final brand = device.description;
     final idText = device.id.toString();
     final loc = AppLocalizations.of(context)!;
-    return Semantics(
-      label: '${device.name}, ${brand.isNotEmpty ? '$brand, ' : ''}ID $idText',
-      button: true,
-      child: BrandOutline(
-        onTap: onTap,
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  BrandGradientText(
-                    device.name,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: theme.textTheme.titleMedium,
+    final brandTheme = theme.extension<AppBrandTheme>();
+    final brandColor = brandTheme?.outline ?? theme.colorScheme.secondary;
+    final secondaryColor = theme.colorScheme.onSurface.withOpacity(0.7);
+    final idColor = brandColor.withOpacity(0.85);
+
+    final semanticsLabel =
+        '${device.name}, ${brand.isNotEmpty ? '$brand, ' : ''}ID $idText';
+
+    return BrandInteractiveCard(
+      onTap: onTap,
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.sm,
+        vertical: 12,
+      ),
+      semanticLabel: semanticsLabel,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  device.name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: brandColor,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 0.2,
                   ),
-                  if (brand.isNotEmpty)
-                    Padding(
-                      padding: const EdgeInsets.only(top: 4),
-                      child: BrandGradientText(
-                        brand,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
-                        ),
+                ),
+                if (brand.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: AppSpacing.xs / 2),
+                    child: Text(
+                      brand,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: secondaryColor,
+                        letterSpacing: 0.15,
                       ),
                     ),
-                ],
-              ),
-            ),
-            const SizedBox(width: 12),
-            ConstrainedBox(
-              constraints: const BoxConstraints(minWidth: 120, maxWidth: 180),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      BrandGradientText(
-                        'ID: $idText',
-                        style: theme.textTheme.labelSmall,
-                      ),
-                      if (onAssignMuscles != null || onResetMuscles != null)
-                        PopupMenuButton<_Menu>(
-                          tooltip: loc.assignMuscleGroups,
-                          icon: const BrandGradientIcon(Icons.more_vert),
-                          onSelected: (v) {
-                            switch (v) {
-                              case _Menu.assign:
-                                onAssignMuscles?.call();
-                                break;
-                              case _Menu.reset:
-                                onResetMuscles?.call();
-                                break;
-                            }
-                          },
-                          itemBuilder: (ctx) => [
-                            if (onAssignMuscles != null)
-                              PopupMenuItem(
-                                value: _Menu.assign,
-                                child: Text(loc.assignMuscleGroups),
-                              ),
-                            if (onResetMuscles != null)
-                              PopupMenuItem(
-                                value: _Menu.reset,
-                                child: Text(loc.resetMuscleGroups),
-                              ),
-                          ],
-                        ),
-                    ],
                   ),
-                  if (!device.isMulti &&
-                      (device.primaryMuscleGroups.isNotEmpty ||
-                          device.secondaryMuscleGroups.isNotEmpty))
-                    Padding(
-                      padding: const EdgeInsets.only(top: 6),
-                      child: Align(
-                        alignment: Alignment.centerRight,
-                        child: MuscleChips(
-                          primaryIds: device.primaryMuscleGroups,
-                          secondaryIds: device.secondaryMuscleGroups,
-                        ),
+              ],
+            ),
+          ),
+          const SizedBox(width: AppSpacing.md),
+          ConstrainedBox(
+            constraints: const BoxConstraints(minWidth: 120, maxWidth: 180),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      'ID: $idText',
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: idColor,
+                        fontWeight: FontWeight.w600,
                       ),
                     ),
-                ],
-              ),
+                    if (onAssignMuscles != null || onResetMuscles != null)
+                      PopupMenuButton<_Menu>(
+                        tooltip: loc.assignMuscleGroups,
+                        icon: Icon(Icons.more_vert, color: brandColor),
+                        onSelected: (v) {
+                          switch (v) {
+                            case _Menu.assign:
+                              onAssignMuscles?.call();
+                              break;
+                            case _Menu.reset:
+                              onResetMuscles?.call();
+                              break;
+                          }
+                        },
+                        itemBuilder: (ctx) => [
+                          if (onAssignMuscles != null)
+                            PopupMenuItem(
+                              value: _Menu.assign,
+                              child: Text(loc.assignMuscleGroups),
+                            ),
+                          if (onResetMuscles != null)
+                            PopupMenuItem(
+                              value: _Menu.reset,
+                              child: Text(loc.resetMuscleGroups),
+                            ),
+                        ],
+                      ),
+                  ],
+                ),
+                if (!device.isMulti &&
+                    (device.primaryMuscleGroups.isNotEmpty ||
+                        device.secondaryMuscleGroups.isNotEmpty))
+                  Padding(
+                    padding: const EdgeInsets.only(top: AppSpacing.xs),
+                    child: Align(
+                      alignment: Alignment.centerRight,
+                      child: MuscleChips(
+                        primaryIds: device.primaryMuscleGroups,
+                        secondaryIds: device.secondaryMuscleGroups,
+                      ),
+                    ),
+                  ),
+              ],
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add a reusable `BrandInteractiveCard` widget that encapsulates the animated outline style from the profile actions
- restyle the gym device cards and profile action buttons to use the shared interactive card
- update the leaderboard rank entries to use the same card design with contextual icons and subtitles

## Testing
- Not run (flutter CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e11abcae1c83208eadedbe873ead4f