### PR TITLE
Configure audio session for profile sound playback

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -1,5 +1,7 @@
 // lib/features/profile/presentation/screens/profile_screen.dart
 
+import 'dart:async';
+
 import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -48,6 +50,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
   void initState() {
     super.initState();
     _audioPlayer = AudioPlayer();
+    _configureAudioSession();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       context.read<ProfileProvider>().loadTrainingDates(context);
       final uid = context.read<AuthProvider>().userId;
@@ -76,6 +79,25 @@ class _ProfileScreenState extends State<ProfileScreen> {
         debugPrint('[ProfileSound] Failed to play sound: $error');
       }
     }
+  }
+
+  void _configureAudioSession() {
+    const audioContext = AudioContext(
+      android: AudioContextAndroid(
+        contentType: AndroidContentType.sonification,
+        usageType: AndroidUsageType.assistanceSonification,
+        audioFocus: AndroidAudioFocus.gainTransient,
+      ),
+      iOS: AudioContextIOS(
+        category: AVAudioSessionCategory.playback,
+        options: {
+          AVAudioSessionOptions.mixWithOthers,
+          AVAudioSessionOptions.defaultToSpeaker,
+        },
+      ),
+    );
+
+    unawaited(AudioPlayer.global.setAudioContext(audioContext));
   }
 
   void _showLanguageDialog() {


### PR DESCRIPTION
## Summary
- configure the audioplayers session used on the profile screen so playback ignores silent mode and uses an appropriate context
- apply settings for both Android and iOS to make the profile sound button audible

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e282d92a48832090833e77dfc36ff7