### PR TITLE
Show XP card from profile avatar

### DIFF
--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:intl/intl.dart';
 import 'package:tapem/core/providers/app_provider.dart' as app;
 import 'package:tapem/core/providers/profile_provider.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
@@ -22,6 +23,9 @@ import 'package:tapem/core/utils/avatar_assets.dart';
 import 'package:tapem/features/avatars/domain/services/avatar_catalog.dart';
 import 'package:tapem/features/avatars/presentation/providers/avatar_inventory_provider.dart';
 import 'package:tapem/core/providers/xp_provider.dart';
+import 'package:tapem/features/friends/domain/models/public_profile.dart';
+import 'package:tapem/features/rank/domain/services/level_service.dart';
+import 'package:tapem/features/xp/presentation/widgets/daily_xp_card.dart';
 import '../widgets/daily_xp_avatar.dart';
 import '../widgets/calendar.dart';
 import '../widgets/calendar_popup.dart';
@@ -144,7 +148,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
     );
   }
 
-  void _showAvatarSheet(AuthProvider auth) {
+  void _showInventorySheet(AuthProvider auth) {
     final loc = AppLocalizations.of(context)!;
     showModalBottomSheet(
       context: context,
@@ -166,6 +170,65 @@ class _ProfileScreenState extends State<ProfileScreen> {
               );
             }
           },
+        );
+      },
+    );
+  }
+
+  void _showProfileXpSheet(AuthProvider auth) {
+    final xpProv = context.read<XpProvider>();
+    showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      builder: (sheetContext) {
+        final loc = AppLocalizations.of(sheetContext)!;
+        final locale = Localizations.localeOf(sheetContext).toString();
+        final formatter = NumberFormat.decimalPattern(locale);
+        final profile = PublicProfile(
+          uid: auth.userId ?? '',
+          username: auth.userName ?? '',
+          avatarKey: auth.avatarKey,
+          primaryGymCode: auth.gymCode,
+        );
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(
+              AppSpacing.md,
+              AppSpacing.md,
+              AppSpacing.md,
+              AppSpacing.lg,
+            ),
+            child: DailyXpCard(
+              profile: profile,
+              level: xpProv.dailyLevel,
+              xpInLevel: xpProv.dailyLevelXp,
+              totalXp: xpProv.statsDailyXp,
+              numberFormat: formatter,
+              xpPerLevel: LevelService.xpPerLevel,
+              maxLevel: LevelService.maxLevel,
+              margin: EdgeInsets.zero,
+              footer: Align(
+                alignment: Alignment.centerRight,
+                child: TextButton.icon(
+                  style: TextButton.styleFrom(
+                    foregroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.sm,
+                      vertical: AppSpacing.xs,
+                    ),
+                    visualDensity: VisualDensity.compact,
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                  onPressed: () {
+                    Navigator.pop(sheetContext);
+                    _showInventorySheet(auth);
+                  },
+                  icon: const Icon(Icons.collections_bookmark_outlined, size: 18),
+                  label: Text(loc.inventory_section_title),
+                ),
+              ),
+            ),
+          ),
         );
       },
     );
@@ -446,7 +509,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                 button: true,
                 label: loc.profileChangeAvatar,
                 child: GestureDetector(
-                  onTap: () => _showAvatarSheet(auth),
+                  onTap: () => _showProfileXpSheet(auth),
                   child: Builder(builder: (context) {
                     final gymId = context.read<AuthProvider>().gymCode;
                     final path = AvatarCatalog.instance

--- a/lib/features/xp/presentation/screens/day_xp_screen.dart
+++ b/lib/features/xp/presentation/screens/day_xp_screen.dart
@@ -1,13 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:tapem/core/theme/app_brand_theme.dart';
 import 'package:tapem/core/theme/design_tokens.dart';
-import 'package:tapem/features/rank/domain/services/level_service.dart';
 import 'package:intl/intl.dart';
 import '../../../../core/providers/auth_provider.dart';
 import '../../../../core/providers/xp_provider.dart';
 import 'package:tapem/features/friends/domain/models/public_profile.dart';
-import 'package:tapem/features/friends/presentation/widgets/friend_list_tile.dart';
+import '../widgets/daily_xp_card.dart';
 import '../widgets/xp_time_series_chart.dart';
 import 'leaderboard_screen.dart';
 import 'package:tapem/l10n/app_localizations.dart';
@@ -55,17 +53,8 @@ class _DayXpScreenState extends State<DayXpScreen> {
     final xpProv = context.watch<XpProvider>();
     final auth = context.watch<AuthProvider>();
     final theme = Theme.of(context);
-    final brandTheme = theme.extension<AppBrandTheme>();
-    final highlightGradient = brandTheme?.gradient ?? AppGradients.brandGradient;
-    final gradientColors = brandTheme?.gradient.colors ?? AppGradients.brandGradient.colors;
-    final progressColor = gradientColors.first;
-    final xpPerLevel = LevelService.xpPerLevel;
     final userLevel = xpProv.dailyLevel;
     final userXpInLevel = xpProv.dailyLevelXp;
-    final userProgress = userLevel >= LevelService.maxLevel
-        ? 1.0
-        : userXpInLevel / xpPerLevel;
-    final xpRemaining = userLevel >= LevelService.maxLevel ? 0 : xpPerLevel - userXpInLevel;
     final locale = Localizations.localeOf(context).toString();
     final formatter = NumberFormat.decimalPattern(locale);
 
@@ -76,85 +65,12 @@ class _DayXpScreenState extends State<DayXpScreen> {
         avatarKey: auth.avatarKey,
         primaryGymCode: auth.gymCode,
       );
-      final totalXp = formatter.format(xpProv.statsDailyXp);
-      final xpLabel = '${formatter.format(userXpInLevel)} / ${formatter.format(xpPerLevel)} XP';
-      final remainingText = userLevel >= LevelService.maxLevel
-          ? 'Maximallevel erreicht'
-          : '${formatter.format(xpRemaining)} XP bis Level ${userLevel + 1}';
-      final themed = theme.copyWith(
-        textTheme: theme.textTheme.apply(
-          bodyColor: Colors.white,
-          displayColor: Colors.white,
-        ),
-        colorScheme: theme.colorScheme.copyWith(onSurface: Colors.white),
-      );
-
-      return Container(
-        margin: const EdgeInsets.symmetric(
-          horizontal: AppSpacing.sm,
-          vertical: AppSpacing.sm,
-        ),
-        decoration: BoxDecoration(
-          gradient: highlightGradient,
-          borderRadius: BorderRadius.circular(AppRadius.card),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpacing.sm),
-          child: Theme(
-            data: themed,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                FriendListTile(
-                  profile: profile,
-                  subtitle: 'Level $userLevel',
-                  trailing: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.end,
-                    children: [
-                      Text(
-                        xpLabel,
-                        style: theme.textTheme.labelLarge?.copyWith(
-                              color: Colors.white,
-                              fontWeight: FontWeight.w600,
-                            ) ??
-                            const TextStyle(
-                              color: Colors.white,
-                              fontWeight: FontWeight.w600,
-                            ),
-                      ),
-                      Text(
-                        'Gesamt $totalXp XP',
-                        style: theme.textTheme.bodySmall?.copyWith(
-                              color: Colors.white70,
-                            ) ??
-                            const TextStyle(color: Colors.white70, fontSize: 12),
-                      ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: AppSpacing.sm),
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(4),
-                  child: LinearProgressIndicator(
-                    value: userProgress.clamp(0.0, 1.0),
-                    minHeight: 6,
-                    backgroundColor: Colors.white.withOpacity(0.25),
-                    valueColor: const AlwaysStoppedAnimation<Color>(Colors.white),
-                  ),
-                ),
-                const SizedBox(height: 6),
-                Text(
-                  remainingText,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                        color: Colors.white70,
-                      ) ??
-                      const TextStyle(color: Colors.white70, fontSize: 12),
-                ),
-              ],
-            ),
-          ),
-        ),
+      return DailyXpCard(
+        profile: profile,
+        level: userLevel,
+        xpInLevel: userXpInLevel,
+        totalXp: xpProv.statsDailyXp,
+        numberFormat: formatter,
       );
     }
 

--- a/lib/features/xp/presentation/widgets/daily_xp_card.dart
+++ b/lib/features/xp/presentation/widgets/daily_xp_card.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/features/friends/domain/models/public_profile.dart';
+import 'package:tapem/features/friends/presentation/widgets/friend_list_tile.dart';
+import 'package:tapem/features/rank/domain/services/level_service.dart';
+
+class DailyXpCard extends StatelessWidget {
+  const DailyXpCard({
+    super.key,
+    required this.profile,
+    required this.level,
+    required this.xpInLevel,
+    required this.totalXp,
+    this.margin,
+    this.padding = const EdgeInsets.all(AppSpacing.sm),
+    this.gradient,
+    this.numberFormat,
+    this.footer,
+    this.xpPerLevel = LevelService.xpPerLevel,
+    this.maxLevel = LevelService.maxLevel,
+  });
+
+  final PublicProfile profile;
+  final int level;
+  final int xpInLevel;
+  final int totalXp;
+  final EdgeInsetsGeometry? margin;
+  final EdgeInsetsGeometry padding;
+  final Gradient? gradient;
+  final NumberFormat? numberFormat;
+  final Widget? footer;
+  final int xpPerLevel;
+  final int maxLevel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final brandTheme = theme.extension<AppBrandTheme>();
+    final gradientColors = gradient?.colors ??
+        brandTheme?.gradient.colors ??
+        AppGradients.brandGradient.colors;
+    final highlightGradient = gradient ??
+        brandTheme?.gradient ??
+        AppGradients.brandGradient;
+    final progressColor = gradientColors.first;
+    final format = numberFormat ??
+        NumberFormat.decimalPattern(Localizations.localeOf(context).toString());
+
+    final xpLabel = '${format.format(xpInLevel)} / ${format.format(xpPerLevel)} XP';
+    final totalXpLabel = 'Gesamt ${format.format(totalXp)} XP';
+    final userProgress = level >= maxLevel ? 1.0 : xpInLevel / xpPerLevel;
+    final xpRemaining = level >= maxLevel ? 0 : xpPerLevel - xpInLevel;
+    final remainingText = level >= maxLevel
+        ? 'Maximallevel erreicht'
+        : '${format.format(xpRemaining)} XP bis Level ${level + 1}';
+
+    final themed = theme.copyWith(
+      textTheme: theme.textTheme.apply(
+        bodyColor: Colors.white,
+        displayColor: Colors.white,
+      ),
+      colorScheme: theme.colorScheme.copyWith(onSurface: Colors.white),
+    );
+
+    return Container(
+      margin: margin ??
+          const EdgeInsets.symmetric(
+            horizontal: AppSpacing.sm,
+            vertical: AppSpacing.sm,
+          ),
+      decoration: BoxDecoration(
+        gradient: highlightGradient,
+        borderRadius: BorderRadius.circular(AppRadius.card),
+      ),
+      child: Padding(
+        padding: padding,
+        child: Theme(
+          data: themed,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              FriendListTile(
+                profile: profile,
+                subtitle: 'Level $level',
+                trailing: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text(
+                      xpLabel,
+                      style: theme.textTheme.labelLarge?.copyWith(
+                            color: Colors.white,
+                            fontWeight: FontWeight.w600,
+                          ) ??
+                          const TextStyle(
+                            color: Colors.white,
+                            fontWeight: FontWeight.w600,
+                          ),
+                    ),
+                    Text(
+                      totalXpLabel,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                            color: Colors.white70,
+                          ) ??
+                          const TextStyle(color: Colors.white70, fontSize: 12),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: LinearProgressIndicator(
+                  value: userProgress.clamp(0.0, 1.0),
+                  minHeight: 6,
+                  backgroundColor: Colors.white.withOpacity(0.25),
+                  valueColor: AlwaysStoppedAnimation<Color>(progressColor),
+                ),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                remainingText,
+                style: theme.textTheme.bodySmall?.copyWith(
+                      color: Colors.white70,
+                    ) ??
+                    const TextStyle(color: Colors.white70, fontSize: 12),
+              ),
+              if (footer != null) ...[
+                const SizedBox(height: AppSpacing.sm),
+                footer!,
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extract a reusable daily XP card widget that mirrors the experience screen styling
- reuse the shared XP card on the experience screen and open it from the profile avatar
- add a "Sammlung" action to the profile XP card that opens the avatar inventory

## Testing
- flutter test *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e578f1784083208d1b2e8cb0b6078b