### PR TITLE
Fix user Firestore rule for username updates

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -204,16 +204,19 @@ service cloud.firestore {
       allow create: if isOwner(uid);
       allow read: if isAuthed();
       allow update: if isOwner(uid) &&
-        request.resource.data.keys().hasOnly([
-          'username',
-          'usernameLower',
-          'showInLeaderboard',
-          'publicProfile',
-          'avatarUrl',
-          'avatarKey',
-          'avatarUpdatedAt',
-          'equippedAvatarRef'
-        ]);
+        request.resource.data
+            .diff(resource.data)
+            .changedKeys()
+            .hasOnly([
+              'username',
+              'usernameLower',
+              'showInLeaderboard',
+              'publicProfile',
+              'avatarUrl',
+              'avatarKey',
+              'avatarUpdatedAt',
+              'equippedAvatarRef'
+            ]);
       allow update: if isGymAdminFor(uid, request.auth.token.gymId) &&
         request.resource.data.keys().hasOnly(['avatarKey']) &&
         request.resource.data.avatarKey is string;


### PR DESCRIPTION
## Summary
- update the users/{uid} update rule to only restrict changed keys, so members can set usernames without violating the rule

## Testing
- not run (Flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e4b6b978c88320b1a76f8ae8c2f7d0