### PR TITLE
Add missing xl spacing token for rank screen

### DIFF
--- a/lib/core/theme/design_tokens.dart
+++ b/lib/core/theme/design_tokens.dart
@@ -163,6 +163,7 @@ class AppSpacing {
   static const double sm = 16.0;
   static const double md = 24.0;
   static const double lg = 32.0;
+  static const double xl = 40.0;
 }
 
 /// Corner radii definitions.


### PR DESCRIPTION
## Summary
- add an xl spacing constant to the shared AppSpacing tokens so icon fallbacks compile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5942558148320a32c71db4782ebf9