### PR TITLE
Capture muscle XP context from session snapshots

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -7,7 +7,11 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart'; // mapEquals
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:tapem/core/providers/exercise_provider.dart';
+import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/features/device/data/repositories/device_repository_impl.dart';
 import 'package:tapem/features/device/data/sources/firestore_device_source.dart';
 import 'package:tapem/features/device/domain/models/device.dart';
@@ -31,6 +35,7 @@ import 'package:tapem/core/logging/xp_trace.dart';
 import 'package:tapem/core/time/logic_day.dart';
 import 'package:tapem/core/recent_devices_store.dart';
 import 'package:tapem/core/services/workout_session_duration_service.dart';
+import '../../main.dart';
 
 enum DeviceSetFieldFocus {
   weight,
@@ -135,6 +140,16 @@ String _setsBrief(List<Map<String, dynamic>> sets) {
 String? resolveDeviceId(DeviceSessionSnapshot snap) {
   if (snap.deviceId.isNotEmpty) return snap.deviceId;
   return null;
+}
+
+class _ResolvedMuscleAssignments {
+  final List<String> primary;
+  final List<String> secondary;
+
+  const _ResolvedMuscleAssignments({
+    required this.primary,
+    required this.secondary,
+  });
 }
 
 class DeviceProvider extends ChangeNotifier {
@@ -1145,11 +1160,18 @@ class DeviceProvider extends ChangeNotifier {
           .doc(userId);
       batch.set(noteRef, {'note': _note, 'updatedAt': ts});
 
+      final assignments = _resolveMuscleAssignments(
+        device: _device!,
+        exerciseId: _device!.isMulti ? _currentExerciseId : null,
+      );
+
       final snapshot = _buildSnapshot(
         sessionId: sessionId,
         device: _device!,
         exerciseId: _currentExerciseId,
         userId: userId,
+        primaryMuscleGroupIds: assignments.primary,
+        secondaryMuscleGroupIds: assignments.secondary,
       );
 
       await batch.commit();
@@ -1210,6 +1232,8 @@ class DeviceProvider extends ChangeNotifier {
             isMulti: _device!.isMulti,
             exerciseId: _currentExerciseId,
             traceId: traceId,
+            primaryMuscleGroupIds: assignments.primary,
+            secondaryMuscleGroupIds: assignments.secondary,
           );
           if (xpResult != null) {
             XpTrace.log('CALL_RESULT', {
@@ -1298,6 +1322,8 @@ class DeviceProvider extends ChangeNotifier {
     required Device device,
     String? exerciseId,
     required String userId,
+    required List<String> primaryMuscleGroupIds,
+    required List<String> secondaryMuscleGroupIds,
   }) {
     return DeviceSessionSnapshot(
       sessionId: sessionId,
@@ -1336,6 +1362,128 @@ class DeviceProvider extends ChangeNotifier {
           .toList(),
       renderVersion: 1,
       uiHints: {'plannedTableCollapsed': false},
+      primaryMuscleGroupIds: primaryMuscleGroupIds,
+      secondaryMuscleGroupIds: secondaryMuscleGroupIds,
+      muscleGroupRevision: DateTime.now().millisecondsSinceEpoch,
+    );
+  }
+
+  _ResolvedMuscleAssignments _resolveMuscleAssignments({
+    required Device device,
+    String? exerciseId,
+  }) {
+    final ctx = navigatorKey.currentContext;
+    final muscleProv =
+        ctx != null ? Provider.maybeOf<MuscleGroupProvider>(ctx, listen: false) : null;
+    final exerciseProv =
+        ctx != null ? Provider.maybeOf<ExerciseProvider>(ctx, listen: false) : null;
+
+    final groups = muscleProv?.groups ?? const [];
+    final idLookup = {for (final g in groups) g.id: g.id};
+    final regionLookup = {for (final g in groups) g.region.name: g.id};
+    final nameLookup = {for (final g in groups) g.name: g.id};
+
+    List<String> normalize(Iterable<String> raw) {
+      final normalized = <String>[];
+      final seen = <String>{};
+      for (final entry in raw) {
+        final value = entry.trim();
+        if (value.isEmpty) continue;
+        String candidate = value;
+        if (idLookup.containsKey(value)) {
+          candidate = value;
+        } else if (regionLookup.containsKey(value)) {
+          candidate = regionLookup[value]!;
+        } else if (nameLookup.containsKey(value)) {
+          candidate = nameLookup[value]!;
+        }
+        if (seen.add(candidate)) {
+          normalized.add(candidate);
+        }
+      }
+      return normalized;
+    }
+
+    void addAll(Iterable<String> source, List<String> target) {
+      for (final id in normalize(source)) {
+        if (!target.contains(id)) {
+          target.add(id);
+        }
+      }
+    }
+
+    final primary = <String>[];
+    final secondary = <String>[];
+
+    if (device.isMulti) {
+      if (exerciseId != null && exerciseId.isNotEmpty) {
+        final exercise = exerciseProv?.exercises.firstWhereOrNull(
+          (e) => e.id == exerciseId,
+        );
+        if (exercise != null) {
+          addAll(exercise.primaryMuscleGroupIds, primary);
+          addAll(exercise.secondaryMuscleGroupIds, secondary);
+        }
+        if (primary.isEmpty && secondary.isEmpty) {
+          addAll(device.primaryMuscleGroups, primary);
+          addAll(device.secondaryMuscleGroups, secondary);
+        }
+        if (primary.isEmpty && device.muscleGroupIds.isNotEmpty) {
+          addAll(device.muscleGroupIds, primary);
+        }
+        if (primary.isEmpty && muscleProv != null) {
+          final linked = muscleProv.groups
+              .where((g) => g.exerciseIds.contains(exerciseId))
+              .map((g) => g.id);
+          addAll(linked, primary);
+        }
+      }
+      if (primary.isEmpty && secondary.isEmpty) {
+        addAll(device.primaryMuscleGroups, primary);
+        addAll(device.secondaryMuscleGroups, secondary);
+        if (primary.isEmpty && device.muscleGroupIds.isNotEmpty) {
+          addAll(device.muscleGroupIds, primary);
+        }
+        if (primary.isEmpty && muscleProv != null) {
+          final linked = muscleProv.groups
+              .where((g) => g.deviceIds.contains(device.uid))
+              .map((g) => g.id);
+          addAll(linked, primary);
+        }
+      }
+    } else {
+      addAll(device.primaryMuscleGroups, primary);
+      addAll(device.secondaryMuscleGroups, secondary);
+      if (primary.isEmpty && device.muscleGroupIds.isNotEmpty) {
+        addAll(device.muscleGroupIds, primary);
+      }
+      if (muscleProv != null) {
+        if (primary.isEmpty) {
+          final linkedPrimary = muscleProv.groups
+              .where((g) => g.primaryDeviceIds.contains(device.uid))
+              .map((g) => g.id);
+          addAll(linkedPrimary, primary);
+        }
+        if (secondary.isEmpty) {
+          final linkedSecondary = muscleProv.groups
+              .where((g) => g.secondaryDeviceIds.contains(device.uid))
+              .map((g) => g.id);
+          addAll(linkedSecondary, secondary);
+        }
+      }
+    }
+
+    final primarySet = primary.toSet();
+    final filteredSecondary = <String>[];
+    for (final id in secondary) {
+      if (!primarySet.contains(id)) {
+        filteredSecondary.add(id);
+      }
+    }
+
+    return _ResolvedMuscleAssignments(
+      primary: List.unmodifiable(primary),
+      secondary: List.unmodifiable(filteredSecondary),
     );
   }
 

--- a/lib/core/providers/xp_provider.dart
+++ b/lib/core/providers/xp_provider.dart
@@ -48,6 +48,8 @@ class XpProvider extends ChangeNotifier {
       required bool isMulti,
       String? exerciseId,
       required String traceId,
+      List<String> primaryMuscleGroupIds = const [],
+      List<String> secondaryMuscleGroupIds = const [],
     }) async {
       assert(LevelService.xpPerSession == 50);
       XpTrace.log('PROVIDER_IN', {
@@ -77,6 +79,8 @@ class XpProvider extends ChangeNotifier {
           isMulti: isMulti,
           exerciseId: exerciseId,
           traceId: traceId,
+          primaryMuscleGroupIds: primaryMuscleGroupIds,
+          secondaryMuscleGroupIds: secondaryMuscleGroupIds,
         );
         XpTrace.log('PROVIDER_OUT', {
           'result': result.name,

--- a/lib/features/device/domain/models/device_session_snapshot.dart
+++ b/lib/features/device/domain/models/device_session_snapshot.dart
@@ -13,6 +13,9 @@ class DeviceSessionSnapshot {
   final List<SetEntry> sets;
   final int renderVersion;
   final Map<String, dynamic>? uiHints;
+  final List<String> primaryMuscleGroupIds;
+  final List<String> secondaryMuscleGroupIds;
+  final int? muscleGroupRevision;
 
   const DeviceSessionSnapshot({
     required this.sessionId,
@@ -24,6 +27,9 @@ class DeviceSessionSnapshot {
     required this.sets,
     this.renderVersion = 1,
     this.uiHints,
+    this.primaryMuscleGroupIds = const [],
+    this.secondaryMuscleGroupIds = const [],
+    this.muscleGroupRevision,
   });
 
   factory DeviceSessionSnapshot.fromJson(Map<String, dynamic> j) {
@@ -39,6 +45,15 @@ class DeviceSessionSnapshot {
           .toList(),
       renderVersion: j['renderVersion'] as int? ?? 1,
       uiHints: j['uiHints'] as Map<String, dynamic>?,
+      primaryMuscleGroupIds:
+          (j['primaryMuscleGroupIds'] as List<dynamic>? ?? [])
+              .map((e) => e.toString())
+              .toList(),
+      secondaryMuscleGroupIds:
+          (j['secondaryMuscleGroupIds'] as List<dynamic>? ?? [])
+              .map((e) => e.toString())
+              .toList(),
+      muscleGroupRevision: (j['muscleGroupRevision'] as num?)?.toInt(),
     );
   }
 
@@ -52,6 +67,9 @@ class DeviceSessionSnapshot {
         'sets': sets.map((s) => s.toJson()).toList(),
         'renderVersion': renderVersion,
         'uiHints': uiHints,
+        'primaryMuscleGroupIds': primaryMuscleGroupIds,
+        'secondaryMuscleGroupIds': secondaryMuscleGroupIds,
+        'muscleGroupRevision': muscleGroupRevision,
       };
 }
 

--- a/lib/features/training_details/data/repositories/session_repository_impl.dart
+++ b/lib/features/training_details/data/repositories/session_repository_impl.dart
@@ -213,6 +213,8 @@ class SessionRepositoryImpl implements SessionRepository {
       sessionId: session.sessionId,
       dayKey: derivedDayKey,
       exerciseIds: exerciseIds,
+      primaryMuscleGroupIds: snapshot?.primaryMuscleGroupIds ?? const [],
+      secondaryMuscleGroupIds: snapshot?.secondaryMuscleGroupIds ?? const [],
     );
   }
 }

--- a/lib/features/xp/data/repositories/xp_repository_impl.dart
+++ b/lib/features/xp/data/repositories/xp_repository_impl.dart
@@ -17,6 +17,8 @@ class XpRepositoryImpl implements XpRepository {
       required bool isMulti,
       String? exerciseId,
       required String traceId,
+      List<String> primaryMuscleGroupIds = const [],
+      List<String> secondaryMuscleGroupIds = const [],
     }) {
       return _source
           .addSessionXp(
@@ -28,6 +30,8 @@ class XpRepositoryImpl implements XpRepository {
         isMulti: isMulti,
         exerciseId: exerciseId,
         traceId: traceId,
+        primaryMuscleGroupIds: primaryMuscleGroupIds,
+        secondaryMuscleGroupIds: secondaryMuscleGroupIds,
       )
           .then((result) {
         elogDeviceXp('REPO_RETURN', {

--- a/lib/features/xp/data/sources/firestore_xp_source.dart
+++ b/lib/features/xp/data/sources/firestore_xp_source.dart
@@ -26,6 +26,8 @@ class FirestoreXpSource {
         required bool isMulti,
         String? exerciseId,
         required String traceId,
+        List<String> primaryMuscleGroupIds = const [],
+        List<String> secondaryMuscleGroupIds = const [],
       }) async {
         final dayKey = logicDayKey(DateTime.now().toUtc());
         final dateStr = dayKey;
@@ -111,6 +113,14 @@ class FirestoreXpSource {
           exerciseId: exerciseId,
           traceId: traceId,
         );
+        if (result == DeviceXpResult.okAdded) {
+          await _applyMuscleXp(
+            statsRef: statsRef,
+            primaryMuscleGroupIds: primaryMuscleGroupIds,
+            secondaryMuscleGroupIds: secondaryMuscleGroupIds,
+            traceId: traceId,
+          );
+        }
         XpTrace.log('FS_OUT', {
           'result': result.name,
           'traceId': traceId,
@@ -125,6 +135,8 @@ class FirestoreXpSource {
     required String sessionId,
     required String dayKey,
     Iterable<String> exerciseIds = const [],
+    List<String> primaryMuscleGroupIds = const [],
+    List<String> secondaryMuscleGroupIds = const [],
   }) async {
     final uniqueExercises = exerciseIds.where((e) => e.isNotEmpty).toSet();
     final userRef = _firestore.collection('users').doc(userId);
@@ -221,6 +233,97 @@ class FirestoreXpSource {
       'deviceId': deviceId,
       'sessionId': sessionId,
       'dayKey': dayKey,
+    });
+
+    final delta = _buildMuscleXpDelta(
+      primaryMuscleGroupIds,
+      secondaryMuscleGroupIds,
+    );
+    if (delta.isNotEmpty) {
+      final updates = <String, dynamic>{};
+      delta.forEach((key, value) {
+        updates['${key}XP'] = FieldValue.increment(-value);
+      });
+      await statsRef.set(updates, SetOptions(merge: true));
+      XpTrace.log('FS_MUSCLE_REMOVE', {
+        'traceId': 'remove:$dayKey:$sessionId',
+        'primary': primaryMuscleGroupIds.length,
+        'secondary': secondaryMuscleGroupIds.length,
+        'delta': delta,
+      });
+    }
+  }
+
+  Map<String, int> _buildMuscleXpDelta(
+    List<String> primaryMuscleGroupIds,
+    List<String> secondaryMuscleGroupIds,
+  ) {
+    final order = <String>[];
+    final weights = <String, int>{};
+    final seenPrimary = <String>{};
+    final seenSecondary = <String>{};
+
+    void push(String id, int weight, Set<String> seen) {
+      if (id.isEmpty) return;
+      if (seen.add(id)) {
+        order.add(id);
+      }
+      weights[id] = (weights[id] ?? 0) + weight;
+    }
+
+    for (final id in primaryMuscleGroupIds) {
+      push(id, 2, seenPrimary);
+    }
+    for (final id in secondaryMuscleGroupIds) {
+      if (seenPrimary.contains(id)) {
+        continue;
+      }
+      push(id, 1, seenSecondary);
+    }
+
+    final totalWeight = weights.values.fold<int>(0, (sum, w) => sum + w);
+    if (totalWeight == 0) {
+      return const {};
+    }
+
+    final baseXp = LevelService.xpPerSession;
+    final xpPerWeight = baseXp ~/ totalWeight;
+    var remainder = baseXp % totalWeight;
+    final delta = <String, int>{};
+    for (final id in order) {
+      final weight = weights[id] ?? 0;
+      if (weight == 0) continue;
+      var value = weight * xpPerWeight;
+      if (remainder > 0) {
+        value += 1;
+        remainder -= 1;
+      }
+      delta[id] = value;
+    }
+    return delta;
+  }
+
+  Future<void> _applyMuscleXp({
+    required DocumentReference<Map<String, dynamic>> statsRef,
+    required List<String> primaryMuscleGroupIds,
+    required List<String> secondaryMuscleGroupIds,
+    required String traceId,
+  }) async {
+    final delta = _buildMuscleXpDelta(
+      primaryMuscleGroupIds,
+      secondaryMuscleGroupIds,
+    );
+    if (delta.isEmpty) return;
+    final updates = <String, dynamic>{};
+    delta.forEach((key, value) {
+      updates['${key}XP'] = FieldValue.increment(value);
+    });
+    await statsRef.set(updates, SetOptions(merge: true));
+    XpTrace.log('FS_MUSCLE_APPLY', {
+      'traceId': traceId,
+      'primary': primaryMuscleGroupIds.length,
+      'secondary': secondaryMuscleGroupIds.length,
+      'delta': delta,
     });
   }
 

--- a/lib/features/xp/domain/xp_repository.dart
+++ b/lib/features/xp/domain/xp_repository.dart
@@ -10,6 +10,8 @@ abstract class XpRepository {
     required bool isMulti,
     String? exerciseId,
     required String traceId,
+    List<String> primaryMuscleGroupIds = const [],
+    List<String> secondaryMuscleGroupIds = const [],
   });
 
   Stream<int> watchDayXp({required String userId, required DateTime date});

--- a/test/features/device/domain/models/device_session_snapshot_test.dart
+++ b/test/features/device/domain/models/device_session_snapshot_test.dart
@@ -20,6 +20,9 @@ void main() {
         ),
         SetEntry(kg: 0, reps: 5, isBodyweight: true),
       ],
+      primaryMuscleGroupIds: const ['m1'],
+      secondaryMuscleGroupIds: const ['m2'],
+      muscleGroupRevision: 123,
     );
 
     final json = snapshot.toJson();
@@ -33,5 +36,8 @@ void main() {
     expect(decoded.sets.first.drops.first.kg, 10);
     expect(decoded.sets[1].isBodyweight, true);
     expect(decoded.sets[1].kg, 0);
+    expect(decoded.primaryMuscleGroupIds, ['m1']);
+    expect(decoded.secondaryMuscleGroupIds, ['m2']);
+    expect(decoded.muscleGroupRevision, 123);
   });
 }

--- a/test/providers/device_provider_test.dart
+++ b/test/providers/device_provider_test.dart
@@ -105,6 +105,8 @@ class _ExerciseSnapRepo implements DeviceRepository {
       required bool isMulti,
       String? exerciseId,
       required String traceId,
+      List<String> primaryMuscleGroupIds = const [],
+      List<String> secondaryMuscleGroupIds = const [],
     }) async {
       calls++;
       return DeviceXpResult.okAdded;

--- a/test/providers/xp_provider_test.dart
+++ b/test/providers/xp_provider_test.dart
@@ -22,6 +22,8 @@ class FakeXpRepository implements XpRepository {
       required bool isMulti,
       String? exerciseId,
       required String traceId,
+      List<String> primaryMuscleGroupIds = const [],
+      List<String> secondaryMuscleGroupIds = const [],
     }) async {
       addCalls++;
       return DeviceXpResult.okAdded;


### PR DESCRIPTION
## Summary
- resolve muscle group IDs when saving device sessions and persist them in snapshots
- propagate primary and secondary muscle IDs through the XP pipeline and update rank stats
- ensure session removal rolls back muscle XP and adjust related unit tests

## Testing
- not run (Flutter tooling unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3f51ae39c8320bc0ed87395c07f1d