### PR TITLE
Fix Flutter analysis warnings

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -7,7 +7,6 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart'; // mapEquals
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter/material.dart';
 import 'package:tapem/features/device/data/repositories/device_repository_impl.dart';
 import 'package:tapem/features/device/data/sources/firestore_device_source.dart';
 import 'package:tapem/features/device/domain/models/device.dart';

--- a/lib/core/providers/profile_provider.dart
+++ b/lib/core/providers/profile_provider.dart
@@ -1,7 +1,6 @@
 // lib/core/providers/profile_provider.dart
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/logging/elog.dart';

--- a/lib/core/providers/theme_preference_provider.dart
+++ b/lib/core/providers/theme_preference_provider.dart
@@ -78,8 +78,9 @@ class ThemePreferenceProvider extends ChangeNotifier {
     await _loadCachedOverride(uid);
     notifyListeners();
     try {
-      final data = _fetchOverride != null
-          ? await _fetchOverride!(uid)
+      final fetchOverride = _fetchOverride;
+      final data = fetchOverride != null
+          ? await fetchOverride(uid)
           : (await _doc(uid).get()).data();
       final value = data != null ? data['themeId'] as String? : null;
       final resolved = value != null ? BrandThemeIdX.fromStorage(value) : null;

--- a/lib/core/services/workout_session_duration_service.dart
+++ b/lib/core/services/workout_session_duration_service.dart
@@ -335,8 +335,9 @@ class WorkoutSessionDurationService extends ChangeNotifier {
           exerciseName = exerciseDoc.data()?['name'] as String?;
         }
         final parts = [deviceName, exerciseName]
-            .where((value) => value != null && value!.trim().isNotEmpty)
-            .cast<String>()
+            .whereType<String>()
+            .map((value) => value.trim())
+            .where((value) => value.isNotEmpty)
             .toList();
         if (parts.isNotEmpty) {
           title = parts.join(' — ');

--- a/lib/core/theme/brand_theme_preset.dart
+++ b/lib/core/theme/brand_theme_preset.dart
@@ -111,7 +111,7 @@ class BrandThemePresets {
     gradientStart: Colors.white,
     gradientEnd: Colors.white,
     focus: Colors.white,
-    onColors: const BrandOnColors(
+    onColors: BrandOnColors(
       onPrimary: Colors.black,
       onSecondary: Colors.white,
       onGradient: Colors.white,

--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -220,8 +220,8 @@ class SetCardState extends State<SetCard> {
     _dropWeightFocuses.add(weightFocus);
     _dropRepsFocuses.add(repsFocus);
     if (!widget.readOnly) {
-      final weightListener = () => _handleDropWeightChanged(weightCtrl);
-      final repsListener = () => _handleDropRepsChanged(repsCtrl);
+      void weightListener() => _handleDropWeightChanged(weightCtrl);
+      void repsListener() => _handleDropRepsChanged(repsCtrl);
       weightCtrl.addListener(weightListener);
       repsCtrl.addListener(repsListener);
       _dropWeightListeners.add(weightListener);
@@ -1043,10 +1043,8 @@ class _InputPill extends StatefulWidget {
   final VoidCallback? onTap;
   final String? Function(String?)? validator;
   final bool dense;
-  final String? supportingText;
   final bool showLabel;
   final String? placeholder;
-  final TextStyle? placeholderTextStyle;
 
   const _InputPill({
     required this.controller,
@@ -1057,10 +1055,8 @@ class _InputPill extends StatefulWidget {
     this.onTap,
     this.validator,
     this.dense = false,
-    this.supportingText,
     this.showLabel = true,
     this.placeholder,
-    this.placeholderTextStyle,
   });
 
   @override
@@ -1162,16 +1158,8 @@ class _InputPillState extends State<_InputPill> {
       height: 1.15,
     );
 
-    final basePlaceholderStyle = widget.placeholderTextStyle ?? valueStyle;
-    final placeholderColor =
-        widget.placeholderTextStyle?.color ?? brandColor.withOpacity(0.35);
     final placeholderStyle =
-        basePlaceholderStyle.copyWith(color: placeholderColor);
-
-    final supportingStyle = TextStyle(
-      fontSize: widget.dense ? 11 : 12,
-      color: widget.tokens.chipFg.withOpacity(isDark ? 0.55 : 0.5),
-    );
+        valueStyle.copyWith(color: brandColor.withOpacity(0.35));
 
     final double horizontalPadding =
         showLabel ? (widget.dense ? 12 : 14) : (widget.dense ? 12 : 16);
@@ -1259,24 +1247,6 @@ class _InputPillState extends State<_InputPill> {
       ),
     );
 
-    final Widget supporting = AnimatedSwitcher(
-      duration: const Duration(milliseconds: 180),
-      switchInCurve: Curves.easeOutCubic,
-      switchOutCurve: Curves.easeInCubic,
-      child: widget.supportingText == null
-          ? const SizedBox.shrink()
-          : Padding(
-              key: ValueKey(widget.supportingText),
-              padding: EdgeInsets.only(
-                top: showLabel ? (widget.dense ? 4 : 6) : (widget.dense ? 6 : 8),
-              ),
-              child: Text(
-                widget.supportingText!,
-                style: supportingStyle,
-              ),
-            ),
-    );
-
     if (showLabel) {
       return Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -1285,18 +1255,6 @@ class _InputPillState extends State<_InputPill> {
           Text(widget.label, style: labelStyle),
           SizedBox(height: widget.dense ? 2 : 4),
           inputSurface,
-          supporting,
-        ],
-      );
-    }
-
-    if (widget.supportingText != null) {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          inputSurface,
-          supporting,
         ],
       );
     }

--- a/lib/features/profile/presentation/screens/powerlifting_screen.dart
+++ b/lib/features/profile/presentation/screens/powerlifting_screen.dart
@@ -22,9 +22,17 @@ class PowerliftingScreen extends StatefulWidget {
 class _PowerliftingScreenState extends State<PowerliftingScreen> {
   PowerliftingMetric _selectedMetric = PowerliftingMetric.heaviest;
 
+  AppLocalizations _requireLoc(BuildContext context) {
+    final loc = AppLocalizations.of(context);
+    if (loc == null) {
+      throw StateError('AppLocalizations not available in the current context.');
+    }
+    return loc;
+  }
+
   Future<void> _onAddPressed() async {
     final provider = context.read<PowerliftingProvider>();
-    final loc = AppLocalizations.of(context)!;
+    final loc = _requireLoc(context);
     final gymId = provider.activeGymId;
 
     if (gymId == null || gymId.isEmpty) {
@@ -119,7 +127,7 @@ class _PowerliftingScreenState extends State<PowerliftingScreen> {
 
   Future<void> _onClearPressed() async {
     final provider = context.read<PowerliftingProvider>();
-    final loc = AppLocalizations.of(context)!;
+    final loc = _requireLoc(context);
 
     final shouldReset = await showDialog<bool>(
           context: context,
@@ -371,7 +379,7 @@ class _PowerliftingScreenState extends State<PowerliftingScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context)!;
+    final loc = _requireLoc(context);
     final provider = context.watch<PowerliftingProvider>();
     final theme = Theme.of(context);
     final brand = theme.extension<AppBrandTheme>();
@@ -540,7 +548,7 @@ class _PowerliftingTableSwitcher extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context)!;
+    final loc = _requireLoc(context);
 
     final colorScheme = Theme.of(context).colorScheme;
 

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -491,7 +491,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
                       }
                       return const Icon(Icons.person);
                     });
-                    final theme = Theme.of(context);
                     return DailyXpAvatar(
                       image: image.image,
                       size: avatarSize,
@@ -623,7 +622,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
 }
 
 class _ProfileStatsLeadingIcon extends StatelessWidget {
-  const _ProfileStatsLeadingIcon({super.key});
+  const _ProfileStatsLeadingIcon();
 
   @override
   Widget build(BuildContext context) {
@@ -650,7 +649,7 @@ class _ProfileStatsLeadingIcon extends StatelessWidget {
 }
 
 class _ProfileSurveyLeadingIcon extends StatelessWidget {
-  const _ProfileSurveyLeadingIcon({super.key});
+  const _ProfileSurveyLeadingIcon();
 
   @override
   Widget build(BuildContext context) {
@@ -677,7 +676,7 @@ class _ProfileSurveyLeadingIcon extends StatelessWidget {
 }
 
 class _ProfileStatsSparkline extends StatelessWidget {
-  const _ProfileStatsSparkline({super.key});
+  const _ProfileStatsSparkline();
 
   static const _bars = [10.0, 20.0, 14.0, 26.0, 18.0, 30.0];
 

--- a/lib/features/training_details/data/repositories/session_repository_impl.dart
+++ b/lib/features/training_details/data/repositories/session_repository_impl.dart
@@ -161,9 +161,9 @@ class SessionRepositoryImpl implements SessionRepository {
     DateTime? earliest;
     final exerciseIds = <String>{};
     for (final entry in entries) {
-      earliest = earliest == null
-          ? entry.timestamp
-          : (entry.timestamp.isBefore(earliest!) ? entry.timestamp : earliest);
+      if (earliest == null || entry.timestamp.isBefore(earliest)) {
+        earliest = entry.timestamp;
+      }
       if (entry.exerciseId.isNotEmpty) {
         exerciseIds.add(entry.exerciseId);
       }

--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -48,10 +48,6 @@ class NumericKeypadTheme {
     final scheme = theme.colorScheme;
     final brand = theme.extension<AppBrandTheme>();
 
-    Color blend(Color base, Color overlay, double opacity) {
-      return Color.alphaBlend(overlay.withOpacity(opacity), base);
-    }
-
     Color tintTowards(Color source, Color target, double amount) {
       return Color.lerp(source, target, amount) ?? source;
     }
@@ -468,7 +464,7 @@ class OverlayNumericKeypad extends StatelessWidget {
     }
 
     int targetIndex = focusedIndex;
-    DeviceSetFieldFocus? targetField;
+    late final DeviceSetFieldFocus targetField;
     int? targetDropIndex;
 
     switch (focusedField) {
@@ -525,13 +521,11 @@ class OverlayNumericKeypad extends StatelessWidget {
         break;
     }
 
-    if (targetField != null) {
-      prov.requestFocus(
-        index: targetIndex,
-        field: targetField,
-        dropIndex: targetDropIndex,
-      );
-    }
+    prov.requestFocus(
+      index: targetIndex,
+      field: targetField,
+      dropIndex: targetDropIndex,
+    );
 
     _haptic(context);
   }
@@ -938,7 +932,6 @@ class _ActionRailCompact extends StatelessWidget {
       icon: a.icon,
       semanticsLabel: a.label,
       onTap: a.onTap,
-      repeat: a.repeat,
       theme: theme,
     );
 
@@ -1027,7 +1020,6 @@ class _RailAction {
   final IconData icon;
   final String label;
   final VoidCallback onTap;
-  final bool repeat;
   final bool wide;
 
   // internal bookkeeping for layout
@@ -1037,7 +1029,6 @@ class _RailAction {
     this.icon,
     this.label,
     this.onTap, {
-    this.repeat = false,
     this.wide = false,
   });
 }


### PR DESCRIPTION
## Summary
- remove unused Flutter imports in providers and simplify null-safe helper logic
- adjust widget helpers to avoid redundant non-null assertions and unused parameters
- clean up numeric keypad navigation and action rail to satisfy analysis lints

## Testing
- `flutter analyze` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e27cd89df48320afcc4290dd38c639