### PR TITLE
Fix iOS audio context options type

### DIFF
--- a/lib/services/audio/timer_audio_service.dart
+++ b/lib/services/audio/timer_audio_service.dart
@@ -38,7 +38,7 @@ class TimerAudioService {
       AudioContext(
         iOS: AudioContextIOS(
           category: AVAudioSessionCategory.ambient,
-          options: const [AVAudioSessionOptions.mixWithOthers],
+          options: const {AVAudioSessionOptions.mixWithOthers},
         ),
         android: AudioContextAndroid(
           usageType: AndroidUsageType.assistanceSonification,


### PR DESCRIPTION
## Summary
- switch the iOS audio context options from a list to a set to match the expected AVAudioSessionOptions type

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e26b572cbc8320bb42972946ee73b5