### PR TITLE
Update XP overview charts to show level progression

### DIFF
--- a/lib/features/xp/presentation/screens/xp_overview_screen.dart
+++ b/lib/features/xp/presentation/screens/xp_overview_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:collection/collection.dart';
@@ -102,41 +104,58 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
 
     final regions = MuscleRegion.values.toList()
       ..sort((a, b) => (regionXp[b] ?? 0).compareTo(regionXp[a] ?? 0));
-    final totalXp = regionXp.values.fold<int>(0, (sum, xp) => sum + xp);
-    final Map<DateTime, int> dayXpData = {};
-    xpProv.dayListXp.forEach((key, value) {
-      try {
-        dayXpData[DateTime.parse(key)] = value;
-      } catch (_) {
-        // ignore parsing errors
+    const xpPerLevel = LevelService.xpPerLevel;
+    const xpPerSession = LevelService.xpPerSession;
+    final maxTotalXp = LevelService.maxLevel * xpPerLevel;
+
+    List<int> buildXpHistory(int totalXp) {
+      final cappedTotalXp = math.min(totalXp, maxTotalXp);
+      final history = <int>[0];
+      if (cappedTotalXp <= 0) {
+        return history;
       }
-    });
-    final sortedDayEntries = dayXpData.entries.toList()
-      ..sort((a, b) => a.key.compareTo(b.key));
-    final regionSeries = {
-      for (final region in regions) region: <DateTime, int>{},
-    };
-    final regionsWithXp = regions.where((region) => (regionXp[region] ?? 0) > 0).toList();
-    if (sortedDayEntries.isNotEmpty && totalXp > 0 && regionsWithXp.isNotEmpty) {
-      for (final entry in sortedDayEntries) {
-        final date = entry.key;
-        final dayXp = entry.value;
-        var distributed = 0;
-        for (var i = 0; i < regionsWithXp.length; i++) {
-          final region = regionsWithXp[i];
-          final share = (regionXp[region] ?? 0) / totalXp;
-          var assignedXp =
-              i == regionsWithXp.length - 1 ? dayXp - distributed : (dayXp * share).round();
-          if (assignedXp < 0) {
-            assignedXp = 0;
-          }
-          if (distributed + assignedXp > dayXp) {
-            assignedXp = dayXp - distributed;
-          }
-          distributed += assignedXp;
-          regionSeries[region]![date] = assignedXp;
+      final sessionCount = cappedTotalXp ~/ xpPerSession;
+      final remainder = cappedTotalXp % xpPerSession;
+      var xpInLevel = 0;
+      for (var i = 0; i < sessionCount; i++) {
+        xpInLevel += xpPerSession;
+        if (xpInLevel >= xpPerLevel) {
+          xpInLevel -= xpPerLevel;
+          history.add(0);
+        } else {
+          history.add(xpInLevel);
         }
       }
+      if (remainder > 0) {
+        xpInLevel += remainder;
+        if (xpInLevel >= xpPerLevel) {
+          xpInLevel -= xpPerLevel;
+        }
+        history.add(xpInLevel);
+      }
+      return history;
+    }
+
+    final regionLevel = <MuscleRegion, int>{};
+    final regionXpInLevel = <MuscleRegion, int>{};
+    final regionXpHistory = <MuscleRegion, List<int>>{};
+    final regionSessionCount = <MuscleRegion, int>{};
+
+    for (final region in regions) {
+      final total = regionXp[region] ?? 0;
+      var level = (total ~/ xpPerLevel) + 1;
+      if (level > LevelService.maxLevel) {
+        level = LevelService.maxLevel;
+      }
+      var xpInLevel = total % xpPerLevel;
+      if (level >= LevelService.maxLevel) {
+        xpInLevel = 0;
+      }
+      regionLevel[region] = level;
+      regionXpInLevel[region] = xpInLevel;
+      final history = buildXpHistory(total);
+      regionXpHistory[region] = history;
+      regionSessionCount[region] = history.length - 1;
     }
 
     void openLeaderboard(MuscleRegion region) {
@@ -253,19 +272,31 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Expanded(
-                            child: Text(
-                              _regionLabel(region, muscleProv),
-                              style: theme.textTheme.titleSmall?.copyWith(
-                                    color: theme.colorScheme.onSurface,
-                                    fontWeight: FontWeight.w600,
-                                  ),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  _regionLabel(region, muscleProv),
+                                  style: theme.textTheme.titleSmall?.copyWith(
+                                        color: theme.colorScheme.onSurface,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                ),
+                                const SizedBox(height: 2),
+                                Text(
+                                  'Level ${regionLevel[region]}',
+                                  style: theme.textTheme.labelMedium?.copyWith(
+                                        color: theme.colorScheme.onSurface.withOpacity(0.62),
+                                      ),
+                                ),
+                              ],
                             ),
                           ),
                           Text(
-                            '${numberFormatter.format(regionXp[region] ?? 0)} ${loc.xpOverviewTableHeaderXp}',
+                            '${numberFormatter.format(regionXpInLevel[region] ?? 0)} ${loc.xpOverviewTableHeaderXp}',
                             style: theme.textTheme.labelMedium?.copyWith(
                                   color: theme.colorScheme.onSurface.withOpacity(0.7),
                                 ),
@@ -273,22 +304,11 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
                         ],
                       ),
                       const SizedBox(height: AppSpacing.xs),
-                      if (regionSeries[region]?.isNotEmpty ?? false)
-                        XpTimeSeriesChart(
-                          data: regionSeries[region]!,
-                          period: _period,
-                        )
-                      else
-                        Container(
-                          height: 160,
-                          alignment: Alignment.center,
-                          child: Text(
-                            loc.reportDeviceUsageEmpty,
-                            style: theme.textTheme.bodyMedium?.copyWith(
-                                  color: theme.colorScheme.onSurface.withOpacity(0.64),
-                                ),
-                          ),
-                        ),
+                      XpTimeSeriesChart(
+                        xpHistory: regionXpHistory[region] ?? const <int>[0],
+                        totalSessions: regionSessionCount[region] ?? 0,
+                        period: _period,
+                      ),
                       if (region != regions.last)
                         Padding(
                           padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
@@ -332,8 +352,8 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
                   children: [
                     for (final region in regions)
                       XpGauge(
-                        currentXp: regionXp[region] ?? 0,
-                        level: ((regionXp[region] ?? 0) / LevelService.xpPerLevel).floor(),
+                        currentXp: regionXpInLevel[region] ?? 0,
+                        level: regionLevel[region] ?? 1,
                         label: _regionLabel(region, muscleProv),
                         size: gaugeSize,
                         onTap: () => openLeaderboard(region),
@@ -373,7 +393,7 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
                   ),
                 ),
                 Text(
-                  loc.xpOverviewTableHeaderXp,
+                  'Level / ${loc.xpOverviewTableHeaderXp}',
                   style: theme.textTheme.labelMedium?.copyWith(
                         color: theme.colorScheme.onSurface.withOpacity(0.64),
                         fontWeight: FontWeight.w600,
@@ -402,17 +422,18 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
                       crossAxisAlignment: CrossAxisAlignment.end,
                       children: [
                         Text(
-                          numberFormatter.format(regionXp[region] ?? 0),
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                                color: theme.colorScheme.onSurface.withOpacity(0.9),
+                          'Level ${regionLevel[region]}',
+                          style: theme.textTheme.labelMedium?.copyWith(
+                                color: theme.colorScheme.onSurface.withOpacity(0.62),
                                 fontWeight: FontWeight.w600,
                               ),
                         ),
                         const SizedBox(height: 4),
                         Text(
-                          'Lv. ${((regionXp[region] ?? 0) / LevelService.xpPerLevel).floor()}',
-                          style: theme.textTheme.labelSmall?.copyWith(
-                                color: theme.colorScheme.onSurface.withOpacity(0.6),
+                          '${numberFormatter.format(regionXpInLevel[region] ?? 0)} ${loc.xpOverviewTableHeaderXp}',
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                                color: theme.colorScheme.onSurface.withOpacity(0.72),
+                                fontWeight: FontWeight.w600,
                               ),
                         ),
                       ],

--- a/lib/features/xp/presentation/widgets/xp_time_series_chart.dart
+++ b/lib/features/xp/presentation/widgets/xp_time_series_chart.dart
@@ -1,67 +1,76 @@
 import 'package:flutter/material.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:tapem/features/rank/domain/services/level_service.dart';
 
 /// Defines the selectable time periods for the XP time series chart.
 enum XpPeriod { last7Days, last30Days, total }
 
-/// A line chart that visualises the XP progression over time.
+/// A line chart that visualises the XP progression per session.
 ///
-/// It takes a map of DateTime keys to integer XP values and draws a smooth
-/// line with dots at each point. The chart automatically sorts the input
-/// data by date. A tooltip appears when hovering or tapping on a point,
-/// showing the date and XP value. Colours follow the mint→turquoise→amber
-/// gradient defined in the design guidelines.
+/// The chart expects a chronological list of XP values where each entry
+/// represents the accumulated XP within the current level after completing a
+/// session. Level resets at 1000 XP are therefore reflected as drops back to
+/// 0. Tooltips show the session index and XP value for each point. Colours
+/// follow the mint→turquoise→amber gradient defined in the design guidelines.
 class XpTimeSeriesChart extends StatelessWidget {
-  /// Mapping of dates to XP values. Only the dates relevant for the current
-  /// period will be displayed.
-  final Map<DateTime, int> data;
+  /// Ordered list of XP values per session. The first entry represents the
+  /// baseline (0 XP) and each following value reflects the XP after a session
+  /// has been completed, already applying the level reset at 1000 XP.
+  final List<int> xpHistory;
+
+  /// Total number of sessions completed for the respective muscle group.
+  final int totalSessions;
 
   /// The selected time period for the chart. Determines how many points are
-  /// shown and how the x-axis labels are formatted.
+  /// shown.
   final XpPeriod period;
 
-  const XpTimeSeriesChart({Key? key, required this.data, required this.period})
-    : super(key: key);
+  const XpTimeSeriesChart({
+    Key? key,
+    required this.xpHistory,
+    required this.totalSessions,
+    required this.period,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    // Prepare a sorted list of entries for the selected period.
-    final now = DateTime.now();
-    DateTime? cutoff;
+    if (xpHistory.isEmpty) {
+      return const SizedBox(height: 200);
+    }
+
+    // Determine how many sessions should be displayed for the selected period.
+    int? sessionLimit;
     switch (period) {
       case XpPeriod.last7Days:
-        cutoff = now.subtract(const Duration(days: 6));
+        sessionLimit = 7;
         break;
       case XpPeriod.last30Days:
-        cutoff = now.subtract(const Duration(days: 29));
+        sessionLimit = 30;
         break;
       case XpPeriod.total:
-        cutoff = null;
+        sessionLimit = null;
         break;
     }
-    final entries =
-        data.entries
-            .where((e) => cutoff == null || !e.key.isBefore(cutoff))
-            .toList()
-          ..sort((a, b) => a.key.compareTo(b.key));
+
+    final requiredLength = sessionLimit != null ? sessionLimit + 1 : xpHistory.length;
+    final startIndex = xpHistory.length > requiredLength
+        ? xpHistory.length - requiredLength
+        : 0;
+    final visibleHistory = xpHistory.sublist(startIndex);
+    final baseSessionIndex = totalSessions - (visibleHistory.length - 1);
 
     final spots = <FlSpot>[];
-    for (int i = 0; i < entries.length; i++) {
-      final xp = entries[i].value;
-      spots.add(FlSpot(i.toDouble(), xp.toDouble()));
+    for (var i = 0; i < visibleHistory.length; i++) {
+      spots.add(FlSpot(i.toDouble(), visibleHistory[i].toDouble()));
     }
 
-    // Determine axis labels.
     String getFormattedLabel(int index) {
-      if (index < 0 || index >= entries.length) return '';
-      final date = entries[index].key;
-      if (period == XpPeriod.last7Days) {
-        return '${date.day}.${date.month}';
-      } else if (period == XpPeriod.last30Days) {
-        return '${date.day}.${date.month}';
-      } else {
-        return '${date.month}/${date.year % 100}';
+      if (index < 0 || index >= visibleHistory.length) return '';
+      final sessionNumber = baseSessionIndex + index;
+      if (index == 0 && sessionNumber == 0) {
+        return 'S0';
       }
+      return 'S$sessionNumber';
     }
 
     // Colour of the line: start with mint and end with amber.
@@ -70,42 +79,44 @@ class XpTimeSeriesChart extends StatelessWidget {
     const amber = Color(0xFFFFC107);
     final gradientColors = [mint, turquoise, amber];
 
+    final maxY = LevelService.xpPerLevel.toDouble();
+    final lineMaxX = spots.length > 1 ? (spots.length - 1).toDouble() : 1.0;
+
     return SizedBox(
       height: 200,
       child: LineChart(
         LineChartData(
           minX: 0,
-          maxX: spots.isNotEmpty ? (spots.length - 1).toDouble() : 0,
+          maxX: lineMaxX,
           minY: 0,
-          maxY:
-              spots.isNotEmpty
-                  ? (spots.map((e) => e.y).reduce((a, b) => a > b ? a : b) *
-                      1.2)
-                  : 1000,
+          maxY: maxY,
           lineTouchData: LineTouchData(
             handleBuiltInTouches: true,
             touchTooltipData: LineTouchTooltipData(
               getTooltipItems: (touchedSpots) {
                 return touchedSpots.map((spot) {
                   final idx = spot.x.toInt();
-                  final date = entries[idx].key;
-                  final xp = entries[idx].value;
+                  final xp = idx >= 0 && idx < visibleHistory.length
+                      ? visibleHistory[idx]
+                      : 0;
+                  final sessionNumber = baseSessionIndex + idx;
                   return LineTooltipItem(
-                    '${date.day}.${date.month}.${date.year}\n$xp XP',
+                    'Session $sessionNumber\n$xp XP',
                     const TextStyle(color: Colors.white),
                   );
                 }).toList();
               },
             ),
           ),
-          gridData: FlGridData(show: true, horizontalInterval: 500),
+          gridData: FlGridData(show: true, horizontalInterval: 250),
           titlesData: FlTitlesData(
             leftTitles: AxisTitles(
               sideTitles: SideTitles(
                 reservedSize: 40,
                 showTitles: true,
-                interval: 500,
+                interval: 250,
                 getTitlesWidget: (value, meta) {
+                  if (value.toInt() % 250 != 0) return const SizedBox.shrink();
                   return Text(
                     value.toInt().toString(),
                     style: const TextStyle(color: Colors.white70, fontSize: 10),
@@ -118,8 +129,9 @@ class XpTimeSeriesChart extends StatelessWidget {
                 showTitles: true,
                 interval: 1,
                 getTitlesWidget: (value, meta) {
+                  final index = value.toInt();
                   return Text(
-                    getFormattedLabel(value.toInt()),
+                    getFormattedLabel(index),
                     style: const TextStyle(color: Colors.white70, fontSize: 10),
                   );
                 },


### PR DESCRIPTION
## Summary
- rewrite the XP overview muscle charts to derive per-session history with level resets at 1000 XP and fixed 0–1000 y-axis
- display each muscle group’s current level and XP within the active level in both the chart list and summary table
- update the shared time series widget to plot session-based XP progression with improved tooltips and axis labelling

## Testing
- not run (flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e44c680be483208bb791383833872d