### PR TITLE
Allow friends leaderboard to load cross-gym XP

### DIFF
--- a/firestore-tests/security_rules.test.js
+++ b/firestore-tests/security_rules.test.js
@@ -61,6 +61,8 @@ describe('Security Rules v1', function () {
         .set({ fromUserId: 'user1', toUserId: 'user2', status: 'pending' });
       await db.collection('users').doc('user1').collection('friends').doc('user2').set({});
       await db.collection('users').doc('user2').collection('friends').doc('user1').set({});
+      await db.collection('users').doc('user1').collection('friends').doc('user3').set({});
+      await db.collection('users').doc('user3').collection('friends').doc('user1').set({});
       await db.collection('users').doc('user1').collection('publicCalendar').doc('2024-01').set({ month: '2024-01' });
       await db
         .collection('gyms')
@@ -126,6 +128,20 @@ describe('Security Rules v1', function () {
       await db.collection('users').doc('userB').set({});
       await db.collection('publicProfiles').doc('userA').set({ username: 'Alice' });
       await db.collection('publicProfiles').doc('userB').set({ username: 'Bob' });
+      await db
+        .collection('gyms')
+        .doc('G2')
+        .collection('users')
+        .doc('user3')
+        .set({ role: 'member' });
+      await db
+        .collection('gyms')
+        .doc('G2')
+        .collection('users')
+        .doc('user3')
+        .collection('rank')
+        .doc('stats')
+        .set({ dailyXP: 420 });
     });
   });
 
@@ -197,6 +213,30 @@ describe('Security Rules v1', function () {
         .collection('exercises')
         .doc('exFriend');
       await assertSucceeds(ref.get());
+    });
+
+    it('allows friend to read cross-gym rank stats', async () => {
+      const db = p1().firestore();
+      const ref = db
+        .collection('gyms')
+        .doc('G2')
+        .collection('users')
+        .doc('user3')
+        .collection('rank')
+        .doc('stats');
+      await assertSucceeds(ref.get());
+    });
+
+    it('blocks non-friend from reading cross-gym rank stats', async () => {
+      const db = stranger().firestore();
+      const ref = db
+        .collection('gyms')
+        .doc('G2')
+        .collection('users')
+        .doc('user3')
+        .collection('rank')
+        .doc('stats');
+      await assertFails(ref.get());
     });
 
     it('allows public exercise read in same gym', async () => {

--- a/firestore.rules
+++ b/firestore.rules
@@ -432,6 +432,12 @@ service cloud.firestore {
         allow update, delete: if isAdmin(gymId);
       }
 
+      match /users/{userId}/rank/{document=**} {
+        allow read: if ownerOrAdmin(gymId, userId) ||
+                     isFriend(userId, request.auth.uid);
+        allow write: if ownerOrAdmin(gymId, userId);
+      }
+
       match /users/{userId}/{doc=**} {
         allow read, write: if ownerOrAdmin(gymId, userId);
       }

--- a/lib/features/xp/presentation/screens/leaderboard_screen.dart
+++ b/lib/features/xp/presentation/screens/leaderboard_screen.dart
@@ -41,6 +41,39 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
   AuthProvider? _authProvider;
   FriendsProvider? _friendsProvider;
 
+  Future<int> _loadDailyXpAcrossGyms(String uid, Set<String> gymIds) async {
+    if (gymIds.isEmpty) {
+      return 0;
+    }
+    final fs = FirebaseFirestore.instance;
+    final xpValues = await Future.wait(gymIds.map((gymId) async {
+      try {
+        final statsDoc = await fs
+            .collection('gyms')
+            .doc(gymId)
+            .collection('users')
+            .doc(uid)
+            .collection('rank')
+            .doc('stats')
+            .get();
+        return statsDoc.data()?['dailyXP'] as int? ?? 0;
+      } on FirebaseException catch (error, stack) {
+        debugPrint(
+          'Failed to load rank stats for user=$uid gym=$gymId: ${error.message}',
+        );
+        debugPrint('$stack');
+        return 0;
+      } catch (error, stack) {
+        debugPrint(
+          'Unexpected error loading rank stats for user=$uid gym=$gymId: $error',
+        );
+        debugPrint('$stack');
+        return 0;
+      }
+    }));
+    return xpValues.fold<int>(0, (sum, value) => sum + value);
+  }
+
   @override
   void initState() {
     super.initState();
@@ -152,19 +185,20 @@ class _LeaderboardScreenState extends State<LeaderboardScreen> {
           return null;
         }
         final profile = PublicProfile.fromMap(uid, userData);
-        final profileGym = profile.primaryGymCode ?? auth.gymCode;
-        if (profileGym == null || profileGym.isEmpty) {
-          return LeaderboardEntry(profile: profile, xp: 0);
+        final gymCodes = (userData['gymCodes'] as List<dynamic>? ?? const [])
+            .whereType<String>()
+            .where((code) => code.isNotEmpty);
+        final candidateGyms = <String>{
+          if ((profile.primaryGymCode ?? '').isNotEmpty) profile.primaryGymCode!,
+          ...gymCodes,
+        };
+        if (candidateGyms.isEmpty) {
+          final fallbackGym = auth.gymCode;
+          if (fallbackGym != null && fallbackGym.isNotEmpty) {
+            candidateGyms.add(fallbackGym);
+          }
         }
-        final statsDoc = await fs
-            .collection('gyms')
-            .doc(profileGym)
-            .collection('users')
-            .doc(uid)
-            .collection('rank')
-            .doc('stats')
-            .get();
-        final xp = statsDoc.data()?['dailyXP'] as int? ?? 0;
+        final xp = await _loadDailyXpAcrossGyms(uid, candidateGyms);
         return LeaderboardEntry(profile: profile, xp: xp);
       });
       final entries = (await Future.wait(futures))


### PR DESCRIPTION
## Summary
- load friend leaderboard XP across all known gym memberships and handle missing gym metadata more gracefully
- update Firestore rules so friends may read rank stats from other gyms without admin access
- extend Firestore security tests to cover cross-gym rank stat access for friends versus non-friends

## Testing
- npm run rules-test *(fails: Firestore emulator not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f0656f608320930072ffa237fbc9