### PR TITLE
fix: remove const constructor usage for profile sound playback

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -69,7 +69,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
   Future<void> _playProfileSound() async {
     try {
       await _audioPlayer.stop();
-      await _audioPlayer.play(const AssetSource('sounds/sound.wav'));
+      await _audioPlayer.play(AssetSource('sounds/sound.wav'));
     } catch (error) {
       if (kDebugMode) {
         debugPrint('[ProfileSound] Failed to play sound: $error');


### PR DESCRIPTION
## Summary
- remove the const constructor invocation when creating the AssetSource used for the profile sound playback
- keep the audio player stop call before playing the sound

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e272f49a808320ad90f82dff49d6fa