### PR TITLE
Add play button to profile avatar for sound playback

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:audioplayers/audioplayers.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/app_provider.dart' as app;
 import 'package:tapem/core/providers/profile_provider.dart';
@@ -41,9 +42,12 @@ class ProfileScreen extends StatefulWidget {
 }
 
 class _ProfileScreenState extends State<ProfileScreen> {
+  late final AudioPlayer _audioPlayer;
+
   @override
   void initState() {
     super.initState();
+    _audioPlayer = AudioPlayer();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       context.read<ProfileProvider>().loadTrainingDates(context);
       final uid = context.read<AuthProvider>().userId;
@@ -54,6 +58,23 @@ class _ProfileScreenState extends State<ProfileScreen> {
         context.read<XpProvider>().watchStatsDailyXp(gymId, uid);
       }
     });
+  }
+
+  @override
+  void dispose() {
+    _audioPlayer.dispose();
+    super.dispose();
+  }
+
+  Future<void> _playProfileSound() async {
+    try {
+      await _audioPlayer.stop();
+      await _audioPlayer.play(const AssetSource('sounds/sound.wav'));
+    } catch (error) {
+      if (kDebugMode) {
+        debugPrint('[ProfileSound] Failed to play sound: $error');
+      }
+    }
   }
 
   void _showLanguageDialog() {
@@ -459,11 +480,45 @@ class _ProfileScreenState extends State<ProfileScreen> {
                       }
                       return const Icon(Icons.person);
                     });
-                    return DailyXpAvatar(
-                      image: image.image,
-                      size: avatarSize,
-                      xp: xp.dailyLevelXp,
-                      level: xp.dailyLevel,
+                    final theme = Theme.of(context);
+                    return Stack(
+                      clipBehavior: Clip.none,
+                      children: [
+                        DailyXpAvatar(
+                          image: image.image,
+                          size: avatarSize,
+                          xp: xp.dailyLevelXp,
+                          level: xp.dailyLevel,
+                        ),
+                        Positioned(
+                          bottom: -4,
+                          right: -4,
+                          child: Semantics(
+                            button: true,
+                            label: loc.profilePlayAvatarSound,
+                            child: Tooltip(
+                              message: loc.profilePlayAvatarSound,
+                              child: Material(
+                                type: MaterialType.circle,
+                                color: theme.colorScheme.primary,
+                                elevation: 2,
+                                child: InkWell(
+                                  customBorder: const CircleBorder(),
+                                  onTap: _playProfileSound,
+                                  child: const Padding(
+                                    padding: EdgeInsets.all(4),
+                                    child: Icon(
+                                      Icons.play_arrow,
+                                      size: 16,
+                                      color: Colors.white,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
                     );
                   }),
                 ),

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1042,6 +1042,8 @@
   ,"@trainingDetailsDeleteSessionError": {"description": "Snackbar-Text, wenn das Löschen einer Session fehlgeschlagen ist."}
   ,"profileChangeAvatar": "Profilbild ändern"
   ,"@profileChangeAvatar": {"description": "Tooltip und Accessibility-Label zum Ändern des Profilbilds"}
+  ,"profilePlayAvatarSound": "Profil-Sound abspielen"
+  ,"@profilePlayAvatarSound": {"description": "Tooltip und Accessibility-Label zum Abspielen des Profil-Sounds"}
   ,"homeTabAdmin": "Admin"
   ,"@homeTabAdmin": {"description": "Label des Admin-Tabs"}
   ,"homeTabRank": "Ranking"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1040,6 +1040,8 @@
   ,"@trainingDetailsDeleteSessionError": {"description": "Snackbar text shown when deleting a session failed."}
   ,"profileChangeAvatar": "Change profile picture"
   ,"@profileChangeAvatar": {"description": "Tooltip and accessibility label for changing the profile avatar"}
+  ,"profilePlayAvatarSound": "Play profile sound"
+  ,"@profilePlayAvatarSound": {"description": "Tooltip and accessibility label for playing the profile sound"}
   ,"homeTabAdmin": "Admin"
   ,"@homeTabAdmin": {"description": "Label of the admin tab"}
   ,"homeTabRank": "Rank"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1976,6 +1976,9 @@ abstract class AppLocalizations {
   /// No description provided for @profileChangeAvatar.
   String get profileChangeAvatar;
 
+  /// No description provided for @profilePlayAvatarSound.
+  String get profilePlayAvatarSound;
+
   /// No description provided for @homeTabAdmin.
   String get homeTabAdmin;
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -998,6 +998,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get profileChangeAvatar => 'Profilbild ändern';
 
   @override
+  String get profilePlayAvatarSound => 'Profil-Sound abspielen';
+
+  @override
   String get homeTabAdmin => 'Admin';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -998,6 +998,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileChangeAvatar => 'Change profile picture';
 
   @override
+  String get profilePlayAvatarSound => 'Play profile sound';
+
+  @override
   String get homeTabAdmin => 'Admin';
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   flutter_dotenv: ^5.0.2
   json_annotation: ^4.9.0
   url_launcher: ^6.1.7
+  audioplayers: ^6.1.0
 
   # Local Storage & Timezone
   shared_preferences: ^2.4.10
@@ -119,6 +120,7 @@ flutter:
     - assets/muscle_heatmap.svg
     - assets/body_front.svg
     - assets/body_back.svg
+    - assets/sounds/
     # Bundle all avatar assets recursively
     - assets/avatars/global/
     - assets/avatars/lifthouse_koblenz/


### PR DESCRIPTION
## Summary
- add an audioplayers dependency and register the new assets/sounds folder
- expose new localization strings for a profile sound play button
- overlay the profile avatar with a play control that plays assets/sounds/sound.wav

## Testing
- ⚠️ `dart format lib/features/profile/presentation/screens/profile_screen.dart lib/l10n/app_localizations.dart lib/l10n/app_localizations_en.dart lib/l10n/app_localizations_de.dart` *(fails: `dart` not available in environment)*
- ⚠️ `flutter pub get` *(fails: `flutter` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e270873d208320a5e0d6c73d5de497