### PR TITLE
Add timer sound playback without bundling audio asset

### DIFF
--- a/docs/session_timer_audio.md
+++ b/docs/session_timer_audio.md
@@ -1,0 +1,36 @@
+# Session Timer Audio Setup
+
+The session timer uses the `TimerSoundPlayer` class to play a short chime when the countdown completes. The application code expects a WAV file at `assets/audio/session_timer_end.wav`, but the binary is not tracked in version control. Follow the checklist below to enable the sound in your build.
+
+## 1. Prepare the audio asset
+
+1. Create or source a very short (≤ 1 second) notification-style chime in WAV format. The clip should be optimised for low latency and avoid long fades so that the cue is immediately recognisable.
+2. Verify that your chosen audio is licensed for your intended distribution. Keep the license text alongside the asset if attribution is required.
+3. Normalise the audio to avoid clipping while ensuring it remains audible on quiet devices. A peak level of −3 dBFS is typically sufficient.
+
+## 2. Place the asset in the project
+
+1. Create the directory `assets/audio/` if it does not already exist.
+2. Save the WAV file as `session_timer_end.wav` inside that directory. The final path should be:
+
+   ```
+   assets/audio/session_timer_end.wav
+   ```
+
+## 3. Declare the asset in `pubspec.yaml`
+
+Add the file to the Flutter asset list so it is bundled at build time. The relevant section should contain an entry similar to:
+
+```yaml
+flutter:
+  assets:
+    # …existing assets…
+    - assets/audio/session_timer_end.wav
+```
+
+## 4. Update packages and rebuild
+
+1. Run `flutter pub get` to ensure the `audioplayers` dependency is installed.
+2. Rebuild the application. When the session timer completes, you should now hear the audio cue in addition to the existing haptic feedback and system click.
+
+If the sound does not play, check the debug console for log statements from `TimerSoundPlayer`—they will indicate whether the asset is missing or if playback failed on the target platform.

--- a/lib/ui/timer/session_timer_bar.dart
+++ b/lib/ui/timer/session_timer_bar.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 
+import 'timer_sound_player.dart';
 import 'session_timer_service.dart';
 
 class SessionTimerBar extends StatefulWidget {
@@ -25,13 +28,16 @@ class SessionTimerBar extends StatefulWidget {
 class _SessionTimerBarState extends State<SessionTimerBar> {
   late final ValueChanged<Duration> _tickListener;
   late final VoidCallback _doneListener;
+  late final TimerSoundPlayer _soundPlayer;
   SessionTimerService? _service;
 
   @override
   void initState() {
     super.initState();
+    _soundPlayer = TimerSoundPlayer();
     _tickListener = (duration) => widget.onTick?.call(duration);
     _doneListener = () {
+      unawaited(_soundPlayer.play());
       SystemSound.play(SystemSoundType.click);
       HapticFeedback.mediumImpact();
       widget.onDone?.call();

--- a/lib/ui/timer/timer_sound_player.dart
+++ b/lib/ui/timer/timer_sound_player.dart
@@ -1,0 +1,73 @@
+import 'dart:developer';
+
+import 'package:audioplayers/audioplayers.dart';
+import 'package:flutter/foundation.dart';
+
+/// Plays the audible cue that indicates a session timer has completed.
+///
+/// The player keeps a single [AudioPlayer] instance so we can warm the
+/// underlying platform channel and minimise latency when the sound is needed.
+class TimerSoundPlayer {
+  TimerSoundPlayer({AudioPlayer? player}) : _player = player ?? AudioPlayer() {
+    _preloadAsset();
+  }
+
+  static const String _assetPath = 'assets/audio/session_timer_end.wav';
+
+  final AudioPlayer _player;
+  bool _hasValidSource = false;
+  bool _isPreloading = false;
+
+  /// Attempts to preload the asset so the first playback is instant.
+  Future<void> _preloadAsset() async {
+    if (_isPreloading) {
+      return;
+    }
+    _isPreloading = true;
+    try {
+      await _player.setSourceAsset(_assetPath);
+      _hasValidSource = true;
+    } on Object catch (error, stackTrace) {
+      _hasValidSource = false;
+      log(
+        'Unable to prepare the session timer audio asset. '
+        'Verify that the file exists at $_assetPath and is declared in pubspec.yaml.',
+        error: error,
+        stackTrace: stackTrace,
+        name: 'TimerSoundPlayer',
+      );
+    } finally {
+      _isPreloading = false;
+    }
+  }
+
+  /// Plays the end-of-timer chime if the audio asset is available.
+  Future<void> play() async {
+    if (!_hasValidSource) {
+      await _preloadAsset();
+    }
+
+    if (!_hasValidSource) {
+      if (kDebugMode) {
+        log(
+          'Skipping session timer audio playback because the asset '
+          'is unavailable. Ensure the file exists at $_assetPath.',
+          name: 'TimerSoundPlayer',
+        );
+      }
+      return;
+    }
+
+    try {
+      await _player.stop();
+      await _player.resume();
+    } on Object catch (error, stackTrace) {
+      log(
+        'Failed to play the session timer audio cue.',
+        error: error,
+        stackTrace: stackTrace,
+        name: 'TimerSoundPlayer',
+      );
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   flutter_dotenv: ^5.0.2
   json_annotation: ^4.9.0
   url_launcher: ^6.1.7
+  audioplayers: ^5.2.1
 
   # Local Storage & Timezone
   shared_preferences: ^2.4.10


### PR DESCRIPTION
## Summary
- trigger the new TimerSoundPlayer when the session timer completes so the audible cue plays alongside the existing haptics
- introduce a reusable TimerSoundPlayer that preloads the asset path and logs clear guidance when the WAV file is missing
- document how to supply the session timer WAV file and declare the audioplayers dependency needed for playback

## Testing
- ⚠️ flutter pub get *(not run – the Flutter tooling is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ce36a59c832087642ff01a303597