### PR TITLE
Improve report loading concurrency

### DIFF
--- a/lib/core/providers/report_provider.dart
+++ b/lib/core/providers/report_provider.dart
@@ -59,8 +59,11 @@ class ReportProvider extends ChangeNotifier {
     errorMessage = null;
     notifyListeners();
     try {
-      usageStats = await _fetchUsageStats(gymId);
-      heatmapDates = await _getTimestamps.execute(gymId);
+      final usageFuture = _fetchUsageStats(gymId);
+      final timestampsFuture = _getTimestamps.execute(gymId);
+
+      usageStats = await usageFuture;
+      heatmapDates = await timestampsFuture;
       state = ReportState.loaded;
     } catch (e) {
       errorMessage = e.toString();

--- a/lib/features/report/data/repositories/report_repository_impl.dart
+++ b/lib/features/report/data/repositories/report_repository_impl.dart
@@ -16,9 +16,7 @@ class ReportRepositoryImpl implements ReportRepository {
     DateTime? since,
   }) async {
     final devices = await _source.fetchDevices(gymId);
-    final List<DeviceUsageStat> stats = [];
-
-    for (final deviceDoc in devices) {
+    final stats = await Future.wait(devices.map((deviceDoc) async {
       final deviceId = deviceDoc.id;
       final deviceData = deviceDoc.data();
       final deviceName = (deviceData?['name'] as String?)?.trim();
@@ -38,15 +36,13 @@ class ReportRepositoryImpl implements ReportRepository {
       }
 
       // Anzahl der Sessions = Anzahl der eindeutigen sessionIds
-      stats.add(
-        DeviceUsageStat(
-          id: deviceId,
-          name: deviceName?.isNotEmpty == true ? deviceName! : deviceId,
-          description: description ?? '',
-          sessions: sessionIds.length,
-        ),
+      return DeviceUsageStat(
+        id: deviceId,
+        name: deviceName?.isNotEmpty == true ? deviceName! : deviceId,
+        description: description ?? '',
+        sessions: sessionIds.length,
       );
-    }
+    }));
 
     return stats;
   }
@@ -54,20 +50,20 @@ class ReportRepositoryImpl implements ReportRepository {
   @override
   Future<List<DateTime>> fetchAllLogTimestamps(String gymId) async {
     final devices = await _source.fetchDevices(gymId);
-    final List<DateTime> allTimestamps = [];
-
-    for (final deviceDoc in devices) {
+    final allTimestamps = await Future.wait(devices.map((deviceDoc) async {
       final deviceId = deviceDoc.id;
       final logs = await _source.fetchLogsForDevice(gymId, deviceId);
+      final timestamps = <DateTime>[];
       for (final logDoc in logs) {
         final data = logDoc.data();
         final ts = data?['timestamp'];
         if (ts is Timestamp) {
-          allTimestamps.add(ts.toDate());
+          timestamps.add(ts.toDate());
         }
       }
-    }
+      return timestamps;
+    }));
 
-    return allTimestamps;
+    return allTimestamps.expand((timestamps) => timestamps).toList();
   }
 }


### PR DESCRIPTION
## Summary
- load device usage stats and log timestamps concurrently in the report provider
- fetch device log details in parallel for all devices to cut down on sequential Firestore calls
- flatten timestamp results after parallel retrieval for efficient consumption

## Testing
- flutter analyze *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e41bb661e483208ad49a776bd62eb4