### PR TITLE
Fix session timer chime playback

### DIFF
--- a/lib/ui/timer/timer_sound_player.dart
+++ b/lib/ui/timer/timer_sound_player.dart
@@ -60,7 +60,7 @@ class TimerSoundPlayer {
 
     try {
       await _player.stop();
-      await _player.resume();
+      await _player.play(AssetSource(_assetPath));
     } on Object catch (error, stackTrace) {
       log(
         'Failed to play the session timer audio cue.',


### PR DESCRIPTION
## Summary
- ensure the timer sound uses explicit AssetSource playback so the chime reliably starts 3 seconds before completion

## Testing
- flutter analyze lib/ui/timer/timer_sound_player.dart *(fails: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1db5f79e48320b4407f17a0212fd6