### PR TITLE
Add header shortcut to resume active session

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -231,6 +231,14 @@ class DeviceProvider extends ChangeNotifier {
   List<Device> get devices => List.unmodifiable(_devices);
   List<Map<String, dynamic>> get sets => List.unmodifiable(_sets);
   String get note => _note;
+  bool get hasActiveUnsavedSession =>
+      _device != null && _hasCompletedSets() && !_isSaving;
+  String? get activeSessionGymId =>
+      hasActiveUnsavedSession ? _currentGymId : null;
+  String? get activeSessionDeviceId =>
+      hasActiveUnsavedSession ? _device?.uid : null;
+  String? get activeSessionExerciseId =>
+      hasActiveUnsavedSession ? _currentExerciseId : null;
   List<Map<String, dynamic>> get lastSessionSets =>
       List.unmodifiable(_lastSessionSets);
   DateTime? get lastSessionDate => _lastSessionDate;

--- a/lib/core/widgets/base_screen.dart
+++ b/lib/core/widgets/base_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:tapem/features/device/presentation/widgets/back_to_session_button.dart';
 import 'package:tapem/features/nfc/widgets/nfc_scan_button.dart';
 import 'package:tapem/ui/timer/timer_app_bar_title.dart';
 
@@ -22,6 +23,7 @@ class BaseScreen extends StatelessWidget {
           ),
         ),
         actions: const [
+          BackToSessionButton(),
           NfcScanButton(), // Button-getriggertes NFC-Scanning
           SizedBox(width: 8),
         ],

--- a/lib/features/device/presentation/widgets/back_to_session_button.dart
+++ b/lib/features/device/presentation/widgets/back_to_session_button.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/app_router.dart';
+import 'package:tapem/core/providers/device_provider.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
+import 'package:tapem/l10n/app_localizations.dart';
+
+class BackToSessionButton extends StatelessWidget {
+  const BackToSessionButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final data = context.select<DeviceProvider, _BackToSessionData?>(
+      (prov) {
+        if (!prov.hasActiveUnsavedSession) return null;
+        final gymId = prov.activeSessionGymId;
+        final deviceId = prov.activeSessionDeviceId;
+        final exerciseId = prov.activeSessionExerciseId;
+        if (gymId == null || deviceId == null || exerciseId == null) {
+          return null;
+        }
+        return _BackToSessionData(
+          gymId: gymId,
+          deviceId: deviceId,
+          exerciseId: exerciseId,
+        );
+      },
+    );
+
+    final theme = Theme.of(context);
+    final accentColor =
+        theme.extension<AppBrandTheme>()?.outline ?? theme.colorScheme.secondary;
+
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 200),
+      transitionBuilder: (child, animation) => SizeTransition(
+        sizeFactor: animation,
+        axis: Axis.horizontal,
+        child: FadeTransition(opacity: animation, child: child),
+      ),
+      child: data == null
+          ? const SizedBox.shrink()
+          : Padding(
+              key: const ValueKey('backToSessionButton'),
+              padding: const EdgeInsets.only(right: 4),
+              child: OutlinedButton.icon(
+                style: OutlinedButton.styleFrom(
+                  visualDensity: VisualDensity.compact,
+                  padding: const EdgeInsets.symmetric(horizontal: 10),
+                  foregroundColor: accentColor,
+                  side: BorderSide(color: accentColor.withOpacity(0.6)),
+                  textStyle: theme.textTheme.labelSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                icon: const Icon(Icons.restore, size: 18),
+                label: Text(AppLocalizations.of(context)!.resumeSessionButton),
+                onPressed: () {
+                  Navigator.of(context).pushNamed(
+                    AppRouter.device,
+                    arguments: {
+                      'gymId': data.gymId,
+                      'deviceId': data.deviceId,
+                      'exerciseId': data.exerciseId,
+                    },
+                  );
+                },
+              ),
+            ),
+    );
+  }
+}
+
+class _BackToSessionData {
+  final String gymId;
+  final String deviceId;
+  final String exerciseId;
+
+  const _BackToSessionData({
+    required this.gymId,
+    required this.deviceId,
+    required this.exerciseId,
+  });
+}

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -15,6 +15,7 @@ import 'package:tapem/features/rank/presentation/screens/rank_screen.dart';
 import 'package:tapem/features/training_plan/presentation/screens/plan_overview_screen.dart';
 import 'package:tapem/features/auth/presentation/widgets/username_dialog.dart';
 import 'package:tapem/core/config/feature_flags.dart';
+import 'package:tapem/features/device/presentation/widgets/back_to_session_button.dart';
 import 'package:tapem/features/nfc/widgets/nfc_scan_button.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/ui/timer/timer_app_bar_title.dart';
@@ -146,6 +147,7 @@ class _HomeScreenState extends State<HomeScreen> {
         leading: const SizedBox(width: kToolbarHeight + 8),
         title: _buildAppBarTitle(context, currentLabel),
         actions: const [
+          BackToSessionButton(),
           NfcScanButton(),
           SizedBox(width: 8),
         ],

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -941,6 +941,12 @@ abstract class AppLocalizations {
   /// **'Save'**
   String get saveButton;
 
+  /// Label for the button that resumes the active device session
+  ///
+  /// In en, this message translates to:
+  /// **'Back to session'**
+  String get resumeSessionButton;
+
   /// Tooltip for the settings icon
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -463,6 +463,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get saveButton => 'Speichern';
 
   @override
+  String get resumeSessionButton => 'Zurück zur Session';
+
+  @override
   String get settingsIconTooltip => 'Einstellungen';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -463,6 +463,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get saveButton => 'Save';
 
   @override
+  String get resumeSessionButton => 'Back to session';
+
+  @override
   String get settingsIconTooltip => 'Settings';
 
   @override


### PR DESCRIPTION
## Summary
- add a BackToSessionButton widget that links back to the active device session when unsaved sets exist
- update shared app bars to render the new control next to the NFC scanner without breaking title alignment
- expose provider getters and localization strings required by the button

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1a3acfe9c8320bac2a1227ccd53cc