### PR TITLE
Align XP rank card styling

### DIFF
--- a/lib/features/rank/presentation/screens/rank_screen.dart
+++ b/lib/features/rank/presentation/screens/rank_screen.dart
@@ -253,16 +253,29 @@ class _XpMonogram extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return BrandGradientText(
-      '𝑿𝑷',
-      style: theme.textTheme.titleMedium?.copyWith(
-            fontWeight: FontWeight.w800,
-            letterSpacing: -1.2,
-          ) ??
-          const TextStyle(
-            fontWeight: FontWeight.w800,
-            letterSpacing: -1.2,
-          ),
+    final iconTheme = IconTheme.of(context);
+    final size = iconTheme.size ?? AppSpacing.xl;
+    final textStyle = theme.textTheme.titleMedium?.copyWith(
+          color: iconTheme.color,
+          fontSize: size * 0.6,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.4,
+        ) ??
+        TextStyle(
+          color: iconTheme.color,
+          fontSize: size * 0.6,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.4,
+        );
+
+    return SizedBox.square(
+      dimension: size,
+      child: Center(
+        child: Text(
+          'XP',
+          style: textStyle,
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- update the XP rank card monogram to respect the shared icon theme sizing and typography so it matches the other cards

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e58aaeb7f08320a37d6a462f9e70fc