### PR TITLE
Add resume session localization entries

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -652,6 +652,11 @@
     "description": "Beschriftung für Speichern-Button"
   },
 
+  "resumeSessionButton": "Zurück zur Session",
+  "@resumeSessionButton": {
+    "description": "Beschriftung der Schaltfläche zum Fortsetzen der aktiven Gerätesession"
+  },
+
   "settingsIconTooltip": "Einstellungen",
   "@settingsIconTooltip": {
     "description": "Tooltip für das Zahnrad-Icon"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -650,6 +650,11 @@
     "description": "Label for the save button"
   },
 
+  "resumeSessionButton": "Back to session",
+  "@resumeSessionButton": {
+    "description": "Label for the button that resumes the active device session"
+  },
+
   "settingsIconTooltip": "Settings",
   "@settingsIconTooltip": {
     "description": "Tooltip for the settings icon"


### PR DESCRIPTION
## Summary
- add the missing resume session button localization entries to the English and German ARB files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1abe73eac8320b5a6d0475f9fb14a