### PR TITLE
Refactor muscle groups to simplified set

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -1374,9 +1374,9 @@ class DeviceProvider extends ChangeNotifier {
   }) {
     final ctx = navigatorKey.currentContext;
     final muscleProv =
-        ctx != null ? Provider.maybeOf<MuscleGroupProvider>(ctx, listen: false) : null;
+        ctx != null ? Provider.of<MuscleGroupProvider>(ctx, listen: false) : null;
     final exerciseProv =
-        ctx != null ? Provider.maybeOf<ExerciseProvider>(ctx, listen: false) : null;
+        ctx != null ? Provider.of<ExerciseProvider>(ctx, listen: false) : null;
 
     final groups = muscleProv?.groups ?? const [];
     final idLookup = {for (final g in groups) g.id: g.id};

--- a/lib/features/device/presentation/widgets/muscle_chips.dart
+++ b/lib/features/device/presentation/widgets/muscle_chips.dart
@@ -13,44 +13,26 @@ class MuscleChips extends StatelessWidget {
 
   String _fallbackName(MuscleRegion region) {
     switch (region) {
-      case MuscleRegion.chest:
-        return 'Chest';
-      case MuscleRegion.anteriorDeltoid:
-        return 'Anterior Deltoid';
-      case MuscleRegion.biceps:
-        return 'Biceps';
-      case MuscleRegion.wristFlexors:
-        return 'Wrist Flexors';
-      case MuscleRegion.lats:
-        return 'Lats';
-      case MuscleRegion.midBack:
-        return 'Mid Back';
-      case MuscleRegion.posteriorDeltoid:
-        return 'Posterior Deltoid';
-      case MuscleRegion.upperTrapezius:
-        return 'Upper Trapezius';
-      case MuscleRegion.triceps:
-        return 'Triceps';
-      case MuscleRegion.rectusAbdominis:
-        return 'Rectus Abdominis';
-      case MuscleRegion.obliques:
-        return 'Obliques';
-      case MuscleRegion.transversusAbdominis:
-        return 'Transversus Abdominis';
-      case MuscleRegion.quadriceps:
-        return 'Quadriceps';
+      case MuscleRegion.brust:
+        return 'Brust';
+      case MuscleRegion.schulter:
+        return 'Schulter';
+      case MuscleRegion.nacken:
+        return 'Nacken';
+      case MuscleRegion.ruecken:
+        return 'Rücken';
+      case MuscleRegion.bizeps:
+        return 'Bizeps';
+      case MuscleRegion.trizeps:
+        return 'Trizeps';
+      case MuscleRegion.bauch:
+        return 'Bauch';
+      case MuscleRegion.quadrizeps:
+        return 'Quadrizeps';
       case MuscleRegion.hamstrings:
         return 'Hamstrings';
-      case MuscleRegion.glutes:
-        return 'Glutes';
-      case MuscleRegion.adductors:
-        return 'Adductors';
-      case MuscleRegion.abductors:
-        return 'Abductors';
-      case MuscleRegion.calves:
-        return 'Calves';
-      case MuscleRegion.tibialisAnterior:
-        return 'Tibialis Anterior';
+      case MuscleRegion.waden:
+        return 'Waden';
     }
   }
 
@@ -66,7 +48,7 @@ class MuscleChips extends StatelessWidget {
 
     MuscleRegion regionFor(String id, MuscleGroup? g) {
       if (g != null) return g.region;
-      return MuscleRegion.values.firstWhereOrNull((r) => r.name == id) ?? MuscleRegion.rectusAbdominis;
+      return MuscleRegion.values.firstWhereOrNull((r) => r.name == id) ?? MuscleRegion.bauch;
     }
 
     String nameFor(String id) {

--- a/lib/features/muscle_group/data/dtos/muscle_group_dto.dart
+++ b/lib/features/muscle_group/data/dtos/muscle_group_dto.dart
@@ -28,7 +28,7 @@ class MuscleGroupDto {
       name: data['name'] as String? ?? '',
       region: MuscleRegion.values.firstWhere(
         (r) => r.name == data['region'],
-        orElse: () => MuscleRegion.rectusAbdominis,
+        orElse: () => MuscleRegion.bauch,
       ),
       primaryDeviceIds:
           (data['primaryDeviceIds'] as List<dynamic>? ?? [])

--- a/lib/features/muscle_group/domain/models/muscle_group.dart
+++ b/lib/features/muscle_group/domain/models/muscle_group.dart
@@ -1,25 +1,16 @@
 enum MuscleCategory { upperFront, upperBack, core, lower }
 
 enum MuscleRegion {
-  chest(MuscleCategory.upperFront),
-  anteriorDeltoid(MuscleCategory.upperFront),
-  biceps(MuscleCategory.upperFront),
-  wristFlexors(MuscleCategory.upperFront),
-  lats(MuscleCategory.upperBack),
-  midBack(MuscleCategory.upperBack),
-  posteriorDeltoid(MuscleCategory.upperBack),
-  upperTrapezius(MuscleCategory.upperBack),
-  triceps(MuscleCategory.upperBack),
-  rectusAbdominis(MuscleCategory.core),
-  obliques(MuscleCategory.core),
-  transversusAbdominis(MuscleCategory.core),
-  quadriceps(MuscleCategory.lower),
+  brust(MuscleCategory.upperFront),
+  ruecken(MuscleCategory.upperBack),
+  schulter(MuscleCategory.upperFront),
+  nacken(MuscleCategory.upperBack),
+  bizeps(MuscleCategory.upperFront),
+  trizeps(MuscleCategory.upperBack),
+  bauch(MuscleCategory.core),
+  quadrizeps(MuscleCategory.lower),
   hamstrings(MuscleCategory.lower),
-  glutes(MuscleCategory.lower),
-  adductors(MuscleCategory.lower),
-  abductors(MuscleCategory.lower),
-  calves(MuscleCategory.lower),
-  tibialisAnterior(MuscleCategory.lower);
+  waden(MuscleCategory.lower);
 
   final MuscleCategory category;
   const MuscleRegion(this.category);
@@ -36,7 +27,7 @@ class MuscleGroup {
   MuscleGroup({
     required this.id,
     required this.name,
-    this.region = MuscleRegion.rectusAbdominis,
+    this.region = MuscleRegion.bauch,
     List<String>? primaryDeviceIds,
     List<String>? secondaryDeviceIds,
     List<String>? exerciseIds,
@@ -71,7 +62,7 @@ class MuscleGroup {
         name: json['name'] as String? ?? '',
         region: MuscleRegion.values.firstWhere(
           (r) => r.name == json['region'],
-          orElse: () => MuscleRegion.rectusAbdominis,
+          orElse: () => MuscleRegion.bauch,
         ),
         primaryDeviceIds:
             (json['primaryDeviceIds'] as List<dynamic>? ?? [])

--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
@@ -9,24 +9,16 @@ import '../widgets/mesh_3d_heatmap_widget.dart';
 import '../../domain/models/muscle_group.dart';
 
 const Map<String, List<String>> muscleCategoryMap = {
-  'chest': ['pectoral'],
-  'back': ['latissimus_dorsi', 'lower_back', 'rhomboids'],
-  'arms': ['biceps', 'triceps', 'forearm'],
-  'legs': [
-    'quadriceps',
-    'hamstrings',
-    'adductors',
-    'abductors',
-    'calves',
-    'feet',
-  ],
-  'core': ['abs'],
-  'shoulders': [
-    'anterior_deltoid',
-    'lateral_deltoid',
-    'posterior_deltoid',
-    'trapezius',
-  ],
+  'brust': ['pectoral'],
+  'ruecken': ['latissimus_dorsi', 'lower_back', 'rhomboids'],
+  'schulter': ['anterior_deltoid', 'lateral_deltoid', 'posterior_deltoid'],
+  'nacken': ['trapezius'],
+  'bizeps': ['biceps', 'forearm'],
+  'trizeps': ['triceps'],
+  'bauch': ['abs'],
+  'quadrizeps': ['quadriceps', 'adductors'],
+  'hamstrings': ['hamstrings', 'abductors'],
+  'waden': ['calves', 'feet'],
 };
 
 class MuscleGroupScreen extends StatefulWidget {
@@ -73,23 +65,29 @@ class _MuscleGroupScreenState extends State<MuscleGroupScreen> {
               regionXp[g.region] = (regionXp[g.region] ?? 0) + count.toDouble();
             }
 
+            double valueFor(MuscleRegion region) =>
+                regionXp[region]?.toDouble() ?? 0;
+
             final xpMap = <String, double>{
-              'head': 0,
-              'chest': regionXp[MuscleRegion.chest] ?? 0,
-              'core': (regionXp[MuscleRegion.rectusAbdominis] ?? 0) +
-                  (regionXp[MuscleRegion.obliques] ?? 0) +
-                  (regionXp[MuscleRegion.transversusAbdominis] ?? 0),
-              'pelvis': regionXp[MuscleRegion.glutes] ?? 0,
-              'upper_arm_left': regionXp[MuscleRegion.biceps] ?? 0,
-              'upper_arm_right': regionXp[MuscleRegion.triceps] ?? 0,
-              'forearm_left': regionXp[MuscleRegion.wristFlexors] ?? 0,
-              'forearm_right': regionXp[MuscleRegion.wristFlexors] ?? 0,
-              'thigh_left': regionXp[MuscleRegion.quadriceps] ?? 0,
-              'thigh_right': regionXp[MuscleRegion.hamstrings] ?? 0,
-              'calf_left': regionXp[MuscleRegion.calves] ?? 0,
-              'calf_right': regionXp[MuscleRegion.calves] ?? 0,
-              'foot_left': regionXp[MuscleRegion.tibialisAnterior] ?? 0,
-              'foot_right': regionXp[MuscleRegion.tibialisAnterior] ?? 0,
+              'trapezius': valueFor(MuscleRegion.nacken),
+              'anterior_deltoid': valueFor(MuscleRegion.schulter),
+              'lateral_deltoid': valueFor(MuscleRegion.schulter),
+              'posterior_deltoid': valueFor(MuscleRegion.schulter),
+              'pectoral': valueFor(MuscleRegion.brust),
+              'latissimus_dorsi': valueFor(MuscleRegion.ruecken),
+              'lower_back': valueFor(MuscleRegion.ruecken),
+              'rhomboids': valueFor(MuscleRegion.ruecken),
+              'biceps': valueFor(MuscleRegion.bizeps),
+              'triceps': valueFor(MuscleRegion.trizeps),
+              'forearm': 0,
+              'abs': valueFor(MuscleRegion.bauch),
+              'gluteus': 0,
+              'quadriceps': valueFor(MuscleRegion.quadrizeps),
+              'hamstrings': valueFor(MuscleRegion.hamstrings),
+              'adductors': 0,
+              'abductors': 0,
+              'calves': valueFor(MuscleRegion.waden),
+              'feet': valueFor(MuscleRegion.waden),
             };
 
             final values = xpMap.values;

--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
@@ -75,23 +75,28 @@ class _MuscleGroupScreenNewState extends State<MuscleGroupScreenNew> {
       }
     }
 
+    int valueFor(MuscleRegion region) => regionXp[region] ?? 0;
+
     final xpMap = <String, int>{
-      'head': 0,
-      'chest': regionXp[MuscleRegion.chest] ?? 0,
-      'core': (regionXp[MuscleRegion.rectusAbdominis] ?? 0) +
-          (regionXp[MuscleRegion.obliques] ?? 0) +
-          (regionXp[MuscleRegion.transversusAbdominis] ?? 0),
-      'pelvis': regionXp[MuscleRegion.glutes] ?? 0,
-      'upper_arm_left': regionXp[MuscleRegion.biceps] ?? 0,
-      'upper_arm_right': regionXp[MuscleRegion.triceps] ?? 0,
-      'forearm_left': regionXp[MuscleRegion.wristFlexors] ?? 0,
-      'forearm_right': regionXp[MuscleRegion.wristFlexors] ?? 0,
-      'thigh_left': regionXp[MuscleRegion.quadriceps] ?? 0,
-      'thigh_right': regionXp[MuscleRegion.hamstrings] ?? 0,
-      'calf_left': regionXp[MuscleRegion.calves] ?? 0,
-      'calf_right': regionXp[MuscleRegion.calves] ?? 0,
-      'foot_left': regionXp[MuscleRegion.tibialisAnterior] ?? 0,
-      'foot_right': regionXp[MuscleRegion.tibialisAnterior] ?? 0,
+      'trapezius': valueFor(MuscleRegion.nacken),
+      'anterior_deltoid': valueFor(MuscleRegion.schulter),
+      'lateral_deltoid': valueFor(MuscleRegion.schulter),
+      'posterior_deltoid': valueFor(MuscleRegion.schulter),
+      'pectoral': valueFor(MuscleRegion.brust),
+      'latissimus_dorsi': valueFor(MuscleRegion.ruecken),
+      'lower_back': valueFor(MuscleRegion.ruecken),
+      'rhomboids': valueFor(MuscleRegion.ruecken),
+      'biceps': valueFor(MuscleRegion.bizeps),
+      'triceps': valueFor(MuscleRegion.trizeps),
+      'forearm': 0,
+      'abs': valueFor(MuscleRegion.bauch),
+      'gluteus': 0,
+      'quadriceps': valueFor(MuscleRegion.quadrizeps),
+      'hamstrings': valueFor(MuscleRegion.hamstrings),
+      'adductors': 0,
+      'abductors': 0,
+      'calves': valueFor(MuscleRegion.waden),
+      'feet': valueFor(MuscleRegion.waden),
     };
 
     final values = xpMap.values.map((e) => e.toDouble());

--- a/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
+++ b/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
@@ -59,68 +59,41 @@ class _DeviceMuscleAssignmentSheetState
   }
 
   static const List<MuscleRegion> _order = [
-    MuscleRegion.chest,
-    MuscleRegion.anteriorDeltoid,
-    MuscleRegion.biceps,
-    MuscleRegion.wristFlexors,
-    MuscleRegion.lats,
-    MuscleRegion.midBack,
-    MuscleRegion.posteriorDeltoid,
-    MuscleRegion.upperTrapezius,
-    MuscleRegion.triceps,
-    MuscleRegion.rectusAbdominis,
-    MuscleRegion.obliques,
-    MuscleRegion.transversusAbdominis,
-    MuscleRegion.quadriceps,
+    MuscleRegion.brust,
+    MuscleRegion.schulter,
+    MuscleRegion.nacken,
+    MuscleRegion.ruecken,
+    MuscleRegion.bizeps,
+    MuscleRegion.trizeps,
+    MuscleRegion.bauch,
+    MuscleRegion.quadrizeps,
     MuscleRegion.hamstrings,
-    MuscleRegion.glutes,
-    MuscleRegion.adductors,
-    MuscleRegion.abductors,
-    MuscleRegion.calves,
-    MuscleRegion.tibialisAnterior,
+    MuscleRegion.waden,
   ];
 
   String _regionLabel(AppLocalizations loc, MuscleRegion region) {
     // Using English fallback if not localized
     switch (region) {
-      case MuscleRegion.chest:
-        return 'Chest';
-      case MuscleRegion.anteriorDeltoid:
-        return 'Anterior Deltoid';
-      case MuscleRegion.biceps:
-        return 'Biceps';
-      case MuscleRegion.wristFlexors:
-        return 'Wrist Flexors';
-      case MuscleRegion.lats:
-        return 'Lats';
-      case MuscleRegion.midBack:
-        return 'Mid Back';
-      case MuscleRegion.posteriorDeltoid:
-        return 'Posterior Deltoid';
-      case MuscleRegion.upperTrapezius:
-        return 'Upper Trapezius';
-      case MuscleRegion.triceps:
-        return 'Triceps';
-      case MuscleRegion.rectusAbdominis:
-        return 'Rectus Abdominis';
-      case MuscleRegion.obliques:
-        return 'Obliques';
-      case MuscleRegion.transversusAbdominis:
-        return 'Transversus Abdominis';
-      case MuscleRegion.quadriceps:
-        return 'Quadriceps';
+      case MuscleRegion.brust:
+        return 'Brust';
+      case MuscleRegion.schulter:
+        return 'Schulter';
+      case MuscleRegion.nacken:
+        return 'Nacken';
+      case MuscleRegion.ruecken:
+        return 'Rücken';
+      case MuscleRegion.bizeps:
+        return 'Bizeps';
+      case MuscleRegion.trizeps:
+        return 'Trizeps';
+      case MuscleRegion.bauch:
+        return 'Bauch';
+      case MuscleRegion.quadrizeps:
+        return 'Quadrizeps';
       case MuscleRegion.hamstrings:
         return 'Hamstrings';
-      case MuscleRegion.glutes:
-        return 'Glutes';
-      case MuscleRegion.adductors:
-        return 'Adductors';
-      case MuscleRegion.abductors:
-        return 'Abductors';
-      case MuscleRegion.calves:
-        return 'Calves';
-      case MuscleRegion.tibialisAnterior:
-        return 'Tibialis Anterior';
+      case MuscleRegion.waden:
+        return 'Waden';
     }
   }
 

--- a/lib/ui/muscles/muscle_group_card.dart
+++ b/lib/ui/muscles/muscle_group_card.dart
@@ -15,7 +15,7 @@ class MuscleGroupCard extends StatelessWidget {
     final prov = context.watch<MuscleGroupProvider>();
     final group = prov.groups.firstWhere(
       (g) => g.id == muscleGroupId,
-      orElse: () => MuscleGroup(id: '', name: '', region: MuscleRegion.rectusAbdominis),
+      orElse: () => MuscleGroup(id: '', name: '', region: MuscleRegion.bauch),
     );
     if (group.id.isEmpty) return const SizedBox.shrink();
     final loc = AppLocalizations.of(context)!;

--- a/lib/ui/muscles/muscle_group_color.dart
+++ b/lib/ui/muscles/muscle_group_color.dart
@@ -3,30 +3,23 @@ import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
 
 Color colorForRegion(MuscleRegion region) {
   switch (region) {
-    case MuscleRegion.chest:
+    case MuscleRegion.brust:
       return Colors.red;
-    case MuscleRegion.anteriorDeltoid:
-    case MuscleRegion.posteriorDeltoid:
-    case MuscleRegion.upperTrapezius:
+    case MuscleRegion.schulter:
       return Colors.orange;
-    case MuscleRegion.biceps:
-    case MuscleRegion.triceps:
-    case MuscleRegion.wristFlexors:
-      return Colors.blue;
-    case MuscleRegion.lats:
-    case MuscleRegion.midBack:
+    case MuscleRegion.nacken:
+      return Colors.deepOrange;
+    case MuscleRegion.ruecken:
       return Colors.green;
-    case MuscleRegion.rectusAbdominis:
-    case MuscleRegion.obliques:
-    case MuscleRegion.transversusAbdominis:
+    case MuscleRegion.bizeps:
+      return Colors.blue;
+    case MuscleRegion.trizeps:
+      return Colors.indigo;
+    case MuscleRegion.bauch:
       return Colors.purple;
-    case MuscleRegion.quadriceps:
+    case MuscleRegion.quadrizeps:
     case MuscleRegion.hamstrings:
-    case MuscleRegion.glutes:
-    case MuscleRegion.adductors:
-    case MuscleRegion.abductors:
-    case MuscleRegion.calves:
-    case MuscleRegion.tibialisAnterior:
+    case MuscleRegion.waden:
       return Colors.brown;
   }
 }

--- a/lib/ui/muscles/muscle_group_list_selector.dart
+++ b/lib/ui/muscles/muscle_group_list_selector.dart
@@ -27,63 +27,45 @@ class MuscleGroupListSelector extends StatefulWidget {
 
 class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
   static const List<MuscleRegion> _ordered = [
-    MuscleRegion.chest,
-    MuscleRegion.anteriorDeltoid,
-    MuscleRegion.biceps,
-    MuscleRegion.wristFlexors,
-    MuscleRegion.lats,
-    MuscleRegion.midBack,
-    MuscleRegion.posteriorDeltoid,
-    MuscleRegion.upperTrapezius,
-    MuscleRegion.triceps,
-    MuscleRegion.rectusAbdominis,
-    MuscleRegion.obliques,
-    MuscleRegion.transversusAbdominis,
-    MuscleRegion.quadriceps,
+    MuscleRegion.brust,
+    MuscleRegion.schulter,
+    MuscleRegion.nacken,
+    MuscleRegion.ruecken,
+    MuscleRegion.bizeps,
+    MuscleRegion.trizeps,
+    MuscleRegion.bauch,
+    MuscleRegion.quadrizeps,
     MuscleRegion.hamstrings,
-    MuscleRegion.glutes,
-    MuscleRegion.adductors,
-    MuscleRegion.abductors,
-    MuscleRegion.calves,
-    MuscleRegion.tibialisAnterior,
+    MuscleRegion.waden,
   ];
 
   /// Display categories for grouping muscle regions.
   static const List<_Category> _categories = [
     _Category.chest,
     _Category.shoulders,
-    _Category.arms,
     _Category.back,
+    _Category.arms,
     _Category.core,
     _Category.legs,
   ];
 
   _Category _categoryFor(MuscleRegion r) {
     switch (r) {
-      case MuscleRegion.chest:
+      case MuscleRegion.brust:
         return _Category.chest;
-      case MuscleRegion.anteriorDeltoid:
-      case MuscleRegion.posteriorDeltoid:
-      case MuscleRegion.upperTrapezius:
+      case MuscleRegion.schulter:
         return _Category.shoulders;
-      case MuscleRegion.biceps:
-      case MuscleRegion.triceps:
-      case MuscleRegion.wristFlexors:
-        return _Category.arms;
-      case MuscleRegion.lats:
-      case MuscleRegion.midBack:
+      case MuscleRegion.ruecken:
+      case MuscleRegion.nacken:
         return _Category.back;
-      case MuscleRegion.rectusAbdominis:
-      case MuscleRegion.obliques:
-      case MuscleRegion.transversusAbdominis:
+      case MuscleRegion.bizeps:
+      case MuscleRegion.trizeps:
+        return _Category.arms;
+      case MuscleRegion.bauch:
         return _Category.core;
-      case MuscleRegion.quadriceps:
+      case MuscleRegion.quadrizeps:
       case MuscleRegion.hamstrings:
-      case MuscleRegion.glutes:
-      case MuscleRegion.adductors:
-      case MuscleRegion.abductors:
-      case MuscleRegion.calves:
-      case MuscleRegion.tibialisAnterior:
+      case MuscleRegion.waden:
         return _Category.legs;
     }
   }
@@ -121,44 +103,26 @@ class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
 
   String _regionFallbackName(MuscleRegion r) {
     switch (r) {
-      case MuscleRegion.chest:
-        return 'Chest';
-      case MuscleRegion.anteriorDeltoid:
-        return 'Anterior Deltoid';
-      case MuscleRegion.biceps:
-        return 'Biceps';
-      case MuscleRegion.wristFlexors:
-        return 'Wrist Flexors';
-      case MuscleRegion.lats:
-        return 'Lats';
-      case MuscleRegion.midBack:
-        return 'Mid Back';
-      case MuscleRegion.posteriorDeltoid:
-        return 'Posterior Deltoid';
-      case MuscleRegion.upperTrapezius:
-        return 'Upper Trapezius';
-      case MuscleRegion.triceps:
-        return 'Triceps';
-      case MuscleRegion.rectusAbdominis:
-        return 'Rectus Abdominis';
-      case MuscleRegion.obliques:
-        return 'Obliques';
-      case MuscleRegion.transversusAbdominis:
-        return 'Transversus Abdominis';
-      case MuscleRegion.quadriceps:
-        return 'Quadriceps';
+      case MuscleRegion.brust:
+        return 'Brust';
+      case MuscleRegion.schulter:
+        return 'Schulter';
+      case MuscleRegion.nacken:
+        return 'Nacken';
+      case MuscleRegion.ruecken:
+        return 'Rücken';
+      case MuscleRegion.bizeps:
+        return 'Bizeps';
+      case MuscleRegion.trizeps:
+        return 'Trizeps';
+      case MuscleRegion.bauch:
+        return 'Bauch';
+      case MuscleRegion.quadrizeps:
+        return 'Quadrizeps';
       case MuscleRegion.hamstrings:
         return 'Hamstrings';
-      case MuscleRegion.glutes:
-        return 'Glutes';
-      case MuscleRegion.adductors:
-        return 'Adductors';
-      case MuscleRegion.abductors:
-        return 'Abductors';
-      case MuscleRegion.calves:
-        return 'Calves';
-      case MuscleRegion.tibialisAnterior:
-        return 'Tibialis Anterior';
+      case MuscleRegion.waden:
+        return 'Waden';
     }
   }
 

--- a/test/ui/brand_widgets_test.dart
+++ b/test/ui/brand_widgets_test.dart
@@ -109,7 +109,7 @@ void main() {
       theme: theme,
       home: SessionExerciseCard(
         title: 'Bench',
-        subtitle: 'Chest',
+        subtitle: 'Brust',
         sets: [SessionSet(weight: 10, reps: 5, setNumber: 1)],
       ),
     ));

--- a/test/ui/exercise_list_chips_update_test.dart
+++ b/test/ui/exercise_list_chips_update_test.dart
@@ -159,9 +159,9 @@ void main() {
       updateMuscles: UpdateExerciseMuscleGroupsUseCase(repo),
     );
     final muscleProv = _FakeMuscleGroupProvider([
-      MuscleGroup(id: '1', name: 'Chest', region: MuscleRegion.chest),
-      MuscleGroup(id: '2', name: 'Lats', region: MuscleRegion.lats),
-      MuscleGroup(id: '3', name: 'Biceps', region: MuscleRegion.biceps),
+      MuscleGroup(id: '1', name: 'Brust', region: MuscleRegion.brust),
+      MuscleGroup(id: '2', name: 'Rücken', region: MuscleRegion.ruecken),
+      MuscleGroup(id: '3', name: 'Bizeps', region: MuscleRegion.bizeps),
     ]);
     await tester.pumpWidget(
       MultiProvider(
@@ -178,11 +178,11 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    expect(find.text('Chest'), findsOneWidget);
-    expect(find.text('Lats'), findsOneWidget);
+    expect(find.text('Brust'), findsOneWidget);
+    expect(find.text('Rücken'), findsOneWidget);
     await exerciseProvider.updateMuscleGroups('g', 'd', 'e1', 'u1', ['3'], []);
     await tester.pumpAndSettle();
-    expect(find.text('Biceps'), findsOneWidget);
-    expect(find.text('Chest'), findsNothing);
+    expect(find.text('Bizeps'), findsOneWidget);
+    expect(find.text('Brust'), findsNothing);
   });
 }

--- a/test/ui/gym/device_card_test.dart
+++ b/test/ui/gym/device_card_test.dart
@@ -144,7 +144,7 @@ void main() {
       id: 1,
       name: 'Bench',
       description: 'Eleiko',
-      primaryMuscleGroups: const ['chest'],
+      primaryMuscleGroups: const ['brust'],
       secondaryMuscleGroups: const ['back'],
     );
     await tester.pumpWidget(
@@ -184,8 +184,8 @@ void main() {
       id: 1,
       name: 'Bench',
       description: 'Eleiko',
-      primaryMuscleGroups: const ['chest'],
-      secondaryMuscleGroups: const ['back'],
+      primaryMuscleGroups: const ['brust'],
+      secondaryMuscleGroups: const ['ruecken'],
     );
     await tester.pumpWidget(
       _wrapWithMaterialApp(
@@ -198,9 +198,9 @@ void main() {
     final chips = tester.widgetList<Chip>(find.byType(Chip)).toList();
     final context = tester.element(find.byType(DeviceCard));
     final theme = Theme.of(context);
-    expect((chips[0].label as Text).data, 'Chest');
+    expect((chips[0].label as Text).data, 'Brust');
     expect(chips[0].backgroundColor, theme.colorScheme.primary);
-    expect((chips[1].label as Text).data, 'Back');
+    expect((chips[1].label as Text).data, 'Rücken');
     final shape = chips[1].shape as StadiumBorder;
     expect(shape.side.color, theme.colorScheme.tertiary);
   });

--- a/test/ui/gym/search_and_filters_test.dart
+++ b/test/ui/gym/search_and_filters_test.dart
@@ -166,8 +166,8 @@ class _HarnessState extends State<_Harness> {
 
 void main() {
   final groups = [
-    MuscleGroup(id: 'chest', name: 'Chest', region: MuscleRegion.chest),
-    MuscleGroup(id: 'legs', name: 'Quadriceps', region: MuscleRegion.quadriceps),
+    MuscleGroup(id: 'brust', name: 'Brust', region: MuscleRegion.brust),
+    MuscleGroup(id: 'beine', name: 'Quadrizeps', region: MuscleRegion.quadrizeps),
   ];
   testWidgets('muscle filter reduces list', (tester) async {
     await tester.pumpWidget(
@@ -186,7 +186,7 @@ void main() {
     expect(find.text('Beta'), findsOneWidget);
     await tester.tap(find.text('Muscle'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Chest'));
+    await tester.tap(find.text('Brust'));
     await tester.tap(find.text('OK'));
     await tester.pumpAndSettle();
     expect(find.text('Alpha'), findsOneWidget);

--- a/test/ui/muscle_groups/admin_list_filters_test.dart
+++ b/test/ui/muscle_groups/admin_list_filters_test.dart
@@ -120,16 +120,16 @@ void main() {
     final groups = [
       MuscleGroup(
         id: 'm1',
-        name: 'Chest',
-        region: MuscleRegion.chest,
+        name: 'Brust',
+        region: MuscleRegion.brust,
         primaryDeviceIds: const [],
         secondaryDeviceIds: const [],
         exerciseIds: const [],
       ),
       MuscleGroup(
         id: 'm2',
-        name: 'Lats',
-        region: MuscleRegion.lats,
+        name: 'Rücken',
+        region: MuscleRegion.ruecken,
         primaryDeviceIds: const [],
         secondaryDeviceIds: const [],
         exerciseIds: const [],
@@ -161,7 +161,7 @@ void main() {
 
     await tester.tap(find.text('Muskel'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Chest'));
+    await tester.tap(find.text('Brust'));
     await tester.tap(find.text('OK'));
     await tester.pumpAndSettle();
 
@@ -194,16 +194,16 @@ void main() {
     final groups = [
       MuscleGroup(
         id: 'm1',
-        name: 'Chest',
-        region: MuscleRegion.chest,
+        name: 'Brust',
+        region: MuscleRegion.brust,
         primaryDeviceIds: const [],
         secondaryDeviceIds: const [],
         exerciseIds: const [],
       ),
       MuscleGroup(
         id: 'm2',
-        name: 'Lats',
-        region: MuscleRegion.lats,
+        name: 'Rücken',
+        region: MuscleRegion.ruecken,
         primaryDeviceIds: const [],
         secondaryDeviceIds: const [],
         exerciseIds: const [],
@@ -236,7 +236,7 @@ void main() {
 
     await tester.tap(find.text('Muskel'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Chest'));
+    await tester.tap(find.text('Brust'));
     await tester.tap(find.text('OK'));
     await tester.pumpAndSettle();
     expect(find.text('A'), findsOneWidget);
@@ -262,8 +262,8 @@ void main() {
     final groups = [
       MuscleGroup(
         id: 'm1',
-        name: 'Chest',
-        region: MuscleRegion.chest,
+        name: 'Brust',
+        region: MuscleRegion.brust,
         primaryDeviceIds: const [],
         secondaryDeviceIds: const [],
         exerciseIds: const [],
@@ -301,6 +301,6 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(deviceProv.devices.first.primaryMuscleGroups, isEmpty);
-    expect(find.text('Chest'), findsNothing);
+    expect(find.text('Brust'), findsNothing);
   });
 }

--- a/test/ui/muscle_groups/assignment_sheet_test.dart
+++ b/test/ui/muscle_groups/assignment_sheet_test.dart
@@ -79,14 +79,14 @@ Future<void> _openSheet(WidgetTester tester, MuscleGroupProvider prov) async {
 void main() {
   testWidgets('tab counts update and exclusivity', (tester) async {
     final prov = FakeMuscleGroupProvider([
-      MuscleGroup(id: 'c1', name: 'Chest', region: MuscleRegion.chest),
-      MuscleGroup(id: 'c2', name: 'Pecs', region: MuscleRegion.chest),
-      MuscleGroup(id: 'b1', name: 'Lats', region: MuscleRegion.lats),
-      MuscleGroup(id: 'b2', name: 'Mid Back', region: MuscleRegion.midBack),
-      MuscleGroup(id: 's1', name: 'Anterior Deltoid', region: MuscleRegion.anteriorDeltoid),
-      MuscleGroup(id: 'l1', name: 'Quadriceps', region: MuscleRegion.quadriceps),
-      MuscleGroup(id: 'a1', name: 'Biceps', region: MuscleRegion.biceps),
-      MuscleGroup(id: 'co1', name: 'Rectus Abdominis', region: MuscleRegion.rectusAbdominis),
+      MuscleGroup(id: 'br1', name: 'Brust', region: MuscleRegion.brust),
+      MuscleGroup(id: 'br2', name: 'Chest', region: MuscleRegion.brust),
+      MuscleGroup(id: 'ru1', name: 'Rücken', region: MuscleRegion.ruecken),
+      MuscleGroup(id: 'na1', name: 'Nacken', region: MuscleRegion.nacken),
+      MuscleGroup(id: 'sc1', name: 'Schulter', region: MuscleRegion.schulter),
+      MuscleGroup(id: 'qu1', name: 'Quadrizeps', region: MuscleRegion.quadrizeps),
+      MuscleGroup(id: 'bi1', name: 'Bizeps', region: MuscleRegion.bizeps),
+      MuscleGroup(id: 'ba1', name: 'Bauch', region: MuscleRegion.bauch),
     ]);
 
     await _openSheet(tester, prov);
@@ -96,48 +96,48 @@ void main() {
     expect(find.text('Secondary (0)'), findsOneWidget);
 
     // select a primary
-    await tester.tap(find.text('Biceps').first);
+    await tester.tap(find.text('Bizeps').first);
     await tester.pump();
     expect(find.text('Primary (1)'), findsOneWidget);
 
     // switch to secondary tab and select two
     await tester.tap(find.text('Secondary (0)'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Lats').first);
+    await tester.tap(find.text('Rücken').first);
     await tester.pump();
-    await tester.tap(find.text('Mid Back').first);
+    await tester.tap(find.text('Nacken').first);
     await tester.pump();
     expect(find.text('Secondary (2)'), findsOneWidget);
 
     // selecting primary removes from secondary
     await tester.tap(find.text('Primary (1)'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Lats').first);
+    await tester.tap(find.text('Rücken').first);
     await tester.pump();
     expect(find.text('Secondary (1)'), findsOneWidget);
   });
 
   testWidgets('saving creates missing region and assigns', (tester) async {
     final prov = FakeMuscleGroupProvider([
-      MuscleGroup(id: 'c1', name: 'Chest', region: MuscleRegion.chest),
+      MuscleGroup(id: 'br1', name: 'Brust', region: MuscleRegion.brust),
     ]);
 
     await _openSheet(tester, prov);
 
-    await tester.tap(find.text('Biceps').first);
+    await tester.tap(find.text('Bizeps').first);
     await tester.pump();
 
     await tester.tap(find.text('Save'));
     await tester.pumpAndSettle();
 
-    expect(prov.ensuredRegion, MuscleRegion.biceps);
-    expect(prov.lastPrimary, ['biceps-id']);
+    expect(prov.ensuredRegion, MuscleRegion.bizeps);
+    expect(prov.lastPrimary, ['bizeps-id']);
     expect(prov.lastSecondary, isEmpty);
   });
 
   testWidgets('reset clears assignments', (tester) async {
     final prov = FakeMuscleGroupProvider([
-      MuscleGroup(id: 'c1', name: 'Chest', region: MuscleRegion.chest),
+      MuscleGroup(id: 'br1', name: 'Brust', region: MuscleRegion.brust),
     ]);
 
     await _openSheet(tester, prov);

--- a/test/widgets/exercise_bottom_sheet_selected_preview_test.dart
+++ b/test/widgets/exercise_bottom_sheet_selected_preview_test.dart
@@ -114,7 +114,7 @@ class _FakeAuthProvider extends ChangeNotifier implements AuthProvider {
 
 void main() {
   final groups = [
-    MuscleGroup(id: '1', name: 'Latissimus dorsi', region: MuscleRegion.lats),
+    MuscleGroup(id: '1', name: 'Rücken', region: MuscleRegion.ruecken),
   ];
 
   testWidgets('preview updates when selecting muscle groups', (tester) async {
@@ -145,13 +145,13 @@ void main() {
     expect(find.text('No muscle groups available'), findsOneWidget);
     // Category heading should be visible
     expect(find.text('Back'), findsOneWidget);
-    await tester.tap(find.text('Latissimus dorsi'));
+    await tester.tap(find.text('Rücken'));
     await tester.pump();
     expect(find.text('Selected'), findsOneWidget);
     expect(
       find.descendant(
         of: find.byType(MuscleChips),
-        matching: find.text('Latissimus dorsi'),
+        matching: find.text('Rücken'),
       ),
       findsOneWidget,
     );

--- a/test/widgets/muscle_group_list_selector_test.dart
+++ b/test/widgets/muscle_group_list_selector_test.dart
@@ -100,8 +100,8 @@ class _FakeMuscleGroupProvider extends MuscleGroupProvider {
 
 void main() {
   final groups = [
-    MuscleGroup(id: '1', name: 'Chest', region: MuscleRegion.chest),
-    MuscleGroup(id: '2', name: 'Lats', region: MuscleRegion.lats),
+    MuscleGroup(id: '1', name: 'Brust', region: MuscleRegion.brust),
+    MuscleGroup(id: '2', name: 'Rücken', region: MuscleRegion.ruecken),
   ];
 
   testWidgets('tap on selected chip deselects', (tester) async {
@@ -127,10 +127,10 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Lats'));
+    await tester.tap(find.text('Rücken'));
     await tester.pumpAndSettle();
     expect(p, ['2']);
-    await tester.tap(find.text('Lats'));
+    await tester.tap(find.text('Rücken'));
     await tester.pumpAndSettle();
     expect(p, isEmpty);
     expect(s, isEmpty);
@@ -159,8 +159,8 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Chest'));
-    await tester.tap(find.text('Lats'));
+    await tester.tap(find.text('Brust'));
+    await tester.tap(find.text('Rücken'));
     await tester.pump();
     expect(p, ['1']);
     expect(s, ['2']);
@@ -193,7 +193,7 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Lats'));
+    await tester.tap(find.text('Rücken'));
     await tester.pump();
     expect(p, ['2']);
     expect(s, isEmpty);

--- a/test/widgets/muscle_group_selector_test.dart
+++ b/test/widgets/muscle_group_selector_test.dart
@@ -105,8 +105,8 @@ class FakeMuscleGroupProvider extends MuscleGroupProvider {
 
 void main() {
   final groups = [
-    MuscleGroup(id: '1', name: 'Chest', region: MuscleRegion.chest),
-    MuscleGroup(id: '2', name: 'Lats', region: MuscleRegion.lats),
+    MuscleGroup(id: '1', name: 'Brust', region: MuscleRegion.brust),
+    MuscleGroup(id: '2', name: 'Rücken', region: MuscleRegion.ruecken),
   ];
 
   testWidgets('MuscleGroupSelector shows names and toggles', (tester) async {
@@ -127,8 +127,8 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    expect(find.text('Chest'), findsOneWidget);
-    await tester.tap(find.text('Chest'));
+    expect(find.text('Brust'), findsOneWidget);
+    await tester.tap(find.text('Brust'));
     await tester.pumpAndSettle();
     expect(selected, ['1']);
   });
@@ -147,7 +147,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(tester.widget<TextButton>(find.text('Save')).onPressed, isNull);
     await tester.enterText(find.byType(TextField), 'Pushup');
-    await tester.tap(find.text('Chest'));
+    await tester.tap(find.text('Brust'));
     await tester.pump();
     expect(tester.widget<TextButton>(find.text('Save')).onPressed, isNotNull);
   });


### PR DESCRIPTION
## Summary
- replace use of `Provider.maybeOf` with `Provider.of` in the device provider to resolve runtime errors
- collapse the muscle group model to the new set of regions (Brust, Rücken, Schulter, Nacken, Bizeps, Trizeps, Bauch, Quadrizeps, Hamstrings, Waden) and update selectors, coloring, and heatmap mapping accordingly
- update related widget tests and UI expectations to reflect the new muscle group names and identifiers

## Testing
- Not run (Flutter/Dart tooling is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e420d787808320aa6a8db29dd35a02