### PR TITLE
Add usage range filters and interactive device chart details

### DIFF
--- a/lib/core/providers/report_provider.dart
+++ b/lib/core/providers/report_provider.dart
@@ -7,6 +7,25 @@ import 'package:tapem/features/report/domain/usecases/get_all_log_timestamps.dar
 
 enum ReportState { initial, loading, loaded, error }
 
+enum DeviceUsageRange { last7Days, last30Days, last90Days, last365Days, all }
+
+extension DeviceUsageRangeX on DeviceUsageRange {
+  DateTime? resolveSince(DateTime now) {
+    switch (this) {
+      case DeviceUsageRange.last7Days:
+        return now.subtract(const Duration(days: 7));
+      case DeviceUsageRange.last30Days:
+        return now.subtract(const Duration(days: 30));
+      case DeviceUsageRange.last90Days:
+        return now.subtract(const Duration(days: 90));
+      case DeviceUsageRange.last365Days:
+        return now.subtract(const Duration(days: 365));
+      case DeviceUsageRange.all:
+        return null;
+    }
+  }
+}
+
 class ReportProvider extends ChangeNotifier {
   final GetDeviceUsageStats _getUsage;
   final GetAllLogTimestamps _getTimestamps;
@@ -15,6 +34,9 @@ class ReportProvider extends ChangeNotifier {
   List<DeviceUsageStat> usageStats = const [];
   List<DateTime> heatmapDates = [];
   String? errorMessage;
+  DeviceUsageRange usageRange = DeviceUsageRange.last30Days;
+
+  String? _currentGymId;
 
   ReportProvider({
     required GetDeviceUsageStats getUsageStats,
@@ -28,14 +50,16 @@ class ReportProvider extends ChangeNotifier {
       usageStats = const [];
       heatmapDates = [];
       errorMessage = null;
+      _currentGymId = null;
       notifyListeners();
       return;
     }
+    _currentGymId = gymId;
     state = ReportState.loading;
     errorMessage = null;
     notifyListeners();
     try {
-      usageStats = await _getUsage.execute(gymId);
+      usageStats = await _fetchUsageStats(gymId);
       heatmapDates = await _getTimestamps.execute(gymId);
       state = ReportState.loaded;
     } catch (e) {
@@ -43,5 +67,33 @@ class ReportProvider extends ChangeNotifier {
       state = ReportState.error;
     }
     notifyListeners();
+  }
+
+  Future<void> changeUsageRange(DeviceUsageRange range) async {
+    if (usageRange == range) {
+      return;
+    }
+    usageRange = range;
+    if (_currentGymId == null || _currentGymId!.isEmpty) {
+      notifyListeners();
+      return;
+    }
+    state = ReportState.loading;
+    errorMessage = null;
+    notifyListeners();
+    try {
+      usageStats = await _fetchUsageStats(_currentGymId!);
+      state = ReportState.loaded;
+    } catch (e) {
+      errorMessage = e.toString();
+      state = ReportState.error;
+    }
+    notifyListeners();
+  }
+
+  Future<List<DeviceUsageStat>> _fetchUsageStats(String gymId) {
+    final now = DateTime.now();
+    final since = usageRange.resolveSince(now);
+    return _getUsage.execute(gymId, since: since);
   }
 }

--- a/lib/features/report/data/repositories/report_repository_impl.dart
+++ b/lib/features/report/data/repositories/report_repository_impl.dart
@@ -11,7 +11,10 @@ class ReportRepositoryImpl implements ReportRepository {
     : _source = source ?? FirestoreReportSource();
 
   @override
-  Future<List<DeviceUsageStat>> fetchDeviceUsageStats(String gymId) async {
+  Future<List<DeviceUsageStat>> fetchDeviceUsageStats(
+    String gymId, {
+    DateTime? since,
+  }) async {
     final devices = await _source.fetchDevices(gymId);
     final List<DeviceUsageStat> stats = [];
 
@@ -20,7 +23,11 @@ class ReportRepositoryImpl implements ReportRepository {
       final deviceData = deviceDoc.data();
       final deviceName = (deviceData?['name'] as String?)?.trim();
       final description = (deviceData?['description'] as String?)?.trim();
-      final logs = await _source.fetchLogsForDevice(gymId, deviceId);
+      final logs = await _source.fetchLogsForDevice(
+        gymId,
+        deviceId,
+        since: since,
+      );
 
       // Einzigartige sessionId sammeln
       final sessionIds = <String>{};

--- a/lib/features/report/data/sources/firestore_report_source.dart
+++ b/lib/features/report/data/sources/firestore_report_source.dart
@@ -22,15 +22,22 @@ class FirestoreReportSource {
   /// Für ein Gerät alle Log-Dokumente laden
   Future<List<DocumentSnapshot<Map<String, dynamic>>>> fetchLogsForDevice(
     String gymId,
-    String deviceId,
-  ) {
-    return _fs
+    String deviceId, {
+    DateTime? since,
+  }) {
+    Query<Map<String, dynamic>> query = _fs
         .collection('gyms')
         .doc(gymId)
         .collection('devices')
         .doc(deviceId)
-        .collection('logs')
-        .get()
-        .then((snap) => snap.docs);
+        .collection('logs');
+
+    if (since != null) {
+      query = query
+          .where('timestamp', isGreaterThanOrEqualTo: Timestamp.fromDate(since))
+          .orderBy('timestamp', descending: true);
+    }
+
+    return query.get().then((snap) => snap.docs);
   }
 }

--- a/lib/features/report/domain/repositories/report_repository.dart
+++ b/lib/features/report/domain/repositories/report_repository.dart
@@ -4,7 +4,10 @@ import '../models/device_usage_stat.dart';
 
 abstract class ReportRepository {
   /// Gibt aggregierte Nutzungsstatistiken für alle Geräte eines Gyms zurück.
-  Future<List<DeviceUsageStat>> fetchDeviceUsageStats(String gymId);
+  Future<List<DeviceUsageStat>> fetchDeviceUsageStats(
+    String gymId, {
+    DateTime? since,
+  });
 
   /// Liefert alle Log-Timestamps (über alle Geräte) für den Heatmap.
   Future<List<DateTime>> fetchAllLogTimestamps(String gymId);

--- a/lib/features/report/domain/usecases/get_device_usage_stats.dart
+++ b/lib/features/report/domain/usecases/get_device_usage_stats.dart
@@ -6,7 +6,10 @@ class GetDeviceUsageStats {
   final ReportRepository _repo;
   GetDeviceUsageStats(this._repo);
 
-  Future<List<DeviceUsageStat>> execute(String gymId) {
-    return _repo.fetchDeviceUsageStats(gymId);
+  Future<List<DeviceUsageStat>> execute(
+    String gymId, {
+    DateTime? since,
+  }) {
+    return _repo.fetchDeviceUsageStats(gymId, since: since);
   }
 }

--- a/lib/features/report/presentation/screens/report_screen_new.dart
+++ b/lib/features/report/presentation/screens/report_screen_new.dart
@@ -43,6 +43,8 @@ class ReportScreenNew extends StatelessWidget {
                 usageData: usageData,
                 state: reportProvider.state,
                 errorMessage: reportProvider.errorMessage,
+                usageRange: reportProvider.usageRange,
+                onRangeSelected: reportProvider.changeUsageRange,
               ),
               const SizedBox(height: AppSpacing.md),
               BrandActionTile(

--- a/lib/features/report/presentation/widgets/device_usage_chart.dart
+++ b/lib/features/report/presentation/widgets/device_usage_chart.dart
@@ -12,12 +12,16 @@ class DeviceUsageChart extends StatefulWidget {
   final List<DeviceUsageStat> usageData;
   final ReportState state;
   final String? errorMessage;
+  final DeviceUsageRange usageRange;
+  final Future<void> Function(DeviceUsageRange range) onRangeSelected;
 
   const DeviceUsageChart({
     super.key,
     required this.usageData,
     required this.state,
     this.errorMessage,
+    required this.usageRange,
+    required this.onRangeSelected,
   });
 
   @override
@@ -53,9 +57,32 @@ class _DeviceUsageChartState extends State<DeviceUsageChart> {
       hasFilteredData,
     );
 
+    final rangeChips = DeviceUsageRange.values;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          padding: const EdgeInsets.only(bottom: AppSpacing.xs),
+          child: Row(
+            children: [
+              for (final range in rangeChips)
+                Padding(
+                  padding: const EdgeInsets.only(right: AppSpacing.xs),
+                  child: ChoiceChip(
+                    label: Text(_labelForRange(loc, range)),
+                    selected: widget.usageRange == range,
+                    onSelected: (selected) {
+                      if (selected) {
+                        widget.onRangeSelected(range);
+                      }
+                    },
+                  ),
+                ),
+            ],
+          ),
+        ),
         TextField(
           decoration: InputDecoration(
             prefixIcon: const Icon(Icons.search),
@@ -80,6 +107,21 @@ class _DeviceUsageChartState extends State<DeviceUsageChart> {
     );
   }
 
+  String _labelForRange(AppLocalizations loc, DeviceUsageRange range) {
+    switch (range) {
+      case DeviceUsageRange.last7Days:
+        return loc.reportUsageRange7Days;
+      case DeviceUsageRange.last30Days:
+        return loc.reportUsageRange30Days;
+      case DeviceUsageRange.last90Days:
+        return loc.reportUsageRange90Days;
+      case DeviceUsageRange.last365Days:
+        return loc.reportUsageRange365Days;
+      case DeviceUsageRange.all:
+        return loc.reportUsageRangeAll;
+    }
+  }
+
   Widget _buildChartContent(
     BuildContext context,
     AppLocalizations loc,
@@ -90,8 +132,6 @@ class _DeviceUsageChartState extends State<DeviceUsageChart> {
   ) {
     final textStyle = theme.textTheme.bodySmall ??
         const TextStyle(fontSize: 12, fontWeight: FontWeight.w600);
-    final descriptionStyle = theme.textTheme.labelSmall ??
-        const TextStyle(fontSize: 11, fontWeight: FontWeight.w500);
     final valueStyle = theme.textTheme.labelSmall?.copyWith(
           fontWeight: FontWeight.w600,
         ) ??
@@ -156,9 +196,9 @@ class _DeviceUsageChartState extends State<DeviceUsageChart> {
       maxValue: chartMax,
       ticks: ticks,
       nameStyle: textStyle,
-      descriptionStyle: descriptionStyle,
       valueStyle: valueStyle,
       valueFormatter: loc.reportDeviceUsageSessions,
+      onBarTap: _handleBarTap,
     );
   }
 
@@ -177,6 +217,47 @@ class _DeviceUsageChartState extends State<DeviceUsageChart> {
     final sorted = ticks.toList()..sort();
     return sorted;
   }
+
+  void _handleBarTap(DeviceUsageStat stat) {
+    if (!mounted) {
+      return;
+    }
+    final theme = Theme.of(context);
+    final loc = AppLocalizations.of(context)!;
+    showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (ctx) {
+        return Padding(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                stat.name,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.xs),
+              Text(
+                loc.reportDeviceUsageSessions(stat.sessions),
+                style: theme.textTheme.bodyMedium,
+              ),
+              if (stat.description.trim().isNotEmpty) ...[
+                const SizedBox(height: AppSpacing.sm),
+                Text(
+                  stat.description.trim(),
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ],
+            ],
+          ),
+        );
+      },
+    );
+  }
 }
 
 class _UsageChartArea extends StatelessWidget {
@@ -185,18 +266,18 @@ class _UsageChartArea extends StatelessWidget {
     required this.maxValue,
     required this.ticks,
     required this.nameStyle,
-    required this.descriptionStyle,
     required this.valueStyle,
     required this.valueFormatter,
+    required this.onBarTap,
   });
 
   final List<DeviceUsageStat> stats;
   final double maxValue;
   final List<double> ticks;
   final TextStyle nameStyle;
-  final TextStyle descriptionStyle;
   final TextStyle valueStyle;
   final String Function(int) valueFormatter;
+  final void Function(DeviceUsageStat stat) onBarTap;
 
   static const double _axisWidth = 64;
   static const double _topPadding = 16;
@@ -211,13 +292,23 @@ class _UsageChartArea extends StatelessWidget {
     final axisLabelColor = theme.textTheme.labelSmall?.color ??
         theme.colorScheme.onSurface.withOpacity(0.72);
     final gridColor = axisLabelColor.withOpacity(0.25);
-    final descriptionColor = descriptionStyle.color ??
-        Colors.black.withOpacity(theme.brightness == Brightness.dark ? 0.8 : 0.7);
-
     final totalBarsWidth =
         stats.length * _barWidth + math.max(0, stats.length - 1) * _barSpacing;
     final contentWidth = totalBarsWidth + _horizontalPadding * 2;
     final chartHeight = 260 + _topPadding + _bottomPadding;
+
+    final safeMax = maxValue <= 0 ? 1.0 : maxValue;
+    final verticalChartHeight = chartHeight - _topPadding - _bottomPadding;
+    final barGeometries = <_BarGeometry>[
+      for (var i = 0; i < stats.length; i++)
+        _createGeometry(
+          stat: stats[i],
+          index: i,
+          safeMax: safeMax,
+          verticalChartHeight: verticalChartHeight,
+          chartHeight: chartHeight,
+        ),
+    ];
 
     return SizedBox(
       height: chartHeight,
@@ -234,10 +325,18 @@ class _UsageChartArea extends StatelessWidget {
                       final width = math.max(contentWidth, constraints.maxWidth);
                       return SingleChildScrollView(
                         scrollDirection: Axis.horizontal,
-                        child: CustomPaint(
-                          size: Size(width, chartHeight),
+                        child: GestureDetector(
+                          behavior: HitTestBehavior.opaque,
+                          onTapUp: (details) {
+                            final stat = _hitTestBar(details.localPosition, barGeometries);
+                            if (stat != null) {
+                              onBarTap(stat);
+                            }
+                          },
+                          child: CustomPaint(
+                            size: Size(width, chartHeight),
                           painter: _UsageChartPainter(
-                            stats: stats,
+                            bars: barGeometries,
                             maxValue: maxValue,
                             ticks: ticks,
                             barWidth: _barWidth,
@@ -247,11 +346,10 @@ class _UsageChartArea extends StatelessWidget {
                             horizontalPadding: _horizontalPadding,
                             gradient: AppGradients.progress,
                             nameStyle: nameStyle,
-                            descriptionStyle:
-                                descriptionStyle.copyWith(color: descriptionColor),
                             valueStyle: valueStyle,
                             gridColor: gridColor,
                             valueFormatter: valueFormatter,
+                          ),
                           ),
                         ),
                       );
@@ -283,6 +381,35 @@ class _UsageChartArea extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  _BarGeometry _createGeometry({
+    required DeviceUsageStat stat,
+    required int index,
+    required double safeMax,
+    required double verticalChartHeight,
+    required double chartHeight,
+  }) {
+    final left = _horizontalPadding + index * (_barWidth + _barSpacing);
+    final clampedSessions = stat.sessions.toDouble().clamp(0, safeMax);
+    final normalized = safeMax == 0 ? 0 : clampedSessions / safeMax;
+    final barTop = _topPadding + (1 - normalized) * verticalChartHeight;
+    final barBottom = chartHeight - _bottomPadding;
+    final double barHeight = math.max(4.0, barBottom - barTop);
+    final rect = RRect.fromRectAndRadius(
+      Rect.fromLTWH(left, barBottom - barHeight, _barWidth, barHeight),
+      const Radius.circular(AppRadius.card),
+    );
+    return _BarGeometry(stat: stat, rect: rect);
+  }
+
+  DeviceUsageStat? _hitTestBar(Offset position, List<_BarGeometry> geometries) {
+    for (final bar in geometries) {
+      if (bar.rect.contains(position)) {
+        return bar.stat;
+      }
+    }
+    return null;
   }
 }
 
@@ -362,7 +489,7 @@ class _UsageAxisPainter extends CustomPainter {
 
 class _UsageChartPainter extends CustomPainter {
   _UsageChartPainter({
-    required this.stats,
+    required this.bars,
     required this.maxValue,
     required this.ticks,
     required this.barWidth,
@@ -372,13 +499,12 @@ class _UsageChartPainter extends CustomPainter {
     required this.horizontalPadding,
     required this.gradient,
     required this.nameStyle,
-    required this.descriptionStyle,
     required this.valueStyle,
     required this.gridColor,
     required this.valueFormatter,
   });
 
-  final List<DeviceUsageStat> stats;
+  final List<_BarGeometry> bars;
   final double maxValue;
   final List<double> ticks;
   final double barWidth;
@@ -388,7 +514,6 @@ class _UsageChartPainter extends CustomPainter {
   final double horizontalPadding;
   final LinearGradient gradient;
   final TextStyle nameStyle;
-  final TextStyle descriptionStyle;
   final TextStyle valueStyle;
   final Color gridColor;
   final String Function(int) valueFormatter;
@@ -423,21 +548,12 @@ class _UsageChartPainter extends CustomPainter {
       gridPaint,
     );
 
-    for (var i = 0; i < stats.length; i++) {
-      final stat = stats[i];
-      final left = horizontalPadding + i * (barWidth + barSpacing);
-      final barTop = _yForValue(
-        stat.sessions.toDouble(),
-        chartHeight: chartHeight,
-        safeMax: safeMax,
-        topPadding: topPadding,
-      );
-      final barBottom = size.height - bottomPadding;
-      final double barHeight = math.max(4.0, barBottom - barTop);
-      final barRect = RRect.fromRectAndRadius(
-        Rect.fromLTWH(left, barBottom - barHeight, barWidth, barHeight),
-        const Radius.circular(AppRadius.card),
-      );
+    for (final bar in bars) {
+      final stat = bar.stat;
+      final barRect = bar.rect;
+      final left = barRect.left;
+      final barBottom = barRect.bottom;
+      final barHeight = barRect.height;
       final paint = Paint()
         ..shader = gradient.createShader(barRect.outerRect);
       canvas.drawRRect(barRect, paint);
@@ -460,62 +576,47 @@ class _UsageChartPainter extends CustomPainter {
         Offset(left + (barWidth - valuePainter.width) / 2, valueTop),
       );
 
-      final namePainter = TextPainter(
-        text: TextSpan(text: stat.name, style: nameStyle.copyWith(color: Colors.black.withOpacity(0.85))),
-        textAlign: TextAlign.center,
-        textDirection: TextDirection.ltr,
-        maxLines: 2,
-        ellipsis: '…',
-      )..layout(maxWidth: barWidth - 16);
+      if (stat.sessions > 10) {
+        final namePainter = TextPainter(
+          text: TextSpan(
+            text: stat.name,
+            style: nameStyle.copyWith(
+              color: Colors.white,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          textAlign: TextAlign.center,
+          textDirection: TextDirection.ltr,
+          maxLines: 2,
+          ellipsis: '…',
+        )..layout(maxWidth: barWidth - 24);
 
-      final descriptionPainter = stat.description.isEmpty
-          ? null
-          : (TextPainter(
-              text: TextSpan(
-                text: stat.description,
-                style: descriptionStyle,
-              ),
-              textAlign: TextAlign.center,
-              textDirection: TextDirection.ltr,
-              maxLines: 2,
-              ellipsis: '…',
-            )..layout(maxWidth: barWidth - 16));
-
-      final combinedHeight = namePainter.height +
-          (descriptionPainter?.height ?? 0) +
-          (descriptionPainter != null ? 6 : 0);
-      final hasRoomInside = barHeight - 24 >= combinedHeight;
-
-      double textTop;
-      if (hasRoomInside) {
-        textTop = barRect.top + (barHeight - combinedHeight) / 2;
-      } else {
-        textTop = barRect.bottom + 8;
-      }
-
-      namePainter.paint(
-        canvas,
-        Offset(left + (barWidth - namePainter.width) / 2, textTop),
-      );
-
-      if (descriptionPainter != null) {
-        final descTop = textTop + namePainter.height + 6;
-        descriptionPainter.paint(
-          canvas,
-          Offset(left + (barWidth - descriptionPainter.width) / 2, descTop),
-        );
+        final availableHeight = barHeight - 20;
+        if (namePainter.height <= availableHeight) {
+          final labelTop = barRect.top + (barHeight - namePainter.height) / 2;
+          namePainter.paint(
+            canvas,
+            Offset(left + (barWidth - namePainter.width) / 2, labelTop),
+          );
+        }
       }
     }
   }
 
   @override
   bool shouldRepaint(covariant _UsageChartPainter oldDelegate) {
-    return stats != oldDelegate.stats ||
+    return bars != oldDelegate.bars ||
         maxValue != oldDelegate.maxValue ||
         nameStyle != oldDelegate.nameStyle ||
-        descriptionStyle != oldDelegate.descriptionStyle ||
         gridColor != oldDelegate.gridColor;
   }
+}
+
+class _BarGeometry {
+  const _BarGeometry({required this.stat, required this.rect});
+
+  final DeviceUsageStat stat;
+  final RRect rect;
 }
 
 double _yForValue(

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1074,6 +1074,16 @@
   ,"@reportViewSurveysTitle": {"description": "Aktion zum Öffnen der Umfragenübersicht"}
   ,"reportDeviceFilterHint": "Geräte oder Beschreibungen suchen"
   ,"@reportDeviceFilterHint": {"description": "Hinweistext für die Gerätesuche"}
+  ,"reportUsageRange7Days": "Letzte 7 Tage"
+  ,"@reportUsageRange7Days": {"description": "Filteroption für die letzten 7 Tage"}
+  ,"reportUsageRange30Days": "Letzte 30 Tage"
+  ,"@reportUsageRange30Days": {"description": "Filteroption für die letzten 30 Tage"}
+  ,"reportUsageRange90Days": "Letzte 90 Tage"
+  ,"@reportUsageRange90Days": {"description": "Filteroption für die letzten 90 Tage"}
+  ,"reportUsageRange365Days": "Letzte 365 Tage"
+  ,"@reportUsageRange365Days": {"description": "Filteroption für die letzten 365 Tage"}
+  ,"reportUsageRangeAll": "Gesamt"
+  ,"@reportUsageRangeAll": {"description": "Filteroption für den gesamten Zeitraum"}
   ,"reportDeviceUsageEmpty": "Noch keine Nutzungsdaten vorhanden"
   ,"@reportDeviceUsageEmpty": {"description": "Hinweis, wenn keine Nutzungsdaten vorliegen"}
   ,"reportDeviceUsageNoMatches": "Keine Geräte entsprechen deiner Suche"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1072,6 +1072,16 @@
   ,"@reportViewSurveysTitle": {"description": "Action title to open the survey overview"}
   ,"reportDeviceFilterHint": "Search devices or descriptions"
   ,"@reportDeviceFilterHint": {"description": "Hint text for the device usage search field"}
+  ,"reportUsageRange7Days": "Last 7 days"
+  ,"@reportUsageRange7Days": {"description": "Filter option label for viewing usage data of the last 7 days"}
+  ,"reportUsageRange30Days": "Last 30 days"
+  ,"@reportUsageRange30Days": {"description": "Filter option label for viewing usage data of the last 30 days"}
+  ,"reportUsageRange90Days": "Last 90 days"
+  ,"@reportUsageRange90Days": {"description": "Filter option label for viewing usage data of the last 90 days"}
+  ,"reportUsageRange365Days": "Last 365 days"
+  ,"@reportUsageRange365Days": {"description": "Filter option label for viewing usage data of the last 365 days"}
+  ,"reportUsageRangeAll": "All time"
+  ,"@reportUsageRangeAll": {"description": "Filter option label for viewing usage data without a time restriction"}
   ,"reportDeviceUsageEmpty": "No usage data available yet"
   ,"@reportDeviceUsageEmpty": {"description": "Message shown when there is no usage data"}
   ,"reportDeviceUsageNoMatches": "No devices match your search"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2024,6 +2024,21 @@ abstract class AppLocalizations {
   /// No description provided for @reportDeviceFilterHint.
   String get reportDeviceFilterHint;
 
+  /// No description provided for @reportUsageRange7Days.
+  String get reportUsageRange7Days;
+
+  /// No description provided for @reportUsageRange30Days.
+  String get reportUsageRange30Days;
+
+  /// No description provided for @reportUsageRange90Days.
+  String get reportUsageRange90Days;
+
+  /// No description provided for @reportUsageRange365Days.
+  String get reportUsageRange365Days;
+
+  /// No description provided for @reportUsageRangeAll.
+  String get reportUsageRangeAll;
+
   /// No description provided for @reportDeviceUsageEmpty.
   String get reportDeviceUsageEmpty;
 

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1046,6 +1046,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get reportDeviceFilterHint => 'Geräte oder Beschreibungen suchen';
+  String get reportUsageRange7Days => 'Letzte 7 Tage';
+  String get reportUsageRange30Days => 'Letzte 30 Tage';
+  String get reportUsageRange90Days => 'Letzte 90 Tage';
+  String get reportUsageRange365Days => 'Letzte 365 Tage';
+  String get reportUsageRangeAll => 'Gesamt';
 
   @override
   String get reportDeviceUsageEmpty =>

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1046,6 +1046,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get reportDeviceFilterHint => 'Search devices or descriptions';
+  String get reportUsageRange7Days => 'Last 7 days';
+  String get reportUsageRange30Days => 'Last 30 days';
+  String get reportUsageRange90Days => 'Last 90 days';
+  String get reportUsageRange365Days => 'Last 365 days';
+  String get reportUsageRangeAll => 'All time';
 
   @override
   String get reportDeviceUsageEmpty => 'No usage data available yet';

--- a/test/usecases/report_usecases_test.dart
+++ b/test/usecases/report_usecases_test.dart
@@ -8,9 +8,15 @@ class FakeReportRepository implements ReportRepository {
   int usageCalls = 0;
   int timeCalls = 0;
 
+  DateTime? lastSince;
+
   @override
-  Future<List<DeviceUsageStat>> fetchDeviceUsageStats(String gymId) async {
+  Future<List<DeviceUsageStat>> fetchDeviceUsageStats(
+    String gymId, {
+    DateTime? since,
+  }) async {
     usageCalls++;
+    lastSince = since;
     return const [
       DeviceUsageStat(id: 'd1', name: 'Device', sessions: 1),
     ];
@@ -28,9 +34,11 @@ void main() {
     test('GetDeviceUsageStats delegates to repository', () async {
       final repo = FakeReportRepository();
       final usecase = GetDeviceUsageStats(repo);
-      final result = await usecase.execute('g1');
+      final now = DateTime(2024, 01, 15);
+      final result = await usecase.execute('g1', since: now);
       expect(result.first.sessions, 1);
       expect(repo.usageCalls, 1);
+      expect(repo.lastSince, now);
     });
 
     test('GetAllLogTimestamps delegates to repository', () async {

--- a/test/widgets/report_screen_test.dart
+++ b/test/widgets/report_screen_test.dart
@@ -21,7 +21,10 @@ class FakeReportRepository implements ReportRepository {
   final List<DeviceUsageStat> usage;
   final List<DateTime> times;
   @override
-  Future<List<DeviceUsageStat>> fetchDeviceUsageStats(String gymId) async => usage;
+  Future<List<DeviceUsageStat>> fetchDeviceUsageStats(
+    String gymId, {
+    DateTime? since,
+  }) async => usage;
   @override
   Future<List<DateTime>> fetchAllLogTimestamps(String gymId) async => times;
 }
@@ -39,6 +42,8 @@ void main() {
       firestore: FakeFirebaseFirestore(),
       log: (_, [__]) {},
     );
+
+    await reportProvider.loadReport('g1');
 
     await tester.pumpWidget(
       MultiProvider(
@@ -71,6 +76,8 @@ void main() {
       firestore: FakeFirebaseFirestore(),
       log: (_, [__]) {},
     );
+
+    await reportProvider.loadReport('g1');
 
     await tester.pumpWidget(
       MultiProvider(


### PR DESCRIPTION
## Summary
- add selectable time ranges to the device usage chart with a default 30 day filter
- extend the report provider/repository to fetch usage data scoped to a selected date range
- render exercise names inside bars when activity is high and show detailed info in a bottom sheet on tap, plus update localizations and tests

## Testing
- not run (Flutter SDK is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e414adef808320949c6f9df5728726