### PR TITLE
Add favorite exercise popup on profile stats

### DIFF
--- a/lib/core/providers/profile_provider.dart
+++ b/lib/core/providers/profile_provider.dart
@@ -18,6 +18,7 @@ class ProfileProvider extends ChangeNotifier {
   int _totalTrainingDays = 0;
   double _avgTrainingDaysPerWeek = 0;
   String? _favoriteExerciseName;
+  List<FavoriteExerciseUsage> _favoriteExerciseUsages = [];
 
   bool get isLoading => _isLoading;
   String? get error => _error;
@@ -26,6 +27,8 @@ class ProfileProvider extends ChangeNotifier {
   int get totalTrainingDays => _totalTrainingDays;
   double get averageTrainingDaysPerWeek => _avgTrainingDaysPerWeek;
   String? get favoriteExerciseName => _favoriteExerciseName;
+  List<FavoriteExerciseUsage> get favoriteExerciseUsages =>
+      List.unmodifiable(_favoriteExerciseUsages);
 
   /// Lädt alle Trainingstage (YYYY-MM-DD) des aktuellen Users.
   Future<void> loadTrainingDates(BuildContext context) async {
@@ -90,8 +93,7 @@ class ProfileProvider extends ChangeNotifier {
       _totalTrainingDays = _trainingDates.length;
       _avgTrainingDaysPerWeek =
           _calculateAverageTrainingDaysPerWeek(authProv.createdAt);
-      _favoriteExerciseName =
-          await _resolveFavoriteExerciseName(sessionAggregates.values);
+      await _resolveFavoriteExercises(sessionAggregates.values);
     } catch (e, st) {
       _error = 'Fehler beim Laden der Trainingstage: ${e.toString()}';
       if (e is FirebaseException && e.code == 'failed-precondition') {
@@ -141,33 +143,50 @@ class ProfileProvider extends ChangeNotifier {
     return normalized.add(Duration(days: daysToAdd));
   }
 
-  Future<String?> _resolveFavoriteExerciseName(
+  Future<void> _resolveFavoriteExercises(
     Iterable<_ExerciseAggregate> aggregates,
   ) async {
     if (aggregates.isEmpty) {
-      return null;
+      _favoriteExerciseUsages = [];
+      _favoriteExerciseName = null;
+      return;
     }
 
-    _ExerciseAggregate? best;
-    for (final aggregate in aggregates) {
-      if (best == null ||
-          aggregate.sessionIds.length > best.sessionIds.length) {
-        best = aggregate;
-      }
+    final sortedAggregates = aggregates
+        .where((aggregate) => aggregate.sessionIds.isNotEmpty)
+        .toList()
+      ..sort(
+        (a, b) =>
+            b.sessionIds.length.compareTo(a.sessionIds.length),
+      );
+
+    final usages = <FavoriteExerciseUsage>[];
+
+    for (final aggregate in sortedAggregates.take(5)) {
+      final name = await _resolveExerciseName(aggregate);
+      usages.add(
+        FavoriteExerciseUsage(
+          name: name,
+          sessionCount: aggregate.sessionIds.length,
+        ),
+      );
     }
 
-    if (best == null || best.sessionIds.isEmpty) {
-      return null;
-    }
+    _favoriteExerciseUsages = usages;
+    _favoriteExerciseName =
+        usages.isEmpty ? null : usages.first.name;
+  }
 
+  Future<String> _resolveExerciseName(_ExerciseAggregate aggregate) async {
     try {
       final deviceRef = FirebaseFirestore.instance
           .collection('gyms')
-          .doc(best.gymId)
+          .doc(aggregate.gymId)
           .collection('devices')
-          .doc(best.deviceId);
+          .doc(aggregate.deviceId);
+      String deviceName = aggregate.deviceId;
+
       final deviceSnap = await deviceRef.get();
-      String deviceName = best.deviceId;
       if (deviceSnap.exists) {
         final data = deviceSnap.data();
         final name = data?['name'] as String?;
@@ -176,7 +195,7 @@ class ProfileProvider extends ChangeNotifier {
         }
       }
 
-      final exerciseId = best.exerciseId;
+      final exerciseId = aggregate.exerciseId;
       if (exerciseId != null && exerciseId.isNotEmpty) {
         try {
           final exerciseSnap =
@@ -188,10 +207,14 @@ class ProfileProvider extends ChangeNotifier {
         } catch (_) {}
       }
 
+      if (deviceName.trim().isEmpty) {
+        return '—';
+      }
+
       return deviceName;
     } catch (e, st) {
       elogError('PROFILE_FAVORITE_EXERCISE', e.toString(), st);
-      return null;
+      return '—';
     }
   }
 }
@@ -207,4 +230,14 @@ class _ExerciseAggregate {
   final String deviceId;
   final String? exerciseId;
   final Set<String> sessionIds = <String>{};
+}
+
+class FavoriteExerciseUsage {
+  FavoriteExerciseUsage({
+    required this.name,
+    required this.sessionCount,
+  });
+
+  final String name;
+  final int sessionCount;
 }

--- a/lib/features/profile/presentation/screens/profile_stats_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_stats_screen.dart
@@ -86,6 +86,7 @@ class _ProfileStatsScreenState extends State<ProfileStatsScreen> {
                 context,
                 loc.profileStatsFavoriteExercise,
                 favoriteExercise,
+                onTap: () => _showFavoriteExercisesDialog(context, prov, loc),
               ),
               _powerliftingButton(context, loc),
             ],
@@ -112,13 +113,19 @@ class _ProfileStatsScreenState extends State<ProfileStatsScreen> {
     );
   }
 
-  Widget _kpiRing(BuildContext context, String label, String value) {
+  Widget _kpiRing(
+    BuildContext context,
+    String label,
+    String value, {
+    VoidCallback? onTap,
+  }) {
     final theme = Theme.of(context);
     final brand = theme.extension<AppBrandTheme>();
     final onBrandColor = brand?.onBrand ?? theme.colorScheme.onPrimary;
     return _circularBrandCard(
       context,
       semanticsLabel: '$label: $value',
+      onTap: onTap,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
@@ -194,6 +201,67 @@ class _ProfileStatsScreenState extends State<ProfileStatsScreen> {
           child: Center(child: child),
         ),
       ),
+    );
+  }
+
+  Future<void> _showFavoriteExercisesDialog(
+    BuildContext context,
+    ProfileProvider prov,
+    AppLocalizations loc,
+  ) async {
+    final usages = prov.favoriteExerciseUsages;
+
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: Text(loc.profileStatsFavoriteExerciseDialogTitle),
+          content: usages.isEmpty
+              ? Text(loc.profileStatsFavoriteExerciseFallback)
+              : Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    for (final usage in usages)
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                          vertical: AppSpacing.xs,
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Expanded(
+                              child: Text(
+                                usage.name,
+                                style: Theme.of(dialogContext)
+                                    .textTheme
+                                    .bodyMedium,
+                              ),
+                            ),
+                            const SizedBox(width: AppSpacing.sm),
+                            Text(
+                              loc.reportDeviceUsageSessions(
+                                usage.sessionCount,
+                              ),
+                              style: Theme.of(dialogContext)
+                                  .textTheme
+                                  .bodyMedium,
+                            ),
+                          ],
+                        ),
+                      ),
+                  ],
+                ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: Text(
+                MaterialLocalizations.of(dialogContext).closeButtonLabel,
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -368,6 +368,11 @@
     "description": "KPI-Bezeichnung für die Lieblingsübung"
   },
 
+  "profileStatsFavoriteExerciseDialogTitle": "Top 5 Lieblingsübungen",
+  "@profileStatsFavoriteExerciseDialogTitle": {
+    "description": "Dialogtitel, der die fünf meistgenutzten Übungen zeigt"
+  },
+
   "profileStatsFavoriteExerciseFallback": "Noch keine Sessions",
   "@profileStatsFavoriteExerciseFallback": {
     "description": "Fallback-Text, wenn keine Lieblingsübung ermittelt werden kann"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -368,6 +368,11 @@
     "description": "KPI label for favourite exercise"
   },
 
+  "profileStatsFavoriteExerciseDialogTitle": "Top 5 favourite exercises",
+  "@profileStatsFavoriteExerciseDialogTitle": {
+    "description": "Dialog title that shows the top five favourite exercises"
+  },
+
   "profileStatsFavoriteExerciseFallback": "No sessions yet",
   "@profileStatsFavoriteExerciseFallback": {
     "description": "Fallback text when there is no favourite exercise"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -611,6 +611,12 @@ abstract class AppLocalizations {
   /// **'Favourite exercise'**
   String get profileStatsFavoriteExercise;
 
+  /// Dialog title that shows the top five favourite exercises
+  ///
+  /// In en, this message translates to:
+  /// **'Top 5 favourite exercises'**
+  String get profileStatsFavoriteExerciseDialogTitle;
+
   /// Fallback text when there is no favourite exercise
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -289,6 +289,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get profileStatsFavoriteExercise => 'Lieblingsübung';
 
   @override
+  String get profileStatsFavoriteExerciseDialogTitle =>
+      'Top 5 Lieblingsübungen';
+
+  @override
   String get profileStatsFavoriteExerciseFallback => 'Noch keine Sessions';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -289,6 +289,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileStatsFavoriteExercise => 'Favourite exercise';
 
   @override
+  String get profileStatsFavoriteExerciseDialogTitle =>
+      'Top 5 favourite exercises';
+
+  @override
   String get profileStatsFavoriteExerciseFallback => 'No sessions yet';
 
   @override


### PR DESCRIPTION
## Summary
- make the favourite exercise card interactive and show a dialog with the top five exercises
- expose aggregated exercise usage data from the profile provider for reuse in the UI
- add localisation strings for the new dialog title in German and English

## Testing
- not run (flutter is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e1852a5af08320bd39bb0f3f5a40a4