### PR TITLE
Remove session timer audio integration

### DIFF
--- a/lib/ui/timer/session_timer_bar.dart
+++ b/lib/ui/timer/session_timer_bar.dart
@@ -9,13 +9,11 @@ import 'session_timer_service.dart';
 class SessionTimerBar extends StatefulWidget {
   final Duration initialDuration;
   final ValueChanged<Duration>? onTick;
-  final VoidCallback? onDone;
 
   const SessionTimerBar({
     super.key,
     required this.initialDuration,
     this.onTick,
-    this.onDone,
   });
 
   @override
@@ -24,16 +22,22 @@ class SessionTimerBar extends StatefulWidget {
 
 class _SessionTimerBarState extends State<SessionTimerBar> {
   late final ValueChanged<Duration> _tickListener;
-  late final VoidCallback _doneListener;
   SessionTimerService? _service;
+  bool _hasCompleted = false;
 
   @override
   void initState() {
     super.initState();
-    _tickListener = (duration) => widget.onTick?.call(duration);
-    _doneListener = () {
-      HapticFeedback.mediumImpact();
-      widget.onDone?.call();
+    _tickListener = (duration) {
+      widget.onTick?.call(duration);
+      if (duration <= Duration.zero) {
+        if (!_hasCompleted) {
+          _hasCompleted = true;
+          HapticFeedback.mediumImpact();
+        }
+      } else {
+        _hasCompleted = false;
+      }
     };
   }
 
@@ -43,18 +47,16 @@ class _SessionTimerBarState extends State<SessionTimerBar> {
     final nextService = context.read<SessionTimerService>();
     if (!identical(_service, nextService)) {
       _service?.removeTickListener(_tickListener);
-      _service?.removeDoneListener(_doneListener);
       _service = nextService;
       _service!.addTickListener(_tickListener);
-      _service!.addDoneListener(_doneListener);
       _service!.applyInitialDuration(widget.initialDuration);
+      _hasCompleted = false;
     }
   }
 
   @override
   void dispose() {
     _service?.removeTickListener(_tickListener);
-    _service?.removeDoneListener(_doneListener);
     super.dispose();
   }
 

--- a/lib/ui/timer/session_timer_controller.dart
+++ b/lib/ui/timer/session_timer_controller.dart
@@ -6,7 +6,6 @@ class SessionTimerController {
     required Duration total,
     bool initiallyRunning = false,
     this.onTick,
-    this.onDone,
     TickerProvider? vsync,
   })  : _total = total,
         remaining = ValueNotifier(total),
@@ -23,7 +22,6 @@ class SessionTimerController {
   final ValueNotifier<Duration> remaining;
   final ValueNotifier<bool> running;
   final ValueChanged<Duration>? onTick;
-  final VoidCallback? onDone;
 
   late final Ticker _ticker;
   Duration _elapsed = Duration.zero;
@@ -39,7 +37,6 @@ class SessionTimerController {
       running.value = false;
       _ticker.stop();
       onTick?.call(Duration.zero);
-      onDone?.call();
     } else {
       remaining.value = left;
       onTick?.call(left);

--- a/lib/ui/timer/session_timer_service.dart
+++ b/lib/ui/timer/session_timer_service.dart
@@ -12,7 +12,6 @@ class SessionTimerService extends ChangeNotifier {
     _controller = SessionTimerController(
       total: Duration(seconds: _durations[_selectedIndex]),
       onTick: _handleTick,
-      onDone: _handleDone,
     );
   }
 
@@ -24,7 +23,6 @@ class SessionTimerService extends ChangeNotifier {
   bool _hasUserInteraction = false;
 
   final List<ValueChanged<Duration>> _tickListeners = <ValueChanged<Duration>>[];
-  final List<VoidCallback> _doneListeners = <VoidCallback>[];
 
   UnmodifiableListView<int> get availableDurations =>
       UnmodifiableListView(_durations);
@@ -49,16 +47,6 @@ class SessionTimerService extends ChangeNotifier {
 
   void removeTickListener(ValueChanged<Duration> listener) {
     _tickListeners.remove(listener);
-  }
-
-  void addDoneListener(VoidCallback listener) {
-    if (!_doneListeners.contains(listener)) {
-      _doneListeners.add(listener);
-    }
-  }
-
-  void removeDoneListener(VoidCallback listener) {
-    _doneListeners.remove(listener);
   }
 
   void applyInitialDuration(Duration duration) {
@@ -101,12 +89,6 @@ class SessionTimerService extends ChangeNotifier {
   void _handleTick(Duration remaining) {
     for (final listener in List<ValueChanged<Duration>>.from(_tickListeners)) {
       listener(remaining);
-    }
-  }
-
-  void _handleDone() {
-    for (final listener in List<VoidCallback>.from(_doneListeners)) {
-      listener();
     }
   }
 


### PR DESCRIPTION
## Summary
- remove the session timer completion hooks that were previously used to trigger audio playback
- keep the timer bar haptic feedback internal so no external sound player is required
- simplify the timer controller/service now that the done listeners are gone

## Testing
- not run (Flutter SDK unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e28e76c5dc83208a1777d0f979f417