### PR TITLE
Fix TimerAudioService for audioplayers 6.5.1 API

### DIFF
--- a/lib/services/audio/timer_audio_service.dart
+++ b/lib/services/audio/timer_audio_service.dart
@@ -10,13 +10,12 @@ class TimerAudioService {
     AudioPlayer? player,
     this.preAlertAssetPath = defaultAssetPath,
     this.endAssetPath = defaultAssetPath,
-  })  : _player = player ??
-            AudioPlayer(
-              playerId: 'session_timer',
-              mode: PlayerMode.lowLatency,
-            ) {
+  })  : _player = player ?? AudioPlayer(
+            playerId: 'session_timer',
+          ) {
     _ensureAudioContext();
     unawaited(_player.setReleaseMode(ReleaseMode.stop));
+    unawaited(_player.setPlayerMode(PlayerMode.lowLatency));
   }
 
   static const String defaultAssetPath = 'assets/sounds/session_timer_end.wav';
@@ -35,7 +34,7 @@ class TimerAudioService {
   static void _ensureAudioContext() {
     if (_audioContextConfigured) return;
     AudioPlayer.global.setAudioContext(
-      const AudioContext(
+      AudioContext(
         iOS: AudioContextIOS(
           category: AVAudioSessionCategory.ambient,
           options: {AVAudioSessionOptions.mixWithOthers},


### PR DESCRIPTION
## Summary
- remove the deprecated `mode` parameter when constructing the timer AudioPlayer
- set the player mode asynchronously and keep the release mode configuration
- configure the global audio context with the non-const constructors expected by audioplayers 6.5.1

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e26580f18c8320ba7095ef735d56f1