### PR TITLE
Start session timer audio three seconds before completion

### DIFF
--- a/docs/session_timer_audio.md
+++ b/docs/session_timer_audio.md
@@ -4,7 +4,7 @@ The session timer uses the `TimerSoundPlayer` class to play a short chime when t
 
 ## 1. Prepare the audio asset
 
-1. Create or source a very short (≤ 1 second) notification-style chime in WAV format. The clip should be optimised for low latency and avoid long fades so that the cue is immediately recognisable.
+1. Create or source a concise (≈ 3 second) notification-style chime in WAV format. The clip should be optimised for low latency and avoid long fades so that the cue begins crisply and can finish as the countdown reaches zero.
 2. Verify that your chosen audio is licensed for your intended distribution. Keep the license text alongside the asset if attribution is required.
 3. Normalise the audio to avoid clipping while ensuring it remains audible on quiet devices. A peak level of −3 dBFS is typically sufficient.
 
@@ -31,6 +31,6 @@ flutter:
 ## 4. Update packages and rebuild
 
 1. Run `flutter pub get` to ensure the `audioplayers` dependency is installed.
-2. Rebuild the application. When the session timer completes, you should now hear the audio cue in addition to the existing haptic feedback and system click.
+2. Rebuild the application. Three seconds before the session timer completes, you should now hear the audio cue alongside the existing haptic feedback and system click that trigger at completion.
 
 If the sound does not play, check the debug console for log statements from `TimerSoundPlayer`—they will indicate whether the asset is missing or if playback failed on the target platform.

--- a/lib/ui/timer/session_timer_bar.dart
+++ b/lib/ui/timer/session_timer_bar.dart
@@ -26,20 +26,26 @@ class SessionTimerBar extends StatefulWidget {
 }
 
 class _SessionTimerBarState extends State<SessionTimerBar> {
+  static const Duration _soundLeadTime = Duration(seconds: 3);
+
   late final ValueChanged<Duration> _tickListener;
   late final VoidCallback _doneListener;
   late final TimerSoundPlayer _soundPlayer;
   SessionTimerService? _service;
+  bool _hasQueuedSound = false;
 
   @override
   void initState() {
     super.initState();
     _soundPlayer = TimerSoundPlayer();
-    _tickListener = (duration) => widget.onTick?.call(duration);
+    _tickListener = (duration) {
+      _handleSoundScheduling(duration);
+      widget.onTick?.call(duration);
+    };
     _doneListener = () {
-      unawaited(_soundPlayer.play());
       SystemSound.play(SystemSoundType.click);
       HapticFeedback.mediumImpact();
+      _hasQueuedSound = false;
       widget.onDone?.call();
     };
   }
@@ -62,6 +68,9 @@ class _SessionTimerBarState extends State<SessionTimerBar> {
   void dispose() {
     _service?.removeTickListener(_tickListener);
     _service?.removeDoneListener(_doneListener);
+    _hasQueuedSound = false;
+    unawaited(_soundPlayer.stop());
+    unawaited(_soundPlayer.dispose());
     super.dispose();
   }
 
@@ -70,6 +79,27 @@ class _SessionTimerBarState extends State<SessionTimerBar> {
     final m = (s ~/ 60).toString().padLeft(2, '0');
     final r = (s % 60).toString().padLeft(2, '0');
     return '$m:$r';
+  }
+
+  void _handleSoundScheduling(Duration remaining) {
+    if (remaining > _soundLeadTime) {
+      if (_hasQueuedSound) {
+        unawaited(_soundPlayer.stop());
+      }
+      _hasQueuedSound = false;
+      return;
+    }
+
+    if (_hasQueuedSound) {
+      return;
+    }
+
+    if (remaining <= Duration.zero) {
+      return;
+    }
+
+    _hasQueuedSound = true;
+    unawaited(_soundPlayer.play());
   }
 
   @override
@@ -163,7 +193,11 @@ class _SessionTimerBarState extends State<SessionTimerBar> {
                             onPressed: () {
                               if (running) {
                                 service.stop();
+                                _hasQueuedSound = false;
+                                unawaited(_soundPlayer.stop());
                               } else {
+                                _hasQueuedSound = false;
+                                unawaited(_soundPlayer.stop());
                                 service.startWith(service.selectedDuration);
                               }
                             },

--- a/lib/ui/timer/timer_sound_player.dart
+++ b/lib/ui/timer/timer_sound_player.dart
@@ -70,4 +70,23 @@ class TimerSoundPlayer {
       );
     }
   }
+
+  /// Stops playback if the cue is currently playing.
+  Future<void> stop() async {
+    try {
+      await _player.stop();
+    } on Object catch (error, stackTrace) {
+      log(
+        'Failed to stop the session timer audio cue.',
+        error: error,
+        stackTrace: stackTrace,
+        name: 'TimerSoundPlayer',
+      );
+    }
+  }
+
+  /// Releases any resources held by the underlying audio player.
+  Future<void> dispose() async {
+    await _player.dispose();
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -120,6 +120,7 @@ flutter:
     - assets/muscle_heatmap.svg
     - assets/body_front.svg
     - assets/body_back.svg
+    - assets/audio/session_timer_end.wav
     # Bundle all avatar assets recursively
     - assets/avatars/global/
     - assets/avatars/lifthouse_koblenz/


### PR DESCRIPTION
## Summary
- start playing the session timer chime three seconds before the countdown finishes and reset the flag when the timer restarts
- add stop/dispose handling to the timer sound player so audio stops cleanly and resources are released
- document the longer cue and declare the session timer audio asset in the Flutter bundle list

## Testing
- Not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1d4e91c248320b4dba7723d7a2656