### PR TITLE
Fix type issues in device usage chart

### DIFF
--- a/lib/features/report/presentation/widgets/device_usage_chart.dart
+++ b/lib/features/report/presentation/widgets/device_usage_chart.dart
@@ -167,7 +167,8 @@ class _DeviceUsageChartState extends State<DeviceUsageChart> {
       return [0, maxValue];
     }
     final ticks = <double>{0, maxValue};
-    final step = interval.interval <= 0 ? 1 : interval.interval;
+    final double step =
+        interval.interval <= 0 ? 1.0 : interval.interval.toDouble();
     double current = step;
     while (current < maxValue) {
       ticks.add(double.parse(current.toStringAsFixed(2)));
@@ -305,7 +306,7 @@ class _UsageAxisPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final chartHeight = size.height - topPadding - bottomPadding;
-    final safeMax = maxValue <= 0 ? 1 : maxValue;
+    final double safeMax = maxValue <= 0 ? 1.0 : maxValue;
     final axisPaint = Paint()
       ..color = gridColor
       ..strokeWidth = 1;
@@ -395,7 +396,7 @@ class _UsageChartPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final chartHeight = size.height - topPadding - bottomPadding;
-    final safeMax = maxValue <= 0 ? 1 : maxValue;
+    final double safeMax = maxValue <= 0 ? 1.0 : maxValue;
     final gridPaint = Paint()
       ..color = gridColor
       ..strokeWidth = 1;
@@ -432,7 +433,7 @@ class _UsageChartPainter extends CustomPainter {
         topPadding: topPadding,
       );
       final barBottom = size.height - bottomPadding;
-      final barHeight = math.max(4, barBottom - barTop);
+      final double barHeight = math.max(4.0, barBottom - barTop);
       final barRect = RRect.fromRectAndRadius(
         Rect.fromLTWH(left, barBottom - barHeight, barWidth, barHeight),
         const Radius.circular(AppRadius.card),


### PR DESCRIPTION
## Summary
- ensure axis interval step is treated as a double to avoid type errors
- update chart painters to use double-safe maximum and bar height values

## Testing
- flutter analyze *(fails: Flutter SDK is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e410b8e43c8320bb23036c6ce45232