### PR TITLE
Fix chart maxY type

### DIFF
--- a/lib/features/xp/presentation/widgets/xp_time_series_chart.dart
+++ b/lib/features/xp/presentation/widgets/xp_time_series_chart.dart
@@ -116,7 +116,7 @@ class XpTimeSeriesChart extends StatelessWidget {
     }
 
     final maxY = math.max(
-      100,
+      100.0,
       ((maxDailyXp / 50).ceil() * 50).toDouble(),
     );
     final labelInterval = math.max(1, (dayCount / 5).ceil());


### PR DESCRIPTION
## Summary
- ensure the XP time series chart uses a double maxY value for fl_chart compatibility

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e455b6f2b08320aeb97391abd91e38