### PR TITLE
Revamp multi-device exercise UI and sync muscle XP

### DIFF
--- a/lib/core/providers/exercise_provider.dart
+++ b/lib/core/providers/exercise_provider.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:tapem/features/device/domain/models/exercise.dart';
 import 'package:tapem/features/device/domain/usecases/get_exercises_for_device.dart';
+import 'package:tapem/features/device/domain/services/exercise_xp_reassignment_service.dart';
 import 'package:tapem/features/device/domain/usecases/create_exercise_usecase.dart';
 import 'package:tapem/features/device/domain/usecases/delete_exercise_usecase.dart';
 import 'package:tapem/features/device/domain/usecases/update_exercise_usecase.dart';
@@ -13,6 +14,7 @@ class ExerciseProvider extends ChangeNotifier {
   final DeleteExerciseUseCase _deleteEx;
   final UpdateExerciseUseCase _updateEx;
   final UpdateExerciseMuscleGroupsUseCase _updateMuscles;
+  final ExerciseXpReassignmentService _xpReassignment;
 
   ExerciseProvider({
     required GetExercisesForDevice getEx,
@@ -20,11 +22,13 @@ class ExerciseProvider extends ChangeNotifier {
     required DeleteExerciseUseCase deleteEx,
     required UpdateExerciseUseCase updateEx,
     required UpdateExerciseMuscleGroupsUseCase updateMuscles,
-  }) : _getEx = getEx,
-       _createEx = createEx,
-       _deleteEx = deleteEx,
-       _updateEx = updateEx,
-       _updateMuscles = updateMuscles;
+    ExerciseXpReassignmentService? xpReassignment,
+  })  : _getEx = getEx,
+        _createEx = createEx,
+        _deleteEx = deleteEx,
+        _updateEx = updateEx,
+        _updateMuscles = updateMuscles,
+        _xpReassignment = xpReassignment ?? ExerciseXpReassignmentService();
 
   List<Exercise> _exercises = [];
   bool _isLoading = false;
@@ -127,5 +131,23 @@ class ExerciseProvider extends ChangeNotifier {
     } else {
       await loadExercises(gymId, deviceId, userId);
     }
+  }
+
+  Future<void> reassignMuscleXp(
+    String gymId,
+    String deviceId,
+    String exerciseId,
+    String userId,
+    List<String> primaryIds,
+    List<String> secondaryIds,
+  ) {
+    return _xpReassignment.reassign(
+      gymId: gymId,
+      deviceId: deviceId,
+      exerciseId: exerciseId,
+      userId: userId,
+      newPrimaryIds: primaryIds,
+      newSecondaryIds: secondaryIds,
+    );
   }
 }

--- a/lib/features/device/domain/services/exercise_xp_reassignment_service.dart
+++ b/lib/features/device/domain/services/exercise_xp_reassignment_service.dart
@@ -1,0 +1,227 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+
+import 'package:tapem/core/time/logic_day.dart';
+import 'package:tapem/features/training_details/data/session_meta_source.dart';
+import 'package:tapem/features/xp/domain/muscle_xp_calculator.dart';
+
+/// Reassigns muscle XP for all sessions of an exercise when the configuration
+/// changes.
+class ExerciseXpReassignmentService {
+  final FirebaseFirestore _firestore;
+  final SessionMetaSource _metaSource;
+
+  ExerciseXpReassignmentService({
+    FirebaseFirestore? firestore,
+    SessionMetaSource? metaSource,
+  })  : _firestore = firestore ?? FirebaseFirestore.instance,
+        _metaSource = metaSource ?? SessionMetaSource(firestore: firestore);
+
+  Future<void> reassign({
+    required String gymId,
+    required String deviceId,
+    required String exerciseId,
+    required String userId,
+    required List<String> newPrimaryIds,
+    required List<String> newSecondaryIds,
+  }) async {
+    final normalizedPrimary = _normalize(newPrimaryIds);
+    final normalizedSecondary = _normalize(
+      newSecondaryIds,
+      exclude: normalizedPrimary,
+    );
+
+    final query = await _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('devices')
+        .doc(deviceId)
+        .collection('sessions')
+        .where('userId', isEqualTo: userId)
+        .where('exerciseId', isEqualTo: exerciseId)
+        .get();
+
+    if (query.docs.isEmpty) return;
+
+    final adjustments = <_SessionAdjustment>[];
+    for (final doc in query.docs) {
+      final data = doc.data();
+      final sessionId = (data['sessionId'] as String?) ?? doc.id;
+      final createdAtRaw = data['createdAt'];
+      DateTime? createdAt;
+      if (createdAtRaw is Timestamp) {
+        createdAt = createdAtRaw.toDate();
+      }
+      final sessionPrimary = _normalize(
+        _stringListFrom(data['primaryMuscleGroupIds']),
+      );
+      final sessionSecondary = _normalize(
+        _stringListFrom(data['secondaryMuscleGroupIds']),
+        exclude: sessionPrimary,
+      );
+      if (MuscleXpCalculator.listsEqual(sessionPrimary, normalizedPrimary) &&
+          MuscleXpCalculator.listsEqual(sessionSecondary, normalizedSecondary)) {
+        continue;
+      }
+      adjustments.add(
+        _SessionAdjustment(
+          reference: doc.reference,
+          sessionId: sessionId,
+          createdAt: createdAt,
+          previousPrimary: sessionPrimary,
+          previousSecondary: sessionSecondary,
+        ),
+      );
+    }
+
+    if (adjustments.isEmpty) {
+      return;
+    }
+
+    final metas = await Future.wait(adjustments.map((adj) async {
+      try {
+        return await _metaSource.getMetaBySessionId(
+          gymId: gymId,
+          uid: userId,
+          sessionId: adj.sessionId,
+        );
+      } catch (e) {
+        debugPrint('⚠️ Failed to load session meta for ${adj.sessionId}: $e');
+        return null;
+      }
+    }));
+
+    final globalDelta = <String, int>{};
+    final historyDelta = <String, Map<String, int>>{};
+    final newDelta = MuscleXpCalculator.calculateDelta(
+      normalizedPrimary,
+      normalizedSecondary,
+    );
+    final revision = DateTime.now().millisecondsSinceEpoch;
+
+    WriteBatch? batch;
+    var ops = 0;
+    Future<void> commitBatch() async {
+      if (batch != null && ops > 0) {
+        await batch!.commit();
+      }
+      batch = _firestore.batch();
+      ops = 0;
+    }
+
+    await commitBatch();
+
+    for (var i = 0; i < adjustments.length; i++) {
+      final adj = adjustments[i];
+      final meta = metas[i];
+      final dayKey = (meta?['dayKey'] as String?) ??
+          logicDayKey((adj.createdAt ?? DateTime.now()).toUtc());
+
+      final oldDelta = MuscleXpCalculator.calculateDelta(
+        adj.previousPrimary,
+        adj.previousSecondary,
+      );
+      final keys = {...oldDelta.keys, ...newDelta.keys};
+      for (final key in keys) {
+        final change = (newDelta[key] ?? 0) - (oldDelta[key] ?? 0);
+        if (change == 0) continue;
+        globalDelta[key] = (globalDelta[key] ?? 0) + change;
+        final dayMap = historyDelta.putIfAbsent(dayKey, () => {});
+        dayMap[key] = (dayMap[key] ?? 0) + change;
+      }
+
+      batch!.update(adj.reference, {
+        'primaryMuscleGroupIds': normalizedPrimary,
+        'secondaryMuscleGroupIds': normalizedSecondary,
+        'muscleGroupRevision': revision,
+      });
+      ops++;
+      if (ops >= 400) {
+        await commitBatch();
+      }
+    }
+
+    if (ops > 0 && batch != null) {
+      await batch!.commit();
+    }
+
+    if (globalDelta.isEmpty && historyDelta.isEmpty) {
+      return;
+    }
+
+    final statsRef = _firestore
+        .collection('gyms')
+        .doc(gymId)
+        .collection('users')
+        .doc(userId)
+        .collection('rank')
+        .doc('stats');
+
+    if (globalDelta.isNotEmpty) {
+      final statsUpdates = <String, dynamic>{};
+      globalDelta.forEach((key, value) {
+        if (value != 0) {
+          statsUpdates['${key}XP'] = FieldValue.increment(value);
+        }
+      });
+      if (statsUpdates.isNotEmpty) {
+        await statsRef.set(statsUpdates, SetOptions(merge: true));
+      }
+    }
+
+    for (final entry in historyDelta.entries) {
+      final updates = <String, dynamic>{
+        'updatedAt': FieldValue.serverTimestamp(),
+      };
+      entry.value.forEach((key, value) {
+        if (value != 0) {
+          updates['${key}XP'] = FieldValue.increment(value);
+        }
+      });
+      if (updates.length > 1) {
+        await statsRef
+            .collection('muscleXpHistory')
+            .doc(entry.key)
+            .set(updates, SetOptions(merge: true));
+      }
+    }
+  }
+
+  List<String> _normalize(List<String> values, {List<String>? exclude}) {
+    final result = <String>[];
+    final existing = {...?exclude};
+    for (final raw in values) {
+      final value = raw.trim();
+      if (value.isEmpty) continue;
+      if (existing.add(value)) {
+        result.add(value);
+      }
+    }
+    return result;
+  }
+
+  List<String> _stringListFrom(dynamic value) {
+    if (value is Iterable) {
+      return value.map((e) => e.toString()).toList();
+    }
+    return const [];
+  }
+}
+
+class _SessionAdjustment {
+  final DocumentReference<Map<String, dynamic>> reference;
+  final String sessionId;
+  final DateTime? createdAt;
+  final List<String> previousPrimary;
+  final List<String> previousSecondary;
+
+  _SessionAdjustment({
+    required this.reference,
+    required this.sessionId,
+    required this.createdAt,
+    required this.previousPrimary,
+    required this.previousSecondary,
+  });
+}

--- a/lib/features/device/presentation/screens/exercise_list_screen.dart
+++ b/lib/features/device/presentation/screens/exercise_list_screen.dart
@@ -1,14 +1,23 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+
 import 'package:tapem/app_router.dart';
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/core/providers/exercise_provider.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/core/widgets/brand_gradient_icon.dart';
+import 'package:tapem/core/widgets/brand_gradient_text.dart';
+import 'package:tapem/core/widgets/brand_interactive_card.dart';
+import 'package:tapem/core/widgets/brand_outline_button.dart';
+import 'package:tapem/core/widgets/brand_primary_button.dart';
 import 'package:tapem/features/device/domain/models/exercise.dart';
+import 'package:tapem/features/device/presentation/widgets/exercise_bottom_sheet.dart';
+import 'package:tapem/features/device/presentation/widgets/muscle_chips.dart';
+import 'package:tapem/features/muscle_group/domain/models/muscle_group.dart';
 import 'package:tapem/l10n/app_localizations.dart';
-import '../widgets/multi_device_banner.dart';
-import '../widgets/muscle_chips.dart';
-import '../widgets/exercise_bottom_sheet.dart';
 
 class ExerciseListScreen extends StatefulWidget {
   final String gymId;
@@ -23,7 +32,8 @@ class ExerciseListScreen extends StatefulWidget {
 class _ExerciseListScreenState extends State<ExerciseListScreen> {
   final _searchCtr = TextEditingController();
   String _query = '';
-  String? _groupFilter;
+  final Set<String> _selectedGroups = {};
+  bool _sortDescending = false;
 
   @override
   void initState() {
@@ -35,18 +45,24 @@ class _ExerciseListScreenState extends State<ExerciseListScreen> {
     });
   }
 
+  @override
+  void dispose() {
+    _searchCtr.dispose();
+    super.dispose();
+  }
+
   Future<void> _openAdd([Exercise? ex]) async {
     final result = await showModalBottomSheet<Exercise>(
       context: context,
       isScrollControlled: true,
+      backgroundColor: Colors.transparent,
       builder: (_) => ExerciseBottomSheet(
         gymId: widget.gymId,
         deviceId: widget.deviceId,
         exercise: ex,
       ),
     );
-    if (result != null && ex == null) {
-      if (!mounted) return;
+    if (result != null && ex == null && mounted) {
       Navigator.of(context).pushReplacementNamed(
         AppRouter.device,
         arguments: {
@@ -84,50 +100,153 @@ class _ExerciseListScreenState extends State<ExerciseListScreen> {
         .removeExercise(widget.gymId, widget.deviceId, ex.id, userId);
   }
 
+  Future<void> _openMuscleFilter(List<MuscleGroup> groups) async {
+    final loc = AppLocalizations.of(context)!;
+    final result = await showModalBottomSheet<Set<String>>(
+      context: context,
+      builder: (ctx) {
+        final selected = Set<String>.from(_selectedGroups);
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(24),
+            child: StatefulBuilder(
+              builder: (context, setSt) => Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    loc.filterMuscleChip,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 16),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      for (final g in groups)
+                        FilterChip(
+                          label: Text(g.name),
+                          selected: selected.contains(g.id),
+                          onSelected: (value) {
+                            setSt(() {
+                              if (value) {
+                                selected.add(g.id);
+                              } else {
+                                selected.remove(g.id);
+                              }
+                            });
+                          },
+                        ),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                  Row(
+                    children: [
+                      if (selected.isNotEmpty)
+                        TextButton(
+                          onPressed: () => setSt(() => selected.clear()),
+                          child: Text(loc.multiDeviceMuscleGroupFilterAll),
+                        ),
+                      const Spacer(),
+                      BrandPrimaryButton(
+                        onPressed: () => Navigator.of(ctx).pop(selected),
+                        child: Text(loc.commonOk),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+    if (result != null) {
+      setState(() {
+        _selectedGroups
+          ..clear()
+          ..addAll(result);
+      });
+    }
+  }
+
+  List<Exercise> _filteredExercises(List<Exercise> all) {
+    final q = _query.trim().toLowerCase();
+    final filtered = all.where((ex) {
+      final matchesQuery = ex.name.toLowerCase().contains(q);
+      final matchesGroup = _selectedGroups.isEmpty ||
+          _selectedGroups.any((id) => ex.muscleGroupIds.contains(id));
+      return matchesQuery && matchesGroup;
+    }).toList();
+    filtered.sort((a, b) =>
+        _sortDescending ? b.name.compareTo(a.name) : a.name.compareTo(b.name));
+    return filtered;
+  }
+
+  String _groupName(String id, List<MuscleGroup> groups) {
+    return groups.firstWhereOrNull((g) => g.id == id)?.name ?? id;
+  }
+
   @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final brand = theme.extension<AppBrandTheme>();
+    final brandColor = brand?.outline ?? theme.colorScheme.secondary;
+
     final prov = context.watch<ExerciseProvider>();
     final groups = context.watch<MuscleGroupProvider>().groups;
 
-    List<Exercise> exercises = prov.exercises.where((e) {
-      final matchesQuery = e.name.toLowerCase().contains(_query.toLowerCase());
-      final matchesGroup = _groupFilter == null || e.muscleGroupIds.contains(_groupFilter);
-      return matchesQuery && matchesGroup;
-    }).toList();
+    final exercises = _filteredExercises(prov.exercises);
 
     Widget body;
     if (prov.isLoading) {
       body = const Center(child: CircularProgressIndicator());
     } else if (prov.error != null) {
-      body = Center(child: Text('${loc.errorPrefix}: ${prov.error}'));
+      body = Center(
+        child: Text(
+          '${loc.errorPrefix}: ${prov.error}',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium?.copyWith(color: theme.colorScheme.error),
+        ),
+      );
     } else if (exercises.isEmpty) {
       body = Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(loc.multiDeviceNoExercises),
-            const SizedBox(height: 8),
-            ElevatedButton(
-              onPressed: () => _openAdd(),
-              child: Text(loc.multiDeviceNewExercise),
-            ),
-          ],
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.search_off, size: 48, color: brandColor.withOpacity(0.7)),
+              const SizedBox(height: 12),
+              Text(
+                loc.multiDeviceNoExercises,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.titleMedium?.copyWith(color: brandColor),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                loc.multiDeviceNewExercise,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurface.withOpacity(0.7),
+                ),
+              ),
+            ],
+          ),
         ),
       );
     } else {
-      body = ListView.builder(
+      body = ListView.separated(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
         itemCount: exercises.length,
+        separatorBuilder: (_, __) => const SizedBox(height: AppSpacing.md),
         itemBuilder: (_, i) {
           final ex = exercises[i];
-          return ListTile(
-            leading: const Icon(Icons.fitness_center),
-            title: Text(ex.name),
-            subtitle: MuscleChips(
-              primaryIds: ex.primaryMuscleGroupIds,
-              secondaryIds: ex.secondaryMuscleGroupIds,
-            ),
-            onTap: () {
+          return _ExerciseCard(
+            exercise: ex,
+            onOpen: () {
               Navigator.of(context).pushNamed(
                 AppRouter.device,
                 arguments: {
@@ -137,66 +256,203 @@ class _ExerciseListScreenState extends State<ExerciseListScreen> {
                 },
               );
             },
-            trailing: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                IconButton(
-                  icon: const Icon(Icons.edit),
-                  onPressed: () => _openAdd(ex),
-                  tooltip: loc.multiDeviceEditExerciseButton,
-                ),
-                IconButton(
-                  icon: const Icon(Icons.delete),
-                  onPressed: () => _deleteExercise(ex),
-                  tooltip: loc.exerciseDeleteTitle,
-                ),
-              ],
-            ),
+            onEdit: () => _openAdd(ex),
+            onDelete: () => _deleteExercise(ex),
+            editLabel: loc.multiDeviceEditExerciseButton,
+            deleteLabel: loc.exerciseDeleteTitle,
           );
         },
       );
     }
 
     return Scaffold(
-      appBar: AppBar(title: Text(loc.multiDeviceExerciseListTitle)),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () => _openAdd(),
-        tooltip: loc.multiDeviceNewExercise,
-        child: const Icon(Icons.add),
-      ),
-      body: Column(
-        children: [
-          const MultiDeviceBanner(),
-          Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: TextField(
-              controller: _searchCtr,
-              decoration: InputDecoration(
-                hintText: loc.multiDeviceSearchHint,
-                prefixIcon: const Icon(Icons.search),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+              child: Row(
+                children: [
+                  BrandOutlineButton(
+                    onPressed: () => Navigator.of(context).maybePop(),
+                    height: 44,
+                    padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+                    child: const Icon(Icons.arrow_back),
+                  ),
+                  const SizedBox(width: AppSpacing.sm),
+                  Expanded(
+                    child: Text(
+                      loc.multiDeviceExerciseListTitle,
+                      style: theme.textTheme.headlineSmall?.copyWith(
+                        color: brandColor,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ),
+                ],
               ),
-              onChanged: (v) => setState(() => _query = v),
             ),
-          ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-            child: DropdownButton<String?>(
-              value: _groupFilter,
-              hint: Text(loc.multiDeviceMuscleGroupFilter),
-              isExpanded: true,
-              onChanged: (v) => setState(() => _groupFilter = v),
-              items: [
-                DropdownMenuItem<String?>(
-                  value: null,
-                  child: Text(loc.multiDeviceMuscleGroupFilterAll),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 24, 16, 0),
+              child: TextField(
+                controller: _searchCtr,
+                decoration: InputDecoration(
+                  hintText: loc.multiDeviceSearchHint,
+                  prefixIcon: const BrandGradientIcon(Icons.search),
+                  filled: true,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(16),
+                    borderSide: BorderSide.none,
+                  ),
+                  contentPadding: const EdgeInsets.symmetric(vertical: 0),
                 ),
-                for (final g in groups)
-                  DropdownMenuItem<String?>(value: g.id, child: Text(g.name)),
+                onChanged: (value) => setState(() => _query = value),
+                textInputAction: TextInputAction.search,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+              child: Row(
+                children: [
+                  FilterChip(
+                    label: BrandGradientText(
+                      loc.filterNameChip,
+                      style: theme.textTheme.labelLarge,
+                    ),
+                    selected: _sortDescending,
+                    onSelected: (_) => setState(() => _sortDescending = !_sortDescending),
+                    shape: const StadiumBorder(),
+                    selectedColor: theme.colorScheme.primaryContainer,
+                    showCheckmark: false,
+                  ),
+                  const SizedBox(width: 8),
+                  FilterChip(
+                    label: BrandGradientText(
+                      loc.filterMuscleChip,
+                      style: theme.textTheme.labelLarge,
+                    ),
+                    selected: _selectedGroups.isNotEmpty,
+                    onSelected: (_) => _openMuscleFilter(groups),
+                    shape: const StadiumBorder(),
+                    selectedColor: theme.colorScheme.primaryContainer,
+                    showCheckmark: false,
+                  ),
+                ],
+              ),
+            ),
+            if (_selectedGroups.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    for (final id in _selectedGroups)
+                      InputChip(
+                        label: Text(_groupName(id, groups)),
+                        onDeleted: () => setState(() => _selectedGroups.remove(id)),
+                      ),
+                  ],
+                ),
+              ),
+            const SizedBox(height: 16),
+            Expanded(
+              child: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 200),
+                child: body,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+              child: BrandPrimaryButton(
+                onPressed: () => _openAdd(),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(Icons.add),
+                    const SizedBox(width: 8),
+                    Text(loc.multiDeviceNewExercise),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ExerciseCard extends StatelessWidget {
+  final Exercise exercise;
+  final VoidCallback onOpen;
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+  final String editLabel;
+  final String deleteLabel;
+
+  const _ExerciseCard({
+    required this.exercise,
+    required this.onOpen,
+    required this.onEdit,
+    required this.onDelete,
+    required this.editLabel,
+    required this.deleteLabel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final brandColor = theme.extension<AppBrandTheme>()?.outline ?? theme.colorScheme.secondary;
+    final secondaryColor = theme.colorScheme.onSurface.withOpacity(0.7);
+
+    return BrandInteractiveCard(
+      onTap: onOpen,
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.sm,
+        vertical: 12,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  exercise.name,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: brandColor,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                MuscleChips(
+                  primaryIds: exercise.primaryMuscleGroupIds,
+                  secondaryIds: exercise.secondaryMuscleGroupIds,
+                ),
               ],
             ),
           ),
-          const SizedBox(height: 8),
-          Expanded(child: body),
+          const SizedBox(width: AppSpacing.sm),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              IconButton(
+                icon: const Icon(Icons.edit_outlined),
+                color: secondaryColor,
+                tooltip: editLabel,
+                onPressed: onEdit,
+              ),
+              IconButton(
+                icon: const Icon(Icons.delete_outline),
+                color: theme.colorScheme.error,
+                tooltip: deleteLabel,
+                onPressed: onDelete,
+              ),
+            ],
+          ),
         ],
       ),
     );

--- a/lib/features/device/presentation/widgets/exercise_bottom_sheet.dart
+++ b/lib/features/device/presentation/widgets/exercise_bottom_sheet.dart
@@ -2,9 +2,14 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+
 import 'package:tapem/core/providers/auth_provider.dart';
 import 'package:tapem/core/providers/exercise_provider.dart';
 import 'package:tapem/core/providers/muscle_group_provider.dart';
+import 'package:tapem/core/theme/app_brand_theme.dart';
+import 'package:tapem/core/theme/design_tokens.dart';
+import 'package:tapem/core/widgets/brand_outline_button.dart';
+import 'package:tapem/core/widgets/brand_primary_button.dart';
 import 'package:tapem/features/device/domain/models/exercise.dart';
 import 'package:tapem/l10n/app_localizations.dart';
 import 'package:tapem/ui/muscles/muscle_group_list_selector.dart';
@@ -33,6 +38,7 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
   late List<String> _initialPrimary;
   late List<String> _initialSecondary;
   String _filter = '';
+  bool _isSaving = false;
 
   bool get _hasChanges =>
       _nameCtr.text.trim() != (widget.exercise?.name ?? '') ||
@@ -44,21 +50,20 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
     final loc = AppLocalizations.of(context)!;
     final res = await showDialog<bool>(
       context: context,
-      builder:
-          (ctx) => AlertDialog(
-            title: Text(loc.exerciseEdit_discardChangesTitle),
-            content: Text(loc.exerciseEdit_discardChangesMessage),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.pop(ctx, false),
-                child: Text(loc.exerciseEdit_keepEditing),
-              ),
-              TextButton(
-                onPressed: () => Navigator.pop(ctx, true),
-                child: Text(loc.exerciseEdit_discard),
-              ),
-            ],
+      builder: (ctx) => AlertDialog(
+        title: Text(loc.exerciseEdit_discardChangesTitle),
+        content: Text(loc.exerciseEdit_discardChangesMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(loc.exerciseEdit_keepEditing),
           ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(loc.exerciseEdit_discard),
+          ),
+        ],
+      ),
     );
     return res ?? false;
   }
@@ -101,166 +106,244 @@ class _ExerciseBottomSheetState extends State<ExerciseBottomSheet> {
     super.dispose();
   }
 
+  Future<void> _save() async {
+    if (_isSaving) return;
+    final name = _nameCtr.text.trim();
+    if (name.isEmpty) return;
+    FocusScope.of(context).unfocus();
+    setState(() => _isSaving = true);
+
+    final auth = context.read<AuthProvider>();
+    final userId = auth.userId!;
+    final exProv = context.read<ExerciseProvider>();
+    final muscleProv = context.read<MuscleGroupProvider>();
+    final loc = AppLocalizations.of(context)!;
+
+    final normalizedPrimary = muscleProv.canonicalizeGroupIds(_primaryIds);
+    final primaryIds = normalizedPrimary.isEmpty
+        ? const <String>[]
+        : [normalizedPrimary.first];
+    final secondaryIds = muscleProv
+        .canonicalizeGroupIds(_secondaryIds)
+        .where((id) => !primaryIds.contains(id))
+        .toList();
+    final shouldReassign = widget.exercise != null &&
+        (!listEquals(primaryIds, _initialPrimary) ||
+            !listEquals(secondaryIds, _initialSecondary));
+
+    var shouldClose = false;
+    try {
+      Exercise ex;
+      if (widget.exercise == null) {
+        ex = await exProv.addExercise(
+          widget.gymId,
+          widget.deviceId,
+          name,
+          userId,
+          primaryMuscleGroupIds: primaryIds,
+          secondaryMuscleGroupIds: secondaryIds,
+        );
+      } else {
+        await exProv.updateExercise(
+          widget.gymId,
+          widget.deviceId,
+          widget.exercise!.id,
+          name,
+          userId,
+          primaryMuscleGroupIds: primaryIds,
+          secondaryMuscleGroupIds: secondaryIds,
+        );
+        ex = widget.exercise!.copyWith(
+          name: name,
+          primaryMuscleGroupIds: primaryIds,
+          secondaryMuscleGroupIds: secondaryIds,
+        );
+      }
+      await muscleProv.updateExerciseAssignments(
+        context,
+        ex.id,
+        primaryIds,
+        secondaryIds,
+      );
+      if (shouldReassign) {
+        await exProv.reassignMuscleXp(
+          widget.gymId,
+          widget.deviceId,
+          widget.exercise!.id,
+          userId,
+          primaryIds,
+          secondaryIds,
+        );
+      }
+      shouldClose = true;
+      if (!mounted) return;
+      Navigator.pop(context, ex);
+    } on FirebaseException catch (e) {
+      if (!mounted) return;
+      final message = e.code == 'permission-denied'
+          ? loc.commonSaveError
+          : (e.message ?? loc.commonSaveError);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(message)),
+      );
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(loc.commonSaveError)),
+      );
+    } finally {
+      if (!shouldClose && mounted) {
+        setState(() => _isSaving = false);
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context)!;
-    final auth = context.read<AuthProvider>();
-    final userId = auth.userId!;
-    final hasChanges = _hasChanges;
+    final theme = Theme.of(context);
     final canSave =
-        _nameCtr.text.trim().isNotEmpty &&
-        (widget.exercise == null || hasChanges);
+        _nameCtr.text.trim().isNotEmpty && (widget.exercise == null || _hasChanges);
 
     return WillPopScope(
       onWillPop: _confirmDiscard,
-      child: Padding(
+      child: AnimatedPadding(
+        duration: const Duration(milliseconds: 250),
+        curve: Curves.easeOutCubic,
         padding: EdgeInsets.only(
           bottom: MediaQuery.of(context).viewInsets.bottom,
         ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Padding(
-              padding: const EdgeInsets.all(16),
-              child: Text(
-                widget.exercise == null
-                    ? loc.exerciseAddTitle
-                    : loc.exerciseEditTitle,
-                style: Theme.of(context).textTheme.titleLarge,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: TextField(
-                controller: _nameCtr,
-                decoration: InputDecoration(labelText: loc.exerciseNameLabel),
-                onChanged: (_) => setState(() {}),
-                autofocus: true,
-              ),
-            ),
-            const SizedBox(height: 4),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Text(
-                loc.exerciseMuscleGroupsLabel,
-                style: const TextStyle(fontWeight: FontWeight.bold),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: TextField(
-                controller: _searchCtr,
-                decoration: InputDecoration(
-                  hintText: loc.exerciseSearchMuscleGroupsHint,
+        child: SafeArea(
+          top: false,
+          child: Container(
+            decoration: BoxDecoration(
+              color: theme.colorScheme.surface,
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.2),
+                  blurRadius: 24,
+                  offset: const Offset(0, -8),
                 ),
-                onChanged: (v) => setState(() => _filter = v),
-              ),
-            ),
-            const SizedBox(height: 4),
-            SizedBox(
-              height: 300,
-              child: MuscleGroupListSelector(
-                initialPrimary: _initialPrimary,
-                initialSecondary: _initialSecondary,
-                onChanged:
-                    (p, s) => setState(() {
-                      _primaryIds = p;
-                      _secondaryIds = s;
-                    }),
-                filter: _filter,
-              ),
-            ),
-            Row(
-              children: [
-                const SizedBox(width: 16),
-                TextButton(
-                  onPressed: () async {
-                    if (await _confirmDiscard()) {
-                      if (context.mounted) Navigator.pop(context);
-                    }
-                  },
-                  child: Text(loc.commonCancel),
-                ),
-                const Spacer(),
-                TextButton(
-                  onPressed:
-                      canSave
-                          ? () async {
-                              try {
-                                final name = _nameCtr.text.trim();
-                                final exProv = context.read<ExerciseProvider>();
-                                final muscleProv =
-                                    context.read<MuscleGroupProvider>();
-                                final normalizedPrimary =
-                                    muscleProv.canonicalizeGroupIds(_primaryIds);
-                                final primaryIds = normalizedPrimary.isEmpty
-                                    ? const <String>[]
-                                    : [normalizedPrimary.first];
-                                final secondaryIds = muscleProv
-                                    .canonicalizeGroupIds(_secondaryIds)
-                                    .where((id) => !primaryIds.contains(id))
-                                    .toList();
-                                Exercise ex;
-                                if (widget.exercise == null) {
-                                  ex = await exProv.addExercise(
-                                    widget.gymId,
-                                    widget.deviceId,
-                                    name,
-                                    userId,
-                                    primaryMuscleGroupIds: primaryIds,
-                                    secondaryMuscleGroupIds: secondaryIds,
-                                  );
-                                } else {
-                                  await exProv.updateExercise(
-                                    widget.gymId,
-                                    widget.deviceId,
-                                    widget.exercise!.id,
-                                    name,
-                                    userId,
-                                    primaryMuscleGroupIds: primaryIds,
-                                    secondaryMuscleGroupIds: secondaryIds,
-                                  );
-                                  ex = widget.exercise!.copyWith(
-                                    name: name,
-                                    primaryMuscleGroupIds: primaryIds,
-                                    secondaryMuscleGroupIds: secondaryIds,
-                                  );
-                                }
-                                await context
-                                    .read<MuscleGroupProvider>()
-                                    .updateExerciseAssignments(
-                                      context,
-                                      ex.id,
-                                      primaryIds,
-                                      secondaryIds,
-                                    );
-                                if (!mounted) return;
-                                Navigator.pop(context, ex);
-                              } on FirebaseException catch (e) {
-                                if (!mounted) return;
-                                final messenger =
-                                    ScaffoldMessenger.of(context);
-                                final message = e.code == 'permission-denied'
-                                    ? loc.commonSaveError
-                                    : (e.message ?? loc.commonSaveError);
-                                messenger.showSnackBar(
-                                  SnackBar(content: Text(message)),
-                                );
-                              } catch (e) {
-                                if (!mounted) return;
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(content: Text(loc.commonSaveError)),
-                                );
-                              }
-                            }
-                          : null,
-                  child: Text(loc.commonSave),
-                ),
-                const SizedBox(width: 16),
               ],
             ),
-          ],
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.fromLTRB(24, 24, 24, 32),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Center(
+                    child: Container(
+                      width: 48,
+                      height: 4,
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.onSurface.withOpacity(0.1),
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    widget.exercise == null
+                        ? loc.exerciseAddTitle
+                        : loc.exerciseEditTitle,
+                    style: theme.textTheme.headlineSmall?.copyWith(
+                      color: theme.extension<AppBrandTheme>()?.outline ??
+                          theme.colorScheme.secondary,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  TextField(
+                    controller: _nameCtr,
+                    decoration: InputDecoration(
+                      labelText: loc.exerciseNameLabel,
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                    ),
+                    autofocus: true,
+                    onChanged: (_) => setState(() {}),
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    loc.exerciseMuscleGroupsLabel,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    controller: _searchCtr,
+                    decoration: InputDecoration(
+                      hintText: loc.exerciseSearchMuscleGroupsHint,
+                      prefixIcon: const Icon(Icons.search),
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                    ),
+                    onChanged: (v) => setState(() => _filter = v),
+                  ),
+                  const SizedBox(height: 16),
+                  SizedBox(
+                    height: 320,
+                    child: MuscleGroupListSelector(
+                      initialPrimary: _initialPrimary,
+                      initialSecondary: _initialSecondary,
+                      onChanged: (p, s) => setState(() {
+                        _primaryIds = p;
+                        _secondaryIds = s;
+                      }),
+                      filter: _filter,
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: BrandOutlineButton(
+                          onPressed: _isSaving
+                              ? null
+                              : () async {
+                                  if (await _confirmDiscard()) {
+                                    if (mounted) Navigator.pop(context);
+                                  }
+                                },
+                          child: Text(loc.commonCancel),
+                        ),
+                      ),
+                      const SizedBox(width: AppSpacing.md),
+                      Expanded(
+                        child: BrandPrimaryButton(
+                          onPressed: canSave && !_isSaving ? _save : null,
+                          child: AnimatedSwitcher(
+                            duration: const Duration(milliseconds: 200),
+                            child: _isSaving
+                                ? const SizedBox(
+                                    key: ValueKey('saving'),
+                                    width: 20,
+                                    height: 20,
+                                    child: CircularProgressIndicator(strokeWidth: 2),
+                                  )
+                                : Row(
+                                    key: const ValueKey('label'),
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      const Icon(Icons.check),
+                                      const SizedBox(width: 8),
+                                      Text(loc.commonSave),
+                                    ],
+                                  ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
         ),
       ),
     );

--- a/lib/features/xp/data/sources/firestore_xp_source.dart
+++ b/lib/features/xp/data/sources/firestore_xp_source.dart
@@ -9,6 +9,7 @@ import 'package:tapem/core/time/logic_day.dart';
 import 'package:tapem/features/rank/data/sources/firestore_rank_source.dart';
 import 'package:tapem/features/rank/domain/models/level_info.dart';
 import 'package:tapem/features/rank/domain/services/level_service.dart';
+import 'package:tapem/features/xp/domain/muscle_xp_calculator.dart';
 import 'package:tapem/features/xp/domain/device_xp_result.dart';
 
 class FirestoreXpSource {
@@ -228,7 +229,7 @@ class FirestoreXpSource {
       'dayKey': dayKey,
     });
 
-    final delta = _buildMuscleXpDelta(
+    final delta = MuscleXpCalculator.calculateDelta(
       primaryMuscleGroupIds,
       secondaryMuscleGroupIds,
     );
@@ -252,62 +253,13 @@ class FirestoreXpSource {
     }
   }
 
-  Map<String, int> _buildMuscleXpDelta(
-    List<String> primaryMuscleGroupIds,
-    List<String> secondaryMuscleGroupIds,
-  ) {
-    final order = <String>[];
-    final weights = <String, int>{};
-    final seenPrimary = <String>{};
-    final seenSecondary = <String>{};
-
-    void push(String id, int weight, Set<String> seen) {
-      if (id.isEmpty) return;
-      if (seen.add(id)) {
-        order.add(id);
-      }
-      weights[id] = (weights[id] ?? 0) + weight;
-    }
-
-    for (final id in primaryMuscleGroupIds) {
-      push(id, 2, seenPrimary);
-    }
-    for (final id in secondaryMuscleGroupIds) {
-      if (seenPrimary.contains(id)) {
-        continue;
-      }
-      push(id, 1, seenSecondary);
-    }
-
-    final totalWeight = weights.values.fold<int>(0, (sum, w) => sum + w);
-    if (totalWeight == 0) {
-      return const {};
-    }
-
-    final baseXp = LevelService.xpPerSession;
-    final xpPerWeight = baseXp ~/ totalWeight;
-    var remainder = baseXp % totalWeight;
-    final delta = <String, int>{};
-    for (final id in order) {
-      final weight = weights[id] ?? 0;
-      if (weight == 0) continue;
-      var value = weight * xpPerWeight;
-      if (remainder > 0) {
-        value += 1;
-        remainder -= 1;
-      }
-      delta[id] = value;
-    }
-    return delta;
-  }
-
   Future<void> _applyMuscleXp({
     required DocumentReference<Map<String, dynamic>> statsRef,
     required List<String> primaryMuscleGroupIds,
     required List<String> secondaryMuscleGroupIds,
     required String traceId,
   }) async {
-    final delta = _buildMuscleXpDelta(
+    final delta = MuscleXpCalculator.calculateDelta(
       primaryMuscleGroupIds,
       secondaryMuscleGroupIds,
     );

--- a/lib/features/xp/domain/muscle_xp_calculator.dart
+++ b/lib/features/xp/domain/muscle_xp_calculator.dart
@@ -1,0 +1,64 @@
+import 'package:collection/collection.dart';
+import 'package:tapem/features/rank/domain/services/level_service.dart';
+
+/// Helper to split XP per muscle group following the same weighting logic as
+/// used during session XP creation.
+class MuscleXpCalculator {
+  static final _listEquality = const ListEquality<String>();
+
+  /// Calculates the XP delta per muscle group for a single session.
+  ///
+  /// [primaryMuscleGroupIds] receive double weight compared to [secondaryMuscleGroupIds].
+  /// Duplicate ids are ignored while maintaining insertion order.
+  static Map<String, int> calculateDelta(
+    List<String> primaryMuscleGroupIds,
+    List<String> secondaryMuscleGroupIds,
+  ) {
+    final order = <String>[];
+    final weights = <String, int>{};
+    final seenPrimary = <String>{};
+    final seenSecondary = <String>{};
+
+    void push(String id, int weight, Set<String> seen) {
+      if (id.isEmpty) return;
+      if (seen.add(id)) {
+        order.add(id);
+      }
+      weights[id] = (weights[id] ?? 0) + weight;
+    }
+
+    for (final id in primaryMuscleGroupIds) {
+      push(id, 2, seenPrimary);
+    }
+    for (final id in secondaryMuscleGroupIds) {
+      if (seenPrimary.contains(id)) {
+        continue;
+      }
+      push(id, 1, seenSecondary);
+    }
+
+    final totalWeight = weights.values.fold<int>(0, (sum, w) => sum + w);
+    if (totalWeight == 0) {
+      return const {};
+    }
+
+    final baseXp = LevelService.xpPerSession;
+    final xpPerWeight = baseXp ~/ totalWeight;
+    var remainder = baseXp % totalWeight;
+    final delta = <String, int>{};
+    for (final id in order) {
+      final weight = weights[id] ?? 0;
+      if (weight == 0) continue;
+      var value = weight * xpPerWeight;
+      if (remainder > 0) {
+        value += 1;
+        remainder -= 1;
+      }
+      delta[id] = value;
+    }
+    return delta;
+  }
+
+  static bool listsEqual(List<String> a, List<String> b) =>
+      _listEquality.equals(a, b);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -83,6 +83,7 @@ import 'features/device/data/sources/firestore_exercise_source.dart';
 import 'features/device/data/repositories/exercise_repository_impl.dart';
 import 'features/device/domain/repositories/exercise_repository.dart';
 import 'features/device/domain/usecases/get_exercises_for_device.dart';
+import 'features/device/domain/services/exercise_xp_reassignment_service.dart';
 import 'features/device/domain/usecases/create_exercise_usecase.dart';
 import 'features/device/domain/usecases/delete_exercise_usecase.dart';
 import 'features/device/domain/usecases/update_exercise_usecase.dart';
@@ -471,6 +472,10 @@ Future<void> main() async {
           create: (c) =>
               MuscleGroupProvider(membership: c.read<MembershipService>()),
         ),
+        Provider(
+          create: (_) =>
+              ExerciseXpReassignmentService(firestore: FirebaseFirestore.instance),
+        ),
         ChangeNotifierProvider(
           create: (c) => ExerciseProvider(
             getEx: c.read<GetExercisesForDevice>(),
@@ -478,6 +483,7 @@ Future<void> main() async {
             deleteEx: c.read<DeleteExerciseUseCase>(),
             updateEx: c.read<UpdateExerciseUseCase>(),
             updateMuscles: c.read<UpdateExerciseMuscleGroupsUseCase>(),
+            xpReassignment: c.read<ExerciseXpReassignmentService>(),
           ),
         ),
         ChangeNotifierProvider(


### PR DESCRIPTION
## Summary
- restyle the multi-device exercise list to match the gym screen aesthetics with chips, brand buttons, and improved empty state
- refresh the exercise editing bottom sheet with branded styling, saving feedback, and direct XP reassignment when muscle groups change
- add reusable helpers for muscle XP redistribution and wire the service through providers so historical stats stay accurate

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5a55cbde48320b23e20cf52ddc6f7