### PR TITLE
Clean up timer audio leftovers and fix analyzer issues

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -7,7 +7,6 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart'; // mapEquals
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter/material.dart';
 import 'package:tapem/features/device/data/repositories/device_repository_impl.dart';
 import 'package:tapem/features/device/data/sources/firestore_device_source.dart';
 import 'package:tapem/features/device/domain/models/device.dart';

--- a/lib/core/providers/profile_provider.dart
+++ b/lib/core/providers/profile_provider.dart
@@ -1,7 +1,6 @@
 // lib/core/providers/profile_provider.dart
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/logging/elog.dart';

--- a/lib/core/providers/theme_preference_provider.dart
+++ b/lib/core/providers/theme_preference_provider.dart
@@ -78,8 +78,9 @@ class ThemePreferenceProvider extends ChangeNotifier {
     await _loadCachedOverride(uid);
     notifyListeners();
     try {
-      final data = _fetchOverride != null
-          ? await _fetchOverride!(uid)
+      final fetchOverride = _fetchOverride;
+      final data = fetchOverride != null
+          ? await fetchOverride(uid)
           : (await _doc(uid).get()).data();
       final value = data != null ? data['themeId'] as String? : null;
       final resolved = value != null ? BrandThemeIdX.fromStorage(value) : null;

--- a/lib/core/services/workout_session_duration_service.dart
+++ b/lib/core/services/workout_session_duration_service.dart
@@ -335,8 +335,9 @@ class WorkoutSessionDurationService extends ChangeNotifier {
           exerciseName = exerciseDoc.data()?['name'] as String?;
         }
         final parts = [deviceName, exerciseName]
-            .where((value) => value != null && value!.trim().isNotEmpty)
-            .cast<String>()
+            .whereType<String>()
+            .map((value) => value.trim())
+            .where((value) => value.isNotEmpty)
             .toList();
         if (parts.isNotEmpty) {
           title = parts.join(' — ');

--- a/lib/core/theme/brand_theme_preset.dart
+++ b/lib/core/theme/brand_theme_preset.dart
@@ -111,7 +111,7 @@ class BrandThemePresets {
     gradientStart: Colors.white,
     gradientEnd: Colors.white,
     focus: Colors.white,
-    onColors: const BrandOnColors(
+    onColors: BrandOnColors(
       onPrimary: Colors.black,
       onSecondary: Colors.white,
       onGradient: Colors.white,

--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -220,8 +220,8 @@ class SetCardState extends State<SetCard> {
     _dropWeightFocuses.add(weightFocus);
     _dropRepsFocuses.add(repsFocus);
     if (!widget.readOnly) {
-      final weightListener = () => _handleDropWeightChanged(weightCtrl);
-      final repsListener = () => _handleDropRepsChanged(repsCtrl);
+      void weightListener() => _handleDropWeightChanged(weightCtrl);
+      void repsListener() => _handleDropRepsChanged(repsCtrl);
       weightCtrl.addListener(weightListener);
       repsCtrl.addListener(repsListener);
       _dropWeightListeners.add(weightListener);

--- a/lib/features/profile/presentation/screens/powerlifting_screen.dart
+++ b/lib/features/profile/presentation/screens/powerlifting_screen.dart
@@ -105,7 +105,7 @@ class _PowerliftingScreenState extends State<PowerliftingScreen> {
       messages.add(duplicateMessage);
     }
     if (failureMessage != null) {
-      messages.add(failureMessage!);
+      messages.add(failureMessage);
     }
 
     if (messages.isEmpty) {

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -590,7 +590,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
 }
 
 class _ProfileStatsLeadingIcon extends StatelessWidget {
-  const _ProfileStatsLeadingIcon({super.key});
+  const _ProfileStatsLeadingIcon();
 
   @override
   Widget build(BuildContext context) {
@@ -617,7 +617,7 @@ class _ProfileStatsLeadingIcon extends StatelessWidget {
 }
 
 class _ProfileSurveyLeadingIcon extends StatelessWidget {
-  const _ProfileSurveyLeadingIcon({super.key});
+  const _ProfileSurveyLeadingIcon();
 
   @override
   Widget build(BuildContext context) {
@@ -644,7 +644,7 @@ class _ProfileSurveyLeadingIcon extends StatelessWidget {
 }
 
 class _ProfileStatsSparkline extends StatelessWidget {
-  const _ProfileStatsSparkline({super.key});
+  const _ProfileStatsSparkline();
 
   static const _bars = [10.0, 20.0, 14.0, 26.0, 18.0, 30.0];
 

--- a/lib/features/training_details/data/repositories/session_repository_impl.dart
+++ b/lib/features/training_details/data/repositories/session_repository_impl.dart
@@ -161,9 +161,10 @@ class SessionRepositoryImpl implements SessionRepository {
     DateTime? earliest;
     final exerciseIds = <String>{};
     for (final entry in entries) {
-      earliest = earliest == null
-          ? entry.timestamp
-          : (entry.timestamp.isBefore(earliest!) ? entry.timestamp : earliest);
+      final currentEarliest = earliest;
+      if (currentEarliest == null || entry.timestamp.isBefore(currentEarliest)) {
+        earliest = entry.timestamp;
+      }
       if (entry.exerciseId.isNotEmpty) {
         exerciseIds.add(entry.exerciseId);
       }

--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -48,10 +48,6 @@ class NumericKeypadTheme {
     final scheme = theme.colorScheme;
     final brand = theme.extension<AppBrandTheme>();
 
-    Color blend(Color base, Color overlay, double opacity) {
-      return Color.alphaBlend(overlay.withOpacity(opacity), base);
-    }
-
     Color tintTowards(Color source, Color target, double amount) {
       return Color.lerp(source, target, amount) ?? source;
     }
@@ -525,13 +521,17 @@ class OverlayNumericKeypad extends StatelessWidget {
         break;
     }
 
-    if (targetField != null) {
-      prov.requestFocus(
-        index: targetIndex,
-        field: targetField,
-        dropIndex: targetDropIndex,
-      );
+    final fieldToFocus = targetField;
+    if (fieldToFocus == null) {
+      _haptic(context);
+      return;
     }
+
+    prov.requestFocus(
+      index: targetIndex,
+      field: fieldToFocus,
+      dropIndex: targetDropIndex,
+    );
 
     _haptic(context);
   }
@@ -610,16 +610,20 @@ class OverlayNumericKeypad extends StatelessWidget {
         break;
     }
 
-    if (targetField != null) {
-      if (targetIndex != focusedIndex) {
-        prov.markSetNotDone(targetIndex);
-      }
-      prov.requestFocus(
-        index: targetIndex,
-        field: targetField,
-        dropIndex: targetDropIndex,
-      );
+    final fieldToFocus = targetField;
+    if (fieldToFocus == null) {
+      _haptic(context);
+      return;
     }
+
+    if (targetIndex != focusedIndex) {
+      prov.markSetNotDone(targetIndex);
+    }
+    prov.requestFocus(
+      index: targetIndex,
+      field: fieldToFocus,
+      dropIndex: targetDropIndex,
+    );
 
     _haptic(context);
   }

--- a/lib/ui/timer/session_timer_bar.dart
+++ b/lib/ui/timer/session_timer_bar.dart
@@ -32,7 +32,6 @@ class _SessionTimerBarState extends State<SessionTimerBar> {
     super.initState();
     _tickListener = (duration) => widget.onTick?.call(duration);
     _doneListener = () {
-      SystemSound.play(SystemSoundType.click);
       HapticFeedback.mediumImpact();
       widget.onDone?.call();
     };


### PR DESCRIPTION
## Summary
- remove the timer completion sound and other unused audio/timer artifacts
- resolve analyzer warnings by trimming imports, redundant null assertions, and redundant consts
- tighten keypad navigation logic to avoid unreachable null checks

## Testing
- `flutter analyze` *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e28baed99083209a6074887f97bc23