### PR TITLE
Fix timer sound asset path

### DIFF
--- a/lib/ui/timer/timer_sound_player.dart
+++ b/lib/ui/timer/timer_sound_player.dart
@@ -12,8 +12,8 @@ class TimerSoundPlayer {
     _preloadAsset();
   }
 
-  static const String _assetLookupKey = 'audio/session_timer_end.wav';
-  static const String _assetDisplayPath = 'assets/$_assetLookupKey';
+  static const String _assetLookupKey = 'assets/audio/session_timer_end.wav';
+  static const String _assetDisplayPath = _assetLookupKey;
 
   final AudioPlayer _player;
   bool _hasValidSource = false;
@@ -26,7 +26,7 @@ class TimerSoundPlayer {
     }
     _isPreloading = true;
     try {
-      await _player.setSourceAsset(_assetLookupKey);
+      await _player.setSource(AssetSource(_assetLookupKey));
       _hasValidSource = true;
     } on Object catch (error, stackTrace) {
       _hasValidSource = false;


### PR DESCRIPTION
## Summary
- update the timer sound asset key to use the bundled assets/ path
- preload the sound using AssetSource so the same lookup works for playback

## Testing
- dart format lib/ui/timer/timer_sound_player.dart *(fails: dart command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e1bc74dc8320b7017ed02a89fb67