### PR TITLE
Fix non-const AssetSource usage in profile sound

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -70,7 +70,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
     try {
       await _audioPlayer.stop();
       await _audioPlayer.setReleaseMode(ReleaseMode.stop);
-      await _audioPlayer.play(const AssetSource('sounds/sound.wav'));
+      await _audioPlayer.play(AssetSource('sounds/sound.wav'));
     } catch (error) {
       if (kDebugMode) {
         debugPrint('[ProfileSound] Failed to play sound: $error');


### PR DESCRIPTION
## Summary
- remove the const keyword from the AssetSource constructor in the profile sound player to match the non-const API

## Testing
- not run (environment lacks Flutter tooling)


------
https://chatgpt.com/codex/tasks/task_e_68e27989d8a88320936ccdab167f175c