### PR TITLE
Localize core muscle group display labels

### DIFF
--- a/lib/features/device/presentation/widgets/muscle_chips.dart
+++ b/lib/features/device/presentation/widgets/muscle_chips.dart
@@ -5,38 +5,12 @@ import 'package:tapem/l10n/app_localizations.dart';
 
 import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
+import 'package:tapem/ui/muscles/muscle_group_display.dart';
 
 class MuscleChips extends StatelessWidget {
   final List<String> primaryIds;
   final List<String> secondaryIds;
   const MuscleChips({super.key, required this.primaryIds, required this.secondaryIds});
-
-  String _fallbackName(MuscleRegion region) {
-    switch (region) {
-      case MuscleRegion.brust:
-        return 'Brust';
-      case MuscleRegion.schulter:
-        return 'Schulter';
-      case MuscleRegion.nacken:
-        return 'Nacken';
-      case MuscleRegion.ruecken:
-        return 'Rücken';
-      case MuscleRegion.bizeps:
-        return 'Bizeps';
-      case MuscleRegion.trizeps:
-        return 'Trizeps';
-      case MuscleRegion.bauch:
-        return 'Bauch';
-      case MuscleRegion.quadrizeps:
-        return 'Quadrizeps';
-      case MuscleRegion.hamstrings:
-        return 'Hamstrings';
-      case MuscleRegion.gluteus:
-        return 'Gluteus';
-      case MuscleRegion.waden:
-        return 'Waden';
-    }
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -56,8 +30,7 @@ class MuscleChips extends StatelessWidget {
     String nameFor(String id) {
       final g = groups.firstWhereOrNull((e) => e.id == id);
       final region = regionFor(id, g);
-      if (g != null && g.name.trim().isNotEmpty) return g.name;
-      return _fallbackName(region);
+      return displayNameForMuscleGroup(region, g);
     }
 
     Widget buildChip(String id, bool primary) {

--- a/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
+++ b/lib/features/muscle_group/presentation/widgets/device_muscle_assignment_sheet.dart
@@ -6,6 +6,7 @@ import 'package:tapem/core/providers/muscle_group_provider.dart';
 import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/ui/muscles/muscle_group_color.dart';
+import 'package:tapem/ui/muscles/muscle_group_display.dart';
 
 /// Bottom sheet for assigning primary and secondary muscle groups to a device.
 class DeviceMuscleAssignmentSheet extends StatefulWidget {
@@ -73,31 +74,7 @@ class _DeviceMuscleAssignmentSheetState
   ];
 
   String _regionLabel(AppLocalizations loc, MuscleRegion region) {
-    // Using English fallback if not localized
-    switch (region) {
-      case MuscleRegion.brust:
-        return 'Brust';
-      case MuscleRegion.schulter:
-        return 'Schulter';
-      case MuscleRegion.nacken:
-        return 'Nacken';
-      case MuscleRegion.ruecken:
-        return 'Rücken';
-      case MuscleRegion.bizeps:
-        return 'Bizeps';
-      case MuscleRegion.trizeps:
-        return 'Trizeps';
-      case MuscleRegion.bauch:
-        return 'Bauch';
-      case MuscleRegion.quadrizeps:
-        return 'Quadrizeps';
-      case MuscleRegion.hamstrings:
-        return 'Hamstrings';
-      case MuscleRegion.gluteus:
-        return 'Gluteus';
-      case MuscleRegion.waden:
-        return 'Waden';
-    }
+    return fallbackLabelForRegion(region);
   }
 
   Map<MuscleRegion, MuscleGroup?> _canonical(List<MuscleGroup> groups) {
@@ -348,9 +325,7 @@ class _DeviceMuscleAssignmentSheetState
   Widget _buildPrimaryRow(AppLocalizations loc, ThemeData theme,
       MuscleRegion region, MuscleGroup? g) {
     final id = g?.id ?? region.name;
-    final name = (g?.name.trim().isNotEmpty ?? false)
-        ? g!.name
-        : _regionLabel(loc, region);
+    final name = displayNameForMuscleGroup(region, g);
     return Semantics(
       label: '$name, ${loc.muscleTabsPrimary}',
       child: InkWell(
@@ -396,9 +371,7 @@ class _DeviceMuscleAssignmentSheetState
   Widget _buildSecondaryRow(AppLocalizations loc, ThemeData theme,
       MuscleRegion region, MuscleGroup? g) {
     final id = g?.id ?? region.name;
-    final name = (g?.name.trim().isNotEmpty ?? false)
-        ? g!.name
-        : _regionLabel(loc, region);
+    final name = displayNameForMuscleGroup(region, g);
     final checked = _selectedSecondaryIds.contains(id);
     final disabled = _selectedPrimaryId == id;
     return Semantics(

--- a/lib/ui/muscles/muscle_group_display.dart
+++ b/lib/ui/muscles/muscle_group_display.dart
@@ -1,0 +1,69 @@
+import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
+
+/// Returns `true` if the group's name matches its region identifier.
+bool isCanonicalMuscleGroupName(MuscleGroup group) {
+  return group.name.trim().toLowerCase() == group.region.name.toLowerCase();
+}
+
+/// Localized fallback name for a [MuscleRegion].
+String fallbackLabelForRegion(MuscleRegion region) {
+  switch (region) {
+    case MuscleRegion.brust:
+      return 'Brust';
+    case MuscleRegion.schulter:
+      return 'Schulter';
+    case MuscleRegion.nacken:
+      return 'Nacken';
+    case MuscleRegion.ruecken:
+      return 'Rücken';
+    case MuscleRegion.bizeps:
+      return 'Bizeps';
+    case MuscleRegion.trizeps:
+      return 'Trizeps';
+    case MuscleRegion.bauch:
+      return 'Bauch';
+    case MuscleRegion.quadrizeps:
+      return 'Quadrizeps';
+    case MuscleRegion.hamstrings:
+      return 'Hamstrings';
+    case MuscleRegion.gluteus:
+      return 'Gluteus';
+    case MuscleRegion.waden:
+      return 'Waden';
+  }
+}
+
+/// Synonyms that should map back to the fallback label for the region.
+const Map<MuscleRegion, Set<String>> _fallbackAliases = {
+  MuscleRegion.bauch: {
+    'abs',
+    'abdominals',
+    'abdominal',
+    'core',
+    'stomach',
+    'wrist flexors',
+  },
+};
+
+/// Returns the best display name for a muscle group, falling back to the
+/// localized region label when the stored name is canonical, empty or matches a
+/// known alias.
+String displayNameForMuscleGroup(MuscleRegion region, MuscleGroup? group) {
+  final fallback = fallbackLabelForRegion(region);
+  if (group == null) {
+    return fallback;
+  }
+  final raw = group.name.trim();
+  if (raw.isEmpty) {
+    return fallback;
+  }
+  if (isCanonicalMuscleGroupName(group)) {
+    return fallback;
+  }
+  final normalized = raw.toLowerCase();
+  final aliases = _fallbackAliases[region];
+  if (aliases != null && aliases.contains(normalized)) {
+    return fallback;
+  }
+  return raw;
+}

--- a/lib/ui/muscles/muscle_group_list_selector.dart
+++ b/lib/ui/muscles/muscle_group_list_selector.dart
@@ -6,6 +6,7 @@ import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 
 import 'muscle_group_color.dart';
+import 'muscle_group_display.dart';
 
 class MuscleGroupListSelector extends StatefulWidget {
   final List<String> initialPrimary;
@@ -120,33 +121,6 @@ class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
     }
   }
 
-  String _regionFallbackName(MuscleRegion r) {
-    switch (r) {
-      case MuscleRegion.brust:
-        return 'Brust';
-      case MuscleRegion.schulter:
-        return 'Schulter';
-      case MuscleRegion.nacken:
-        return 'Nacken';
-      case MuscleRegion.ruecken:
-        return 'Rücken';
-      case MuscleRegion.bizeps:
-        return 'Bizeps';
-      case MuscleRegion.trizeps:
-        return 'Trizeps';
-      case MuscleRegion.bauch:
-        return 'Bauch';
-      case MuscleRegion.quadrizeps:
-        return 'Quadrizeps';
-      case MuscleRegion.hamstrings:
-        return 'Hamstrings';
-      case MuscleRegion.gluteus:
-        return 'Gluteus';
-      case MuscleRegion.waden:
-        return 'Waden';
-    }
-  }
-
   Future<String> _ensureIdForRegion(
     MuscleRegion region,
     String idOrRegionKey,
@@ -158,7 +132,7 @@ class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
     final g = await prov.getOrCreateByRegion(
       context,
       region,
-      defaultName: _regionFallbackName(region),
+      defaultName: fallbackLabelForRegion(region),
     );
     return g.id;
   }
@@ -207,7 +181,7 @@ class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
   }
 
   bool _isCanonical(MuscleGroup group) {
-    return group.name.trim().toLowerCase() == group.region.name.toLowerCase();
+    return isCanonicalMuscleGroupName(group);
   }
 
   Map<MuscleRegion, MuscleGroup?> _buildCanonical(List<MuscleGroup> all) {
@@ -246,8 +220,7 @@ class _MuscleGroupListSelectorState extends State<MuscleGroupListSelector> {
     };
     for (final r in _ordered) {
       final g = canonical[r];
-      final name =
-          g != null && g.name.isNotEmpty ? g.name : _regionFallbackName(r);
+      final name = displayNameForMuscleGroup(r, g);
       if (name.toLowerCase() == 'arms' && _categoryFor(r) == _Category.core) {
         continue;
       }


### PR DESCRIPTION
## Summary
- add shared helper for localized muscle group fallbacks and alias handling
- ensure selectors and chips use the helper so canonical core groups display as "Bauch" instead of imported aliases

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5a06610d48320b37dc537cc4ed309