### PR TITLE
Persist rest timer state across navigation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,6 +59,7 @@ import 'package:tapem/features/friends/providers/friend_search_provider.dart';
 import 'package:tapem/features/profile/presentation/providers/powerlifting_provider.dart';
 import 'features/gym/data/sources/firestore_gym_source.dart';
 import 'ui/numeric_keypad/overlay_numeric_keypad.dart';
+import 'ui/timer/session_timer_service.dart';
 import 'core/drafts/session_draft_repository_impl.dart';
 import 'services/membership_service.dart';
 
@@ -341,6 +342,9 @@ Future<void> main() async {
         // Numeric keypad
         ChangeNotifierProvider<OverlayNumericKeypadController>(
           create: (_) => OverlayNumericKeypadController(),
+        ),
+        ChangeNotifierProvider(
+          create: (_) => SessionTimerService(),
         ),
 
         // Membership/Branding/Theme

--- a/lib/ui/timer/session_timer_bar.dart
+++ b/lib/ui/timer/session_timer_bar.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
 import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 
-import 'session_timer_controller.dart';
+import 'session_timer_service.dart';
 
 class SessionTimerBar extends StatefulWidget {
   final Duration initialDuration;
@@ -21,35 +22,40 @@ class SessionTimerBar extends StatefulWidget {
   State<SessionTimerBar> createState() => _SessionTimerBarState();
 }
 
-class _SessionTimerBarState extends State<SessionTimerBar>
-    with SingleTickerProviderStateMixin {
-  static const _durations = [60, 90, 120, 150, 180];
-  late int _selectedIndex;
-  late final SessionTimerController _controller;
+class _SessionTimerBarState extends State<SessionTimerBar> {
+  late final ValueChanged<Duration> _tickListener;
+  late final VoidCallback _doneListener;
+  SessionTimerService? _service;
 
   @override
   void initState() {
     super.initState();
-    final initialSeconds = widget.initialDuration.inSeconds;
-    _selectedIndex = _durations.indexOf(initialSeconds);
-    if (_selectedIndex == -1) {
-      _selectedIndex = _durations.indexOf(90);
+    _tickListener = (duration) => widget.onTick?.call(duration);
+    _doneListener = () {
+      SystemSound.play(SystemSoundType.click);
+      HapticFeedback.mediumImpact();
+      widget.onDone?.call();
+    };
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final nextService = context.read<SessionTimerService>();
+    if (!identical(_service, nextService)) {
+      _service?.removeTickListener(_tickListener);
+      _service?.removeDoneListener(_doneListener);
+      _service = nextService;
+      _service!.addTickListener(_tickListener);
+      _service!.addDoneListener(_doneListener);
+      _service!.applyInitialDuration(widget.initialDuration);
     }
-    _controller = SessionTimerController(
-      total: Duration(seconds: _durations[_selectedIndex]),
-      onTick: widget.onTick,
-      onDone: () {
-        SystemSound.play(SystemSoundType.click);
-        HapticFeedback.mediumImpact();
-        widget.onDone?.call();
-      },
-      vsync: this,
-    );
   }
 
   @override
   void dispose() {
-    _controller.dispose();
+    _service?.removeTickListener(_tickListener);
+    _service?.removeDoneListener(_doneListener);
     super.dispose();
   }
 
@@ -60,25 +66,21 @@ class _SessionTimerBarState extends State<SessionTimerBar>
     return '$m:$r';
   }
 
-  void _changeDuration(int delta) {
-    setState(() {
-      _selectedIndex =
-          (_selectedIndex + delta).clamp(0, _durations.length - 1);
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
+    final service = context.watch<SessionTimerService>();
     final theme = Theme.of(context);
     final loc = AppLocalizations.of(context)!;
     final brand = theme.extension<AppBrandTheme>();
     final highContrast = MediaQuery.of(context).highContrast;
 
     return ValueListenableBuilder<Duration>(
-      valueListenable: _controller.remaining,
+      valueListenable: service.remaining,
       builder: (context, remaining, _) {
-        final progress =
-            1 - (remaining.inMilliseconds / _controller.total.inMilliseconds).clamp(0.0, 1.0);
+        final totalMillis = service.total.inMilliseconds;
+        final progress = totalMillis <= 0
+            ? 0.0
+            : 1 - (remaining.inMilliseconds / totalMillis).clamp(0.0, 1.0);
         Color? textColor = Color.lerp(
           theme.colorScheme.onSurface,
           theme.colorScheme.onPrimary,
@@ -146,27 +148,37 @@ class _SessionTimerBarState extends State<SessionTimerBar>
                   ),
                   Row(
                     children: [
-                      IconButton(
-                        tooltip: loc.timerStart,
-                        icon: const Icon(Icons.play_arrow),
-                        onPressed: () => _controller.startWith(
-                            Duration(seconds: _durations[_selectedIndex])),
+                      ValueListenableBuilder<bool>(
+                        valueListenable: service.running,
+                        builder: (context, running, _) {
+                          return IconButton(
+                            tooltip: running ? loc.timerStop : loc.timerStart,
+                            icon: Icon(running ? Icons.stop : Icons.play_arrow),
+                            onPressed: () {
+                              if (running) {
+                                service.stop();
+                              } else {
+                                service.startWith(service.selectedDuration);
+                              }
+                            },
+                          );
+                        },
                       ),
                       IconButton(
                         tooltip: loc.timerDecrease,
                         icon: const Icon(Icons.remove),
                         onPressed: () =>
-                            _changeDuration(-1),
+                            service.changeDuration(-1),
                       ),
                       Text(
-                        '${_durations[_selectedIndex]} ${loc.secondsAbbreviation}',
+                        '${service.selectedDuration.inSeconds} ${loc.secondsAbbreviation}',
                         style: theme.textTheme.titleMedium,
                       ),
                       IconButton(
                         tooltip: loc.timerIncrease,
                         icon: const Icon(Icons.add),
                         onPressed: () =>
-                            _changeDuration(1),
+                            service.changeDuration(1),
                       ),
                       Expanded(
                         child: Center(

--- a/lib/ui/timer/session_timer_controller.dart
+++ b/lib/ui/timer/session_timer_controller.dart
@@ -7,11 +7,13 @@ class SessionTimerController {
     bool initiallyRunning = false,
     this.onTick,
     this.onDone,
-    required TickerProvider vsync,
+    TickerProvider? vsync,
   })  : _total = total,
         remaining = ValueNotifier(total),
         running = ValueNotifier(initiallyRunning) {
-    _ticker = vsync.createTicker(_onTick);
+    _ticker = (vsync != null)
+        ? vsync.createTicker(_onTick)
+        : Ticker(_onTick);
     if (initiallyRunning) {
       _ticker.start();
     }
@@ -68,8 +70,18 @@ class SessionTimerController {
     _ticker.stop();
     _elapsed = Duration.zero;
     _lastTick = Duration.zero;
-      remaining.value = _total;
+    remaining.value = _total;
     running.value = false;
+  }
+
+  void setTotal(Duration total) {
+    final isRunning = running.value;
+    _total = total;
+    if (!isRunning) {
+      _elapsed = Duration.zero;
+      _lastTick = Duration.zero;
+      remaining.value = _total;
+    }
   }
 
   void dispose() {

--- a/lib/ui/timer/session_timer_service.dart
+++ b/lib/ui/timer/session_timer_service.dart
@@ -1,0 +1,118 @@
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+
+import 'session_timer_controller.dart';
+
+class SessionTimerService extends ChangeNotifier {
+  SessionTimerService({Duration? initialDuration}) {
+    final initialSeconds = initialDuration?.inSeconds ?? _durations[_defaultIndex];
+    final matchedIndex = _durations.indexOf(initialSeconds);
+    _selectedIndex = matchedIndex == -1 ? _defaultIndex : matchedIndex;
+    _controller = SessionTimerController(
+      total: Duration(seconds: _durations[_selectedIndex]),
+      onTick: _handleTick,
+      onDone: _handleDone,
+    );
+  }
+
+  static const _durations = [60, 90, 120, 150, 180];
+  static const _defaultIndex = 1;
+
+  late final SessionTimerController _controller;
+  int _selectedIndex = _defaultIndex;
+  bool _hasUserInteraction = false;
+
+  final List<ValueChanged<Duration>> _tickListeners = <ValueChanged<Duration>>[];
+  final List<VoidCallback> _doneListeners = <VoidCallback>[];
+
+  UnmodifiableListView<int> get availableDurations =>
+      UnmodifiableListView(_durations);
+
+  int get selectedIndex => _selectedIndex;
+
+  Duration get selectedDuration =>
+      Duration(seconds: _durations[_selectedIndex]);
+
+  ValueListenable<Duration> get remaining => _controller.remaining;
+  ValueListenable<bool> get running => _controller.running;
+
+  Duration get total => _controller.total;
+
+  bool get isRunning => _controller.running.value;
+
+  void addTickListener(ValueChanged<Duration> listener) {
+    if (!_tickListeners.contains(listener)) {
+      _tickListeners.add(listener);
+    }
+  }
+
+  void removeTickListener(ValueChanged<Duration> listener) {
+    _tickListeners.remove(listener);
+  }
+
+  void addDoneListener(VoidCallback listener) {
+    if (!_doneListeners.contains(listener)) {
+      _doneListeners.add(listener);
+    }
+  }
+
+  void removeDoneListener(VoidCallback listener) {
+    _doneListeners.remove(listener);
+  }
+
+  void applyInitialDuration(Duration duration) {
+    if (_hasUserInteraction) return;
+    final seconds = duration.inSeconds;
+    final idx = _durations.indexOf(seconds);
+    if (idx == -1 || idx == _selectedIndex) return;
+    _selectedIndex = idx;
+    if (!isRunning) {
+      _controller.setTotal(selectedDuration);
+    }
+    notifyListeners();
+  }
+
+  void changeDuration(int delta) {
+    final newIndex = (_selectedIndex + delta).clamp(0, _durations.length - 1);
+    if (newIndex == _selectedIndex) return;
+    _selectedIndex = newIndex;
+    _hasUserInteraction = true;
+    if (!isRunning) {
+      _controller.setTotal(selectedDuration);
+    }
+    notifyListeners();
+  }
+
+  void start() {
+    startWith(selectedDuration);
+  }
+
+  void startWith(Duration total) {
+    _hasUserInteraction = true;
+    _controller.startWith(total);
+  }
+
+  void stop() {
+    _hasUserInteraction = true;
+    _controller.reset();
+  }
+
+  void _handleTick(Duration remaining) {
+    for (final listener in List<ValueChanged<Duration>>.from(_tickListeners)) {
+      listener(remaining);
+    }
+  }
+
+  void _handleDone() {
+    for (final listener in List<VoidCallback>.from(_doneListeners)) {
+      listener();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+}

--- a/test/ui/timer/session_timer_bar_test.dart
+++ b/test/ui/timer/session_timer_bar_test.dart
@@ -1,13 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:provider/provider.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/ui/timer/session_timer_bar.dart';
+import 'package:tapem/ui/timer/session_timer_service.dart';
 
-Widget _wrap(Widget child) => MaterialApp(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      home: child,
+Widget _wrap(Widget child) => ChangeNotifierProvider(
+      create: (_) => SessionTimerService(),
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: child,
+      ),
     );
 
 void main() {


### PR DESCRIPTION
## Summary
- add a shared `SessionTimerService` so the rest timer keeps running when navigating away from the device page
- refactor `SessionTimerBar` to consume the shared service, toggle between play/stop, and reuse the selected duration
- register the new service in the global provider tree and update timer widget tests to include it

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1ba0cab288320b7bd8722ee3d46c3