### PR TITLE
Fix muscle XP accrual and speed up overview

### DIFF
--- a/lib/core/providers/muscle_group_provider.dart
+++ b/lib/core/providers/muscle_group_provider.dart
@@ -82,6 +82,9 @@ class MuscleGroupProvider extends ChangeNotifier {
   String? _error;
   List<MuscleGroup> _groups = [];
   final Map<String, int> _counts = {};
+  String? _loadedGymId;
+  bool _hasLoadedSuccessfully = false;
+  Future<void>? _activeLoad;
 
   bool get isLoading => _isLoading;
   String? get error => _error;
@@ -96,20 +99,41 @@ class MuscleGroupProvider extends ChangeNotifier {
     return _ensureRegionGroup.execute(gymId, region);
   }
 
-  Future<void> loadGroups(BuildContext context) async {
+  Future<void> loadGroups(BuildContext context, {bool force = false}) async {
+    final auth = Provider.of<AuthProvider>(context, listen: false);
+    final gymId = auth.gymCode;
+    final userId = auth.userId;
+    if (gymId == null || userId == null) {
+      _error = 'Benutzer nicht eingeloggt';
+      notifyListeners();
+      return;
+    }
+
+    if (!force &&
+        _hasLoadedSuccessfully &&
+        _loadedGymId == gymId &&
+        _activeLoad == null) {
+      return;
+    }
+
+    _activeLoad ??=
+        _performLoad(gymId: gymId, userId: userId).whenComplete(() {
+      _activeLoad = null;
+    });
+    return _activeLoad;
+  }
+
+  Future<void> _performLoad({
+    required String gymId,
+    required String userId,
+  }) async {
     _isLoading = true;
     _error = null;
     notifyListeners();
 
     try {
-      final auth = Provider.of<AuthProvider>(context, listen: false);
-      final gymId = auth.gymCode;
-      final userId = auth.userId;
-      if (gymId == null || userId == null) {
-        throw Exception('Benutzer nicht eingeloggt');
-      }
-
       await _membership.ensureMembership(gymId, userId);
+      _counts.clear();
       try {
         _groups = await _getGroups.execute(gymId);
       } on FirebaseException catch (e) {
@@ -124,6 +148,8 @@ class MuscleGroupProvider extends ChangeNotifier {
         }
       }
       await _loadCounts(gymId, userId);
+      _loadedGymId = gymId;
+      _hasLoadedSuccessfully = true;
     } catch (e, st) {
       _error = e.toString();
       debugPrintStack(label: 'MuscleGroupProvider.loadGroups', stackTrace: st);
@@ -131,6 +157,10 @@ class MuscleGroupProvider extends ChangeNotifier {
       _isLoading = false;
       notifyListeners();
     }
+  }
+
+  Future<void> ensureLoaded(BuildContext context, {bool force = false}) {
+    return loadGroups(context, force: force);
   }
 
   Future<void> saveGroup(BuildContext context, MuscleGroup group) async {
@@ -162,7 +192,7 @@ class MuscleGroupProvider extends ChangeNotifier {
       } catch (_) {}
     }
 
-    await loadGroups(context);
+    await loadGroups(context, force: true);
   }
 
   Future<void> deleteGroup(BuildContext context, String groupId) async {
@@ -170,7 +200,7 @@ class MuscleGroupProvider extends ChangeNotifier {
     final gymId = auth.gymCode;
     if (gymId == null) return;
     await _deleteGroup.execute(gymId, groupId);
-    await loadGroups(context);
+    await loadGroups(context, force: true);
   }
 
   Future<MuscleGroup> getOrCreateByRegion(
@@ -189,7 +219,7 @@ class MuscleGroupProvider extends ChangeNotifier {
       exerciseIds: const [],
     );
     await saveGroup(ctx, g);
-    await loadGroups(ctx);
+    await loadGroups(ctx, force: true);
     return _groups.firstWhereOrNull((x) => x.id == g.id) ?? g;
   }
 
@@ -209,7 +239,7 @@ class MuscleGroupProvider extends ChangeNotifier {
         await _saveGroup.execute(gymId, updated);
       }
     }
-    await loadGroups(context);
+    await loadGroups(context, force: true);
   }
 
   Future<void> assignExercise(
@@ -226,7 +256,7 @@ class MuscleGroupProvider extends ChangeNotifier {
         await _saveGroup.execute(gymId, updated);
       }
     }
-    await loadGroups(context);
+    await loadGroups(context, force: true);
   }
 
   Future<void> updateExerciseAssignments(
@@ -253,7 +283,7 @@ class MuscleGroupProvider extends ChangeNotifier {
         await _saveGroup.execute(gymId, updated);
       }
     }
-    await loadGroups(context);
+    await loadGroups(context, force: true);
   }
 
   Future<void> updateDeviceAssignments(
@@ -310,7 +340,7 @@ class MuscleGroupProvider extends ChangeNotifier {
       );
     } catch (_) {}
 
-    await loadGroups(context);
+    await loadGroups(context, force: true);
   }
 
   Future<void> _loadCounts(String gymId, String userId) async {

--- a/lib/features/rank/data/sources/firestore_rank_source.dart
+++ b/lib/features/rank/data/sources/firestore_rank_source.dart
@@ -37,18 +37,12 @@ class FirestoreRankSource {
             .doc(userId);
         final lbSess = lbUser.collection('sessions').doc(sessionId);
         final lbDay = lbUser.collection('days').doc(dayKey);
-        final lbEx = isMulti && exerciseId != null
-            ? lbUser.collection('exercises').doc('$exerciseId-$dayKey')
-            : null;
-
         try {
           final result = await _firestore.runTransaction<DeviceXpResult>((tx) async {
             final userSnap = await tx.get(lbUser);
             final sessSnap = await tx.get(lbSess);
-            final exSnap = lbEx != null ? await tx.get(lbEx) : null;
             XpTrace.log('TXN_READ', {
               'existsSessionDoc': sessSnap.exists,
-              'existsExerciseDoc': exSnap?.exists ?? false,
               'xpCurrent': (userSnap.data()?['xp'] as int?) ?? 0,
               'levelCurrent': (userSnap.data()?['level'] as int?) ?? 1,
               'traceId': traceId,
@@ -57,17 +51,6 @@ class FirestoreRankSource {
             if (sessSnap.exists) {
               XpTrace.log('TXN_DECISION', {
                 'result': 'alreadySession',
-                'showInLeaderboard': showInLeaderboard,
-                'isMulti': isMulti,
-                'exerciseId': exerciseId ?? '',
-                'traceId': traceId,
-              });
-              return DeviceXpResult.idempotentHit;
-            }
-
-            if (exSnap?.exists ?? false) {
-              XpTrace.log('TXN_DECISION', {
-                'result': 'alreadyExercise',
                 'showInLeaderboard': showInLeaderboard,
                 'isMulti': isMulti,
                 'exerciseId': exerciseId ?? '',
@@ -108,11 +91,6 @@ class FirestoreRankSource {
               'sessionId': sessionId,
               'creditedAt': FieldValue.serverTimestamp(),
             });
-            bool wroteExercise = false;
-            if (lbEx != null) {
-              tx.set(lbEx, {'creditedAt': FieldValue.serverTimestamp()});
-              wroteExercise = true;
-            }
 
             XpTrace.log('TXN_WRITE', {
               'deltaXp': xpDelta,
@@ -120,7 +98,6 @@ class FirestoreRankSource {
               'newLevel': info.level,
               'wroteSessionMarker': true,
               'wroteDayMarker': true,
-              'wroteExerciseMarker': wroteExercise,
               'traceId': traceId,
             });
 

--- a/lib/features/xp/data/sources/firestore_xp_source.dart
+++ b/lib/features/xp/data/sources/firestore_xp_source.dart
@@ -138,7 +138,6 @@ class FirestoreXpSource {
     List<String> primaryMuscleGroupIds = const [],
     List<String> secondaryMuscleGroupIds = const [],
   }) async {
-    final uniqueExercises = exerciseIds.where((e) => e.isNotEmpty).toSet();
     final userRef = _firestore.collection('users').doc(userId);
     final dayRef = userRef.collection('trainingDayXP').doc(dayKey);
     final statsRef = _firestore
@@ -157,10 +156,6 @@ class FirestoreXpSource {
         .doc(userId);
     final lbSess = lbUser.collection('sessions').doc(sessionId);
     final lbDay = lbUser.collection('days').doc(dayKey);
-    final exerciseRefs = [
-      for (final ex in uniqueExercises)
-        lbUser.collection('exercises').doc('$ex-$dayKey'),
-    ];
 
     XpTrace.log('FS_REMOVE_IN', {
       'gymId': gymId,
@@ -168,7 +163,7 @@ class FirestoreXpSource {
       'deviceId': deviceId,
       'sessionId': sessionId,
       'dayKey': dayKey,
-      'exerciseCount': uniqueExercises.length,
+      'exerciseCount': exerciseIds.where((e) => e.isNotEmpty).length,
     });
 
     await _firestore.runTransaction((tx) async {
@@ -177,10 +172,6 @@ class FirestoreXpSource {
       final lbUserSnap = await tx.get(lbUser);
       final lbSessSnap = await tx.get(lbSess);
       final lbDaySnap = await tx.get(lbDay);
-      final exerciseSnaps = <DocumentSnapshot<Map<String, dynamic>>>[];
-      for (final ref in exerciseRefs) {
-        exerciseSnaps.add(await tx.get(ref));
-      }
 
       const xpDelta = LevelService.xpPerSession;
       var adjustStats = false;
@@ -219,11 +210,6 @@ class FirestoreXpSource {
       }
       if (lbDaySnap.exists) {
         tx.delete(lbDay);
-      }
-      for (final snap in exerciseSnaps) {
-        if (snap.exists) {
-          tx.delete(snap.reference);
-        }
       }
     });
 

--- a/lib/features/xp/presentation/screens/xp_overview_screen.dart
+++ b/lib/features/xp/presentation/screens/xp_overview_screen.dart
@@ -47,7 +47,7 @@ class _XpOverviewScreenState extends State<XpOverviewScreen> {
       xpProv.watchMuscleDailyXp(gymId, uid);
       xpProv.watchTrainingDays(uid);
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        muscleProv.loadGroups(context);
+        muscleProv.ensureLoaded(context);
       });
     }
   }

--- a/test/features/rank/data/firestore_rank_source_test.dart
+++ b/test/features/rank/data/firestore_rank_source_test.dart
@@ -1,0 +1,68 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tapem/features/rank/data/sources/firestore_rank_source.dart';
+import 'package:tapem/features/xp/domain/device_xp_result.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('FirestoreRankSource.addXp', () {
+    test('credits XP for every session even if exercise repeats on the same day', () async {
+      final firestore = FakeFirebaseFirestore();
+      final source = FirestoreRankSource(firestore: firestore);
+
+      final result1 = await source.addXp(
+        gymId: 'g1',
+        userId: 'u1',
+        deviceId: 'd1',
+        sessionId: 's1',
+        showInLeaderboard: true,
+        isMulti: true,
+        exerciseId: 'ex1',
+        traceId: 't1',
+      );
+      expect(result1, DeviceXpResult.okAdded);
+
+      final result2 = await source.addXp(
+        gymId: 'g1',
+        userId: 'u1',
+        deviceId: 'd1',
+        sessionId: 's2',
+        showInLeaderboard: true,
+        isMulti: true,
+        exerciseId: 'ex1',
+        traceId: 't2',
+      );
+      expect(result2, DeviceXpResult.okAdded);
+
+      final leaderboardDoc = await firestore
+          .collection('gyms')
+          .doc('g1')
+          .collection('devices')
+          .doc('d1')
+          .collection('leaderboard')
+          .doc('u1')
+          .get();
+
+      expect(leaderboardDoc.data()?['xp'], 100);
+
+      final sessionsSnap = await leaderboardDoc.reference.collection('sessions').get();
+      expect(sessionsSnap.docs.length, 2);
+
+      final result3 = await source.addXp(
+        gymId: 'g1',
+        userId: 'u1',
+        deviceId: 'd1',
+        sessionId: 's1',
+        showInLeaderboard: true,
+        isMulti: true,
+        exerciseId: 'ex1',
+        traceId: 't3',
+      );
+      expect(result3, DeviceXpResult.idempotentHit);
+
+      final leaderboardDocAfter = await leaderboardDoc.reference.get();
+      expect(leaderboardDocAfter.data()?['xp'], 100);
+    });
+  });
+}

--- a/test/ui/exercise_list_chips_update_test.dart
+++ b/test/ui/exercise_list_chips_update_test.dart
@@ -130,7 +130,7 @@ class _FakeMuscleGroupProvider extends MuscleGroupProvider {
   @override
   List<MuscleGroup> get groups => _groups;
   @override
-  Future<void> loadGroups(BuildContext context) async {}
+  Future<void> loadGroups(BuildContext context, {bool force = false}) async {}
 }
 
 class _FakeAuth extends ChangeNotifier implements AuthProvider {

--- a/test/ui/muscle_groups/admin_list_filters_test.dart
+++ b/test/ui/muscle_groups/admin_list_filters_test.dart
@@ -59,7 +59,7 @@ class FakeMuscleGroupProvider extends ChangeNotifier
   @override
   Map<String, int> get counts => {};
   @override
-  Future<void> loadGroups(BuildContext context) async {}
+  Future<void> loadGroups(BuildContext context, {bool force = false}) async {}
   @override
   Future<void> updateDeviceAssignments(BuildContext context, String deviceId,
           List<String> primaryGroupIds, List<String> secondaryGroupIds) async {}

--- a/test/ui/muscle_groups/assignment_sheet_test.dart
+++ b/test/ui/muscle_groups/assignment_sheet_test.dart
@@ -24,7 +24,7 @@ class FakeMuscleGroupProvider extends ChangeNotifier implements MuscleGroupProvi
   Map<String, int> get counts => {};
 
   @override
-  Future<void> loadGroups(BuildContext context) async {}
+  Future<void> loadGroups(BuildContext context, {bool force = false}) async {}
 
   @override
   Future<String?> ensureRegionGroup(BuildContext context, MuscleRegion region) async {

--- a/test/widgets/exercise_bottom_sheet_selected_preview_test.dart
+++ b/test/widgets/exercise_bottom_sheet_selected_preview_test.dart
@@ -102,7 +102,7 @@ class FakeMuscleGroupProvider extends MuscleGroupProvider {
   List<MuscleGroup> get groups => _groups;
 
   @override
-  Future<void> loadGroups(BuildContext context) async {}
+  Future<void> loadGroups(BuildContext context, {bool force = false}) async {}
 }
 
 class _FakeAuthProvider extends ChangeNotifier implements AuthProvider {

--- a/test/widgets/muscle_group_list_selector_test.dart
+++ b/test/widgets/muscle_group_list_selector_test.dart
@@ -95,7 +95,7 @@ class _FakeMuscleGroupProvider extends MuscleGroupProvider {
   @override
   List<MuscleGroup> get groups => _groups;
   @override
-  Future<void> loadGroups(BuildContext context) async {}
+  Future<void> loadGroups(BuildContext context, {bool force = false}) async {}
 }
 
 void main() {

--- a/test/widgets/muscle_group_selector_test.dart
+++ b/test/widgets/muscle_group_selector_test.dart
@@ -100,7 +100,7 @@ class FakeMuscleGroupProvider extends MuscleGroupProvider {
   List<MuscleGroup> get groups => _groups;
 
   @override
-  Future<void> loadGroups(BuildContext context) async {}
+  Future<void> loadGroups(BuildContext context, {bool force = false}) async {}
 }
 
 void main() {


### PR DESCRIPTION
## Summary
- allow repeated sessions for the same exercise to award XP and simplify cleanup bookkeeping
- add a regression test covering multiple same-exercise sessions and adjust muscle group provider caching to avoid redundant loads
- switch the XP overview screen to the cached loader so the graphs populate faster

## Testing
- not run (tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e457d466a883209a6590fd9860f1d9