### PR TITLE
Fix analyzer errors in powerlifting screen and numeric keypad

### DIFF
--- a/lib/features/profile/presentation/screens/powerlifting_screen.dart
+++ b/lib/features/profile/presentation/screens/powerlifting_screen.dart
@@ -12,6 +12,14 @@ import 'package:tapem/features/profile/domain/models/powerlifting_record.dart';
 import 'package:tapem/features/profile/presentation/providers/powerlifting_provider.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 
+AppLocalizations _requireLoc(BuildContext context) {
+  final loc = AppLocalizations.of(context);
+  if (loc == null) {
+    throw StateError('AppLocalizations not available in the current context.');
+  }
+  return loc;
+}
+
 class PowerliftingScreen extends StatefulWidget {
   const PowerliftingScreen({super.key});
 
@@ -21,14 +29,6 @@ class PowerliftingScreen extends StatefulWidget {
 
 class _PowerliftingScreenState extends State<PowerliftingScreen> {
   PowerliftingMetric _selectedMetric = PowerliftingMetric.heaviest;
-
-  AppLocalizations _requireLoc(BuildContext context) {
-    final loc = AppLocalizations.of(context);
-    if (loc == null) {
-      throw StateError('AppLocalizations not available in the current context.');
-    }
-    return loc;
-  }
 
   Future<void> _onAddPressed() async {
     final provider = context.read<PowerliftingProvider>();
@@ -113,7 +113,7 @@ class _PowerliftingScreenState extends State<PowerliftingScreen> {
       messages.add(duplicateMessage);
     }
     if (failureMessage != null) {
-      messages.add(failureMessage!);
+      messages.add(failureMessage);
     }
 
     if (messages.isEmpty) {

--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -933,6 +933,7 @@ class _ActionRailCompact extends StatelessWidget {
       semanticsLabel: a.label,
       onTap: a.onTap,
       theme: theme,
+      repeat: a.repeat,
     );
 
     Widget wideBtn(_RailAction a) => _RailBtnWide(
@@ -1021,6 +1022,7 @@ class _RailAction {
   final String label;
   final VoidCallback onTap;
   final bool wide;
+  final bool repeat;
 
   // internal bookkeeping for layout
   bool _consumed = false;
@@ -1030,6 +1032,7 @@ class _RailAction {
     this.label,
     this.onTap, {
     this.wide = false,
+    this.repeat = false,
   });
 }
 


### PR DESCRIPTION
## Summary
- expose a shared localization helper for the powerlifting screen widgets
- remove a redundant null assertion when combining error messages
- allow the action rail button to accept a repeat flag so the analyzer no longer warns about the unused parameter

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e27fe18bf88320a32e2c08ddf2cef6