### PR TITLE
Improve report page analytics experience

### DIFF
--- a/lib/core/providers/report_provider.dart
+++ b/lib/core/providers/report_provider.dart
@@ -1,6 +1,7 @@
 // lib/core/providers/report_provider.dart
 
 import 'package:flutter/material.dart';
+import 'package:tapem/features/report/domain/models/device_usage_stat.dart';
 import 'package:tapem/features/report/domain/usecases/get_device_usage_stats.dart';
 import 'package:tapem/features/report/domain/usecases/get_all_log_timestamps.dart';
 
@@ -11,7 +12,7 @@ class ReportProvider extends ChangeNotifier {
   final GetAllLogTimestamps _getTimestamps;
 
   ReportState state = ReportState.initial;
-  Map<String, int> usageCounts = {};
+  List<DeviceUsageStat> usageStats = const [];
   List<DateTime> heatmapDates = [];
   String? errorMessage;
 
@@ -24,13 +25,17 @@ class ReportProvider extends ChangeNotifier {
   Future<void> loadReport(String gymId) async {
     if (gymId.isEmpty) {
       state = ReportState.initial;
+      usageStats = const [];
+      heatmapDates = [];
+      errorMessage = null;
       notifyListeners();
       return;
     }
     state = ReportState.loading;
+    errorMessage = null;
     notifyListeners();
     try {
-      usageCounts = await _getUsage.execute(gymId);
+      usageStats = await _getUsage.execute(gymId);
       heatmapDates = await _getTimestamps.execute(gymId);
       state = ReportState.loaded;
     } catch (e) {

--- a/lib/features/report/data/repositories/report_repository_impl.dart
+++ b/lib/features/report/data/repositories/report_repository_impl.dart
@@ -2,6 +2,7 @@
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:tapem/features/report/data/sources/firestore_report_source.dart';
+import 'package:tapem/features/report/domain/models/device_usage_stat.dart';
 import 'package:tapem/features/report/domain/repositories/report_repository.dart';
 
 class ReportRepositoryImpl implements ReportRepository {
@@ -10,12 +11,15 @@ class ReportRepositoryImpl implements ReportRepository {
     : _source = source ?? FirestoreReportSource();
 
   @override
-  Future<Map<String, int>> fetchUsageCountPerMachine(String gymId) async {
+  Future<List<DeviceUsageStat>> fetchDeviceUsageStats(String gymId) async {
     final devices = await _source.fetchDevices(gymId);
-    final Map<String, int> counts = {};
+    final List<DeviceUsageStat> stats = [];
 
     for (final deviceDoc in devices) {
       final deviceId = deviceDoc.id;
+      final deviceData = deviceDoc.data();
+      final deviceName = (deviceData?['name'] as String?)?.trim();
+      final description = (deviceData?['description'] as String?)?.trim();
       final logs = await _source.fetchLogsForDevice(gymId, deviceId);
 
       // Einzigartige sessionId sammeln
@@ -27,10 +31,17 @@ class ReportRepositoryImpl implements ReportRepository {
       }
 
       // Anzahl der Sessions = Anzahl der eindeutigen sessionIds
-      counts[deviceId] = sessionIds.length;
+      stats.add(
+        DeviceUsageStat(
+          id: deviceId,
+          name: deviceName?.isNotEmpty == true ? deviceName! : deviceId,
+          description: description ?? '',
+          sessions: sessionIds.length,
+        ),
+      );
     }
 
-    return counts;
+    return stats;
   }
 
   @override

--- a/lib/features/report/domain/models/device_usage_stat.dart
+++ b/lib/features/report/domain/models/device_usage_stat.dart
@@ -1,0 +1,16 @@
+// lib/features/report/domain/models/device_usage_stat.dart
+
+/// Aggregated usage information for a single device on the report screen.
+class DeviceUsageStat {
+  final String id;
+  final String name;
+  final String description;
+  final int sessions;
+
+  const DeviceUsageStat({
+    required this.id,
+    required this.name,
+    this.description = '',
+    required this.sessions,
+  });
+}

--- a/lib/features/report/domain/repositories/report_repository.dart
+++ b/lib/features/report/domain/repositories/report_repository.dart
@@ -1,8 +1,10 @@
 // lib/features/report/domain/repositories/report_repository.dart
 
+import '../models/device_usage_stat.dart';
+
 abstract class ReportRepository {
-  /// Gibt pro Geräte-ID die Anzahl aller Logs zurück.
-  Future<Map<String, int>> fetchUsageCountPerMachine(String gymId);
+  /// Gibt aggregierte Nutzungsstatistiken für alle Geräte eines Gyms zurück.
+  Future<List<DeviceUsageStat>> fetchDeviceUsageStats(String gymId);
 
   /// Liefert alle Log-Timestamps (über alle Geräte) für den Heatmap.
   Future<List<DateTime>> fetchAllLogTimestamps(String gymId);

--- a/lib/features/report/domain/usecases/get_device_usage_stats.dart
+++ b/lib/features/report/domain/usecases/get_device_usage_stats.dart
@@ -1,11 +1,12 @@
 // lib/features/report/domain/usecases/get_device_usage_stats.dart
-import 'package:tapem/features/report/domain/repositories/report_repository.dart';
+import '../models/device_usage_stat.dart';
+import '../repositories/report_repository.dart';
 
 class GetDeviceUsageStats {
   final ReportRepository _repo;
   GetDeviceUsageStats(this._repo);
 
-  Future<Map<String, int>> execute(String gymId) {
-    return _repo.fetchUsageCountPerMachine(gymId);
+  Future<List<DeviceUsageStat>> execute(String gymId) {
+    return _repo.fetchDeviceUsageStats(gymId);
   }
 }

--- a/lib/features/report/presentation/screens/report_screen_new.dart
+++ b/lib/features/report/presentation/screens/report_screen_new.dart
@@ -21,7 +21,8 @@ class ReportScreenNew extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final usageData = context.watch<ReportProvider>().usageCounts;
+    final reportProvider = context.watch<ReportProvider>();
+    final usageData = reportProvider.usageStats;
     final feedbackProvider = context.watch<FeedbackProvider>();
     final loc = AppLocalizations.of(context)!;
     if (!feedbackProvider.isLoading && feedbackProvider.entries.isEmpty) {
@@ -32,55 +33,60 @@ class ReportScreenNew extends StatelessWidget {
     final int openCount = feedbackProvider.openEntries.length;
 
     return Scaffold(
-      appBar: AppBar(title: Text(loc.reportTitle)),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(AppSpacing.sm),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            DeviceUsageChart(usageData: usageData),
-            const SizedBox(height: AppSpacing.md),
-            BrandActionTile(
-              leadingIcon: Icons.feedback_outlined,
-              title: loc.reportFeedbackCardTitle,
-              subtitle: openCount > 0
-                  ? loc.reportFeedbackOpenEntries(openCount)
-                  : loc.reportFeedbackNoOpenEntries,
-              onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => FeedbackOverviewScreen(gymId: gymId),
-                  ),
-                );
-              },
-              variant: BrandActionTileVariant.outlined,
-              uiLogEvent: 'REPORT_CARD_RENDER',
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            BrandActionTile(
-              leadingIcon: Icons.add_circle_outline,
-              title: loc.reportCreateSurveyTitle,
-              onTap: () => _showCreateSurveyDialog(context),
-              variant: BrandActionTileVariant.outlined,
-              uiLogEvent: 'REPORT_CARD_RENDER',
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            BrandActionTile(
-              leadingIcon: Icons.poll,
-              title: loc.reportViewSurveysTitle,
-              onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => SurveyOverviewScreen(gymId: gymId),
-                  ),
-                );
-              },
-              variant: BrandActionTileVariant.outlined,
-              uiLogEvent: 'REPORT_CARD_RENDER',
-            ),
-          ],
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(AppSpacing.sm),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              DeviceUsageChart(
+                usageData: usageData,
+                state: reportProvider.state,
+                errorMessage: reportProvider.errorMessage,
+              ),
+              const SizedBox(height: AppSpacing.md),
+              BrandActionTile(
+                leadingIcon: Icons.feedback_outlined,
+                title: loc.reportFeedbackCardTitle,
+                subtitle: openCount > 0
+                    ? loc.reportFeedbackOpenEntries(openCount)
+                    : loc.reportFeedbackNoOpenEntries,
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => FeedbackOverviewScreen(gymId: gymId),
+                    ),
+                  );
+                },
+                variant: BrandActionTileVariant.gradient,
+                uiLogEvent: 'REPORT_CARD_RENDER',
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              BrandActionTile(
+                leadingIcon: Icons.add_circle_outline,
+                title: loc.reportCreateSurveyTitle,
+                onTap: () => _showCreateSurveyDialog(context),
+                variant: BrandActionTileVariant.gradient,
+                uiLogEvent: 'REPORT_CARD_RENDER',
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              BrandActionTile(
+                leadingIcon: Icons.poll,
+                title: loc.reportViewSurveysTitle,
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => SurveyOverviewScreen(gymId: gymId),
+                    ),
+                  );
+                },
+                variant: BrandActionTileVariant.gradient,
+                uiLogEvent: 'REPORT_CARD_RENDER',
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/report/presentation/widgets/device_usage_chart.dart
+++ b/lib/features/report/presentation/widgets/device_usage_chart.dart
@@ -1,13 +1,24 @@
-import 'package:fl_chart/fl_chart.dart';
-import 'package:flutter/material.dart';
-import 'package:tapem/l10n/app_localizations.dart';
+import 'dart:math' as math;
 
+import 'package:flutter/material.dart';
+
+import '../../../../core/providers/report_provider.dart';
+import '../../../../core/theme/design_tokens.dart';
 import '../../../../core/utils/chart_interval.dart';
+import '../../../../l10n/app_localizations.dart';
+import '../../domain/models/device_usage_stat.dart';
 
 class DeviceUsageChart extends StatefulWidget {
-  final Map<String, int> usageData;
+  final List<DeviceUsageStat> usageData;
+  final ReportState state;
+  final String? errorMessage;
 
-  const DeviceUsageChart({Key? key, required this.usageData}) : super(key: key);
+  const DeviceUsageChart({
+    super.key,
+    required this.usageData,
+    required this.state,
+    this.errorMessage,
+  });
 
   @override
   State<DeviceUsageChart> createState() => _DeviceUsageChartState();
@@ -18,58 +29,29 @@ class _DeviceUsageChartState extends State<DeviceUsageChart> {
 
   @override
   Widget build(BuildContext context) {
-    final entries =
-        widget.usageData.entries.toList()
-          ..sort((a, b) => b.value.compareTo(a.value));
-
     final loc = AppLocalizations.of(context)!;
-
-    final filtered =
-        entries
-            .where((e) => e.key.toLowerCase().contains(_filter.toLowerCase()))
+    final theme = Theme.of(context);
+    final entries = [...widget.usageData]
+      ..sort((a, b) => b.sessions.compareTo(a.sessions));
+    final query = _filter.trim().toLowerCase();
+    final filtered = query.isEmpty
+        ? entries
+        : entries
+            .where((e) => e.name.toLowerCase().contains(query) ||
+                e.description.toLowerCase().contains(query))
             .toList();
 
-    final maxBars = 20;
-    var display = filtered;
-    int otherSum = 0;
-    if (filtered.length > maxBars) {
-      display = filtered.take(maxBars - 1).toList();
-      otherSum = filtered.skip(maxBars - 1).fold(0, (a, b) => a + b.value);
-      display.add(MapEntry('Other', otherSum));
-    }
+    final bool hasBaseData = entries.isNotEmpty;
+    final bool hasFilteredData = filtered.isNotEmpty;
 
-    if (display.isEmpty) {
-      return const SizedBox(
-        height: 220,
-        child: Center(child: Text('Keine Daten')),
-      );
-    }
-
-    final bars = <BarChartGroupData>[];
-    final gradient = [Colors.tealAccent, Colors.cyan, Colors.amber];
-    for (var i = 0; i < display.length; i++) {
-      final e = display[i];
-      bars.add(
-        BarChartGroupData(
-          x: i,
-          barRods: [
-            BarChartRodData(
-              toY: e.value.toDouble(),
-              width: 16,
-              borderRadius: BorderRadius.circular(4),
-              gradient: LinearGradient(colors: gradient),
-            ),
-          ],
-        ),
-      );
-    }
-
-    final maxY =
-        display.map((e) => e.value).reduce((a, b) => a > b ? a : b).toDouble();
-    final yInterval = resolveAxisInterval(0, maxY, targetLabels: 5);
-    final xMax = (display.length - 1).toDouble();
-    final xInterval =
-        resolveAxisInterval(0, xMax, targetLabels: 6, maxLabels: 10);
+    final chartContent = _buildChartContent(
+      context,
+      loc,
+      theme,
+      filtered,
+      hasBaseData,
+      hasFilteredData,
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -78,66 +60,470 @@ class _DeviceUsageChartState extends State<DeviceUsageChart> {
           decoration: InputDecoration(
             prefixIcon: const Icon(Icons.search),
             hintText: loc.reportDeviceFilterHint,
+            filled: true,
+            fillColor: theme.colorScheme.surfaceVariant
+                .withOpacity(theme.brightness == Brightness.dark ? 0.24 : 0.12),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(AppRadius.button),
+              borderSide: BorderSide.none,
+            ),
           ),
+          textInputAction: TextInputAction.search,
           onChanged: (v) => setState(() => _filter = v),
         ),
-        const SizedBox(height: 12),
-        SizedBox(
-          height: 220,
-          child: BarChart(
-            BarChartData(
-              maxY: maxY * 1.2,
-              gridData: FlGridData(show: true),
-              titlesData: FlTitlesData(
-                bottomTitles: AxisTitles(
-                  sideTitles: SideTitles(
-                    showTitles: xInterval.showTitles,
-                    interval: xInterval.interval,
-                    getTitlesWidget: (value, meta) {
-                      final i = value.toInt();
-                      if (i < 0 || i >= display.length) return const SizedBox();
-                      return RotatedBox(
-                        quarterTurns: 1,
-                        child: Text(
-                          display[i].key,
-                          style: const TextStyle(fontSize: 10),
-                          overflow: TextOverflow.ellipsis,
+        const SizedBox(height: AppSpacing.sm),
+        AnimatedSwitcher(
+          duration: const Duration(milliseconds: 200),
+          child: chartContent,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildChartContent(
+    BuildContext context,
+    AppLocalizations loc,
+    ThemeData theme,
+    List<DeviceUsageStat> filtered,
+    bool hasBaseData,
+    bool hasFilteredData,
+  ) {
+    final textStyle = theme.textTheme.bodySmall ??
+        const TextStyle(fontSize: 12, fontWeight: FontWeight.w600);
+    final descriptionStyle = theme.textTheme.labelSmall ??
+        const TextStyle(fontSize: 11, fontWeight: FontWeight.w500);
+    final valueStyle = theme.textTheme.labelSmall?.copyWith(
+          fontWeight: FontWeight.w600,
+        ) ??
+        const TextStyle(fontSize: 12, fontWeight: FontWeight.w600);
+
+    if (widget.state == ReportState.loading && !hasBaseData) {
+      return const SizedBox(
+        height: 260,
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (widget.state == ReportState.error && !hasBaseData) {
+      final message = widget.errorMessage ?? loc.reportDeviceUsageError;
+      return SizedBox(
+        height: 260,
+        child: Center(
+          child: Text(
+            message,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyMedium,
+          ),
+        ),
+      );
+    }
+
+    if (!hasBaseData) {
+      return SizedBox(
+        height: 260,
+        child: Center(
+          child: Text(
+            loc.reportDeviceUsageEmpty,
+            style: theme.textTheme.bodyMedium,
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+
+    if (!hasFilteredData) {
+      return SizedBox(
+        height: 260,
+        child: Center(
+          child: Text(
+            loc.reportDeviceUsageNoMatches,
+            style: theme.textTheme.bodyMedium,
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+
+    final maxSessions = filtered
+        .map((e) => e.sessions)
+        .fold<int>(0, (previousValue, element) => math.max(previousValue, element));
+    final double chartMax = math.max(1, maxSessions.toDouble());
+    final interval = resolveAxisInterval(0, chartMax, targetLabels: 5);
+    final ticks = _buildTicks(chartMax, interval);
+
+    return _UsageChartArea(
+      stats: filtered,
+      maxValue: chartMax,
+      ticks: ticks,
+      nameStyle: textStyle,
+      descriptionStyle: descriptionStyle,
+      valueStyle: valueStyle,
+      valueFormatter: loc.reportDeviceUsageSessions,
+    );
+  }
+
+  List<double> _buildTicks(double maxValue, AxisInterval interval) {
+    if (!interval.showTitles) {
+      return [0, maxValue];
+    }
+    final ticks = <double>{0, maxValue};
+    final step = interval.interval <= 0 ? 1 : interval.interval;
+    double current = step;
+    while (current < maxValue) {
+      ticks.add(double.parse(current.toStringAsFixed(2)));
+      current += step;
+    }
+    final sorted = ticks.toList()..sort();
+    return sorted;
+  }
+}
+
+class _UsageChartArea extends StatelessWidget {
+  const _UsageChartArea({
+    required this.stats,
+    required this.maxValue,
+    required this.ticks,
+    required this.nameStyle,
+    required this.descriptionStyle,
+    required this.valueStyle,
+    required this.valueFormatter,
+  });
+
+  final List<DeviceUsageStat> stats;
+  final double maxValue;
+  final List<double> ticks;
+  final TextStyle nameStyle;
+  final TextStyle descriptionStyle;
+  final TextStyle valueStyle;
+  final String Function(int) valueFormatter;
+
+  static const double _axisWidth = 64;
+  static const double _topPadding = 16;
+  static const double _bottomPadding = 56;
+  static const double _horizontalPadding = 16;
+  static const double _barWidth = 104;
+  static const double _barSpacing = 20;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final axisLabelColor = theme.textTheme.labelSmall?.color ??
+        theme.colorScheme.onSurface.withOpacity(0.72);
+    final gridColor = axisLabelColor.withOpacity(0.25);
+    final descriptionColor = descriptionStyle.color ??
+        Colors.black.withOpacity(theme.brightness == Brightness.dark ? 0.8 : 0.7);
+
+    final totalBarsWidth =
+        stats.length * _barWidth + math.max(0, stats.length - 1) * _barSpacing;
+    final contentWidth = totalBarsWidth + _horizontalPadding * 2;
+    final chartHeight = 260 + _topPadding + _bottomPadding;
+
+    return SizedBox(
+      height: chartHeight,
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const SizedBox(width: _axisWidth),
+                Expanded(
+                  child: LayoutBuilder(
+                    builder: (context, constraints) {
+                      final width = math.max(contentWidth, constraints.maxWidth);
+                      return SingleChildScrollView(
+                        scrollDirection: Axis.horizontal,
+                        child: CustomPaint(
+                          size: Size(width, chartHeight),
+                          painter: _UsageChartPainter(
+                            stats: stats,
+                            maxValue: maxValue,
+                            ticks: ticks,
+                            barWidth: _barWidth,
+                            barSpacing: _barSpacing,
+                            topPadding: _topPadding,
+                            bottomPadding: _bottomPadding,
+                            horizontalPadding: _horizontalPadding,
+                            gradient: AppGradients.progress,
+                            nameStyle: nameStyle,
+                            descriptionStyle:
+                                descriptionStyle.copyWith(color: descriptionColor),
+                            valueStyle: valueStyle,
+                            gridColor: gridColor,
+                            valueFormatter: valueFormatter,
+                          ),
                         ),
                       );
                     },
                   ),
                 ),
-                leftTitles: AxisTitles(
-                  sideTitles: SideTitles(
-                      showTitles: yInterval.showTitles,
-                      interval: yInterval.interval),
+              ],
+            ),
+          ),
+          Positioned(
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: _axisWidth,
+            child: CustomPaint(
+              painter: _UsageAxisPainter(
+                ticks: ticks,
+                maxValue: maxValue,
+                topPadding: _topPadding,
+                bottomPadding: _bottomPadding,
+                labelStyle: nameStyle.copyWith(
+                  color: axisLabelColor,
+                  fontWeight: FontWeight.w500,
                 ),
-                topTitles: AxisTitles(
-                  sideTitles: SideTitles(showTitles: false),
-                ),
-                rightTitles: AxisTitles(
-                  sideTitles: SideTitles(showTitles: false),
-                ),
-              ),
-              borderData: FlBorderData(show: false),
-              barGroups: bars,
-              barTouchData: BarTouchData(
-                enabled: true,
-                touchTooltipData: BarTouchTooltipData(
-                  getTooltipItem: (group, _, rod, __) {
-                    final i = group.x.toInt();
-                    final entry = display[i];
-                    return BarTooltipItem(
-                      '${entry.key}\n${loc.reportDeviceUsageSessions(entry.value)}',
-                      const TextStyle(color: Colors.white, fontSize: 12),
-                    );
-                  },
-                ),
+                gridColor: gridColor,
               ),
             ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
+}
+
+class _UsageAxisPainter extends CustomPainter {
+  _UsageAxisPainter({
+    required this.ticks,
+    required this.maxValue,
+    required this.topPadding,
+    required this.bottomPadding,
+    required this.labelStyle,
+    required this.gridColor,
+  });
+
+  final List<double> ticks;
+  final double maxValue;
+  final double topPadding;
+  final double bottomPadding;
+  final TextStyle labelStyle;
+  final Color gridColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final chartHeight = size.height - topPadding - bottomPadding;
+    final safeMax = maxValue <= 0 ? 1 : maxValue;
+    final axisPaint = Paint()
+      ..color = gridColor
+      ..strokeWidth = 1;
+
+    final baselineY = size.height - bottomPadding;
+    canvas.drawLine(
+      Offset(size.width - 4, baselineY),
+      Offset(size.width - 4, topPadding),
+      axisPaint,
+    );
+
+    for (final tick in ticks) {
+      final y = _yForValue(
+        tick,
+        chartHeight: chartHeight,
+        safeMax: safeMax,
+        topPadding: topPadding,
+      );
+      canvas.drawLine(
+        Offset(size.width - 8, y),
+        Offset(size.width - 4, y),
+        axisPaint,
+      );
+
+      final formatted = _formatTick(tick);
+      final painter = TextPainter(
+        text: TextSpan(text: formatted, style: labelStyle),
+        textAlign: TextAlign.right,
+        textDirection: TextDirection.ltr,
+      )..layout(maxWidth: size.width - 12);
+      painter.paint(
+        canvas,
+        Offset(size.width - painter.width - 12, y - painter.height / 2),
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _UsageAxisPainter oldDelegate) {
+    return ticks != oldDelegate.ticks ||
+        maxValue != oldDelegate.maxValue ||
+        labelStyle != oldDelegate.labelStyle ||
+        gridColor != oldDelegate.gridColor;
+  }
+
+  String _formatTick(double value) {
+    if (value % 1 == 0) {
+      return value.toInt().toString();
+    }
+    return value.toStringAsFixed(1);
+  }
+}
+
+class _UsageChartPainter extends CustomPainter {
+  _UsageChartPainter({
+    required this.stats,
+    required this.maxValue,
+    required this.ticks,
+    required this.barWidth,
+    required this.barSpacing,
+    required this.topPadding,
+    required this.bottomPadding,
+    required this.horizontalPadding,
+    required this.gradient,
+    required this.nameStyle,
+    required this.descriptionStyle,
+    required this.valueStyle,
+    required this.gridColor,
+    required this.valueFormatter,
+  });
+
+  final List<DeviceUsageStat> stats;
+  final double maxValue;
+  final List<double> ticks;
+  final double barWidth;
+  final double barSpacing;
+  final double topPadding;
+  final double bottomPadding;
+  final double horizontalPadding;
+  final LinearGradient gradient;
+  final TextStyle nameStyle;
+  final TextStyle descriptionStyle;
+  final TextStyle valueStyle;
+  final Color gridColor;
+  final String Function(int) valueFormatter;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final chartHeight = size.height - topPadding - bottomPadding;
+    final safeMax = maxValue <= 0 ? 1 : maxValue;
+    final gridPaint = Paint()
+      ..color = gridColor
+      ..strokeWidth = 1;
+
+    // Draw background grid lines.
+    for (final tick in ticks) {
+      final y = _yForValue(
+        tick,
+        chartHeight: chartHeight,
+        safeMax: safeMax,
+        topPadding: topPadding,
+      );
+      canvas.drawLine(
+        Offset(0, y),
+        Offset(size.width, y),
+        gridPaint,
+      );
+    }
+
+    final baselineY = size.height - bottomPadding;
+    canvas.drawLine(
+      Offset(0, baselineY),
+      Offset(size.width, baselineY),
+      gridPaint,
+    );
+
+    for (var i = 0; i < stats.length; i++) {
+      final stat = stats[i];
+      final left = horizontalPadding + i * (barWidth + barSpacing);
+      final barTop = _yForValue(
+        stat.sessions.toDouble(),
+        chartHeight: chartHeight,
+        safeMax: safeMax,
+        topPadding: topPadding,
+      );
+      final barBottom = size.height - bottomPadding;
+      final barHeight = math.max(4, barBottom - barTop);
+      final barRect = RRect.fromRectAndRadius(
+        Rect.fromLTWH(left, barBottom - barHeight, barWidth, barHeight),
+        const Radius.circular(AppRadius.card),
+      );
+      final paint = Paint()
+        ..shader = gradient.createShader(barRect.outerRect);
+      canvas.drawRRect(barRect, paint);
+
+      // Render usage value above the bar.
+      final valuePainter = TextPainter(
+        text: TextSpan(
+          text: valueFormatter(stat.sessions),
+          style: valueStyle,
+        ),
+        textAlign: TextAlign.center,
+        textDirection: TextDirection.ltr,
+      )..layout(maxWidth: barWidth + 16);
+      final valueTop = math.max(
+        topPadding,
+        barRect.top - valuePainter.height - 6,
+      );
+      valuePainter.paint(
+        canvas,
+        Offset(left + (barWidth - valuePainter.width) / 2, valueTop),
+      );
+
+      final namePainter = TextPainter(
+        text: TextSpan(text: stat.name, style: nameStyle.copyWith(color: Colors.black.withOpacity(0.85))),
+        textAlign: TextAlign.center,
+        textDirection: TextDirection.ltr,
+        maxLines: 2,
+        ellipsis: '…',
+      )..layout(maxWidth: barWidth - 16);
+
+      final descriptionPainter = stat.description.isEmpty
+          ? null
+          : (TextPainter(
+              text: TextSpan(
+                text: stat.description,
+                style: descriptionStyle,
+              ),
+              textAlign: TextAlign.center,
+              textDirection: TextDirection.ltr,
+              maxLines: 2,
+              ellipsis: '…',
+            )..layout(maxWidth: barWidth - 16));
+
+      final combinedHeight = namePainter.height +
+          (descriptionPainter?.height ?? 0) +
+          (descriptionPainter != null ? 6 : 0);
+      final hasRoomInside = barHeight - 24 >= combinedHeight;
+
+      double textTop;
+      if (hasRoomInside) {
+        textTop = barRect.top + (barHeight - combinedHeight) / 2;
+      } else {
+        textTop = barRect.bottom + 8;
+      }
+
+      namePainter.paint(
+        canvas,
+        Offset(left + (barWidth - namePainter.width) / 2, textTop),
+      );
+
+      if (descriptionPainter != null) {
+        final descTop = textTop + namePainter.height + 6;
+        descriptionPainter.paint(
+          canvas,
+          Offset(left + (barWidth - descriptionPainter.width) / 2, descTop),
+        );
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _UsageChartPainter oldDelegate) {
+    return stats != oldDelegate.stats ||
+        maxValue != oldDelegate.maxValue ||
+        nameStyle != oldDelegate.nameStyle ||
+        descriptionStyle != oldDelegate.descriptionStyle ||
+        gridColor != oldDelegate.gridColor;
+  }
+}
+
+double _yForValue(
+  double value, {
+  required double chartHeight,
+  required double safeMax,
+  required double topPadding,
+}) {
+  final clamped = value.clamp(0, safeMax);
+  final normalized = safeMax == 0 ? 0 : clamped / safeMax;
+  return topPadding + (1 - normalized) * chartHeight;
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1072,8 +1072,14 @@
   ,"@reportCreateSurveyTitle": {"description": "Aktion zum Erstellen einer Umfrage"}
   ,"reportViewSurveysTitle": "Umfragen ansehen"
   ,"@reportViewSurveysTitle": {"description": "Aktion zum Öffnen der Umfragenübersicht"}
-  ,"reportDeviceFilterHint": "Gerät filtern"
+  ,"reportDeviceFilterHint": "Geräte oder Beschreibungen suchen"
   ,"@reportDeviceFilterHint": {"description": "Hinweistext für die Gerätesuche"}
+  ,"reportDeviceUsageEmpty": "Noch keine Nutzungsdaten vorhanden"
+  ,"@reportDeviceUsageEmpty": {"description": "Hinweis, wenn keine Nutzungsdaten vorliegen"}
+  ,"reportDeviceUsageNoMatches": "Keine Geräte entsprechen deiner Suche"
+  ,"@reportDeviceUsageNoMatches": {"description": "Hinweis, wenn keine Geräte zur Suche passen"}
+  ,"reportDeviceUsageError": "Die Nutzungsdaten konnten nicht geladen werden."
+  ,"@reportDeviceUsageError": {"description": "Hinweis, wenn das Laden der Nutzungsdaten fehlschlägt"}
   ,"reportDeviceUsageSessions": "{count} Sessions"
   ,"@reportDeviceUsageSessions": {"description": "Tooltip-Zeile mit der Anzahl an Sessions","placeholders": {"count": {"type": "int"}}}
   ,"exerciseDeleteTitle": "Übung löschen"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1070,8 +1070,14 @@
   ,"@reportCreateSurveyTitle": {"description": "Action title to create a survey"}
   ,"reportViewSurveysTitle": "View surveys"
   ,"@reportViewSurveysTitle": {"description": "Action title to open the survey overview"}
-  ,"reportDeviceFilterHint": "Filter devices"
+  ,"reportDeviceFilterHint": "Search devices or descriptions"
   ,"@reportDeviceFilterHint": {"description": "Hint text for the device usage search field"}
+  ,"reportDeviceUsageEmpty": "No usage data available yet"
+  ,"@reportDeviceUsageEmpty": {"description": "Message shown when there is no usage data"}
+  ,"reportDeviceUsageNoMatches": "No devices match your search"
+  ,"@reportDeviceUsageNoMatches": {"description": "Message shown when the device search has no matches"}
+  ,"reportDeviceUsageError": "We couldn't load the usage data."
+  ,"@reportDeviceUsageError": {"description": "Message shown when fetching usage data fails"}
   ,"reportDeviceUsageSessions": "{count} sessions"
   ,"@reportDeviceUsageSessions": {"description": "Tooltip line with the number of sessions","placeholders": {"count": {"type": "int"}}}
   ,"exerciseDeleteTitle": "Delete exercise"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2024,6 +2024,15 @@ abstract class AppLocalizations {
   /// No description provided for @reportDeviceFilterHint.
   String get reportDeviceFilterHint;
 
+  /// No description provided for @reportDeviceUsageEmpty.
+  String get reportDeviceUsageEmpty;
+
+  /// No description provided for @reportDeviceUsageNoMatches.
+  String get reportDeviceUsageNoMatches;
+
+  /// No description provided for @reportDeviceUsageError.
+  String get reportDeviceUsageError;
+
   /// No description provided for @reportDeviceUsageSessions.
   String reportDeviceUsageSessions(int count);
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1045,7 +1045,19 @@ class AppLocalizationsDe extends AppLocalizations {
   String get reportViewSurveysTitle => 'Umfragen ansehen';
 
   @override
-  String get reportDeviceFilterHint => 'Gerät filtern';
+  String get reportDeviceFilterHint => 'Geräte oder Beschreibungen suchen';
+
+  @override
+  String get reportDeviceUsageEmpty =>
+      'Noch keine Nutzungsdaten vorhanden';
+
+  @override
+  String get reportDeviceUsageNoMatches =>
+      'Keine Geräte entsprechen deiner Suche';
+
+  @override
+  String get reportDeviceUsageError =>
+      'Die Nutzungsdaten konnten nicht geladen werden.';
 
   @override
   String reportDeviceUsageSessions(int count) {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1045,7 +1045,18 @@ class AppLocalizationsEn extends AppLocalizations {
   String get reportViewSurveysTitle => 'View surveys';
 
   @override
-  String get reportDeviceFilterHint => 'Filter devices';
+  String get reportDeviceFilterHint => 'Search devices or descriptions';
+
+  @override
+  String get reportDeviceUsageEmpty => 'No usage data available yet';
+
+  @override
+  String get reportDeviceUsageNoMatches =>
+      'No devices match your search';
+
+  @override
+  String get reportDeviceUsageError =>
+      "We couldn't load the usage data.";
 
   @override
   String reportDeviceUsageSessions(int count) {

--- a/test/usecases/report_usecases_test.dart
+++ b/test/usecases/report_usecases_test.dart
@@ -1,16 +1,19 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:tapem/features/report/domain/usecases/get_device_usage_stats.dart';
-import 'package:tapem/features/report/domain/usecases/get_all_log_timestamps.dart';
+import 'package:tapem/features/report/domain/models/device_usage_stat.dart';
 import 'package:tapem/features/report/domain/repositories/report_repository.dart';
+import 'package:tapem/features/report/domain/usecases/get_all_log_timestamps.dart';
+import 'package:tapem/features/report/domain/usecases/get_device_usage_stats.dart';
 
 class FakeReportRepository implements ReportRepository {
   int usageCalls = 0;
   int timeCalls = 0;
 
   @override
-  Future<Map<String, int>> fetchUsageCountPerMachine(String gymId) async {
+  Future<List<DeviceUsageStat>> fetchDeviceUsageStats(String gymId) async {
     usageCalls++;
-    return {'d1': 1};
+    return const [
+      DeviceUsageStat(id: 'd1', name: 'Device', sessions: 1),
+    ];
   }
 
   @override
@@ -26,7 +29,7 @@ void main() {
       final repo = FakeReportRepository();
       final usecase = GetDeviceUsageStats(repo);
       final result = await usecase.execute('g1');
-      expect(result, {'d1': 1});
+      expect(result.first.sessions, 1);
       expect(repo.usageCalls, 1);
     });
 

--- a/test/widgets/report_screen_test.dart
+++ b/test/widgets/report_screen_test.dart
@@ -2,20 +2,26 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
-import 'package:tapem/features/report/presentation/screens/report_screen_new.dart';
 import 'package:tapem/core/providers/report_provider.dart';
 import 'package:tapem/features/feedback/feedback_provider.dart';
-import 'package:tapem/features/report/domain/usecases/get_device_usage_stats.dart';
-import 'package:tapem/features/report/domain/usecases/get_all_log_timestamps.dart';
+import 'package:tapem/features/report/domain/models/device_usage_stat.dart';
 import 'package:tapem/features/report/domain/repositories/report_repository.dart';
+import 'package:tapem/features/report/domain/usecases/get_all_log_timestamps.dart';
+import 'package:tapem/features/report/domain/usecases/get_device_usage_stats.dart';
+import 'package:tapem/features/report/presentation/screens/report_screen_new.dart';
 import 'package:tapem/features/report/presentation/widgets/device_usage_chart.dart';
 
 class FakeReportRepository implements ReportRepository {
-  FakeReportRepository({this.usage = const {}, this.times = const []});
-  final Map<String, int> usage;
+  FakeReportRepository({
+    this.usage = const [
+      DeviceUsageStat(id: 'd1', name: 'Device 1', sessions: 1),
+    ],
+    this.times = const [],
+  });
+  final List<DeviceUsageStat> usage;
   final List<DateTime> times;
   @override
-  Future<Map<String, int>> fetchUsageCountPerMachine(String gymId) async => usage;
+  Future<List<DeviceUsageStat>> fetchDeviceUsageStats(String gymId) async => usage;
   @override
   Future<List<DateTime>> fetchAllLogTimestamps(String gymId) async => times;
 }
@@ -52,7 +58,11 @@ void main() {
   });
 
   testWidgets('ReportScreenNew uses provided usage data', (tester) async {
-    final repo = FakeReportRepository(usage: const {'Device X': 5});
+    final repo = FakeReportRepository(
+      usage: const [
+        DeviceUsageStat(id: 'x', name: 'Device X', sessions: 5),
+      ],
+    );
     final reportProvider = ReportProvider(
       getUsageStats: GetDeviceUsageStats(repo),
       getLogTimestamps: GetAllLogTimestamps(repo),
@@ -75,6 +85,7 @@ void main() {
     await tester.pump();
 
     final chart = tester.widget<DeviceUsageChart>(find.byType(DeviceUsageChart));
-    expect(chart.usageData, {'Device X': 5});
+    expect(chart.usageData.first.sessions, 5);
+    expect(chart.usageData.first.name, 'Device X');
   });
 }


### PR DESCRIPTION
## Summary
- replace the report usage map with a typed device usage model containing names, descriptions, and session counts
- redesign the report analytics chart for horizontal scrolling with inline labels, clearer axes, and improved filtering UX
- align report action tiles with profile styling and update localizations plus tests for the new data flow

## Testing
- Not run (flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3f3505a6c8320b81aabd82c6d2c31