### PR TITLE
Fix TimerAudioService for latest audioplayers API

### DIFF
--- a/lib/services/audio/timer_audio_service.dart
+++ b/lib/services/audio/timer_audio_service.dart
@@ -13,9 +13,9 @@ class TimerAudioService {
   })  : _player = player ??
             AudioPlayer(
               playerId: 'session_timer',
-              mode: PlayerMode.lowLatency,
             ) {
     _ensureAudioContext();
+    unawaited(_player.setPlayerMode(PlayerMode.lowLatency));
     unawaited(_player.setReleaseMode(ReleaseMode.stop));
   }
 
@@ -35,7 +35,7 @@ class TimerAudioService {
   static void _ensureAudioContext() {
     if (_audioContextConfigured) return;
     AudioPlayer.global.setAudioContext(
-      const AudioContext(
+      AudioContext(
         iOS: AudioContextIOS(
           category: AVAudioSessionCategory.ambient,
           options: {AVAudioSessionOptions.mixWithOthers},


### PR DESCRIPTION
## Summary
- update TimerAudioService to set the low-latency player mode after construction
- remove const constructors when configuring the global AudioContext to match audioplayers 6.x API

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e26580f18c8320ba7095ef735d56f1