### PR TITLE
Handle resource exhausted when setting usernames

### DIFF
--- a/lib/features/auth/data/sources/firestore_auth_source.dart
+++ b/lib/features/auth/data/sources/firestore_auth_source.dart
@@ -1,16 +1,29 @@
+import 'dart:async';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:tapem/features/auth/data/dtos/user_data_dto.dart';
 import 'package:tapem/features/auth/data/services/username_service.dart';
 import 'package:tapem/features/gym/data/sources/firestore_gym_source.dart';
 
+typedef ChangeUsernameRunner = Future<void> Function({
+  required FirebaseFirestore firestore,
+  required String uid,
+  required String newUsername,
+});
+
 class FirestoreAuthSource {
   final FirebaseAuth _auth;
   final FirebaseFirestore _firestore;
+  final ChangeUsernameRunner _changeUsername;
 
-  FirestoreAuthSource({FirebaseAuth? auth, FirebaseFirestore? firestore})
-      : _auth = auth ?? FirebaseAuth.instance,
-        _firestore = firestore ?? FirebaseFirestore.instance;
+  FirestoreAuthSource({
+    FirebaseAuth? auth,
+    FirebaseFirestore? firestore,
+    ChangeUsernameRunner? changeUsername,
+  })  : _auth = auth ?? FirebaseAuth.instance,
+        _firestore = firestore ?? FirebaseFirestore.instance,
+        _changeUsername = changeUsername ?? changeUsernameTransaction;
 
   Future<UserDataDto> login(String email, String password) async {
     final cred = await _auth.signInWithEmailAndPassword(
@@ -85,18 +98,22 @@ class FirestoreAuthSource {
   }
 
   Future<void> setUsername(String userId, String username) async {
-    Future<void> run() => changeUsernameTransaction(
+    const retryable = {'aborted', 'resource-exhausted', 'unavailable'};
+    var attempts = 0;
+    while (true) {
+      try {
+        await _changeUsername(
           firestore: _firestore,
           uid: userId,
           newUsername: username,
         );
-    try {
-      await run();
-    } on FirebaseException catch (e) {
-      if (e.code == 'aborted') {
-        await run();
-      } else {
-        rethrow;
+        return;
+      } on FirebaseException catch (e) {
+        if (!retryable.contains(e.code) || attempts >= 2) {
+          rethrow;
+        }
+        attempts += 1;
+        await Future<void>.delayed(Duration(milliseconds: 100 * attempts));
       }
     }
   }

--- a/test/features/auth/data/sources/firestore_auth_source_test.dart
+++ b/test/features/auth/data/sources/firestore_auth_source_test.dart
@@ -1,0 +1,86 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:tapem/features/auth/data/services/username_service.dart';
+import 'package:tapem/features/auth/data/sources/firestore_auth_source.dart';
+
+class _MockChangeUsernameRunner extends Mock implements ChangeUsernameRunner {}
+
+class _FakeFirebaseAuth extends Fake implements FirebaseAuth {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue('');
+  });
+
+  group('FirestoreAuthSource.setUsername', () {
+    test('retries once when transaction is resource-exhausted', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore.collection('users').doc('u1').set({});
+      final runner = _MockChangeUsernameRunner();
+      var callCount = 0;
+      when(() => runner(
+            firestore: firestore,
+            uid: any(named: 'uid'),
+            newUsername: any(named: 'newUsername'),
+          )).thenAnswer((invocation) async {
+        callCount += 1;
+        if (callCount == 1) {
+          throw FirebaseException(
+            plugin: 'firestore',
+            code: 'resource-exhausted',
+          );
+        }
+        await changeUsernameTransaction(
+          firestore: invocation.namedArguments[#firestore] as FirebaseFirestore,
+          uid: invocation.namedArguments[#uid] as String,
+          newUsername: invocation.namedArguments[#newUsername] as String,
+        );
+      });
+
+      final source = FirestoreAuthSource(
+        auth: _FakeFirebaseAuth(),
+        firestore: firestore,
+        changeUsername: runner,
+      );
+
+      await source.setUsername('u1', 'Alice');
+
+      expect(callCount, 2);
+      final userDoc = await firestore.collection('users').doc('u1').get();
+      expect(userDoc.data()!['username'], 'Alice');
+    });
+
+    test('throws after max retries when resource-exhausted persists', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore.collection('users').doc('u1').set({});
+      final runner = _MockChangeUsernameRunner();
+      when(() => runner(
+            firestore: firestore,
+            uid: any(named: 'uid'),
+            newUsername: any(named: 'newUsername'),
+          )).thenThrow(
+        FirebaseException(plugin: 'firestore', code: 'resource-exhausted'),
+      );
+
+      final source = FirestoreAuthSource(
+        auth: _FakeFirebaseAuth(),
+        firestore: firestore,
+        changeUsername: runner,
+      );
+
+      await expectLater(
+        source.setUsername('u1', 'Alice'),
+        throwsA(isA<FirebaseException>().having((e) => e.code, 'code', 'resource-exhausted')),
+      );
+
+      verify(() => runner(
+            firestore: firestore,
+            uid: any(named: 'uid'),
+            newUsername: any(named: 'newUsername'),
+          )).called(3);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- retry username updates on Firestore transient errors and allow injecting the runner for tests
- add tests covering retry and max retry behaviour for username updates

## Testing
- not run (Flutter/Dart SDK not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e4b6b978c88320b1a76f8ae8c2f7d0