### PR TITLE
Add gluteus muscle region support

### DIFF
--- a/lib/features/device/presentation/widgets/muscle_chips.dart
+++ b/lib/features/device/presentation/widgets/muscle_chips.dart
@@ -31,6 +31,8 @@ class MuscleChips extends StatelessWidget {
         return 'Quadrizeps';
       case MuscleRegion.hamstrings:
         return 'Hamstrings';
+      case MuscleRegion.gluteus:
+        return 'Gluteus';
       case MuscleRegion.waden:
         return 'Waden';
     }

--- a/lib/features/muscle_group/domain/models/muscle_group.dart
+++ b/lib/features/muscle_group/domain/models/muscle_group.dart
@@ -10,6 +10,7 @@ enum MuscleRegion {
   bauch(MuscleCategory.core),
   quadrizeps(MuscleCategory.lower),
   hamstrings(MuscleCategory.lower),
+  gluteus(MuscleCategory.lower),
   waden(MuscleCategory.lower);
 
   final MuscleCategory category;

--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen.dart
@@ -18,6 +18,7 @@ const Map<String, List<String>> muscleCategoryMap = {
   'bauch': ['abs'],
   'quadrizeps': ['quadriceps', 'adductors'],
   'hamstrings': ['hamstrings', 'abductors'],
+  'gluteus': ['gluteus'],
   'waden': ['calves', 'feet'],
 };
 
@@ -81,7 +82,7 @@ class _MuscleGroupScreenState extends State<MuscleGroupScreen> {
               'triceps': valueFor(MuscleRegion.trizeps),
               'forearm': 0,
               'abs': valueFor(MuscleRegion.bauch),
-              'gluteus': 0,
+              'gluteus': valueFor(MuscleRegion.gluteus),
               'quadriceps': valueFor(MuscleRegion.quadrizeps),
               'hamstrings': valueFor(MuscleRegion.hamstrings),
               'adductors': 0,

--- a/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
+++ b/lib/features/muscle_group/presentation/screens/muscle_group_screen_new.dart
@@ -90,7 +90,7 @@ class _MuscleGroupScreenNewState extends State<MuscleGroupScreenNew> {
       'triceps': valueFor(MuscleRegion.trizeps),
       'forearm': 0,
       'abs': valueFor(MuscleRegion.bauch),
-      'gluteus': 0,
+      'gluteus': valueFor(MuscleRegion.gluteus),
       'quadriceps': valueFor(MuscleRegion.quadrizeps),
       'hamstrings': valueFor(MuscleRegion.hamstrings),
       'adductors': 0,

--- a/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
+++ b/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
@@ -68,6 +68,7 @@ class _DeviceMuscleAssignmentSheetState
     MuscleRegion.bauch,
     MuscleRegion.quadrizeps,
     MuscleRegion.hamstrings,
+    MuscleRegion.gluteus,
     MuscleRegion.waden,
   ];
 
@@ -92,6 +93,8 @@ class _DeviceMuscleAssignmentSheetState
         return 'Quadrizeps';
       case MuscleRegion.hamstrings:
         return 'Hamstrings';
+      case MuscleRegion.gluteus:
+        return 'Gluteus';
       case MuscleRegion.waden:
         return 'Waden';
     }

--- a/lib/ui/muscles/muscle_group_color.dart
+++ b/lib/ui/muscles/muscle_group_color.dart
@@ -19,6 +19,7 @@ Color colorForRegion(MuscleRegion region) {
       return Colors.purple;
     case MuscleRegion.quadrizeps:
     case MuscleRegion.hamstrings:
+    case MuscleRegion.gluteus:
     case MuscleRegion.waden:
       return Colors.brown;
   }

--- a/lib/ui/muscles/muscle_group_list_selector.dart
+++ b/lib/ui/muscles/muscle_group_list_selector.dart
@@ -36,6 +36,7 @@ class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
     MuscleRegion.bauch,
     MuscleRegion.quadrizeps,
     MuscleRegion.hamstrings,
+    MuscleRegion.gluteus,
     MuscleRegion.waden,
   ];
 
@@ -65,6 +66,7 @@ class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
         return _Category.core;
       case MuscleRegion.quadrizeps:
       case MuscleRegion.hamstrings:
+      case MuscleRegion.gluteus:
       case MuscleRegion.waden:
         return _Category.legs;
     }
@@ -121,6 +123,8 @@ class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
         return 'Quadrizeps';
       case MuscleRegion.hamstrings:
         return 'Hamstrings';
+      case MuscleRegion.gluteus:
+        return 'Gluteus';
       case MuscleRegion.waden:
         return 'Waden';
     }


### PR DESCRIPTION
## Summary
- add the gluteus muscle region to the domain model with lower-body categorisation
- extend selection widgets, chips, and colour helpers to surface the new region label and styling
- wire the heatmap mappings so gluteus XP is displayed across both muscle group screens

## Testing
- not run (flutter not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e430adbbc48320a6a52b0da0ea76a1