### PR TITLE
Clean up analyzer warnings

### DIFF
--- a/lib/core/providers/theme_preference_provider.dart
+++ b/lib/core/providers/theme_preference_provider.dart
@@ -79,7 +79,7 @@ class ThemePreferenceProvider extends ChangeNotifier {
     notifyListeners();
     try {
       final data = _fetchOverride != null
-          ? await _fetchOverride!(uid)
+          ? await _fetchOverride(uid)
           : (await _doc(uid).get()).data();
       final value = data != null ? data['themeId'] as String? : null;
       final resolved = value != null ? BrandThemeIdX.fromStorage(value) : null;

--- a/lib/core/services/workout_session_duration_service.dart
+++ b/lib/core/services/workout_session_duration_service.dart
@@ -335,8 +335,8 @@ class WorkoutSessionDurationService extends ChangeNotifier {
           exerciseName = exerciseDoc.data()?['name'] as String?;
         }
         final parts = [deviceName, exerciseName]
-            .where((value) => value != null && value!.trim().isNotEmpty)
-            .cast<String>()
+            .where((value) => value?.trim().isNotEmpty == true)
+            .map((value) => value!)
             .toList();
         if (parts.isNotEmpty) {
           title = parts.join(' — ');

--- a/lib/features/device/presentation/widgets/set_card.dart
+++ b/lib/features/device/presentation/widgets/set_card.dart
@@ -220,8 +220,8 @@ class SetCardState extends State<SetCard> {
     _dropWeightFocuses.add(weightFocus);
     _dropRepsFocuses.add(repsFocus);
     if (!widget.readOnly) {
-      final weightListener = () => _handleDropWeightChanged(weightCtrl);
-      final repsListener = () => _handleDropRepsChanged(repsCtrl);
+      void weightListener() => _handleDropWeightChanged(weightCtrl);
+      void repsListener() => _handleDropRepsChanged(repsCtrl);
       weightCtrl.addListener(weightListener);
       repsCtrl.addListener(repsListener);
       _dropWeightListeners.add(weightListener);
@@ -1043,10 +1043,8 @@ class _InputPill extends StatefulWidget {
   final VoidCallback? onTap;
   final String? Function(String?)? validator;
   final bool dense;
-  final String? supportingText;
   final bool showLabel;
   final String? placeholder;
-  final TextStyle? placeholderTextStyle;
 
   const _InputPill({
     required this.controller,
@@ -1057,10 +1055,8 @@ class _InputPill extends StatefulWidget {
     this.onTap,
     this.validator,
     this.dense = false,
-    this.supportingText,
     this.showLabel = true,
     this.placeholder,
-    this.placeholderTextStyle,
   });
 
   @override
@@ -1162,15 +1158,8 @@ class _InputPillState extends State<_InputPill> {
       height: 1.15,
     );
 
-    final basePlaceholderStyle = widget.placeholderTextStyle ?? valueStyle;
-    final placeholderColor =
-        widget.placeholderTextStyle?.color ?? brandColor.withOpacity(0.35);
-    final placeholderStyle =
-        basePlaceholderStyle.copyWith(color: placeholderColor);
-
-    final supportingStyle = TextStyle(
-      fontSize: widget.dense ? 11 : 12,
-      color: widget.tokens.chipFg.withOpacity(isDark ? 0.55 : 0.5),
+    final placeholderStyle = valueStyle.copyWith(
+      color: brandColor.withOpacity(0.35),
     );
 
     final double horizontalPadding =
@@ -1259,24 +1248,6 @@ class _InputPillState extends State<_InputPill> {
       ),
     );
 
-    final Widget supporting = AnimatedSwitcher(
-      duration: const Duration(milliseconds: 180),
-      switchInCurve: Curves.easeOutCubic,
-      switchOutCurve: Curves.easeInCubic,
-      child: widget.supportingText == null
-          ? const SizedBox.shrink()
-          : Padding(
-              key: ValueKey(widget.supportingText),
-              padding: EdgeInsets.only(
-                top: showLabel ? (widget.dense ? 4 : 6) : (widget.dense ? 6 : 8),
-              ),
-              child: Text(
-                widget.supportingText!,
-                style: supportingStyle,
-              ),
-            ),
-    );
-
     if (showLabel) {
       return Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -1285,18 +1256,6 @@ class _InputPillState extends State<_InputPill> {
           Text(widget.label, style: labelStyle),
           SizedBox(height: widget.dense ? 2 : 4),
           inputSurface,
-          supporting,
-        ],
-      );
-    }
-
-    if (widget.supportingText != null) {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          inputSurface,
-          supporting,
         ],
       );
     }

--- a/lib/features/profile/presentation/screens/powerlifting_screen.dart
+++ b/lib/features/profile/presentation/screens/powerlifting_screen.dart
@@ -104,8 +104,9 @@ class _PowerliftingScreenState extends State<PowerliftingScreen> {
     if (duplicateFailure) {
       messages.add(duplicateMessage);
     }
-    if (failureMessage != null) {
-      messages.add(failureMessage!);
+    final message = failureMessage;
+    if (message != null) {
+      messages.add(message);
     }
 
     if (messages.isEmpty) {

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -590,7 +590,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
 }
 
 class _ProfileStatsLeadingIcon extends StatelessWidget {
-  const _ProfileStatsLeadingIcon({super.key});
+  const _ProfileStatsLeadingIcon();
 
   @override
   Widget build(BuildContext context) {
@@ -617,7 +617,7 @@ class _ProfileStatsLeadingIcon extends StatelessWidget {
 }
 
 class _ProfileSurveyLeadingIcon extends StatelessWidget {
-  const _ProfileSurveyLeadingIcon({super.key});
+  const _ProfileSurveyLeadingIcon();
 
   @override
   Widget build(BuildContext context) {
@@ -644,7 +644,7 @@ class _ProfileSurveyLeadingIcon extends StatelessWidget {
 }
 
 class _ProfileStatsSparkline extends StatelessWidget {
-  const _ProfileStatsSparkline({super.key});
+  const _ProfileStatsSparkline();
 
   static const _bars = [10.0, 20.0, 14.0, 26.0, 18.0, 30.0];
 

--- a/lib/features/training_details/data/repositories/session_repository_impl.dart
+++ b/lib/features/training_details/data/repositories/session_repository_impl.dart
@@ -161,9 +161,14 @@ class SessionRepositoryImpl implements SessionRepository {
     DateTime? earliest;
     final exerciseIds = <String>{};
     for (final entry in entries) {
-      earliest = earliest == null
-          ? entry.timestamp
-          : (entry.timestamp.isBefore(earliest!) ? entry.timestamp : earliest);
+      final currentEarliest = earliest;
+      if (currentEarliest == null) {
+        earliest = entry.timestamp;
+      } else {
+        earliest = entry.timestamp.isBefore(currentEarliest)
+            ? entry.timestamp
+            : currentEarliest;
+      }
       if (entry.exerciseId.isNotEmpty) {
         exerciseIds.add(entry.exerciseId);
       }

--- a/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
+++ b/lib/ui/numeric_keypad/overlay_numeric_keypad.dart
@@ -48,10 +48,6 @@ class NumericKeypadTheme {
     final scheme = theme.colorScheme;
     final brand = theme.extension<AppBrandTheme>();
 
-    Color blend(Color base, Color overlay, double opacity) {
-      return Color.alphaBlend(overlay.withOpacity(opacity), base);
-    }
-
     Color tintTowards(Color source, Color target, double amount) {
       return Color.lerp(source, target, amount) ?? source;
     }
@@ -468,7 +464,7 @@ class OverlayNumericKeypad extends StatelessWidget {
     }
 
     int targetIndex = focusedIndex;
-    DeviceSetFieldFocus? targetField;
+    late final DeviceSetFieldFocus targetField;
     int? targetDropIndex;
 
     switch (focusedField) {
@@ -525,13 +521,11 @@ class OverlayNumericKeypad extends StatelessWidget {
         break;
     }
 
-    if (targetField != null) {
-      prov.requestFocus(
-        index: targetIndex,
-        field: targetField,
-        dropIndex: targetDropIndex,
-      );
-    }
+    prov.requestFocus(
+      index: targetIndex,
+      field: targetField,
+      dropIndex: targetDropIndex,
+    );
 
     _haptic(context);
   }
@@ -938,7 +932,6 @@ class _ActionRailCompact extends StatelessWidget {
       icon: a.icon,
       semanticsLabel: a.label,
       onTap: a.onTap,
-      repeat: a.repeat,
       theme: theme,
     );
 
@@ -1027,7 +1020,6 @@ class _RailAction {
   final IconData icon;
   final String label;
   final VoidCallback onTap;
-  final bool repeat;
   final bool wide;
 
   // internal bookkeeping for layout
@@ -1037,7 +1029,6 @@ class _RailAction {
     this.icon,
     this.label,
     this.onTap, {
-    this.repeat = false,
     this.wide = false,
   });
 }


### PR DESCRIPTION
## Summary
- remove redundant null assertions and unused parameters flagged by the analyzer across providers and repositories
- simplify the device set card input handling by using listener declarations and dropping unused supporting-text plumbing
- tidy the overlay numeric keypad helpers by removing unused utilities and ensuring focus changes rely on non-nullable targets

## Testing
- not run (flutter tool not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3c5b4d0548320be3eca95292d4179