### PR TITLE
feat(timer): add low-latency pre-alert & end sound

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Eine Übersicht über die Steuerung des Pausen-Timers findet sich in [docs/devic
    ```bash
    flutter pub get
    ```
+   > Hinweis: Lege die vom Maintainer bereitgestellte Audiodatei `assets/sounds/session_timer_end.wav` ab, bevor du den Session-Timer testest. Fehlt die Datei, werden die akustischen Hinweise bewusst übersprungen.
 4. **Firebase konfigurieren**
    - `google-services.json` in `android/app/`
    - `GoogleService-Info.plist` in `ios/Runner/`

--- a/assets/sounds/README.md
+++ b/assets/sounds/README.md
@@ -1,0 +1,3 @@
+# Session Timer Sounds
+
+This directory must contain `session_timer_end.wav`, which provides the short pre-alert and end sounds for the session timer. The repository does not ship the binary asset. Place the maintainer-supplied WAV file here before running the app; otherwise, audio cues will be skipped gracefully at runtime.

--- a/lib/services/audio/timer_audio_service.dart
+++ b/lib/services/audio/timer_audio_service.dart
@@ -1,0 +1,109 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:audioplayers/audioplayers.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+class TimerAudioService {
+  TimerAudioService({
+    AudioPlayer? player,
+    this.preAlertAssetPath = defaultAssetPath,
+    this.endAssetPath = defaultAssetPath,
+  })  : _player = player ??
+            AudioPlayer(
+              playerId: 'session_timer',
+              mode: PlayerMode.lowLatency,
+            ) {
+    _ensureAudioContext();
+    unawaited(_player.setReleaseMode(ReleaseMode.stop));
+  }
+
+  static const String defaultAssetPath = 'assets/sounds/session_timer_end.wav';
+
+  final AudioPlayer _player;
+  final String preAlertAssetPath;
+  final String endAssetPath;
+
+  Uint8List? _preAlertBytes;
+  Uint8List? _endBytes;
+  bool _preloaded = false;
+  bool _disposed = false;
+
+  static bool _audioContextConfigured = false;
+
+  static void _ensureAudioContext() {
+    if (_audioContextConfigured) return;
+    AudioPlayer.global.setAudioContext(
+      const AudioContext(
+        iOS: AudioContextIOS(
+          category: AVAudioSessionCategory.ambient,
+          options: {AVAudioSessionOptions.mixWithOthers},
+        ),
+        android: AudioContextAndroid(
+          usageType: AndroidUsageType.assistanceSonification,
+          contentType: AndroidContentType.sonification,
+          audioFocus: AndroidAudioFocus.gainTransientMayDuck,
+        ),
+      ),
+    );
+    _audioContextConfigured = true;
+  }
+
+  Future<void> preload() async {
+    if (_preloaded) return;
+    await Future.wait([
+      _loadAsset(preAlertAssetPath, isPreAlert: true),
+      if (endAssetPath != preAlertAssetPath)
+        _loadAsset(endAssetPath, isPreAlert: false),
+    ]);
+    _preloaded = true;
+  }
+
+  Future<void> playPreAlert() => _play(preAlertAssetPath, isPreAlert: true);
+
+  Future<void> playEnd() => _play(endAssetPath, isPreAlert: false);
+
+  Future<void> dispose() async {
+    _disposed = true;
+    try {
+      await _player.stop();
+    } catch (error, stackTrace) {
+      debugPrint('TimerAudioService: stop failed: $error');
+      debugPrint('$stackTrace');
+    }
+    await _player.dispose();
+  }
+
+  Future<void> _loadAsset(String assetPath, {required bool isPreAlert}) async {
+    try {
+      final data = await rootBundle.load(assetPath);
+      final bytes = data.buffer.asUint8List();
+      if (isPreAlert) {
+        _preAlertBytes = bytes;
+      } else {
+        _endBytes = bytes;
+      }
+    } catch (error, stackTrace) {
+      debugPrint('TimerAudioService: failed to load $assetPath: $error');
+      debugPrint('$stackTrace');
+    }
+  }
+
+  Future<void> _play(String assetPath, {required bool isPreAlert}) async {
+    if (_disposed) return;
+    try {
+      await _player.stop();
+      final bytes = isPreAlert ? _preAlertBytes : _endBytes;
+      if (bytes != null) {
+        await _player.setSource(BytesSource(bytes));
+      } else {
+        await _player.setSource(AssetSource(assetPath));
+      }
+      await _player.resume();
+    } catch (error, stackTrace) {
+      debugPrint('TimerAudioService: failed to play $assetPath: $error');
+      debugPrint('$stackTrace');
+    }
+  }
+}

--- a/lib/ui/timer/session_timer_service.dart
+++ b/lib/ui/timer/session_timer_service.dart
@@ -1,11 +1,19 @@
+import 'dart:async';
 import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
 
+import 'package:tapem/services/audio/timer_audio_service.dart';
+
 import 'session_timer_controller.dart';
 
 class SessionTimerService extends ChangeNotifier {
-  SessionTimerService({Duration? initialDuration}) {
+  SessionTimerService({
+    Duration? initialDuration,
+    Duration preAlertAt = const Duration(seconds: 3),
+    TimerAudioService? audioService,
+  })  : _preAlertAt = preAlertAt,
+        _audioService = audioService ?? TimerAudioService() {
     final initialSeconds = initialDuration?.inSeconds ?? _durations[_defaultIndex];
     final matchedIndex = _durations.indexOf(initialSeconds);
     _selectedIndex = matchedIndex == -1 ? _defaultIndex : matchedIndex;
@@ -14,6 +22,8 @@ class SessionTimerService extends ChangeNotifier {
       onTick: _handleTick,
       onDone: _handleDone,
     );
+    _preAlertEligible = _isPreAlertEnabledFor(_controller.total);
+    unawaited(_audioService.preload());
   }
 
   static const _durations = [60, 90, 120, 150, 180];
@@ -22,9 +32,13 @@ class SessionTimerService extends ChangeNotifier {
   late final SessionTimerController _controller;
   int _selectedIndex = _defaultIndex;
   bool _hasUserInteraction = false;
+  bool _preAlertFired = false;
+  bool _preAlertEligible = true;
+  late Duration _preAlertAt;
 
   final List<ValueChanged<Duration>> _tickListeners = <ValueChanged<Duration>>[];
   final List<VoidCallback> _doneListeners = <VoidCallback>[];
+  final TimerAudioService _audioService;
 
   UnmodifiableListView<int> get availableDurations =>
       UnmodifiableListView(_durations);
@@ -40,6 +54,19 @@ class SessionTimerService extends ChangeNotifier {
   Duration get total => _controller.total;
 
   bool get isRunning => _controller.running.value;
+
+  Duration get preAlertAt => _preAlertAt;
+  set preAlertAt(Duration value) {
+    _preAlertAt = value;
+    _preAlertEligible = _isPreAlertEnabledFor(total);
+    if (_preAlertAt <= Duration.zero) {
+      _preAlertFired = false;
+      return;
+    }
+    if (remaining.value > _preAlertAt) {
+      _preAlertFired = false;
+    }
+  }
 
   void addTickListener(ValueChanged<Duration> listener) {
     if (!_tickListeners.contains(listener)) {
@@ -90,29 +117,56 @@ class SessionTimerService extends ChangeNotifier {
 
   void startWith(Duration total) {
     _hasUserInteraction = true;
+    _preAlertFired = false;
+    _preAlertEligible = _isPreAlertEnabledFor(total);
     _controller.startWith(total);
   }
 
   void stop() {
     _hasUserInteraction = true;
+    _preAlertFired = false;
+    _preAlertEligible = true;
     _controller.reset();
   }
 
   void _handleTick(Duration remaining) {
+    if (_shouldFirePreAlert(remaining)) {
+      _preAlertFired = true;
+      unawaited(_audioService.playPreAlert());
+    }
     for (final listener in List<ValueChanged<Duration>>.from(_tickListeners)) {
       listener(remaining);
     }
   }
 
   void _handleDone() {
+    _preAlertFired = false;
+    _preAlertEligible = true;
+    unawaited(_audioService.playEnd());
     for (final listener in List<VoidCallback>.from(_doneListeners)) {
       listener();
     }
   }
 
+  bool _shouldFirePreAlert(Duration remaining) {
+    if (_preAlertFired || !_preAlertEligible) return false;
+    if (!isRunning) return false;
+    if (_preAlertAt <= Duration.zero) return false;
+    if (remaining <= Duration.zero) return false;
+    return remaining <= _preAlertAt;
+  }
+
+  bool _isPreAlertEnabledFor(Duration total) {
+    if (_preAlertAt <= Duration.zero) {
+      return false;
+    }
+    return total > _preAlertAt;
+  }
+
   @override
   void dispose() {
     _controller.dispose();
+    unawaited(_audioService.dispose());
     super.dispose();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   flutter_dotenv: ^5.0.2
   json_annotation: ^4.9.0
   url_launcher: ^6.1.7
+  audioplayers: ^6.1.0
 
   # Local Storage & Timezone
   shared_preferences: ^2.4.10
@@ -130,6 +131,7 @@ flutter:
     - assets/avatars/gym_frankfurt/
     - assets/avatars/bodypower_weissenthurm/
     - assets/avatars/studentgym_london/
+    - assets/sounds/
 
 l10n:
   arb-dir: lib/l10n

--- a/test/ui/timer/session_timer_service_test.dart
+++ b/test/ui/timer/session_timer_service_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tapem/services/audio/timer_audio_service.dart';
+import 'package:tapem/ui/timer/session_timer_service.dart';
+
+class _MockTimerAudioService extends Mock implements TimerAudioService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  _MockTimerAudioService createAudioMock() {
+    final audio = _MockTimerAudioService();
+    when(audio.preload).thenAnswer((_) async {});
+    when(audio.playPreAlert).thenAnswer((_) async {});
+    when(audio.playEnd).thenAnswer((_) async {});
+    when(audio.dispose).thenAnswer((_) async {});
+    return audio;
+  }
+
+  testWidgets('fires pre-alert once per countdown and plays end sound', (tester) async {
+    final audio = createAudioMock();
+    final service = SessionTimerService(
+      initialDuration: const Duration(seconds: 5),
+      preAlertAt: const Duration(seconds: 3),
+      audioService: audio,
+    );
+
+    service.startWith(const Duration(seconds: 5));
+
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump(const Duration(seconds: 1));
+
+    verify(() => audio.preload()).called(1);
+    verify(() => audio.playPreAlert()).called(1);
+    verify(() => audio.playEnd()).called(1);
+
+    service.dispose();
+    await tester.pump();
+    verify(() => audio.dispose()).called(1);
+  });
+
+  testWidgets('skips pre-alert when starting below threshold', (tester) async {
+    final audio = createAudioMock();
+    final service = SessionTimerService(
+      initialDuration: const Duration(seconds: 2),
+      preAlertAt: const Duration(seconds: 3),
+      audioService: audio,
+    );
+
+    service.startWith(const Duration(seconds: 2));
+
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 2));
+
+    verifyNever(() => audio.playPreAlert());
+    verify(() => audio.playEnd()).called(1);
+
+    service.dispose();
+    await tester.pump();
+  });
+
+  testWidgets('resets pre-alert after stop and restart', (tester) async {
+    final audio = createAudioMock();
+    final service = SessionTimerService(
+      initialDuration: const Duration(seconds: 5),
+      preAlertAt: const Duration(seconds: 3),
+      audioService: audio,
+    );
+
+    service.startWith(const Duration(seconds: 5));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    service.stop();
+    await tester.pump();
+
+    verifyNever(() => audio.playPreAlert());
+
+    service.startWith(const Duration(seconds: 5));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 2));
+
+    verify(() => audio.playPreAlert()).called(1);
+
+    service.dispose();
+    await tester.pump();
+  });
+}

--- a/thesis/gamification/2025-10-05_session-timer-prealert-sound.md
+++ b/thesis/gamification/2025-10-05_session-timer-prealert-sound.md
@@ -1,0 +1,202 @@
+# Session Timer – Pre-Alert & End-Sound
+
+## Prompt
+```
+Prompt für Codex: Session Timer – Pre-Alert & End-Sound (Flutter)
+Ziel
+
+Implementiere in der bestehenden Session-Timer-Funktionalität einen kurzen Audio-Hinweis kurz vor Ablauf (Pre-Alert) und den finalen End-Sound bei 0 s. Die Lösung muss plattformübergreifend (Android, iOS, Emulatoren/Simulatoren) funktionieren, geringe Latenz besitzen, robust gegenüber Pausieren/Stoppen sein und keinerlei bestehende Trainings-/Workout-Logik verändern.
+
+Wichtig (Projektregel): Lege zusätzlich eine .md unter thesis/gamification/ an, die Prompt, Ziel/Kontext, Änderungen und Ergebnis dieses PRs dokumentiert (siehe Abschnitt PR & Doku).
+
+Kontext (aktueller Stand)
+
+State/Service: SessionTimerService (ChangeNotifier) mit auswählbaren Presets (60/90/120/150/180 s), Listenern für Tick und Done.
+
+Controller: SessionTimerController zählt via Ticker herunter, stellt ValueNotifier<Duration> remaining und ValueListenable<bool> running.
+
+UI: SessionTimerBar konsumiert den Service, rendert Fortschritt, Start/Stop, ± Buttons und triggert bei 0 s bereits SystemSound.click + Haptik.
+
+Scope: Der Pausen-Timer ist rein lokal; keine Backend-Calls. Es existiert parallel ein separater Workout-Dauer-Timer – den nicht anfassen.
+
+Funktionale Anforderungen
+
+Pre-Alert: Standardmäßig bei 3 Sekunden Restzeit 1× ein kurzer Sound abspielen.
+
+Einmalig pro Countdown-Zyklus; bei Stop/Restart wieder erlauben.
+
+Kein Pre-Alert, wenn Timer mit <3 s gestartet oder vor Erreichen gestoppt wird.
+
+End-Sound: Bei Ablauf (== 0:00) den finalen Sound abspielen (bestehendes SystemSound/Haptik darf bleiben).
+
+Konfigurierbar: preAlertAt als Duration (Default 3s) in SessionTimerService.
+
+Low-Latency & Preload: Audio vorab laden; Playback soll sofort feuern (ohne wahrnehmbare Verzögerung).
+
+Fehlerrobust: Keine Crashes, wenn Asset (noch) fehlt; Logging + stilles Überspringen.
+
+Keine Änderungen an Trainingslogik, XP, Sets etc.
+
+Technische Umsetzung (Vorgaben)
+Paketwahl
+
+Verwende audioplayers (aktuelles Stable) mit PlayerMode.lowLatency für kurze SFX. Kein Streaming, kein just_audio nötig.
+
+Asset & Platzierung der .wav
+
+Erstelle Ordner assets/sounds/ im Flutter-Projekt.
+
+Dateiname: session_timer_end.wav (vom Maintainer geliefert).
+
+pubspec.yaml:
+
+flutter:
+  assets:
+    - assets/sounds/
+
+Hinweis in README: Der Ordner muss die Datei enthalten, sonst wird der Sound übersprungen (Code fängt das ab).
+
+Audio-Service (neu)
+
+Neue Klasse TimerAudioService (z. B. unter lib/src/services/audio/):
+
+Kapselt AudioPlayer (lowLatency), preload des Assets, playPreAlert() und playEnd() Methoden.
+
+Mixing/Focus: iOS per Plugin-Defaults; setze, wenn verfügbar, Category auf ambient (mischt mit anderer Musik). Keine zusätzlichen Android-Permissions erforderlich.
+
+Lifecycle: dispose() sauber implementieren.
+
+Registriere TimerAudioService top-level (z. B. Provider/GetIt) – analog zu den bestehenden Services – oder lazy-instantiate in SessionTimerService (bevorzugt via Injektion, um testbar zu bleiben).
+
+Integration in SessionTimerService
+
+Neue Felder:
+
+Duration preAlertAt = const Duration(seconds: 3);
+
+bool _preAlertFired = false;
+
+Reset _preAlertFired bei startWith(...), bei stop() und wenn der Timer natürlich abläuft.
+
+Im Tick-Handling: Wenn remaining <= preAlertAt && !_preAlertFired && running, dann audio.playPreAlert() und _preAlertFired = true;.
+
+Beim Done-Event: audio.playEnd() (bestehendes SystemSound/Haptik darf bleiben).
+
+UI (SessionTimerBar)
+
+Keine sichtbaren UI-Änderungen erforderlich.
+
+Optional (kleine DX-Hilfe): Tooltip/Info-Icon im i-Dialog erwähnen: „Akustischer Hinweis 3 s vor Ablauf“.
+
+Emulator/Simulator-Hinweise (DX)
+
+Android-Emulator: „Enable audio“ muss aktiv sein.
+
+iOS-Simulator: System-Lautstärke nicht stumm. Silent switch gilt nur für echte Geräte.
+
+Edge Cases
+
+Daueränderung während der Laufzeit: Pre-Alert bezieht sich weiterhin auf die Restzeit; _preAlertFired bleibt korrekt, kein doppeltes Abspielen.
+
+Start mit Restzeit < preAlertAt: kein Pre-Alert.
+
+Timer gestoppt, bevor preAlertAt erreicht: kein Pre-Alert.
+
+Mehrfaches Start/Stop in kurzer Folge: Keine Overlaps – audioplayers Instanz reuse + stop() vor erneutem play.
+
+App im Hintergrund: Kein spezielles Handling nötig (Out-of-Scope).
+
+Tests & QS
+
+Unit: Fake-Ticker/Fake-Time – verifiziere, dass playPreAlert() genau einmal bei <= preAlertAt aufgerufen wird; playEnd() bei 0 s.
+
+Widget Smoke: SessionTimerBar rendert/bedient sich wie zuvor.
+
+Manual:
+
+Start 90 s → Pre-Alert bei 0:03, End-Sound bei 0:00.
+
+Start 2 s → nur End-Sound.
+
+Start 10 s, Stop bei 5 s → kein Sound.
+
+Start 10 s, +/- drücken → weiterhin genau ein Pre-Alert.
+
+Dateien (typisch)
+
+lib/src/services/session_timer/session_timer_service.dart (Erweiterung)
+
+lib/src/services/session_timer/session_timer_controller.dart (nur falls nötig)
+
+Neu: lib/src/services/audio/timer_audio_service.dart
+
+lib/src/widgets/session_timer/session_timer_bar.dart (minimal/gar nicht)
+
+pubspec.yaml (Assets + Dependency)
+
+assets/sounds/ (Ordner, README)
+
+Abnahme-Kriterien (Definition of Done)
+
+Pre-Alert und End-Sound funktionieren deterministisch, ohne spürbare Latenz, ohne Dopplungen.
+
+Build läuft auf Android & iOS & Emulator/Simulator.
+
+Kein Einfluss auf Workout-Timer/Backend.
+
+Code dokumentiert, sauber getestet (mind. Unit-Tests für Trigger-Logik).
+
+Kein zusätzlicher App-Permission-Dialog.
+
+PR & Doku (Gamification-Log)
+
+Branch: codex/session-timer-prealert-sound
+
+PR-Titel: feat(timer): add low-latency pre-alert & end sound
+
+PR-Beschreibung: Kurz Zweck, technische Umsetzung, Tests, DX-Hinweise.
+
+.md anlegen: thesis/gamification/2025-10-05_session-timer-prealert-sound.md
+
+Inhalt: Prompt (dieser Text), Ziel, Kontext, Änderungen (Dateiliste, Kerndiffs), Testplan, offene Punkte/Follow-Ups, Merge-Entscheidung/Outcome.
+
+Hinweis im PR: Maintainer muss die Datei assets/sounds/session_timer_end.wav bereitstellen (3 s), dann flutter pub get und testen.
+
+Wichtig: Was du nicht tun sollst
+
+Keine Änderungen an XP-, Satz-, History- oder Backend-Logik.
+
+Kein neues globales Permission-Handling, keine Notifications.
+
+Kein Vendor-Lock-in über komplexe Audio-Engines.
+
+Auf geht’s. Bitte setze das um, beachte die Abnahme-Kriterien und liefere einen sauberen, review-fertigen PR inkl. der .md-Dokumentation unter thesis/gamification/.
+```
+
+## Ziel & Kontext
+- Audio-Hinweise kurz vor Ablauf und bei Ende des Session-Timers bereitstellen, ohne die bestehende Workout-Logik zu verändern.
+- Sicherstellen, dass die Lösung geringe Latenz bietet, robust gegenüber Benutzerinteraktionen ist und auf allen Zielplattformen funktioniert.
+
+## Änderungen
+- **Dateien**
+  - `pubspec.yaml`
+  - `assets/sounds/README.md`
+  - `lib/services/audio/timer_audio_service.dart`
+  - `lib/ui/timer/session_timer_service.dart`
+  - `test/ui/timer/session_timer_service_test.dart`
+  - `README.md`
+- **Kerndiffs**
+  - Neue Low-Latency-Audioverwaltung für Pre-Alert und End-Sound inklusive Preloading und robustem Fehlerhandling.
+  - Erweiterung des SessionTimerService um Pre-Alert-Konfiguration, Zustandsverwaltung und Audio-Integration.
+  - Unit-Tests zur Absicherung der Trigger-Logik und Verifikation der Audioaufrufe.
+  - Dokumentations-Updates für Asset-Voraussetzungen.
+
+## Testplan
+- `flutter test`
+
+## Offene Punkte / Follow-Ups
+- Maintainer muss `assets/sounds/session_timer_end.wav` bereitstellen, damit Audio wiedergegeben wird.
+- Optionaler UI-Hinweis (Tooltip/Dialog) kann später ergänzt werden.
+
+## Merge-Entscheidung / Outcome
+- Bereit für Merge nach Review.


### PR DESCRIPTION
## Summary
- add a low-latency `TimerAudioService` that preloads the session timer sound asset and configures platform audio mixing
- extend `SessionTimerService` with configurable pre-alert handling and audio triggers while keeping existing UI callbacks intact
- document the required WAV asset, add regression tests for the trigger logic, and log the change in the gamification thesis journal

## Testing
- `flutter test` *(fails: Flutter SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e26295bedc8320bce387acf12294d7