### PR TITLE
Fix leaderboard spacing token references

### DIFF
--- a/lib/features/xp/presentation/screens/leaderboard_screen.dart
+++ b/lib/features/xp/presentation/screens/leaderboard_screen.dart
@@ -199,7 +199,7 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
     Widget buildContent() {
       if (isLoading) {
         return const Padding(
-          padding: EdgeInsets.symmetric(vertical: AppSpacing.xl),
+          padding: EdgeInsets.symmetric(vertical: AppSpacing.lg),
           child: Center(child: CircularProgressIndicator()),
         );
       }
@@ -208,7 +208,7 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
             ? loc.leaderboardEmptyGym
             : loc.leaderboardEmptyFriends;
         return Padding(
-          padding: const EdgeInsets.symmetric(vertical: AppSpacing.xl),
+          padding: const EdgeInsets.symmetric(vertical: AppSpacing.lg),
           child: Center(
             child: Text(
               emptyText,


### PR DESCRIPTION
## Summary
- replace references to the non-existent `AppSpacing.xl` token with the existing `AppSpacing.lg`
- ensure leaderboard loading and empty states use valid spacing constants

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4eeaa2e148320ad5ea03b75bb5269