### PR TITLE
feat: improve XP history and experience UI

### DIFF
--- a/lib/core/providers/xp_provider.dart
+++ b/lib/core/providers/xp_provider.dart
@@ -18,6 +18,7 @@ class XpProvider extends ChangeNotifier {
   int _dayXp = 0;
   StreamSubscription<int>? _daySub;
   StreamSubscription<Map<String, int>>? _muscleSub;
+  StreamSubscription<Map<String, Map<String, int>>>? _muscleDailySub;
   Map<String, int> _dayListXp = {};
   final Map<String, int> _deviceXp = {};
   StreamSubscription<Map<String, int>>? _dayListSub;
@@ -26,6 +27,7 @@ class XpProvider extends ChangeNotifier {
   int _dailyLevel = 1;
   int _dailyLevelXp = 0;
   StreamSubscription<int>? _statsDailySub;
+  Map<String, Map<String, int>> _muscleDailyXp = {};
 
   Map<String, int> get muscleXp => _muscleXp;
   int get dayXp => _dayXp;
@@ -34,6 +36,7 @@ class XpProvider extends ChangeNotifier {
   int get statsDailyXp => _statsDailyXp;
   int get dailyLevel => _dailyLevel;
   int get dailyLevelXp => _dailyLevelXp;
+  Map<String, Map<String, int>> get muscleDailyXp => _muscleDailyXp;
   double get dailyProgress =>
       _dailyLevel >= LevelService.maxLevel
           ? 1
@@ -137,6 +140,18 @@ class XpProvider extends ChangeNotifier {
     });
   }
 
+  void watchMuscleDailyXp(String gymId, String userId) {
+    debugPrint('👀 provider watchMuscleDailyXp userId=$userId gymId=$gymId');
+    _muscleDailySub?.cancel();
+    _muscleDailySub = _repo
+        .watchMuscleXpHistory(gymId: gymId, userId: userId)
+        .listen((map) {
+      _muscleDailyXp = map;
+      debugPrint('🔄 provider muscleDailyXp=${map.length} days');
+      notifyListeners();
+    });
+  }
+
   void watchTrainingDays(String userId) {
     debugPrint('👀 provider watchTrainingDays userId=$userId');
     _dayListSub?.cancel();
@@ -210,6 +225,7 @@ class XpProvider extends ChangeNotifier {
   void dispose() {
     _daySub?.cancel();
     _muscleSub?.cancel();
+    _muscleDailySub?.cancel();
     _dayListSub?.cancel();
     _statsDailySub?.cancel();
     for (final sub in _deviceSubs.values) {

--- a/lib/features/rank/data/sources/firestore_rank_source.dart
+++ b/lib/features/rank/data/sources/firestore_rank_source.dart
@@ -44,12 +44,10 @@ class FirestoreRankSource {
         try {
           final result = await _firestore.runTransaction<DeviceXpResult>((tx) async {
             final userSnap = await tx.get(lbUser);
-            final daySnap = await tx.get(lbDay);
             final sessSnap = await tx.get(lbSess);
             final exSnap = lbEx != null ? await tx.get(lbEx) : null;
             XpTrace.log('TXN_READ', {
               'existsSessionDoc': sessSnap.exists,
-              'existsDayDoc': daySnap.exists,
               'existsExerciseDoc': exSnap?.exists ?? false,
               'xpCurrent': (userSnap.data()?['xp'] as int?) ?? 0,
               'levelCurrent': (userSnap.data()?['level'] as int?) ?? 1,
@@ -67,17 +65,15 @@ class FirestoreRankSource {
               return DeviceXpResult.idempotentHit;
             }
 
-            if (daySnap.exists || (exSnap?.exists ?? false)) {
+            if (exSnap?.exists ?? false) {
               XpTrace.log('TXN_DECISION', {
-                'result': daySnap.exists ? 'alreadyToday' : 'alreadyExercise',
+                'result': 'alreadyExercise',
                 'showInLeaderboard': showInLeaderboard,
                 'isMulti': isMulti,
                 'exerciseId': exerciseId ?? '',
                 'traceId': traceId,
               });
-              return daySnap.exists
-                  ? DeviceXpResult.alreadyToday
-                  : DeviceXpResult.idempotentHit;
+              return DeviceXpResult.idempotentHit;
             }
 
             const xpDelta = LevelService.xpPerSession;
@@ -104,7 +100,10 @@ class FirestoreRankSource {
               });
             }
 
-            tx.set(lbDay, {'creditedAt': FieldValue.serverTimestamp()});
+            tx.set(lbDay, {
+              'creditedAt': FieldValue.serverTimestamp(),
+              'sessionCount': FieldValue.increment(1),
+            }, SetOptions(merge: true));
             tx.set(lbSess, {
               'sessionId': sessionId,
               'creditedAt': FieldValue.serverTimestamp(),

--- a/lib/features/xp/data/repositories/xp_repository_impl.dart
+++ b/lib/features/xp/data/repositories/xp_repository_impl.dart
@@ -60,6 +60,14 @@ class XpRepositoryImpl implements XpRepository {
   }
 
   @override
+  Stream<Map<String, Map<String, int>>> watchMuscleXpHistory({
+    required String gymId,
+    required String userId,
+  }) {
+    return _source.watchMuscleXpHistory(gymId: gymId, userId: userId);
+  }
+
+  @override
   Stream<Map<String, int>> watchTrainingDaysXp(String userId) {
     return _source.watchTrainingDaysXp(userId);
   }

--- a/lib/features/xp/data/sources/firestore_xp_source.dart
+++ b/lib/features/xp/data/sources/firestore_xp_source.dart
@@ -245,6 +245,11 @@ class FirestoreXpSource {
         updates['${key}XP'] = FieldValue.increment(-value);
       });
       await statsRef.set(updates, SetOptions(merge: true));
+      await _updateMuscleXpHistory(
+        statsRef: statsRef,
+        dayKey: dayKey,
+        delta: delta.map((key, value) => MapEntry(key, -value)),
+      );
       XpTrace.log('FS_MUSCLE_REMOVE', {
         'traceId': 'remove:$dayKey:$sessionId',
         'primary': primaryMuscleGroupIds.length,
@@ -319,12 +324,34 @@ class FirestoreXpSource {
       updates['${key}XP'] = FieldValue.increment(value);
     });
     await statsRef.set(updates, SetOptions(merge: true));
+    final dayKey = logicDayKey(DateTime.now().toUtc());
+    await _updateMuscleXpHistory(
+      statsRef: statsRef,
+      dayKey: dayKey,
+      delta: delta,
+    );
     XpTrace.log('FS_MUSCLE_APPLY', {
       'traceId': traceId,
       'primary': primaryMuscleGroupIds.length,
       'secondary': secondaryMuscleGroupIds.length,
       'delta': delta,
     });
+  }
+
+  Future<void> _updateMuscleXpHistory({
+    required DocumentReference<Map<String, dynamic>> statsRef,
+    required String dayKey,
+    required Map<String, int> delta,
+  }) async {
+    if (delta.isEmpty) return;
+    final historyDoc = statsRef.collection('muscleXpHistory').doc(dayKey);
+    final updates = <String, dynamic>{
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
+    delta.forEach((key, value) {
+      updates['${key}XP'] = FieldValue.increment(value);
+    });
+    await historyDoc.set(updates, SetOptions(merge: true));
   }
 
     Stream<int> watchDayXp({required String userId, required DateTime date}) {
@@ -365,6 +392,38 @@ class FirestoreXpSource {
         }
       }
       debugPrint('📥 muscleXp snapshot ${map.length} entries $map');
+      return map;
+    });
+  }
+
+  Stream<Map<String, Map<String, int>>> watchMuscleXpHistory({
+    required String gymId,
+    required String userId,
+  }) {
+    final col = _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('users')
+        .doc(userId)
+        .collection('rank')
+        .doc('stats')
+        .collection('muscleXpHistory')
+        .orderBy(FieldPath.documentId);
+    debugPrint('👀 watchMuscleXpHistory userId=$userId gymId=$gymId');
+    return col.snapshots().map((snap) {
+      final map = <String, Map<String, int>>{};
+      for (final doc in snap.docs) {
+        final data = doc.data();
+        final dayMap = <String, int>{};
+        data.forEach((key, value) {
+          if (key.endsWith('XP') && key != 'dailyXP') {
+            final group = key.substring(0, key.length - 2);
+            dayMap[group] = (value as num?)?.toInt() ?? 0;
+          }
+        });
+        map[doc.id] = dayMap;
+      }
+      debugPrint('📥 muscleXpHistory snapshot days=${map.length}');
       return map;
     });
   }

--- a/lib/features/xp/domain/xp_repository.dart
+++ b/lib/features/xp/domain/xp_repository.dart
@@ -21,6 +21,11 @@ abstract class XpRepository {
     required String userId,
   });
 
+  Stream<Map<String, Map<String, int>>> watchMuscleXpHistory({
+    required String gymId,
+    required String userId,
+  });
+
   Stream<Map<String, int>> watchTrainingDaysXp(String userId);
 
   Stream<int> watchDeviceXp({

--- a/lib/features/xp/presentation/screens/day_xp_screen.dart
+++ b/lib/features/xp/presentation/screens/day_xp_screen.dart
@@ -3,6 +3,10 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/features/rank/domain/services/level_service.dart';
+import 'package:intl/intl.dart';
 import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/xp_provider.dart';
 import 'package:tapem/features/friends/domain/models/public_profile.dart';
@@ -120,6 +124,21 @@ class _DayXpScreenState extends State<DayXpScreen> {
         });
   }
 
+  _LevelProgress _resolveLevelProgress(int totalXp) {
+    final xpPerLevel = LevelService.xpPerLevel;
+    final maxLevel = LevelService.maxLevel;
+    var level = (totalXp ~/ xpPerLevel) + 1;
+    if (level > maxLevel) {
+      level = maxLevel;
+    }
+    var xpInLevel = totalXp % xpPerLevel;
+    if (level >= maxLevel) {
+      xpInLevel = 0;
+    }
+    final progress = level >= maxLevel ? 1.0 : xpInLevel / xpPerLevel;
+    return _LevelProgress(level: level, xpInLevel: xpInLevel, progress: progress);
+  }
+
   @override
   void dispose() {
     _lbSub?.cancel();
@@ -129,8 +148,228 @@ class _DayXpScreenState extends State<DayXpScreen> {
   @override
   Widget build(BuildContext context) {
     final xpProv = context.watch<XpProvider>();
-    final totalXp = xpProv.statsDailyXp;
     final auth = context.watch<AuthProvider>();
+    final theme = Theme.of(context);
+    final brandTheme = theme.extension<AppBrandTheme>();
+    final borderColor =
+        brandTheme?.outline.withOpacity(0.22) ?? theme.colorScheme.onSurface.withOpacity(0.12);
+    final highlightGradient = brandTheme?.gradient ?? AppGradients.brandGradient;
+    final gradientColors = brandTheme?.gradient.colors ?? AppGradients.brandGradient.colors;
+    final progressColor = gradientColors.first;
+    final xpPerLevel = LevelService.xpPerLevel;
+    final userLevel = xpProv.dailyLevel;
+    final userXpInLevel = xpProv.dailyLevelXp;
+    final userProgress = userLevel >= LevelService.maxLevel
+        ? 1.0
+        : userXpInLevel / xpPerLevel;
+    final xpRemaining = userLevel >= LevelService.maxLevel ? 0 : xpPerLevel - userXpInLevel;
+    final locale = Localizations.localeOf(context).toString();
+    final formatter = NumberFormat.decimalPattern(locale);
+
+    Widget buildSurfaceCard(
+      Widget child, {
+      EdgeInsetsGeometry? padding,
+      EdgeInsetsGeometry? margin,
+    }) {
+      return Container(
+        margin: margin ??
+            const EdgeInsets.symmetric(
+              horizontal: AppSpacing.sm,
+              vertical: AppSpacing.xs,
+            ),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surface,
+          borderRadius: BorderRadius.circular(AppRadius.card),
+          border: Border.all(color: borderColor, width: 1.2),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.32),
+              blurRadius: 28,
+              offset: const Offset(0, 16),
+            ),
+          ],
+        ),
+        child: Padding(
+          padding: padding ?? const EdgeInsets.all(AppSpacing.sm),
+          child: child,
+        ),
+      );
+    }
+
+    Widget buildCurrentUserCard() {
+      final profile = PublicProfile(
+        uid: auth.userId ?? '',
+        username: auth.userName ?? '',
+        avatarKey: auth.avatarKey,
+        primaryGymCode: auth.gymCode,
+      );
+      final totalXp = formatter.format(xpProv.statsDailyXp);
+      final xpLabel = '${formatter.format(userXpInLevel)} / ${formatter.format(xpPerLevel)} XP';
+      final remainingText = userLevel >= LevelService.maxLevel
+          ? 'Maximallevel erreicht'
+          : '${formatter.format(xpRemaining)} XP bis Level ${userLevel + 1}';
+      final themed = theme.copyWith(
+        textTheme: theme.textTheme.apply(
+          bodyColor: Colors.white,
+          displayColor: Colors.white,
+        ),
+        colorScheme: theme.colorScheme.copyWith(onSurface: Colors.white),
+      );
+
+      return Container(
+        margin: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.sm,
+          vertical: AppSpacing.sm,
+        ),
+        decoration: BoxDecoration(
+          gradient: highlightGradient,
+          borderRadius: BorderRadius.circular(AppRadius.card),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.sm),
+          child: Theme(
+            data: themed,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                FriendListTile(
+                  profile: profile,
+                  subtitle: 'Level $userLevel',
+                  trailing: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        xpLabel,
+                        style: theme.textTheme.labelLarge?.copyWith(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w600,
+                            ) ??
+                            const TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w600,
+                            ),
+                      ),
+                      Text(
+                        'Gesamt $totalXp XP',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                              color: Colors.white70,
+                            ) ??
+                            const TextStyle(color: Colors.white70, fontSize: 12),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: userProgress.clamp(0.0, 1.0),
+                    minHeight: 6,
+                    backgroundColor: Colors.white.withOpacity(0.25),
+                    valueColor: const AlwaysStoppedAnimation<Color>(Colors.white),
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  remainingText,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                        color: Colors.white70,
+                      ) ??
+                      const TextStyle(color: Colors.white70, fontSize: 12),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    Widget buildLeaderboardCard() {
+      final maxRank = _lbEntries.length < 10 ? _lbEntries.length : 10;
+      if (maxRank == 0) {
+        return buildSurfaceCard(
+          Center(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: AppSpacing.md),
+              child: Text(
+                'Keine Ranglisten-Daten',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurface.withOpacity(0.6),
+                    ),
+              ),
+            ),
+          ),
+        );
+      }
+
+      return buildSurfaceCard(
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Top 10',
+              style: theme.textTheme.titleMedium?.copyWith(
+                    color: theme.colorScheme.onSurface,
+                    fontWeight: FontWeight.w600,
+                  ),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            ..._lbEntries.asMap().entries.take(maxRank).map((entry) {
+              final rank = entry.key + 1;
+              final data = entry.value;
+              final progress = _resolveLevelProgress(data.xp);
+              final progressValue = progress.progress.clamp(0.0, 1.0);
+              final xpLabel =
+                  '${formatter.format(progress.xpInLevel)} / ${formatter.format(xpPerLevel)} XP';
+              final isLast = entry.key == maxRank - 1;
+              return Padding(
+                padding: EdgeInsets.only(bottom: isLast ? 0 : AppSpacing.sm),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    FriendListTile(
+                      profile: data.profile,
+                      subtitle: '#$rank',
+                      trailing: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.end,
+                        children: [
+                          Text(
+                            'Level ${progress.level}',
+                            style: theme.textTheme.labelMedium?.copyWith(
+                                  color: theme.colorScheme.onSurface,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                          ),
+                          Text(
+                            xpLabel,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                                  color: theme.colorScheme.onSurface.withOpacity(0.7),
+                                ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(4),
+                      child: LinearProgressIndicator(
+                        value: progressValue,
+                        minHeight: 4,
+                        backgroundColor:
+                            theme.colorScheme.onSurface.withOpacity(0.1),
+                        valueColor: AlwaysStoppedAnimation<Color>(progressColor),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            }),
+          ],
+        ),
+      );
+    }
 
     return Scaffold(
       appBar: AppBar(
@@ -144,26 +383,25 @@ class _DayXpScreenState extends State<DayXpScreen> {
         ],
       ),
       body: ListView(
+        padding: const EdgeInsets.only(bottom: AppSpacing.lg),
         children: [
-          FriendListTile(
-            profile: PublicProfile(
-              uid: auth.userId ?? '',
-              username: auth.userName ?? '',
-              avatarKey: auth.avatarKey,
-              primaryGymCode: auth.gymCode,
-            ),
-            trailing: Text('$totalXp'),
-          ),
-          const Divider(),
-          ..._lbEntries.asMap().entries.take(10).map(
-                (e) => FriendListTile(
-                  profile: e.value.profile,
-                  subtitle: '#${e.key + 1}',
-                  trailing: Text('${e.value.xp} XP'),
-                ),
-              ),
+          const SizedBox(height: AppSpacing.sm),
+          buildCurrentUserCard(),
+          buildLeaderboardCard(),
         ],
       ),
     );
   }
+}
+
+class _LevelProgress {
+  final int level;
+  final int xpInLevel;
+  final double progress;
+
+  const _LevelProgress({
+    required this.level,
+    required this.xpInLevel,
+    required this.progress,
+  });
 }

--- a/lib/features/xp/presentation/screens/xp_overview_screen.dart
+++ b/lib/features/xp/presentation/screens/xp_overview_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:collection/collection.dart';
@@ -46,6 +44,7 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
     if (uid != null && gymId != null) {
       xpProv.watchDayXp(uid, DateTime.now());
       xpProv.watchMuscleXp(gymId, uid);
+      xpProv.watchMuscleDailyXp(gymId, uid);
       xpProv.watchTrainingDays(uid);
       WidgetsBinding.instance.addPostFrameCallback((_) {
         muscleProv.loadGroups(context);
@@ -78,68 +77,97 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
     final highlightGradient = brandTheme?.gradient ?? AppGradients.brandGradient;
     final locale = Localizations.localeOf(context).toString();
     final numberFormatter = NumberFormat.decimalPattern(locale);
+    final dateFormatter = DateFormat.Md(locale);
+    final now = DateTime.now();
+    final referenceDate = DateTime(now.year, now.month, now.day);
+
+    DateTime? parseDayKey(String key) {
+      if (key.isEmpty) return null;
+      try {
+        final parts = key.split('-');
+        if (parts.length == 3) {
+          final year = int.parse(parts[0]);
+          final month = int.parse(parts[1]);
+          final day = int.parse(parts[2]);
+          return DateTime(year, month, day);
+        }
+        return DateTime.parse(key);
+      } catch (_) {
+        return null;
+      }
+    }
 
     // Map region→total XP by summing all muscle group entries and mapping to
     // their region via MuscleGroupProvider.
     final Map<MuscleRegion, int> regionXp = {
       for (final region in MuscleRegion.values) region: 0,
     };
+    final regionDailyXp = <MuscleRegion, Map<DateTime, int>>{
+      for (final region in MuscleRegion.values) region: <DateTime, int>{},
+    };
+
+    final muscleDailyXp = xpProv.muscleDailyXp;
+    final regionCache = <String, MuscleRegion?>{};
+
     for (final entry in xpProv.muscleXp.entries) {
-      MuscleRegion? region;
-      final group = muscleProv.groups.firstWhereOrNull(
-        (g) => g.id == entry.key,
-      );
-      if (group != null) {
-        region = group.region;
-      } else {
-        // Fallback: try to interpret the key as a region name.
-        region = MuscleRegion.values.firstWhereOrNull(
+      final region = regionCache.putIfAbsent(entry.key, () {
+        final group = muscleProv.groups.firstWhereOrNull(
+          (g) => g.id == entry.key,
+        );
+        if (group != null) {
+          return group.region;
+        }
+        return MuscleRegion.values.firstWhereOrNull(
           (r) => r.name == entry.key,
         );
-      }
+      });
       if (region != null) {
         regionXp[region] = (regionXp[region] ?? 0) + entry.value;
       }
     }
 
+    muscleDailyXp.forEach((dayKey, muscleMap) {
+      final parsed = parseDayKey(dayKey);
+      if (parsed == null) {
+        return;
+      }
+      final normalized = DateTime(parsed.year, parsed.month, parsed.day);
+      muscleMap.forEach((muscleId, value) {
+        if (value == 0) return;
+        final region = regionCache.putIfAbsent(muscleId, () {
+          final group = muscleProv.groups.firstWhereOrNull(
+            (g) => g.id == muscleId,
+          );
+          if (group != null) {
+            return group.region;
+          }
+          return MuscleRegion.values.firstWhereOrNull(
+            (r) => r.name == muscleId,
+          );
+        });
+        if (region != null) {
+          final map = regionDailyXp[region]!;
+          map[normalized] = (map[normalized] ?? 0) + value;
+        }
+      });
+    });
+
+    final regionDailyEntries = <MuscleRegion, List<XpDailyEntry>>{};
+    for (final region in MuscleRegion.values) {
+      final entries = regionDailyXp[region]!.entries.toList()
+        ..sort((a, b) => a.key.compareTo(b.key));
+      regionDailyEntries[region] = [
+        for (final entry in entries)
+          XpDailyEntry(date: entry.key, xp: entry.value),
+      ];
+    }
+
     final regions = MuscleRegion.values.toList()
       ..sort((a, b) => (regionXp[b] ?? 0).compareTo(regionXp[a] ?? 0));
     const xpPerLevel = LevelService.xpPerLevel;
-    const xpPerSession = LevelService.xpPerSession;
-    final maxTotalXp = LevelService.maxLevel * xpPerLevel;
-
-    List<int> buildXpHistory(int totalXp) {
-      final cappedTotalXp = math.min(totalXp, maxTotalXp);
-      final history = <int>[0];
-      if (cappedTotalXp <= 0) {
-        return history;
-      }
-      final sessionCount = cappedTotalXp ~/ xpPerSession;
-      final remainder = cappedTotalXp % xpPerSession;
-      var xpInLevel = 0;
-      for (var i = 0; i < sessionCount; i++) {
-        xpInLevel += xpPerSession;
-        if (xpInLevel >= xpPerLevel) {
-          xpInLevel -= xpPerLevel;
-          history.add(0);
-        } else {
-          history.add(xpInLevel);
-        }
-      }
-      if (remainder > 0) {
-        xpInLevel += remainder;
-        if (xpInLevel >= xpPerLevel) {
-          xpInLevel -= xpPerLevel;
-        }
-        history.add(xpInLevel);
-      }
-      return history;
-    }
 
     final regionLevel = <MuscleRegion, int>{};
     final regionXpInLevel = <MuscleRegion, int>{};
-    final regionXpHistory = <MuscleRegion, List<int>>{};
-    final regionSessionCount = <MuscleRegion, int>{};
 
     for (final region in regions) {
       final total = regionXp[region] ?? 0;
@@ -153,9 +181,6 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
       }
       regionLevel[region] = level;
       regionXpInLevel[region] = xpInLevel;
-      final history = buildXpHistory(total);
-      regionXpHistory[region] = history;
-      regionSessionCount[region] = history.length - 1;
     }
 
     void openLeaderboard(MuscleRegion region) {
@@ -305,9 +330,11 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
                       ),
                       const SizedBox(height: AppSpacing.xs),
                       XpTimeSeriesChart(
-                        xpHistory: regionXpHistory[region] ?? const <int>[0],
-                        totalSessions: regionSessionCount[region] ?? 0,
+                        dailyXp: regionDailyEntries[region] ??
+                            const <XpDailyEntry>[],
                         period: _period,
+                        dateFormatter: dateFormatter,
+                        referenceDate: referenceDate,
                       ),
                       if (region != regions.last)
                         Padding(

--- a/lib/features/xp/presentation/widgets/xp_time_series_chart.dart
+++ b/lib/features/xp/presentation/widgets/xp_time_series_chart.dart
@@ -1,93 +1,137 @@
-import 'package:flutter/material.dart';
+import 'dart:math' as math;
+
 import 'package:fl_chart/fl_chart.dart';
-import 'package:tapem/features/rank/domain/services/level_service.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 /// Defines the selectable time periods for the XP time series chart.
 enum XpPeriod { last7Days, last30Days, total }
 
-/// A line chart that visualises the XP progression per session.
+/// Represents the XP earned for a muscle group on a specific day.
+class XpDailyEntry {
+  final DateTime date;
+  final int xp;
+
+  const XpDailyEntry({required this.date, required this.xp});
+}
+
+/// A line chart that visualises the XP progression per muscle group by day.
 ///
-/// The chart expects a chronological list of XP values where each entry
-/// represents the accumulated XP within the current level after completing a
-/// session. Level resets at 1000 XP are therefore reflected as drops back to
-/// 0. Tooltips show the session index and XP value for each point. Colours
-/// follow the mint→turquoise→amber gradient defined in the design guidelines.
+/// The chart receives daily XP values and renders one point per calendar day
+/// in the selected period. Dates without XP are rendered as 0 XP to maintain a
+/// continuous timeline. Tooltips show the formatted date and XP value for the
+/// touched point.
 class XpTimeSeriesChart extends StatelessWidget {
-  /// Ordered list of XP values per session. The first entry represents the
-  /// baseline (0 XP) and each following value reflects the XP after a session
-  /// has been completed, already applying the level reset at 1000 XP.
-  final List<int> xpHistory;
-
-  /// Total number of sessions completed for the respective muscle group.
-  final int totalSessions;
-
-  /// The selected time period for the chart. Determines how many points are
-  /// shown.
+  final List<XpDailyEntry> dailyXp;
   final XpPeriod period;
+  final DateFormat dateFormatter;
+  final DateTime referenceDate;
 
   const XpTimeSeriesChart({
-    Key? key,
-    required this.xpHistory,
-    required this.totalSessions,
+    super.key,
+    required this.dailyXp,
     required this.period,
-  }) : super(key: key);
+    required this.dateFormatter,
+    required this.referenceDate,
+  });
 
   @override
   Widget build(BuildContext context) {
-    if (xpHistory.isEmpty) {
-      return const SizedBox(height: 200);
+    if (dailyXp.isEmpty) {
+      final theme = Theme.of(context);
+      return SizedBox(
+        height: 200,
+        child: Center(
+          child: Text(
+            'Noch keine XP',
+            style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurface.withOpacity(0.6),
+                ) ??
+                TextStyle(
+                  color: theme.colorScheme.onSurface.withOpacity(0.6),
+                  fontSize: 12,
+                ),
+          ),
+        ),
+      );
     }
 
-    // Determine how many sessions should be displayed for the selected period.
-    int? sessionLimit;
+    final normalizedReference =
+        DateTime(referenceDate.year, referenceDate.month, referenceDate.day);
+    final sorted = dailyXp.toList()
+      ..sort((a, b) => a.date.compareTo(b.date));
+    final aggregated = <DateTime, int>{};
+    for (final entry in sorted) {
+      final normalized =
+          DateTime(entry.date.year, entry.date.month, entry.date.day);
+      aggregated[normalized] = (aggregated[normalized] ?? 0) + entry.xp;
+    }
+    final earliest = DateTime(
+      sorted.first.date.year,
+      sorted.first.date.month,
+      sorted.first.date.day,
+    );
+    final latest = DateTime(
+      sorted.last.date.year,
+      sorted.last.date.month,
+      sorted.last.date.day,
+    );
+
+    DateTime endDate;
     switch (period) {
       case XpPeriod.last7Days:
-        sessionLimit = 7;
+        endDate = normalizedReference;
         break;
       case XpPeriod.last30Days:
-        sessionLimit = 30;
+        endDate = normalizedReference;
         break;
       case XpPeriod.total:
-        sessionLimit = null;
+        endDate = latest;
         break;
     }
 
-    final requiredLength = sessionLimit != null ? sessionLimit + 1 : xpHistory.length;
-    final startIndex = xpHistory.length > requiredLength
-        ? xpHistory.length - requiredLength
-        : 0;
-    final visibleHistory = xpHistory.sublist(startIndex);
-    final baseSessionIndex = totalSessions - (visibleHistory.length - 1);
+    DateTime startDate;
+    if (period == XpPeriod.total) {
+      startDate = earliest;
+    } else {
+      final days = period == XpPeriod.last7Days ? 6 : 29;
+      startDate = endDate.subtract(Duration(days: days));
+    }
+    if (startDate.isAfter(endDate)) {
+      startDate = endDate;
+    }
+
+    final normalizedStart = DateTime(startDate.year, startDate.month, startDate.day);
+    final normalizedEnd = DateTime(endDate.year, endDate.month, endDate.day);
+    final totalDays = normalizedEnd.difference(normalizedStart).inDays;
+    final dayCount = totalDays + 1;
 
     final spots = <FlSpot>[];
-    for (var i = 0; i < visibleHistory.length; i++) {
-      spots.add(FlSpot(i.toDouble(), visibleHistory[i].toDouble()));
+    var maxDailyXp = 0;
+    for (var i = 0; i < dayCount; i++) {
+      final day = normalizedStart.add(Duration(days: i));
+      final xp = aggregated[day] ?? 0;
+      maxDailyXp = math.max(maxDailyXp, xp);
+      spots.add(FlSpot(i.toDouble(), xp.toDouble()));
     }
 
-    String getFormattedLabel(int index) {
-      if (index < 0 || index >= visibleHistory.length) return '';
-      final sessionNumber = baseSessionIndex + index;
-      if (index == 0 && sessionNumber == 0) {
-        return 'S0';
-      }
-      return 'S$sessionNumber';
-    }
+    final maxY = math.max(
+      100,
+      ((maxDailyXp / 50).ceil() * 50).toDouble(),
+    );
+    final labelInterval = math.max(1, (dayCount / 5).ceil());
 
-    // Colour of the line: start with mint and end with amber.
     const mint = Color(0xFF00E676);
     const turquoise = Color(0xFF00BCD4);
     const amber = Color(0xFFFFC107);
     final gradientColors = [mint, turquoise, amber];
-
-    final maxY = LevelService.xpPerLevel.toDouble();
-    final lineMaxX = spots.length > 1 ? (spots.length - 1).toDouble() : 1.0;
 
     return SizedBox(
       height: 200,
       child: LineChart(
         LineChartData(
           minX: 0,
-          maxX: lineMaxX,
+          maxX: (dayCount - 1).toDouble(),
           minY: 0,
           maxY: maxY,
           lineTouchData: LineTouchData(
@@ -95,28 +139,27 @@ class XpTimeSeriesChart extends StatelessWidget {
             touchTooltipData: LineTouchTooltipData(
               getTooltipItems: (touchedSpots) {
                 return touchedSpots.map((spot) {
-                  final idx = spot.x.toInt();
-                  final xp = idx >= 0 && idx < visibleHistory.length
-                      ? visibleHistory[idx]
-                      : 0;
-                  final sessionNumber = baseSessionIndex + idx;
+                  final index = spot.x.round().clamp(0, dayCount - 1);
+                  final day = normalizedStart.add(Duration(days: index));
+                  final xp = aggregated[day] ?? 0;
                   return LineTooltipItem(
-                    'Session $sessionNumber\n$xp XP',
+                    '${dateFormatter.format(day)}\n$xp XP',
                     const TextStyle(color: Colors.white),
                   );
                 }).toList();
               },
             ),
           ),
-          gridData: FlGridData(show: true, horizontalInterval: 250),
+          gridData: FlGridData(show: true, horizontalInterval: 50),
           titlesData: FlTitlesData(
             leftTitles: AxisTitles(
               sideTitles: SideTitles(
                 reservedSize: 40,
                 showTitles: true,
-                interval: 250,
+                interval: 50,
                 getTitlesWidget: (value, meta) {
-                  if (value.toInt() % 250 != 0) return const SizedBox.shrink();
+                  if (value < 0) return const SizedBox.shrink();
+                  if (value % 50 != 0) return const SizedBox.shrink();
                   return Text(
                     value.toInt().toString(),
                     style: const TextStyle(color: Colors.white70, fontSize: 10),
@@ -127,12 +170,22 @@ class XpTimeSeriesChart extends StatelessWidget {
             bottomTitles: AxisTitles(
               sideTitles: SideTitles(
                 showTitles: true,
-                interval: 1,
                 getTitlesWidget: (value, meta) {
-                  final index = value.toInt();
-                  return Text(
-                    getFormattedLabel(index),
-                    style: const TextStyle(color: Colors.white70, fontSize: 10),
+                  final index = value.round();
+                  if (index < 0 || index >= dayCount) {
+                    return const SizedBox.shrink();
+                  }
+                  final isEdge = index == 0 || index == dayCount - 1;
+                  if (!isEdge && index % labelInterval != 0) {
+                    return const SizedBox.shrink();
+                  }
+                  final day = normalizedStart.add(Duration(days: index));
+                  return Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text(
+                      dateFormatter.format(day),
+                      style: const TextStyle(color: Colors.white70, fontSize: 10),
+                    ),
                   );
                 },
               ),


### PR DESCRIPTION
## Summary
- track muscle XP per day by persisting history entries in Firestore and exposing them through the XP provider
- allow multiple session credits per day while recording daily session counts and keep muscle XP totals in sync
- render region charts against calendar dates and refresh the daily experience screen with level-aware styling

## Testing
- not run (Flutter SDK is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68e45141ac80832089264089bd0e48dc