### PR TITLE
Handle XP permission denials for multi-device sessions

### DIFF
--- a/lib/core/providers/device_provider.dart
+++ b/lib/core/providers/device_provider.dart
@@ -1238,11 +1238,16 @@ class DeviceProvider extends ChangeNotifier {
           if (xpResult != null) {
             XpTrace.log('CALL_RESULT', {
               'result': xpResult.name,
-              'deltaXp': xpResult == DeviceXpResult.okAdded ? 50 : 0,
+              'deltaXp':
+                  xpResult == DeviceXpResult.okAdded ||
+                          xpResult == DeviceXpResult.okAddedNoLeaderboard
+                      ? 50
+                      : 0,
               'traceId': traceId,
             });
           }
-          if (xpResult == DeviceXpResult.okAdded) {
+          if (xpResult == DeviceXpResult.okAdded ||
+              xpResult == DeviceXpResult.okAddedNoLeaderboard) {
             final info = LevelService()
                 .addXp(LevelInfo(level: _level, xp: _xp), LevelService.xpPerSession);
             _level = info.level;

--- a/lib/core/providers/muscle_group_provider.dart
+++ b/lib/core/providers/muscle_group_provider.dart
@@ -180,7 +180,7 @@ class MuscleGroupProvider extends ChangeNotifier {
     final auth = Provider.of<AuthProvider>(context, listen: false);
     final gymId = auth.gymCode;
     if (gymId == null) return;
-    await _saveGroup.execute(gymId, group);
+    await _safeSaveGroup(gymId, group);
 
     final devices = Provider.of<GymProvider>(context, listen: false).devices;
     for (final dId in group.primaryDeviceIds) {
@@ -251,7 +251,7 @@ class MuscleGroupProvider extends ChangeNotifier {
         final updated = g.copyWith(
           primaryDeviceIds: [...g.primaryDeviceIds, deviceId],
         );
-        await _saveGroup.execute(gymId, updated);
+        await _safeSaveGroup(gymId, updated);
       }
     }
     await loadGroups(context, force: true);
@@ -270,7 +270,7 @@ class MuscleGroupProvider extends ChangeNotifier {
     for (final g in _groups) {
       if (normalized.contains(g.id) && !g.exerciseIds.contains(exerciseId)) {
         final updated = g.copyWith(exerciseIds: [...g.exerciseIds, exerciseId]);
-        await _saveGroup.execute(gymId, updated);
+        await _safeSaveGroup(gymId, updated);
       }
     }
     await loadGroups(context, force: true);
@@ -298,11 +298,11 @@ class MuscleGroupProvider extends ChangeNotifier {
       final contains = all.contains(g.id);
       if (contains && !g.exerciseIds.contains(exerciseId)) {
         final updated = g.copyWith(exerciseIds: [...g.exerciseIds, exerciseId]);
-        await _saveGroup.execute(gymId, updated);
+        await _safeSaveGroup(gymId, updated);
       } else if (!contains && g.exerciseIds.contains(exerciseId)) {
         final newIds = List<String>.from(g.exerciseIds)..remove(exerciseId);
         final updated = g.copyWith(exerciseIds: newIds);
-        await _saveGroup.execute(gymId, updated);
+        await _safeSaveGroup(gymId, updated);
       }
     }
     await loadGroups(context, force: true);
@@ -345,7 +345,7 @@ class MuscleGroupProvider extends ChangeNotifier {
         primaryDeviceIds: newPrimary,
         secondaryDeviceIds: newSecondary,
       );
-      await _saveGroup.execute(gymId, updated);
+      await _safeSaveGroup(gymId, updated);
     }
 
     await _setDeviceGroups.execute(
@@ -365,6 +365,20 @@ class MuscleGroupProvider extends ChangeNotifier {
     } catch (_) {}
 
     await loadGroups(context, force: true);
+  }
+
+  Future<void> _safeSaveGroup(String gymId, MuscleGroup group) async {
+    try {
+      await _saveGroup.execute(gymId, group);
+    } on FirebaseException catch (e) {
+      if (e.code == 'permission-denied') {
+        debugPrint(
+          '[MuscleGroupProvider] permission denied saving group ${group.id} in gym $gymId',
+        );
+      } else {
+        rethrow;
+      }
+    }
   }
 
   Future<void> _loadCounts(String gymId, String userId) async {

--- a/lib/core/providers/xp_provider.dart
+++ b/lib/core/providers/xp_provider.dart
@@ -87,11 +87,17 @@ class XpProvider extends ChangeNotifier {
         );
         XpTrace.log('PROVIDER_OUT', {
           'result': result.name,
-          'deltaXp': result == DeviceXpResult.okAdded ? 50 : 0,
-          'updatedLocalCache': result == DeviceXpResult.okAdded,
+          'deltaXp':
+              result == DeviceXpResult.okAdded ||
+                      result == DeviceXpResult.okAddedNoLeaderboard
+                  ? 50
+                  : 0,
+          'updatedLocalCache': result == DeviceXpResult.okAdded ||
+              result == DeviceXpResult.okAddedNoLeaderboard,
           'traceId': traceId,
         });
-        if (result == DeviceXpResult.okAdded) {
+        if (result == DeviceXpResult.okAdded ||
+            result == DeviceXpResult.okAddedNoLeaderboard) {
           _deviceXp[deviceId] =
               (_deviceXp[deviceId] ?? 0) + LevelService.xpPerSession;
           XpTrace.log('CACHE_BUMP', {

--- a/lib/features/device/presentation/screens/device_screen.dart
+++ b/lib/features/device/presentation/screens/device_screen.dart
@@ -60,6 +60,13 @@ class _DeviceScreenState extends State<DeviceScreen> {
   final _scrollController = ScrollController();
   final List<GlobalKey<SetCardState>> _setKeys = [];
   final _pagerKey = GlobalKey<DevicePagerState>();
+  OverlayNumericKeypadController? _keypadController;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _keypadController ??= context.read<OverlayNumericKeypadController>();
+  }
 
   @override
   void initState() {
@@ -117,7 +124,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
 
   void _closeKeyboard() {
     FocusManager.instance.primaryFocus?.unfocus();
-    context.read<OverlayNumericKeypadController>().close();
+    (_keypadController ?? context.read<OverlayNumericKeypadController>()).close();
   }
 
   String? _resolveExerciseTitle(
@@ -487,7 +494,8 @@ class _DeviceScreenState extends State<DeviceScreen> {
 
   @override
   void dispose() {
-    _closeKeyboard();
+    FocusManager.instance.primaryFocus?.unfocus();
+    _keypadController?.close();
     _scrollController.dispose();
     super.dispose();
   }

--- a/lib/features/device/presentation/widgets/exercise_bottom_sheet.dart
+++ b/lib/features/device/presentation/widgets/exercise_bottom_sheet.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -186,56 +187,73 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
                   onPressed:
                       canSave
                           ? () async {
-                            final name = _nameCtr.text.trim();
-                            final exProv = context.read<ExerciseProvider>();
-                            final muscleProv =
-                                context.read<MuscleGroupProvider>();
-                            final normalizedPrimary =
-                                muscleProv.canonicalizeGroupIds(_primaryIds);
-                            final primaryIds = normalizedPrimary.isEmpty
-                                ? const <String>[]
-                                : [normalizedPrimary.first];
-                            final secondaryIds = muscleProv
-                                .canonicalizeGroupIds(_secondaryIds)
-                                .where((id) => !primaryIds.contains(id))
-                                .toList();
-                            Exercise ex;
-                            if (widget.exercise == null) {
-                              ex = await exProv.addExercise(
-                                widget.gymId,
-                                widget.deviceId,
-                                name,
-                                userId,
-                                primaryMuscleGroupIds: primaryIds,
-                                secondaryMuscleGroupIds: secondaryIds,
-                              );
-                            } else {
-                              await exProv.updateExercise(
-                                widget.gymId,
-                                widget.deviceId,
-                                widget.exercise!.id,
-                                name,
-                                userId,
-                                primaryMuscleGroupIds: primaryIds,
-                                secondaryMuscleGroupIds: secondaryIds,
-                              );
-                              ex = widget.exercise!.copyWith(
-                                name: name,
-                                primaryMuscleGroupIds: primaryIds,
-                                secondaryMuscleGroupIds: secondaryIds,
-                              );
-                            }
-                            await context
-                                .read<MuscleGroupProvider>()
-                                .updateExerciseAssignments(
-                                  context,
-                                  ex.id,
-                                  primaryIds,
-                                  secondaryIds,
+                              try {
+                                final name = _nameCtr.text.trim();
+                                final exProv = context.read<ExerciseProvider>();
+                                final muscleProv =
+                                    context.read<MuscleGroupProvider>();
+                                final normalizedPrimary =
+                                    muscleProv.canonicalizeGroupIds(_primaryIds);
+                                final primaryIds = normalizedPrimary.isEmpty
+                                    ? const <String>[]
+                                    : [normalizedPrimary.first];
+                                final secondaryIds = muscleProv
+                                    .canonicalizeGroupIds(_secondaryIds)
+                                    .where((id) => !primaryIds.contains(id))
+                                    .toList();
+                                Exercise ex;
+                                if (widget.exercise == null) {
+                                  ex = await exProv.addExercise(
+                                    widget.gymId,
+                                    widget.deviceId,
+                                    name,
+                                    userId,
+                                    primaryMuscleGroupIds: primaryIds,
+                                    secondaryMuscleGroupIds: secondaryIds,
+                                  );
+                                } else {
+                                  await exProv.updateExercise(
+                                    widget.gymId,
+                                    widget.deviceId,
+                                    widget.exercise!.id,
+                                    name,
+                                    userId,
+                                    primaryMuscleGroupIds: primaryIds,
+                                    secondaryMuscleGroupIds: secondaryIds,
+                                  );
+                                  ex = widget.exercise!.copyWith(
+                                    name: name,
+                                    primaryMuscleGroupIds: primaryIds,
+                                    secondaryMuscleGroupIds: secondaryIds,
+                                  );
+                                }
+                                await context
+                                    .read<MuscleGroupProvider>()
+                                    .updateExerciseAssignments(
+                                      context,
+                                      ex.id,
+                                      primaryIds,
+                                      secondaryIds,
+                                    );
+                                if (!mounted) return;
+                                Navigator.pop(context, ex);
+                              } on FirebaseException catch (e) {
+                                if (!mounted) return;
+                                final messenger =
+                                    ScaffoldMessenger.of(context);
+                                final message = e.code == 'permission-denied'
+                                    ? loc.commonSaveError
+                                    : (e.message ?? loc.commonSaveError);
+                                messenger.showSnackBar(
+                                  SnackBar(content: Text(message)),
                                 );
-                            if (!mounted) return;
-                            Navigator.pop(context, ex);
-                          }
+                              } catch (e) {
+                                if (!mounted) return;
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(content: Text(loc.commonSaveError)),
+                                );
+                              }
+                            }
                           : null,
                   child: Text(loc.commonSave),
                 ),

--- a/lib/features/rank/data/sources/firestore_rank_source.dart
+++ b/lib/features/rank/data/sources/firestore_rank_source.dart
@@ -126,6 +126,7 @@ class FirestoreRankSource {
               'uid': userId,
               'reason': 'rules-path',
             });
+            return DeviceXpResult.okAddedNoLeaderboard;
           }
           elogError('TXN_FIREBASE_ERROR', e, st, {
             'userPath': lbUser.path,

--- a/lib/features/xp/data/sources/firestore_xp_source.dart
+++ b/lib/features/xp/data/sources/firestore_xp_source.dart
@@ -119,7 +119,8 @@ class FirestoreXpSource {
           exerciseId: exerciseId,
           traceId: traceId,
         );
-        if (result == DeviceXpResult.okAdded) {
+        if (result == DeviceXpResult.okAdded ||
+            result == DeviceXpResult.okAddedNoLeaderboard) {
           await _applyMuscleXp(
             statsRef: statsRef,
             primaryMuscleGroupIds: primaryMuscleGroupIds,

--- a/lib/features/xp/domain/device_xp_result.dart
+++ b/lib/features/xp/domain/device_xp_result.dart
@@ -1,5 +1,6 @@
 enum DeviceXpResult {
   okAdded,
+  okAddedNoLeaderboard,
   alreadyToday,
   idempotentHit,
   skipNoDevice,


### PR DESCRIPTION
## Summary
- avoid reading providers from a disposed DeviceScreen by caching the numeric keypad controller and closing it safely
- treat leaderboard permission denials as a successful XP credit while guarding muscle group updates and exercise editing against permission errors

## Testing
- not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e59c39b7008320b1148f95d153cb55