### PR TITLE
Fix average training day calculation

### DIFF
--- a/lib/core/providers/profile_provider.dart
+++ b/lib/core/providers/profile_provider.dart
@@ -1,8 +1,7 @@
 // lib/core/providers/profile_provider.dart
 
-import 'dart:math';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/logging/elog.dart';
@@ -109,7 +108,10 @@ class ProfileProvider extends ChangeNotifier {
     }
   }
 
-  double _calculateAverageTrainingDaysPerWeek(DateTime? createdAt) {
+  double _calculateAverageTrainingDaysPerWeek(
+    DateTime? createdAt, {
+    DateTime Function()? nowProvider,
+  }) {
     if (_trainingDayDates.isEmpty) {
       return 0;
     }
@@ -118,22 +120,50 @@ class ProfileProvider extends ChangeNotifier {
         ? _trainingDayDates.first
         : DateTime(createdAt.year, createdAt.month, createdAt.day);
     final firstMonday = _firstMondayAfter(normalizedCreatedAt);
-    final filteredDays =
-        _trainingDayDates.where((day) => !day.isBefore(firstMonday)).toList();
+    final now = (nowProvider ?? DateTime.now).call();
+    final today = DateTime(now.year, now.month, now.day);
+    final daysSinceSunday = today.weekday % 7;
+    final lastCompletedWeekEnd = today.subtract(
+      Duration(days: daysSinceSunday == 0 ? 7 : daysSinceSunday),
+    );
+
+    if (lastCompletedWeekEnd
+        .isBefore(firstMonday.add(const Duration(days: 6)))) {
+      return 0;
+    }
+
+    final filteredDays = _trainingDayDates.where((day) {
+      return !day.isBefore(firstMonday) && !day.isAfter(lastCompletedWeekEnd);
+    }).toList();
+
     if (filteredDays.isEmpty) {
       return 0;
     }
 
-    final now = DateTime.now();
-    final lastRelevantDay = filteredDays.last.isAfter(now)
-        ? filteredDays.last
-        : now;
-    final spanDays = max(1, lastRelevantDay.difference(firstMonday).inDays + 1);
-    final weeks = spanDays / 7.0;
-    if (weeks <= 0) {
-      return filteredDays.length.toDouble();
+    final completedWeeks =
+        (lastCompletedWeekEnd.difference(firstMonday).inDays + 1) ~/ 7;
+    if (completedWeeks <= 0) {
+      return 0;
     }
-    return filteredDays.length / weeks;
+
+    return filteredDays.length / completedWeeks;
+  }
+
+  @visibleForTesting
+  void setTrainingDayDatesForTest(List<DateTime> days) {
+    _trainingDayDates = List<DateTime>.from(days)
+      ..sort((a, b) => a.compareTo(b));
+  }
+
+  @visibleForTesting
+  double calculateAverageTrainingDaysPerWeekForTest(
+    DateTime? createdAt, {
+    DateTime Function()? nowProvider,
+  }) {
+    return _calculateAverageTrainingDaysPerWeek(
+      createdAt,
+      nowProvider: nowProvider,
+    );
   }
 
   DateTime _firstMondayAfter(DateTime date) {

--- a/test/providers/profile_provider_test.dart
+++ b/test/providers/profile_provider_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/core/providers/profile_provider.dart';
+
+void main() {
+  group('ProfileProvider._calculateAverageTrainingDaysPerWeek', () {
+    test('ignores ongoing week when calculating average', () {
+      final provider = ProfileProvider();
+      final now = DateTime(2024, 4, 10); // Wednesday
+
+      provider.setTrainingDayDatesForTest([
+        DateTime(2024, 4, 1),
+        DateTime(2024, 4, 3),
+        DateTime(2024, 4, 9), // current week, should be ignored
+      ]);
+
+      final average = provider.calculateAverageTrainingDaysPerWeekForTest(
+        DateTime(2024, 3, 28),
+        nowProvider: () => now,
+      );
+
+      expect(average, closeTo(2.0, 1e-9));
+    });
+
+    test('counts weeks with a single training day correctly', () {
+      final provider = ProfileProvider();
+      final now = DateTime(2024, 3, 25); // Monday
+
+      provider.setTrainingDayDatesForTest([
+        DateTime(2024, 3, 12), // before first Monday, ignored
+        DateTime(2024, 3, 19),
+      ]);
+
+      final average = provider.calculateAverageTrainingDaysPerWeekForTest(
+        DateTime(2024, 3, 11),
+        nowProvider: () => now,
+      );
+
+      expect(average, closeTo(1.0, 1e-9));
+    });
+
+    test('averages across multiple completed weeks', () {
+      final provider = ProfileProvider();
+      final now = DateTime(2024, 3, 27); // Wednesday
+
+      provider.setTrainingDayDatesForTest([
+        DateTime(2024, 3, 12),
+        DateTime(2024, 3, 14),
+        DateTime(2024, 3, 19),
+      ]);
+
+      final average = provider.calculateAverageTrainingDaysPerWeekForTest(
+        DateTime(2024, 3, 9),
+        nowProvider: () => now,
+      );
+
+      expect(average, closeTo(1.5, 1e-9));
+    });
+
+    test('returns zero when there is no completed week', () {
+      final provider = ProfileProvider();
+      final now = DateTime(2024, 4, 17); // Wednesday
+
+      provider.setTrainingDayDatesForTest([
+        DateTime(2024, 4, 12),
+        DateTime(2024, 4, 14),
+      ]);
+
+      final average = provider.calculateAverageTrainingDaysPerWeekForTest(
+        DateTime(2024, 4, 10),
+        nowProvider: () => now,
+      );
+
+      expect(average, 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- adjust the average training days per week calculation to only consider completed weeks
- expose testing hooks and add targeted unit tests for different registration and training scenarios

## Testing
- flutter test test/providers/profile_provider_test.dart *(fails: flutter is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e191b27ee88320bc4237576065a4c2