### PR TITLE
Normalize multi-device muscle group assignments

### DIFF
--- a/lib/core/providers/muscle_group_provider.dart
+++ b/lib/core/providers/muscle_group_provider.dart
@@ -73,10 +73,10 @@ class MuscleGroupProvider extends ChangeNotifier {
            ),
        _ensureRegionGroup =
            ensureRegionGroup ??
-          EnsureRegionGroup(
-            MuscleGroupRepositoryImpl(FirestoreMuscleGroupSource()),
-          ),
-        _membership = membership ?? FirestoreMembershipService();
+           EnsureRegionGroup(
+             MuscleGroupRepositoryImpl(FirestoreMuscleGroupSource()),
+           ),
+       _membership = membership ?? FirestoreMembershipService();
 
   bool _isLoading = false;
   String? _error;
@@ -136,6 +136,19 @@ class MuscleGroupProvider extends ChangeNotifier {
       _counts.clear();
       try {
         _groups = await _getGroups.execute(gymId);
+        bool createdCanonical = false;
+        for (final region in MuscleRegion.values) {
+          final hasCanonical = _groups.any(
+            (g) => g.region == region && _isCanonicalName(g),
+          );
+          if (!hasCanonical) {
+            await _ensureRegionGroup.execute(gymId, region);
+            createdCanonical = true;
+          }
+        }
+        if (createdCanonical) {
+          _groups = await _getGroups.execute(gymId);
+        }
       } on FirebaseException catch (e) {
         if (e.code == 'permission-denied') {
           debugPrint('RULES_DENIED path=gyms/$gymId/muscleGroups op=read');
@@ -231,8 +244,10 @@ class MuscleGroupProvider extends ChangeNotifier {
     final auth = Provider.of<AuthProvider>(context, listen: false);
     final gymId = auth.gymCode;
     if (gymId == null) return;
+    final normalized = canonicalizeGroupIds(groupIds);
+
     for (final g in _groups) {
-      if (groupIds.contains(g.id) && !g.primaryDeviceIds.contains(deviceId)) {
+      if (normalized.contains(g.id) && !g.primaryDeviceIds.contains(deviceId)) {
         final updated = g.copyWith(
           primaryDeviceIds: [...g.primaryDeviceIds, deviceId],
         );
@@ -250,8 +265,10 @@ class MuscleGroupProvider extends ChangeNotifier {
     final auth = Provider.of<AuthProvider>(context, listen: false);
     final gymId = auth.gymCode;
     if (gymId == null) return;
+    final normalized = canonicalizeGroupIds(groupIds);
+
     for (final g in _groups) {
-      if (groupIds.contains(g.id) && !g.exerciseIds.contains(exerciseId)) {
+      if (normalized.contains(g.id) && !g.exerciseIds.contains(exerciseId)) {
         final updated = g.copyWith(exerciseIds: [...g.exerciseIds, exerciseId]);
         await _saveGroup.execute(gymId, updated);
       }
@@ -268,9 +285,14 @@ class MuscleGroupProvider extends ChangeNotifier {
     final auth = Provider.of<AuthProvider>(context, listen: false);
     final gymId = auth.gymCode;
     if (gymId == null) return;
+    final normalizedPrimary = canonicalizeGroupIds(primaryGroupIds);
+    final normalizedSecondary = canonicalizeGroupIds(secondaryGroupIds)
+        .where((id) => !normalizedPrimary.contains(id))
+        .toList();
+
     final all = {
-      ...primaryGroupIds,
-      ...secondaryGroupIds,
+      ...normalizedPrimary,
+      ...normalizedSecondary,
     };
     for (final g in _groups) {
       final contains = all.contains(g.id);
@@ -296,12 +318,14 @@ class MuscleGroupProvider extends ChangeNotifier {
     final gymId = auth.gymCode;
     if (gymId == null) return;
 
-    secondaryGroupIds =
-        secondaryGroupIds.where((id) => !primaryGroupIds.contains(id)).toList();
+    final normalizedPrimary = canonicalizeGroupIds(primaryGroupIds);
+    final normalizedSecondary = canonicalizeGroupIds(secondaryGroupIds)
+        .where((id) => !normalizedPrimary.contains(id))
+        .toList();
 
     for (final g in _groups) {
-      final isPrimary = primaryGroupIds.contains(g.id);
-      final isSecondary = secondaryGroupIds.contains(g.id);
+      final isPrimary = normalizedPrimary.contains(g.id);
+      final isSecondary = normalizedSecondary.contains(g.id);
 
       if (!isPrimary && !isSecondary) {
         if (!g.primaryDeviceIds.contains(deviceId) &&
@@ -327,16 +351,16 @@ class MuscleGroupProvider extends ChangeNotifier {
     await _setDeviceGroups.execute(
       gymId,
       deviceId,
-      primaryGroupIds,
-      secondaryGroupIds,
+      normalizedPrimary,
+      normalizedSecondary,
     );
 
     try {
       final deviceProv = Provider.of<DeviceProvider>(context, listen: false);
       deviceProv.applyMuscleAssignments(
         deviceId,
-        primaryGroupIds,
-        secondaryGroupIds,
+        normalizedPrimary,
+        normalizedSecondary,
       );
     } catch (_) {}
 
@@ -359,5 +383,51 @@ class MuscleGroupProvider extends ChangeNotifier {
       }
       _counts[group.id] = sum;
     }
+  }
+
+  List<String> canonicalizeGroupIds(Iterable<String> ids) {
+    final seen = <String>{};
+    if (_groups.isEmpty) {
+      final List<String> result = [];
+      for (final id in ids) {
+        if (seen.add(id)) result.add(id);
+      }
+      return result;
+    }
+
+    MuscleGroup? canonicalFor(MuscleRegion region) {
+      MuscleGroup? canonical;
+      for (final group in _groups.where((g) => g.region == region)) {
+        canonical ??= group;
+        if (_isCanonicalName(group)) {
+          canonical = group;
+          break;
+        }
+      }
+      return canonical;
+    }
+
+    final Map<String, MuscleGroup> byId = {
+      for (final g in _groups) g.id: g,
+    };
+
+    final Map<MuscleRegion, String> canonicalIds = {};
+    for (final region in MuscleRegion.values) {
+      final canonical = canonicalFor(region);
+      if (canonical != null) canonicalIds[region] = canonical.id;
+    }
+
+    final List<String> normalized = [];
+    for (final rawId in ids) {
+      final group = byId[rawId];
+      if (group == null) continue;
+      final canonicalId = canonicalIds[group.region] ?? rawId;
+      if (seen.add(canonicalId)) normalized.add(canonicalId);
+    }
+    return normalized;
+  }
+
+  bool _isCanonicalName(MuscleGroup group) {
+    return group.name.trim().toLowerCase() == group.region.name.toLowerCase();
   }
 }

--- a/lib/features/device/presentation/widgets/exercise_bottom_sheet.dart
+++ b/lib/features/device/presentation/widgets/exercise_bottom_sheet.dart
@@ -73,8 +73,23 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
     );
     _initialPrimary = List.of(_primaryIds);
     _initialSecondary = List.of(_secondaryIds);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      context.read<MuscleGroupProvider>().loadGroups(context);
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final prov = context.read<MuscleGroupProvider>();
+      await prov.loadGroups(context);
+      if (!mounted) return;
+      final normalizedPrimary = prov.canonicalizeGroupIds(_primaryIds);
+      final normalizedSecondary = prov
+          .canonicalizeGroupIds(_secondaryIds)
+          .where((id) => !normalizedPrimary.contains(id))
+          .toList();
+      setState(() {
+        _primaryIds = normalizedPrimary.isEmpty
+            ? const []
+            : [normalizedPrimary.first];
+        _secondaryIds = normalizedSecondary;
+        _initialPrimary = List.of(_primaryIds);
+        _initialSecondary = List.of(_secondaryIds);
+      });
     });
   }
 
@@ -173,6 +188,17 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
                           ? () async {
                             final name = _nameCtr.text.trim();
                             final exProv = context.read<ExerciseProvider>();
+                            final muscleProv =
+                                context.read<MuscleGroupProvider>();
+                            final normalizedPrimary =
+                                muscleProv.canonicalizeGroupIds(_primaryIds);
+                            final primaryIds = normalizedPrimary.isEmpty
+                                ? const <String>[]
+                                : [normalizedPrimary.first];
+                            final secondaryIds = muscleProv
+                                .canonicalizeGroupIds(_secondaryIds)
+                                .where((id) => !primaryIds.contains(id))
+                                .toList();
                             Exercise ex;
                             if (widget.exercise == null) {
                               ex = await exProv.addExercise(
@@ -180,8 +206,8 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
                                 widget.deviceId,
                                 name,
                                 userId,
-                                primaryMuscleGroupIds: _primaryIds,
-                                secondaryMuscleGroupIds: _secondaryIds,
+                                primaryMuscleGroupIds: primaryIds,
+                                secondaryMuscleGroupIds: secondaryIds,
                               );
                             } else {
                               await exProv.updateExercise(
@@ -190,13 +216,13 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
                                 widget.exercise!.id,
                                 name,
                                 userId,
-                                primaryMuscleGroupIds: _primaryIds,
-                                secondaryMuscleGroupIds: _secondaryIds,
+                                primaryMuscleGroupIds: primaryIds,
+                                secondaryMuscleGroupIds: secondaryIds,
                               );
                               ex = widget.exercise!.copyWith(
                                 name: name,
-                                primaryMuscleGroupIds: _primaryIds,
-                                secondaryMuscleGroupIds: _secondaryIds,
+                                primaryMuscleGroupIds: primaryIds,
+                                secondaryMuscleGroupIds: secondaryIds,
                               );
                             }
                             await context
@@ -204,8 +230,8 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
                                 .updateExerciseAssignments(
                                   context,
                                   ex.id,
-                                  _primaryIds,
-                                  _secondaryIds,
+                                  primaryIds,
+                                  secondaryIds,
                                 );
                             if (!mounted) return;
                             Navigator.pop(context, ex);

--- a/lib/ui/muscles/muscle_group_list_selector.dart
+++ b/lib/ui/muscles/muscle_group_list_selector.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
@@ -103,6 +104,22 @@ class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
     _initialSecondary = List.of(widget.initialSecondary);
   }
 
+  @override
+  void didUpdateWidget(covariant MuscleGroupListSelector oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final initialPrimaryChanged =
+        !listEquals(widget.initialPrimary, oldWidget.initialPrimary);
+    final initialSecondaryChanged =
+        !listEquals(widget.initialSecondary, oldWidget.initialSecondary);
+    if (initialPrimaryChanged || initialSecondaryChanged) {
+      _selected = [...widget.initialPrimary, ...widget.initialSecondary];
+      _primaryId =
+          widget.initialPrimary.isNotEmpty ? widget.initialPrimary.first : null;
+      _initialPrimary = List.of(widget.initialPrimary);
+      _initialSecondary = List.of(widget.initialSecondary);
+    }
+  }
+
   String _regionFallbackName(MuscleRegion r) {
     switch (r) {
       case MuscleRegion.brust:
@@ -189,6 +206,10 @@ class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
     _emit();
   }
 
+  bool _isCanonical(MuscleGroup group) {
+    return group.name.trim().toLowerCase() == group.region.name.toLowerCase();
+  }
+
   Map<MuscleRegion, MuscleGroup?> _buildCanonical(List<MuscleGroup> all) {
     final Map<MuscleRegion, MuscleGroup?> canonical = {
       for (final r in _ordered) r: null
@@ -198,7 +219,9 @@ class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
       final current = canonical[g.region];
       if (current == null) {
         canonical[g.region] = g;
-      } else if (current.name.isEmpty && g.name.isNotEmpty) {
+      } else if (!_isCanonical(current) && _isCanonical(g)) {
+        canonical[g.region] = g;
+      } else if (!_isCanonical(current) && current.name.isEmpty && g.name.isNotEmpty) {
         canonical[g.region] = g;
       }
     }


### PR DESCRIPTION
## Summary
- ensure canonical region muscle groups exist and normalize device/exercise assignments to those canonical ids
- sanitize the exercise editor to map selections to canonical primary and secondary muscle groups before persisting
- refresh the muscle group selector when initial values change and prioritise canonical region groups in the list

## Testing
- Not run (flutter is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e596b9eb4c83208a6a2ee8421278e1