### PR TITLE
Fix iOS audio context options type

### DIFF
--- a/lib/services/audio/timer_audio_service.dart
+++ b/lib/services/audio/timer_audio_service.dart
@@ -38,7 +38,7 @@ class TimerAudioService {
       AudioContext(
         iOS: AudioContextIOS(
           category: AVAudioSessionCategory.ambient,
-          options: {AVAudioSessionOptions.mixWithOthers},
+          options: const [AVAudioSessionOptions.mixWithOthers],
         ),
         android: AudioContextAndroid(
           usageType: AndroidUsageType.assistanceSonification,


### PR DESCRIPTION
## Summary
- update the iOS audio context configuration to pass a list of options instead of a set literal

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2676a17b88320bdc35b69c93b2b08