### PR TITLE
Remove level badge from profile avatar

### DIFF
--- a/lib/features/profile/presentation/widgets/daily_xp_avatar.dart
+++ b/lib/features/profile/presentation/widgets/daily_xp_avatar.dart
@@ -24,7 +24,6 @@ class DailyXpAvatar extends StatelessWidget {
     final progress = level >= LevelService.maxLevel
         ? 1.0
         : xp / LevelService.xpPerLevel;
-    final badgeText = _toRoman(level);
     return Stack(
       alignment: Alignment.center,
       children: [
@@ -44,61 +43,10 @@ class DailyXpAvatar extends StatelessWidget {
           radius: size / 2 - stroke / 2,
           backgroundImage: image,
         ),
-        Positioned(
-          bottom: 0,
-          right: 0,
-          child: Semantics(
-            label: 'Level $level',
-            child: Container(
-              width: 24,
-              height: 24,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                border: Border.all(
-                  color: Theme.of(context).colorScheme.secondary,
-                ),
-              ),
-              alignment: Alignment.center,
-              child: Text(
-                badgeText,
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      fontSize: 10,
-                      color: Theme.of(context).colorScheme.secondary,
-                    ),
-              ),
-            ),
-          ),
-        ),
       ],
     );
   }
 
-  String _toRoman(int number) {
-    const Map<int, String> romans = {
-      1000: 'M',
-      900: 'CM',
-      500: 'D',
-      400: 'CD',
-      100: 'C',
-      90: 'XC',
-      50: 'L',
-      40: 'XL',
-      10: 'X',
-      9: 'IX',
-      5: 'V',
-      4: 'IV',
-      1: 'I',
-    };
-    var result = '';
-    var remaining = number;
-    romans.forEach((value, numeral) {
-      while (remaining >= value) {
-        result += numeral;
-        remaining -= value;
-      }
-    });
-    return result;
-  }
 }
 
 class _RingPainter extends CustomPainter {


### PR DESCRIPTION
## Summary
- remove the level badge overlay from the profile avatar so only the picture and progress ring remain
- delete the unused Roman numeral helper

## Testing
- not run (Flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e5823057f88320b63489b30e6359b0